### PR TITLE
feat: a deterministic index over the roadmap archive, measured before anything depends on it

### DIFF
--- a/.github/workflows/consistency.yml
+++ b/.github/workflows/consistency.yml
@@ -148,6 +148,13 @@ jobs:
       - name: Verify the artefact index + catalog are regenerated
         run: task check-index
 
+      # The archive index is generated from 500 archived roadmaps, so it goes
+      # stale the moment a roadmap is archived — which happens inside the PR
+      # that closes it. Registered here and not only in `task ci`, because no
+      # workflow invokes `task ci`.
+      - name: Verify the archive index is regenerated
+        run: task check-archive-index
+
       - name: Verify dist == rewrite(src) byte-for-byte
         run: task check-condensation
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -96,6 +96,10 @@ tasks:
       - task: check-ci-strict-superset
       - task: counts-check
       - task: check-index
+      # src/scripts/build_archive_index — the dedup index over the roadmap
+      # archive. A generated artefact nobody re-derives goes stale in one
+      # merge, so the drift check rides the same chain as check-index.
+      - task: check-archive-index
       - task: check-router
       - task: check-condensation
       - task: check-condensed-paths

--- a/agents/evidence/analysis/archive-index-saving.md
+++ b/agents/evidence/analysis/archive-index-saving.md
@@ -1,0 +1,113 @@
+# Does the archive index pay? — the before/after file-open reading
+
+> **Produced by:** step 1.3 of the archive-index roadmap, in an isolated
+> worktree against `main` @ `ffec3acb7`, 2026-08-16.
+> **Pre-registered bar:** at least **80 % fewer archive files opened** to answer
+> a dedup question. Below the bar the index is reverted and this reading is
+> published as a null.
+> **Verdict: the bar is cleared in aggregate — 82 % (140 → 24 files opened).**
+> **6 of 14 individual questions fall below it.** The index pays on a large
+> candidate set and is a wash below roughly five candidates. Both halves are
+> load-bearing; the second is the one a reader should carry away.
+
+## What was measured
+
+The dedup question a screen actually asks is *"has this already been tried,
+closed, or refuted?"*. Answering it means, for each archived roadmap that might
+be about the topic: know its title, and know how it closed.
+
+- **Without the index**, neither is visible from outside the file. Slugs are
+  suggestive, dispositions are not written anywhere but the body. So the cost
+  is **one open per slug-matching archived roadmap**.
+- **With the index**, one read of `INDEX.md` yields slug, title, disposition,
+  phase count and step tally for every match. A file is still opened for any
+  row the index marks `not-extractable` — a roadmap with no checkbox anywhere,
+  where the index genuinely cannot say how it closed.
+
+The baseline is deliberately the *cheapest* honest procedure available today,
+not the soundest. A slug filter misses every archived roadmap whose name does
+not carry the term, and the index does not (it carries titles too). Counting
+the sound baseline — open enough files to be sure — would inflate the saving,
+so it is not counted.
+
+## The question set, and why it is not hand-picked
+
+Term choice is exactly the selection this reading cannot afford, so the set is
+derived by a rule instead of by judgement: **every token appearing in at least
+two active roadmap slugs**, minus structural stopwords.
+
+```bash
+ls agents/roadmaps/*.md | sed 's/\.md$//' | tr '-' '\n' | grep -v '^$' |
+  grep -Ev '^(road|to|inbox|harvest|2026|08|a|b|c|d|the|of|for|and|followup)$' |
+  sort | uniq -c | sort -rn | awk '$1>=2 {print $2}'
+```
+
+That yields 14 terms, all of which are kept — including the weak ones (`run`,
+`first`, `ci`), because dropping a term after seeing its number is the same
+selection under a different name.
+
+**An earlier, hand-picked 8-term probe read 70 %** and is published here rather
+than discarded: `index 1→1 · prompt 2→1 · evidence 9→2 · reach 3→1 ·
+description 1→1 · orchestration 7→1` (plus two terms with no candidate at all),
+pooling to 23 → 7. It was replaced because the terms were chosen by hand, and a
+70 % reading dropped in favour of an 82 % one would be indistinguishable from
+denominator shopping if only the survivor were shown. The two differ for a
+substantive reason, not a favourable one: the hand-picked set is dominated by
+one- and two-candidate questions, which is precisely the regime where the index
+does not pay.
+
+## The reading
+
+| Question | Files opened without | `not-extractable` | Files opened with | Saving |
+|---|---:|---:|---:|---:|
+| `ci` | 36 | 1 | 2 | 94 % |
+| `skill` | 24 | 4 | 5 | 79 % |
+| `ecosystem` | 17 | 0 | 1 | 94 % |
+| `gate` | 13 | 0 | 1 | 92 % |
+| `run` | 9 | 2 | 3 | 66 % |
+| `rule` | 7 | 2 | 3 | 57 % |
+| `orchestration` | 7 | 0 | 1 | 85 % |
+| `integrity` | 6 | 0 | 1 | 83 % |
+| `subagent` | 5 | 0 | 1 | 80 % |
+| `economy` | 5 | 0 | 1 | 80 % |
+| `lifecycle` | 4 | 1 | 2 | 50 % |
+| `measurement` | 3 | 0 | 1 | 66 % |
+| `first` | 3 | 0 | 1 | 66 % |
+| `frontend` | 1 | 0 | 1 | 0 % |
+| **Total** | **140** | **10** | **24** | **82 %** |
+
+Read once per sweep rather than once per question — which is what a screen
+actually does, since the index stays in context across the questions it asks —
+the same 14 questions cost 11 opens instead of 24, i.e. **92 %**. The 82 %
+figure is the conservative one and is the one the verdict rests on.
+
+## What the number does not say
+
+- **Six of fourteen questions fall below the bar** (`run`, `rule`,
+  `measurement`, `lifecycle`, `first`, `frontend`). The break-even is around
+  five candidates: below it, opening the index costs about what opening the
+  files costs. A screen with one narrow question should not expect a saving.
+- **"Refuted?" is largely not answered.** Only 3 archived roadmaps carry a
+  frontmatter `verdict:`, so the index answers *tried?* and *closed?* and sends
+  the reader to the file for *why*. This is a property of the archive, not a
+  gap in the extractor — inventing the missing verdicts is the non-goal the
+  roadmap opens with.
+- **`disposition` describes shape, not intent.** It is derived from the
+  checkbox tally, acceptance-criteria boxes included. `completed` means every
+  box is ticked, never that the work succeeded.
+- **Bytes are not files.** `INDEX.md` is ~95 KB; nobody reads it whole. The
+  measured unit is files opened, per the pre-registered bar, and a grep over
+  one file returns matching rows only. A reader who loads the whole index into
+  context has spent more than the files would have cost.
+
+## Reproducing it
+
+```bash
+./scripts-run src/scripts/build_archive_index          # regenerate
+./scripts-run src/scripts/build_archive_index --check   # drift gate
+
+# per-term: candidates without the index vs rows the index cannot resolve
+T=gate
+ls agents/roadmaps/archive/*.md | xargs -n1 basename | grep -Fi -- "$T" | grep -vc '^INDEX.md$'
+grep -Fi -- "$T" agents/roadmaps/archive/INDEX.md | grep '^| \[' | grep -c 'not-extractable |'
+```

--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -2,14 +2,14 @@
 
 > Auto-generated — do not edit. Regenerate with `task roadmap-progress` or by running the `update_roadmap_progress` script for your install; rewritten on every roadmap create / execute / completion change (timestamp lives in git history).
 >
-> 30 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **35** open blockers, **10** need you → `agent-config gates`
+> 29 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **35** open blockers, **10** need you → `agent-config gates`
 
 ## Overall
 
-**243 / 445 steps done · 55%**
+**243 / 435 steps done · 56%**
 
 ```text
-██████████████████████░░░░░░░░░░░░░░░░░░   55%
+██████████████████████░░░░░░░░░░░░░░░░░░   56%
 ```
 
 ## Open roadmaps
@@ -29,23 +29,22 @@
 | 11 | [road-to-inbox-harvest-2026-08-b-ledger-truth.md](roadmaps/road-to-inbox-harvest-2026-08-b-ledger-truth.md) | 3 | 19 | 1 | 12 | 0 | 6 | [1](#blockers-road-to-inbox-harvest-2026-08-b-ledger-truth) | █████████░ 92% |
 | 12 | [road-to-inbox-harvest-2026-08-c-evidence-lifecycle.md](roadmaps/road-to-inbox-harvest-2026-08-c-evidence-lifecycle.md) | 3 | 13 | 1 | 9 | 0 | 3 | [1](#blockers-road-to-inbox-harvest-2026-08-c-evidence-lifecycle) | █████████░ 90% |
 | 13 | [road-to-inbox-harvest-2026-08-c-prompt-deinflation.md](roadmaps/road-to-inbox-harvest-2026-08-c-prompt-deinflation.md) | 2 | 9 | 9 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
-| 14 | [road-to-inbox-harvest-2026-08-d-archive-index.md](roadmaps/road-to-inbox-harvest-2026-08-d-archive-index.md) | 2 | 10 | 10 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
-| 15 | [road-to-inbox-harvest-2026-08-d-top-band-model-economy.md](roadmaps/road-to-inbox-harvest-2026-08-d-top-band-model-economy.md) | 4 | 14 | 2 | 11 | 1 | 0 | [1](#blockers-road-to-inbox-harvest-2026-08-d-top-band-model-economy) | ████████░░ 85% |
-| 16 | [road-to-inbox-harvest-residuals.md](roadmaps/road-to-inbox-harvest-residuals.md) | 1 | 4 | 4 | 0 | 0 | 0 | [2](#blockers-road-to-inbox-harvest-residuals) | ░░░░░░░░░░ 0% |
-| 17 | [road-to-kernel-question-triangle.md](roadmaps/road-to-kernel-question-triangle.md) | 1 | 3 | 3 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
-| 18 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 11 | 4 | 7 | 0 | 0 | 0 | ██████░░░░ 64% |
-| 19 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
-| 20 | [road-to-rule-coherence-followup.md](roadmaps/road-to-rule-coherence-followup.md) | 5 | 9 | 8 | 1 | 0 | 0 | [2](#blockers-road-to-rule-coherence-followup) | █░░░░░░░░░ 11% |
-| 21 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | [1](#blockers-road-to-scale-history-bench-run) | ░░░░░░░░░░ 0% |
-| 22 | [road-to-skill-description-measurement.md](roadmaps/road-to-skill-description-measurement.md) | 1 | 4 | 4 | 0 | 0 | 0 | [1](#blockers-road-to-skill-description-measurement) | ░░░░░░░░░░ 0% |
-| 23 | [road-to-skill-ecosystem-executable-payloads.md](roadmaps/road-to-skill-ecosystem-executable-payloads.md) | 6 | 21 | 14 | 6 | 0 | 1 | [1](#blockers-road-to-skill-ecosystem-executable-payloads) | ███░░░░░░░ 30% |
-| 24 | [road-to-skill-ecosystem-gate-integrity.md](roadmaps/road-to-skill-ecosystem-gate-integrity.md) | 5 | 43 | 3 | 40 | 0 | 0 | [1](#blockers-road-to-skill-ecosystem-gate-integrity) | █████████░ 93% |
-| 25 | [road-to-solution-minimalism.md](roadmaps/road-to-solution-minimalism.md) | 4 | 36 | 10 | 25 | 0 | 1 | 0 | ███████░░░ 71% |
-| 26 | [road-to-source-first-frontend.md](roadmaps/road-to-source-first-frontend.md) | 6 | 18 | 8 | 9 | 1 | 0 | 0 | █████░░░░░ 53% |
-| 27 | [road-to-subagent-lifecycle-integrity.md](roadmaps/road-to-subagent-lifecycle-integrity.md) | 7 | 21 | 9 | 10 | 0 | 2 | [1](#blockers-road-to-subagent-lifecycle-integrity) | █████░░░░░ 53% |
-| 28 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
-| 29 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 3 | 14 | 1 | 12 | 1 | 0 | [2](#blockers-road-to-surface-consolidation) | █████████░ 92% |
-| 30 | [road-to-ui-track-integrity-followup.md](roadmaps/road-to-ui-track-integrity-followup.md) | 1 | 10 | 10 | 0 | 0 | 0 | [2](#blockers-road-to-ui-track-integrity-followup) | ░░░░░░░░░░ 0% |
+| 14 | [road-to-inbox-harvest-2026-08-d-top-band-model-economy.md](roadmaps/road-to-inbox-harvest-2026-08-d-top-band-model-economy.md) | 4 | 14 | 2 | 11 | 1 | 0 | [1](#blockers-road-to-inbox-harvest-2026-08-d-top-band-model-economy) | ████████░░ 85% |
+| 15 | [road-to-inbox-harvest-residuals.md](roadmaps/road-to-inbox-harvest-residuals.md) | 1 | 4 | 4 | 0 | 0 | 0 | [2](#blockers-road-to-inbox-harvest-residuals) | ░░░░░░░░░░ 0% |
+| 16 | [road-to-kernel-question-triangle.md](roadmaps/road-to-kernel-question-triangle.md) | 1 | 3 | 3 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 17 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 11 | 4 | 7 | 0 | 0 | 0 | ██████░░░░ 64% |
+| 18 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
+| 19 | [road-to-rule-coherence-followup.md](roadmaps/road-to-rule-coherence-followup.md) | 5 | 9 | 8 | 1 | 0 | 0 | [2](#blockers-road-to-rule-coherence-followup) | █░░░░░░░░░ 11% |
+| 20 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | [1](#blockers-road-to-scale-history-bench-run) | ░░░░░░░░░░ 0% |
+| 21 | [road-to-skill-description-measurement.md](roadmaps/road-to-skill-description-measurement.md) | 1 | 4 | 4 | 0 | 0 | 0 | [1](#blockers-road-to-skill-description-measurement) | ░░░░░░░░░░ 0% |
+| 22 | [road-to-skill-ecosystem-executable-payloads.md](roadmaps/road-to-skill-ecosystem-executable-payloads.md) | 6 | 21 | 14 | 6 | 0 | 1 | [1](#blockers-road-to-skill-ecosystem-executable-payloads) | ███░░░░░░░ 30% |
+| 23 | [road-to-skill-ecosystem-gate-integrity.md](roadmaps/road-to-skill-ecosystem-gate-integrity.md) | 5 | 43 | 3 | 40 | 0 | 0 | [1](#blockers-road-to-skill-ecosystem-gate-integrity) | █████████░ 93% |
+| 24 | [road-to-solution-minimalism.md](roadmaps/road-to-solution-minimalism.md) | 4 | 36 | 10 | 25 | 0 | 1 | 0 | ███████░░░ 71% |
+| 25 | [road-to-source-first-frontend.md](roadmaps/road-to-source-first-frontend.md) | 6 | 18 | 8 | 9 | 1 | 0 | 0 | █████░░░░░ 53% |
+| 26 | [road-to-subagent-lifecycle-integrity.md](roadmaps/road-to-subagent-lifecycle-integrity.md) | 7 | 21 | 9 | 10 | 0 | 2 | [1](#blockers-road-to-subagent-lifecycle-integrity) | █████░░░░░ 53% |
+| 27 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
+| 28 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 3 | 14 | 1 | 12 | 1 | 0 | [2](#blockers-road-to-surface-consolidation) | █████████░ 92% |
+| 29 | [road-to-ui-track-integrity-followup.md](roadmaps/road-to-ui-track-integrity-followup.md) | 1 | 10 | 10 | 0 | 0 | 0 | [2](#blockers-road-to-ui-track-integrity-followup) | ░░░░░░░░░░ 0% |
 
 ---
 
@@ -382,15 +381,6 @@ _1 blocker resolved._
 |---|---|---|---:|---:|---:|---:|---:|
 | 1 | A de-inflation step in Diagnose | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
 | 2 | Provenance, recorded either way | ⬜ not started | 6 | 0 | 0 | 0 | 0% |
-
-### [road-to-inbox-harvest-2026-08-d-archive-index.md](roadmaps/road-to-inbox-harvest-2026-08-d-archive-index.md)
-
-**Road to an archive index, so sweeps stop paying for history** — 0 / 10 done (0%)
-
-| # | Phase | State | Open | Done | Deferred | Cancelled | % |
-|---|---|---|---:|---:|---:|---:|---:|
-| 1 | Build the index, then prove it paid | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
-| 2 | Point the consumers at it | ⬜ not started | 7 | 0 | 0 | 0 | 0% |
 
 ### [road-to-inbox-harvest-2026-08-d-top-band-model-economy.md](roadmaps/road-to-inbox-harvest-2026-08-d-top-band-model-economy.md)
 

--- a/agents/roadmaps/archive/INDEX.md
+++ b/agents/roadmaps/archive/INDEX.md
@@ -1,0 +1,527 @@
+# Archive index
+
+> Auto-generated — do not edit. Regenerate with `task build-archive-index`;
+> `task check-archive-index` fails on drift. Generation time lives in git
+> history, not in this file (a clock here would make every drift check a
+> false red).
+
+**501 archived roadmaps** · archived-with-open-steps 32 · closed-with-cancellations 166 · completed 244 · completed-with-deferrals 25 · not-extractable 34
+
+Every column is extracted deterministically from the file itself. No
+summary here is model-written: a verdict the frontmatter does not carry
+reads _not extractable_ rather than being inferred. `Disposition` is
+derived from the checkbox tally alone (acceptance-criteria boxes
+included) and records how the file looks, never why it was archived —
+so for anything the index marks _not extractable_, open the file.
+
+**Limits worth knowing before you rely on this.** Only a handful of
+archived roadmaps carry a frontmatter `verdict:`, so the index answers
+_tried?_ and _closed?_ and sends you to the file for _why_. The measured
+saving is 82 % fewer files opened on a pre-registered question set — and
+below roughly five candidate files it is a wash, so a single narrow
+question is cheaper answered directly. Reading, method and full
+distribution: [`archive-index-saving`](../../evidence/analysis/archive-index-saving.md).
+
+| Roadmap | Title | Disposition | Phases | Steps (done/total) | Verdict |
+|---|---|---|---:|---|---|
+| [`00-overview-and-ordering`](00-overview-and-ordering.md) | Phase 3 Overview and Ordering | completed | 0 | 5/5 | _not extractable_ |
+| [`00-overview`](00-overview.md) | Roadmap Overview — agent-config External Review | not-extractable | 0 | — | _not extractable_ |
+| [`00-phase4-overview`](00-phase4-overview.md) | Phase 4: Activation — Make the Infrastructure Usable | archived-with-open-steps | 0 | 0/14 | _not extractable_ |
+| [`01-critical-blockers`](01-critical-blockers.md) | Roadmap 01 — Kritische Blocker (P0) | not-extractable | 0 | — | _not extractable_ |
+| [`01-e2e-integration-roadmap`](01-e2e-integration-roadmap.md) | End-to-End Integration + Tool Adapter Roadmap | not-extractable | 0 | — | _not extractable_ |
+| [`01-runtime-layer-pr-series`](01-runtime-layer-pr-series.md) | Runtime Layer — Concrete PR Series | completed | 0 | 5/5 | _not extractable_ |
+| [`01-runtime-layer-roadmap`](01-runtime-layer-roadmap.md) | Runtime Layer Roadmap | not-extractable | 0 | — | _not extractable_ |
+| [`02-architecture-issues`](02-architecture-issues.md) | Roadmap 02 — Architektur-Probleme (P1) | not-extractable | 0 | — | _not extractable_ |
+| [`02-skill-activation-roadmap`](02-skill-activation-roadmap.md) | Skill Activation + Boundary Hygiene Roadmap | not-extractable | 0 | — | _not extractable_ |
+| [`02-tool-integration-pr-series`](02-tool-integration-pr-series.md) | Tool Integration — Concrete PR Series | completed | 0 | 5/5 | _not extractable_ |
+| [`02-tool-integration-roadmap`](02-tool-integration-roadmap.md) | Tool Integration Roadmap | not-extractable | 0 | — | _not extractable_ |
+| [`03-consumable-output-roadmap`](03-consumable-output-roadmap.md) | Consumable Output + Feedback Governance Roadmap | not-extractable | 0 | — | _not extractable_ |
+| [`03-installer-system`](03-installer-system.md) | Roadmap 03 — Installer-System (P1) | not-extractable | 0 | — | _not extractable_ |
+| [`03-observability-pr-series`](03-observability-pr-series.md) | Observability — Concrete PR Series | completed | 0 | 5/5 | _not extractable_ |
+| [`03-observability-roadmap`](03-observability-roadmap.md) | Observability Roadmap | not-extractable | 0 | — | _not extractable_ |
+| [`04-developer-judgment-roadmap`](04-developer-judgment-roadmap.md) | Developer Judgment Activation Roadmap | not-extractable | 0 | — | _not extractable_ |
+| [`04-documentation-gaps`](04-documentation-gaps.md) | Roadmap 04 — Dokumentationslücken (P2) | not-extractable | 0 | — | _not extractable_ |
+| [`04-feedback-loop-pr-series`](04-feedback-loop-pr-series.md) | Feedback Loop — Concrete PR Series | completed | 0 | 4/4 | _not extractable_ |
+| [`04-feedback-loop-roadmap`](04-feedback-loop-roadmap.md) | Feedback Loop Roadmap | not-extractable | 0 | — | _not extractable_ |
+| [`05-public-package-readiness`](05-public-package-readiness.md) | Roadmap 05 — Bereitschaft für öffentliche Nutzung (P2) | not-extractable | 0 | — | _not extractable_ |
+| [`05-skill-lifecycle-pr-series`](05-skill-lifecycle-pr-series.md) | Skill Lifecycle — Concrete PR Series | completed | 0 | 5/5 | _not extractable_ |
+| [`05-skill-lifecycle-roadmap`](05-skill-lifecycle-roadmap.md) | Skill Lifecycle Roadmap | not-extractable | 0 | — | _not extractable_ |
+| [`06-strategic-positioning`](06-strategic-positioning.md) | Roadmap 06 — Strategische Positionierung (P3) | not-extractable | 0 | — | _not extractable_ |
+| [`ai-video-pipeline`](ai-video-pipeline.md) | Roadmap: AI Video Pipeline — Hollywood-level video generation via Claude | completed | 6 | 57/57 | _not extractable_ |
+| [`automated-pack-workspace-and-skill-discovery`](automated-pack-workspace-and-skill-discovery.md) | Roadmap: Automated Pack, Workspace & Skill Discovery | completed | 8 | 137/137 | _not extractable_ |
+| [`compare-with-main`](compare-with-main.md) | Rules / Guardrails Review — `main` vs PR #3 | not-extractable | 0 | — | _not extractable_ |
+| [`controlled-self-optimization`](controlled-self-optimization.md) | Roadmap: Controlled Self-Optimization (Phase 2) | completed | 5 | 39/39 | _not extractable_ |
+| [`deferred-followups`](deferred-followups.md) | Deferred Follow-Ups | archived-with-open-steps | 1 | 0/16 | _not extractable_ |
+| [`explainability-v2-explain-last`](explainability-v2-explain-last.md) | Roadmap: Explainability v2 — `agent-config explain last` | completed | 10 | 74/74 | _not extractable_ |
+| [`external-review-followup`](external-review-followup.md) | External Review Follow-Up | not-extractable | 0 | — | _not extractable_ |
+| [`fix-this-now-checklist`](fix-this-now-checklist.md) | fix-this-now-checklist | completed | 0 | 14/14 | _not extractable_ |
+| [`framework-neutrality-audit`](framework-neutrality-audit.md) | Roadmap: Framework Neutrality Audit — Remove PHP/Laravel Leakage from Generic Skills, Rules & Commands | archived-with-open-steps | 10 | 0/219 | _not extractable_ |
+| [`implementation-sequence`](implementation-sequence.md) | Implementation Sequence — TS-Foundation · Discovery · GUI · Explain · Visibility | archived-with-open-steps | 0 | 0/50 | _not extractable_ |
+| [`intent-based-orchestration`](intent-based-orchestration.md) | Roadmap: Intent-based orchestration | archived-with-open-steps | 4 | 0/49 | _not extractable_ |
+| [`linter-execution-governance`](linter-execution-governance.md) | Roadmap: Skill Linter — Execution Governance ✅ | archived-with-open-steps | 5 | 55/66 | _not extractable_ |
+| [`monorepo-phase-1-frontmatter-metadata`](monorepo-phase-1-frontmatter-metadata.md) | Monorepo Phase 1 — Frontmatter Metadata on All Artefacts | closed-with-cancellations | 6 | 33/37 | _not extractable_ |
+| [`monorepo-phase-2-virtual-packs-discovery`](monorepo-phase-2-virtual-packs-discovery.md) | Monorepo Phase 2 — Auto-Discovery Manifest from Frontmatter | completed | 6 | 35/35 | _not extractable_ |
+| [`monorepo-phase-3-typescript-installer`](monorepo-phase-3-typescript-installer.md) | Monorepo Phase 3 — TypeScript Installer (CLI + Lockfile + Agent Mode) | closed-with-cancellations | 6 | 39/40 | _not extractable_ |
+| [`monorepo-phase-4-physical-package-layout`](monorepo-phase-4-physical-package-layout.md) | Monorepo Phase 4 — Physical Package Layout | completed | 6 | 30/30 | _not extractable_ |
+| [`monorepo-phase-5-trust-safety-layer`](monorepo-phase-5-trust-safety-layer.md) | Monorepo Phase 5 — Trust & Safety Layer | completed-with-deferrals | 5 | 24/25 | _not extractable_ |
+| [`monorepo-phase-6-browser-wizard-gui`](monorepo-phase-6-browser-wizard-gui.md) | Monorepo Phase 6 — Browser Wizard GUI (Optional) | completed | 5 | 35/35 | _not extractable_ |
+| [`multi-agent-compatibility`](multi-agent-compatibility.md) | Roadmap: Multi-Agent Compatibility Layer | completed | 9 | 142/142 | _not extractable_ |
+| [`naming-consistency`](naming-consistency.md) | Naming Consistency Roadmap | completed | 4 | 3/3 | _not extractable_ |
+| [`onboard-skill-wizard-convergence`](onboard-skill-wizard-convergence.md) | Roadmap: `/onboard` skill — wizard convergence | completed | 4 | 20/20 | _not extractable_ |
+| [`onboarding-wizard-takeover`](onboarding-wizard-takeover.md) | Onboarding wizard takeover — retire `/onboard`, add `--dry-run` | completed | 5 | 21/21 | _not extractable_ |
+| [`open-questions-2`](open-questions-2.md) | Open Questions 2 — Autonomous-Pass Blockers | not-extractable | 0 | — | _not extractable_ |
+| [`open-questions-3`](open-questions-3.md) | Open Questions 3 — Council-Modes + Pre-Existing Budget Breach | not-extractable | 0 | — | _not extractable_ |
+| [`open-questions`](open-questions.md) | Open Questions — Roadmap Blockers | not-extractable | 0 | — | _not extractable_ |
+| [`phase-3-observability`](phase-3-observability.md) | Phase 3 Roadmap — 9.2 → 9.8 — ✅ COMPLETE | not-extractable | 4 | — | _not extractable_ |
+| [`phase-3-pr-plan`](phase-3-pr-plan.md) | Phase 3 — PR Order and Implementation Plan | not-extractable | 0 | — | _not extractable_ |
+| [`phase3bc-feasibility`](phase3bc-feasibility.md) | Phase 3b/3c — feasibility audit (project-analysis-* + skill-*) | not-extractable | 0 | — | do_not_consolidate |
+| [`phase6-2b-coupling`](phase6-2b-coupling.md) | Phase 6 → 2B coupling proof | not-extractable | 0 | — | _not extractable_ |
+| [`phase6-dependency-scan`](phase6-dependency-scan.md) | Phase 6.0 — chat-history-* dependency surface scan | not-extractable | 0 | — | _not extractable_ |
+| [`phase6-non-overlap-evidence`](phase6-non-overlap-evidence.md) | Phase 6.1 — non-overlap evidence (chat-history-* rules) | not-extractable | 0 | — | keep_separate |
+| [`phase6-trigger-matrix`](phase6-trigger-matrix.md) | Phase 6.1 — chat-history-* trigger overlap matrix | not-extractable | 0 | — | stop_at_6_1 |
+| [`plugin-symlink-strategy`](plugin-symlink-strategy.md) | Roadmap: Plugin Symlink Strategy — copy rules, symlink everything else | closed-with-cancellations | 5 | 66/68 | _not extractable_ |
+| [`post-pr2-hardening`](post-pr2-hardening.md) | Post-PR#2 Hardening Roadmap | completed-with-deferrals | 8 | 99/101 | _not extractable_ |
+| [`pr-description-tiers`](pr-description-tiers.md) | Roadmap: Token-efficient, capability-aware PR descriptions | completed | 5 | 16/16 | _not extractable_ |
+| [`product-maturity`](product-maturity.md) | Product Maturity Roadmap | archived-with-open-steps | 2 | 37/40 | _not extractable_ |
+| [`readme-and-docs-improvement`](readme-and-docs-improvement.md) | README & Docs Improvement Roadmap | archived-with-open-steps | 9 | 48/64 | _not extractable_ |
+| [`remove-galawork-specifics`](remove-galawork-specifics.md) | Roadmap: Remove project-specific references from shared agent config | completed | 7 | 83/83 | _not extractable_ |
+| [`road-to-1-15-followups`](road-to-1-15-followups.md) | Road to 1.15 Followups | completed | 9 | 14/14 | _not extractable_ |
+| [`road-to-1-16-followups`](road-to-1-16-followups.md) | Road to 1.16.0 Follow-ups | closed-with-cancellations | 8 | 29/34 | _not extractable_ |
+| [`road-to-10`](road-to-10.md) | Road to 10/10 | completed-with-deferrals | 5 | 21/22 | _not extractable_ |
+| [`road-to-3-condition-value-benchmark`](road-to-3-condition-value-benchmark.md) | Roadmap: 3-condition value benchmark — show the package + RDP lift in numbers | archived-with-open-steps | 6 | 20/27 | _not extractable_ |
+| [`road-to-6.0.0-a-positioning-and-validation`](road-to-6.0.0-a-positioning-and-validation.md) | Road to 6.0.0-A — Positioning, Validation, and the Execution-Model decision | completed | 3 | 13/13 | _not extractable_ |
+| [`road-to-6.0.0-b-pack-scoped-projection`](road-to-6.0.0-b-pack-scoped-projection.md) | Road to 6.0.0-B — Pack-scoped projection (the breaking change) | completed | 5 | 20/20 | _not extractable_ |
+| [`road-to-6.0.0-c-governance-and-evals`](road-to-6.0.0-c-governance-and-evals.md) | Road to 6.0.0-C — Governance, evals, and evidence-based pruning | closed-with-cancellations | 5 | 20/21 | _not extractable_ |
+| [`road-to-6.0.0-d-structural-restructure`](road-to-6.0.0-d-structural-restructure.md) | Road to 6.0.0-D — Structural restructure (the hard break) | completed | 9 | 37/37 | _not extractable_ |
+| [`road-to-6.0.0-e-documentation-refactor`](road-to-6.0.0-e-documentation-refactor.md) | Road to 6.0.0-E — Documentation refactor (all docs English) | completed | 4 | 12/12 | _not extractable_ |
+| [`road-to-6.0.0-final-readiness`](road-to-6.0.0-final-readiness.md) | Road to 6.0.0 final-readiness & product coherence | completed | 6 | 17/17 | _not extractable_ |
+| [`road-to-6.0.x-workspace-structural-cleanup`](road-to-6.0.x-workspace-structural-cleanup.md) | Road to 6.0.x — Workspace structural cleanup (the deferred Step-16 remainder) | completed | 2 | 11/11 | _not extractable_ |
+| [`road-to-6.1.0-product-consolidation`](road-to-6.1.0-product-consolidation.md) | Road to 6.1.0 — Product consolidation (behavioral cuts after the structural break) | closed-with-cancellations | 6 | 16/17 | _not extractable_ |
+| [`road-to-6.2.0-consolidation-evidence-gates`](road-to-6.2.0-consolidation-evidence-gates.md) | Road to 6.2.0 — Consolidation evidence-gates (the council-deferred remainder) | closed-with-cancellations | 4 | 5/8 | _not extractable_ |
+| [`road-to-9`](road-to-9.md) | Roadmap: Road to 9/10 — Proof of Power | archived-with-open-steps | 6 | 33/44 | _not extractable_ |
+| [`road-to-abstraction-budget-discovery`](road-to-abstraction-budget-discovery.md) | Roadmap: Abstraction-budget discovery — measure before you cut | completed | 2 | 8/8 | _not extractable_ |
+| [`road-to-abstraction-reduction`](road-to-abstraction-reduction.md) | Roadmap: Abstraction reduction — factor frontmatter boilerplate into contract defaults | completed | 4 | 22/22 | _not extractable_ |
+| [`road-to-ac-embeddable-gui`](road-to-ac-embeddable-gui.md) | Road to an embeddable AC GUI — host-ready without weakening a single security invariant | completed | 4 | 30/30 | _not extractable_ |
+| [`road-to-activation-evidence-or-refusal`](road-to-activation-evidence-or-refusal.md) | Road to activation evidence — produce the red baseline or refuse the resolver permanently | closed-with-cancellations | 2 | 6/7 | _not extractable_ |
+| [`road-to-additive-settings-sync`](road-to-additive-settings-sync.md) | Roadmap: Additive Settings Sync | completed | 7 | 35/35 | _not extractable_ |
+| [`road-to-adoption-proof-and-ci-green`](road-to-adoption-proof-and-ci-green.md) | Adoption Proof + CI Green — convert the three deferred 3.2.0 actions into shipped reality | closed-with-cancellations | 4 | 22/33 | _not extractable_ |
+| [`road-to-adversarial-council-benchmark`](road-to-adversarial-council-benchmark.md) | Road to resolving the adversarial-council finding-coverage claim (benchmark arm) | completed | 2 | 8/8 | _not extractable_ |
+| [`road-to-adversarial-verification-council`](road-to-adversarial-verification-council.md) | Road to an adversarial verification council — a cross-model skeptic panel that maximizes defect-finding coverage on a real change | closed-with-cancellations | 6 | 25/27 | _not extractable_ |
+| [`road-to-agent-behavior-conformance`](road-to-agent-behavior-conformance.md) | Road to agent-behaviour conformance — 30 sessions audited, ~130 rule violations, every rule already in context | completed | 6 | 30/30 | _not extractable_ |
+| [`road-to-agent-command-consolidation`](road-to-agent-command-consolidation.md) | Road to Agent-Command Consolidation | completed | 5 | 24/24 | _not extractable_ |
+| [`road-to-agent-handoff-resume`](road-to-agent-handoff-resume.md) | Roadmap: Agent-handoff v2 — session picker, generated handoff, auto-seeded fresh session | completed | 6 | 35/35 | _not extractable_ |
+| [`road-to-agent-memory-integration`](road-to-agent-memory-integration.md) | Roadmap: agent-memory integration (agent-config side) | completed | 5 | 20/20 | _not extractable_ |
+| [`road-to-agent-memory-removal`](road-to-agent-memory-removal.md) | Road to agent-memory removal | archived-with-open-steps | 6 | 26/28 | _not extractable_ |
+| [`road-to-agent-outcomes`](road-to-agent-outcomes.md) | Roadmap: Engineering OS for Agents — the master frame | completed | 0 | 5/5 | _not extractable_ |
+| [`road-to-agentic-headroom-benchmark`](road-to-agentic-headroom-benchmark.md) | Roadmap: agentic-headroom benchmark (v4) — long-horizon, does governance finally show? | closed-with-cancellations | 4 | 4/7 | _not extractable_ |
+| [`road-to-agents-dir-and-gitignore-hygiene`](road-to-agents-dir-and-gitignore-hygiene.md) | Road to agents/-dir and gitignore hygiene | closed-with-cancellations | 9 | 36/37 | _not extractable_ |
+| [`road-to-ai-council`](road-to-ai-council.md) | Road to AI Council | completed | 4 | 38/38 | _not extractable_ |
+| [`road-to-ai-employee-borrowings`](road-to-ai-employee-borrowings.md) | Road to AI-employee borrowings — measure first, harden the kernel, gate the builds | completed | 4 | 12/12 | _not extractable_ |
+| [`road-to-ai-os-product-ui`](road-to-ai-os-product-ui.md) | Roadmap: AI OS Product UI — beyond the installer shell | closed-with-cancellations | 5 | 32/37 | _not extractable_ |
+| [`road-to-always-budget-relief`](road-to-always-budget-relief.md) | Road to Always-Budget Relief | closed-with-cancellations | 4 | 10/14 | _not extractable_ |
+| [`road-to-always-loaded-corpus-scoping`](road-to-always-loaded-corpus-scoping.md) | Roadmap: Scope the always-loaded rule corpus | closed-with-cancellations | 4 | 13/19 | _not extractable_ |
+| [`road-to-analysis-workbench`](road-to-analysis-workbench.md) | Roadmap: Analysis Workbench — RCA / post-mortem / premortem as an integrated learning loop (not a skill dump) | closed-with-cancellations | 6 | 28/33 | _not extractable_ |
+| [`road-to-anti-slop-detector`](road-to-anti-slop-detector.md) | Road to an Anti-Slop Detector (deterministic aesthetic-tell layer) | completed | 5 | 16/16 | _not extractable_ |
+| [`road-to-api-cost-optimization`](road-to-api-cost-optimization.md) | Road to API-cost optimization — cut the dollar bill of paid LLM calls | completed | 5 | 18/18 | _not extractable_ |
+| [`road-to-artifact-completeness-rubrics`](road-to-artifact-completeness-rubrics.md) | Road to artifact-completeness scoring rubrics | closed-with-cancellations | 3 | 13/17 | _not extractable_ |
+| [`road-to-artifact-engagement-telemetry`](road-to-artifact-engagement-telemetry.md) | Roadmap: Artifact Engagement Telemetry | completed-with-deferrals | 7 | 38/40 | _not extractable_ |
+| [`road-to-augment-limit-fit`](road-to-augment-limit-fit.md) | Road to Augment Workspace-Guidelines Limit Fit | closed-with-cancellations | 8 | 47/53 | _not extractable_ |
+| [`road-to-august-program`](road-to-august-program.md) | Road to the August program — the four 2026-08-12 roadmaps, re-planned as one sequence | not-extractable | 0 | — | _not extractable_ |
+| [`road-to-auto-subagent-orchestration-followup`](road-to-auto-subagent-orchestration-followup.md) | Roadmap: Follow-up to automatic subagent orchestration — benchmark & default-flip | closed-with-cancellations | 1 | 6/7 | _not extractable_ |
+| [`road-to-auto-subagent-orchestration-v2`](road-to-auto-subagent-orchestration-v2.md) | Road to auto-subagent-orchestration v2 — make it real: trigger, bundle, synthesis | completed | 4 | 15/15 | _not extractable_ |
+| [`road-to-auto-subagent-orchestration`](road-to-auto-subagent-orchestration.md) | Road to automatic subagent orchestration — delegate by default, gated by evidence | completed-with-deferrals | 8 | 33/35 | _not extractable_ |
+| [`road-to-autonomous-agent`](road-to-autonomous-agent.md) | Roadmap: Road to Autonomous Agent | closed-with-cancellations | 10 | 82/132 | _not extractable_ |
+| [`road-to-autonomous-roadmap-execution`](road-to-autonomous-roadmap-execution.md) | Roadmap: Autonomous roadmap execution | completed | 4 | 16/16 | _not extractable_ |
+| [`road-to-autonomous-verify-loop`](road-to-autonomous-verify-loop.md) | Roadmap: Autonomous verify→repair loop (GAN-adapted, council-gated) | closed-with-cancellations | 2 | 9/10 | _not extractable_ |
+| [`road-to-batch-b-stub-consistency`](road-to-batch-b-stub-consistency.md) | Road to Batch B Stub Consistency | completed | 3 | 7/7 | _not extractable_ |
+| [`road-to-bench-headtohead-metrics`](road-to-bench-headtohead-metrics.md) | Roadmap: Bench head-to-head + pass^k/pass@k reliability metrics | completed | 1 | 2/2 | _not extractable_ |
+| [`road-to-better-skills-and-profiles`](road-to-better-skills-and-profiles.md) | Road to Better Skills (Thinking Layer) | completed-with-deferrals | 1 | 34/35 | _not extractable_ |
+| [`road-to-blocker-visibility`](road-to-blocker-visibility.md) | Road to Blocker Visibility | completed | 4 | 23/23 | _not extractable_ |
+| [`road-to-cache-economy`](road-to-cache-economy.md) | Road to cache economy — pay read rates, not write rates | completed | 5 | 35/35 | _not extractable_ |
+| [`road-to-capability-answerability`](road-to-capability-answerability.md) | Road to capability answerability — twelve places the agent must guess whether a capability exists | completed | 4 | 19/19 | _not extractable_ |
+| [`road-to-capability-discoverability`](road-to-capability-discoverability.md) | Roadmap: Capability discoverability — disposition of "fable-feedback-3" | closed-with-cancellations | 4 | 9/17 | _not extractable_ |
+| [`road-to-capability-governance`](road-to-capability-governance.md) | Road to capability governance — boundary matrix, risk-class, growth gate | completed | 6 | 17/17 | _not extractable_ |
+| [`road-to-capability-headroom-benchmark`](road-to-capability-headroom-benchmark.md) | Roadmap: capability-headroom benchmark (v3) — GAIA-honest, can it finally show a lift? | closed-with-cancellations | 4 | 4/7 | _not extractable_ |
+| [`road-to-changelog-era-auto-split`](road-to-changelog-era-auto-split.md) | Roadmap: CHANGELOG era auto-split — turn release-blocker into release-script affordance | completed | 4 | 21/21 | _not extractable_ |
+| [`road-to-changelog-unreleased-drain`](road-to-changelog-unreleased-drain.md) | Road to CHANGELOG [Unreleased] drain — clean the stale 6.0.0 fossil + guard it | completed | 2 | 7/7 | _not extractable_ |
+| [`road-to-character-image-fidelity`](road-to-character-image-fidelity.md) | Road to Character-Image Fidelity | completed | 6 | 27/27 | _not extractable_ |
+| [`road-to-chat-history-cross-agent-hardening`](road-to-chat-history-cross-agent-hardening.md) | Road to chat-history cross-agent hardening | closed-with-cancellations | 5 | 28/37 | _not extractable_ |
+| [`road-to-chat-history-hook-only`](road-to-chat-history-hook-only.md) | Road to Chat-History Hook-Only | completed | 6 | 27/27 | _not extractable_ |
+| [`road-to-chat-history-session-isolation`](road-to-chat-history-session-isolation.md) | Roadmap: Per-Session Isolation in Chat-History | completed | 7 | 38/38 | _not extractable_ |
+| [`road-to-chat-history-sidecar-shrink`](road-to-chat-history-sidecar-shrink.md) | Roadmap: Chat-History Sidecar Shrink | archived-with-open-steps | 6 | 30/31 | _not extractable_ |
+| [`road-to-ci-native-release`](road-to-ci-native-release.md) | Roadmap: CI-native release path alongside `task release` | closed-with-cancellations | 6 | 27/32 | _not extractable_ |
+| [`road-to-claude-code-global-distribution`](road-to-claude-code-global-distribution.md) | Roadmap: Claude Code Global Distribution — close the four-defect chain | closed-with-cancellations | 5 | 34/37 | _not extractable_ |
+| [`road-to-claude-code-single-surface`](road-to-claude-code-single-surface.md) | Roadmap: Claude Code single distribution surface — retire the dual npx/marketplace overlap | closed-with-cancellations | 5 | 21/22 | _not extractable_ |
+| [`road-to-claude-skills-untrack`](road-to-claude-skills-untrack.md) | Roadmap: Untrack `.claude/skills/` (follow-up to projection cleanup) | closed-with-cancellations | 4 | 12/13 | _not extractable_ |
+| [`road-to-clean-skill-distribution-channels`](road-to-clean-skill-distribution-channels.md) | Clean Skill Distribution Channels — eliminate dual-registration across Claude, Augment, and cross-scope installs | completed | 4 | 30/30 | _not extractable_ |
+| [`road-to-cloudflare-mcp-hosting`](road-to-cloudflare-mcp-hosting.md) | Road to Cloudflare-hosted MCP | closed-with-cancellations | 7 | 23/28 | _not extractable_ |
+| [`road-to-command-structure-optimization`](road-to-command-structure-optimization.md) | Road to Command Structure Optimization | closed-with-cancellations | 6 | 24/28 | _not extractable_ |
+| [`road-to-command-surface-refactor-residuals`](road-to-command-surface-refactor-residuals.md) | Roadmap: Command-Surface Refactor — Residuals | closed-with-cancellations | 3 | 10/13 | _not extractable_ |
+| [`road-to-competitive-borrow`](road-to-competitive-borrow.md) | Roadmap: Competitive Borrow | closed-with-cancellations | 4 | 23/35 | _not extractable_ |
+| [`road-to-completion-loop`](road-to-completion-loop.md) | Road to the completion loop — measure "delivered less than was asked" before refusing on it | closed-with-cancellations | 3 | 5/8 | _not extractable_ |
+| [`road-to-composition-ratchet`](road-to-composition-ratchet.md) | Road to composition ratchet — stop the falsifiability dilution without resurrecting the skill-DAG | completed | 2 | 7/7 | _not extractable_ |
+| [`road-to-configurable-modules`](road-to-configurable-modules.md) | Road to configurable modules — project-driven module paths and per-module agent folders | closed-with-cancellations | 5 | 40/42 | _not extractable_ |
+| [`road-to-conformance-round5`](road-to-conformance-round5.md) | Road to conformance round 5 — the first post-fix measurement, and what it says about mechanism class | completed | 6 | 31/31 | _not extractable_ |
+| [`road-to-conformance-round6`](road-to-conformance-round6.md) | Road to conformance round 6 — the guard regress I shipped, the unmeasured half, and the therapy that has not started | closed-with-cancellations | 6 | 33/34 | _not extractable_ |
+| [`road-to-conformance-round7`](road-to-conformance-round7.md) | Road to conformance round 7 — the rules held, the tooling did not | closed-with-cancellations | 7 | 31/35 | _not extractable_ |
+| [`road-to-consistent-rule-scoping`](road-to-consistent-rule-scoping.md) | Road to consistent rule scoping — the CLI global install ships rules the wizard filters out | completed | 2 | 5/5 | _not extractable_ |
+| [`road-to-context-aware-command-suggestion`](road-to-context-aware-command-suggestion.md) | Roadmap: Context-Aware Command Suggestion | completed | 7 | 52/52 | _not extractable_ |
+| [`road-to-context-layer-maturity`](road-to-context-layer-maturity.md) | Road to Context Layer Maturity | closed-with-cancellations | 6 | 27/31 | _not extractable_ |
+| [`road-to-corpus-expansion-evidence-based-cuts`](road-to-corpus-expansion-evidence-based-cuts.md) | Roadmap: Corpus expansion → evidence-based tier-1 cuts | archived-with-open-steps | 7 | 27/37 | _not extractable_ |
+| [`road-to-cost-aware-model-routing`](road-to-cost-aware-model-routing.md) | Road to Cost-Aware Model Routing | completed | 6 | 24/24 | _not extractable_ |
+| [`road-to-cost-parity-0-program`](road-to-cost-parity-0-program.md) | Road to cost parity — 0: the median session gets a measured target and the family gets its order | completed | 4 | 25/25 | _not extractable_ |
+| [`road-to-cost-parity-3-handoff-envelope`](road-to-cost-parity-3-handoff-envelope.md) | Road to cost parity — 3: the handoff envelope carries what the successor actually needs | completed | 4 | 30/30 | _not extractable_ |
+| [`road-to-cost-profile-untangle`](road-to-cost-profile-untangle.md) | Roadmap: Untangle `cost_profile` | closed-with-cancellations | 8 | 41/45 | _not extractable_ |
+| [`road-to-council-modes`](road-to-council-modes.md) | Road to Council Modes | closed-with-cancellations | 3 | 14/24 | _not extractable_ |
+| [`road-to-council-solo-floor-implementation`](road-to-council-solo-floor-implementation.md) | Road to the gate-scoped solo-attendance floor | closed-with-cancellations | 3 | 15/16 | _not extractable_ |
+| [`road-to-cross-corpus-verification`](road-to-cross-corpus-verification.md) | Roadmap: A cross-corpus proposal is measured before it is adopted | completed | 4 | 19/19 | _not extractable_ |
+| [`road-to-cross-repo-differential-loop`](road-to-cross-repo-differential-loop.md) | Road to the cross-repo differential loop — the reference-analysis command stops contradicting its own doctrine | completed | 6 | 31/31 | _not extractable_ |
+| [`road-to-cross-source-consistency`](road-to-cross-source-consistency.md) | Roadmap: Cross-source consistency — detect discrepancies, ask before guessing | closed-with-cancellations | 5 | 30/32 | _not extractable_ |
+| [`road-to-curated-self-improvement`](road-to-curated-self-improvement.md) | Roadmap: Curated Self-Improvement — closed-loop learning with a human gate | completed | 4 | 16/16 | _not extractable_ |
+| [`road-to-dead-surface-removal`](road-to-dead-surface-removal.md) | Road to dead-surface removal — apply the package's own null rule to the package's own code | completed | 3 | 8/8 | _not extractable_ |
+| [`road-to-decision-revisit-discipline`](road-to-decision-revisit-discipline.md) | Road to decision-revisit discipline | completed | 5 | 18/18 | _not extractable_ |
+| [`road-to-deep-root-restructure`](road-to-deep-root-restructure.md) | Deep Root Restructure — sink maintainer + projection dirs out of the root | closed-with-cancellations | 7 | 15/17 | _not extractable_ |
+| [`road-to-defensive-agent`](road-to-defensive-agent.md) | Roadmap: Defensive Agent — Senior-Engineer Security & Analysis | closed-with-cancellations | 0 | 33/51 | _not extractable_ |
+| [`road-to-demand-gate-audience`](road-to-demand-gate-audience.md) | Road to Demand-Gate Audience | completed | 4 | 18/18 | _not extractable_ |
+| [`road-to-design-artifact-fidelity`](road-to-design-artifact-fidelity.md) | Road to design artifact fidelity — make visual work production-grade before it reaches the user | completed | 8 | 39/39 | _not extractable_ |
+| [`road-to-design-canon-grounding`](road-to-design-canon-grounding.md) | Road to Design-Canon Grounding | completed | 4 | 10/10 | _not extractable_ |
+| [`road-to-design-craft-antislop`](road-to-design-craft-antislop.md) | Road to design-craft / anti-slop enforcement | closed-with-cancellations | 8 | 30/34 | _not extractable_ |
+| [`road-to-design-detector-evidence`](road-to-design-detector-evidence.md) | Road to design-detector evidence — make the traceability claim checkable and publish the number the expansion was deferred on | completed | 3 | 12/12 | _not extractable_ |
+| [`road-to-design-exploration-skills`](road-to-design-exploration-skills.md) | Road to design exploration skills | completed | 6 | 28/28 | _not extractable_ |
+| [`road-to-design-mechanism-harvest`](road-to-design-mechanism-harvest.md) | Road to design-mechanism harvest | completed | 6 | 18/18 | _not extractable_ |
+| [`road-to-design-system-extraction-contract`](road-to-design-system-extraction-contract.md) | Road to a Design-System Extraction Contract | completed | 4 | 8/8 | _not extractable_ |
+| [`road-to-design-system-onramp`](road-to-design-system-onramp.md) | Road to the design-system onramp — consume the crawler ecosystem, one optional command | closed-with-cancellations | 5 | 11/13 | _not extractable_ |
+| [`road-to-discipline-axis-benchmark`](road-to-discipline-axis-benchmark.md) | Roadmap: discipline-axis benchmark (v2) — measure the lift, not the capability | completed | 7 | 24/24 | _not extractable_ |
+| [`road-to-discipline-axis-meso-pilot`](road-to-discipline-axis-meso-pilot.md) | Roadmap: discipline-axis benchmark — complexity-stratified pilot (meso/multi + weak host) | closed-with-cancellations | 7 | 14/17 | _not extractable_ |
+| [`road-to-discipline-lift-significance`](road-to-discipline-lift-significance.md) | Roadmap: discipline-lift to significance (clean harness) | completed | 3 | 5/5 | _not extractable_ |
+| [`road-to-discipline-profile-tiering`](road-to-discipline-profile-tiering.md) | Road to discipline-profile tiering — the ~3x lift as the default shape, host-gated | completed-with-deferrals | 5 | 16/18 | _not extractable_ |
+| [`road-to-distribution-and-adoption`](road-to-distribution-and-adoption.md) | Road to Distribution and Adoption | closed-with-cancellations | 6 | 5/14 | _not extractable_ |
+| [`road-to-distribution-identity`](road-to-distribution-identity.md) | Roadmap: Distribution identity — make npm-primary explicit, retire the stale registry | completed | 3 | 11/11 | _not extractable_ |
+| [`road-to-distribution-maturity`](road-to-distribution-maturity.md) | Road to distribution maturity (post-2.2.2 evaluation follow-ups) | completed | 12 | 49/49 | _not extractable_ |
+| [`road-to-doc-follows-code`](road-to-doc-follows-code.md) | Road to doc-follows-code — a deterministic, framework-agnostic doc-impact discipline | completed | 5 | 27/27 | _not extractable_ |
+| [`road-to-doc-screenshot-anonymization`](road-to-doc-screenshot-anonymization.md) | Road to Doc-Screenshot Anonymization | completed | 5 | 15/15 | _not extractable_ |
+| [`road-to-doctor-global-only-readiness`](road-to-doctor-global-only-readiness.md) | Road to `doctor` Global-Only Readiness | completed | 1 | 4/4 | _not extractable_ |
+| [`road-to-domain-soundness`](road-to-domain-soundness.md) | Road to domain soundness — prove or honestly scope the non-forged, non-coding domains | completed | 4 | 15/15 | _not extractable_ |
+| [`road-to-drafting-protocol`](road-to-drafting-protocol.md) | Roadmap: Drafting Protocol | completed | 7 | 3/3 | _not extractable_ |
+| [`road-to-ecosystem-harvest-bug-security-rigor`](road-to-ecosystem-harvest-bug-security-rigor.md) | Roadmap: Ecosystem-Harvest — Bug & Security Rigor | completed | 2 | 11/11 | _not extractable_ |
+| [`road-to-ecosystem-harvest-document-skills`](road-to-ecosystem-harvest-document-skills.md) | Roadmap: Ecosystem-Harvest — Document-Generation Skills | closed-with-cancellations | 2 | 10/11 | _not extractable_ |
+| [`road-to-ecosystem-harvest-domain-watch`](road-to-ecosystem-harvest-domain-watch.md) | Roadmap: Ecosystem-Harvest — Domain Watch (gated verticals) | closed-with-cancellations | 3 | 6/8 | _not extractable_ |
+| [`road-to-ecosystem-harvest-ergonomics`](road-to-ecosystem-harvest-ergonomics.md) | Roadmap: Ecosystem-Harvest — Ergonomics | completed | 1 | 9/9 | _not extractable_ |
+| [`road-to-ecosystem-harvest-index`](road-to-ecosystem-harvest-index.md) | Roadmap: Ecosystem-Harvest Index | completed | 1 | 11/11 | _not extractable_ |
+| [`road-to-ecosystem-harvest-prelaunch-diagnostics`](road-to-ecosystem-harvest-prelaunch-diagnostics.md) | Roadmap: Ecosystem-Harvest — Pre-Launch Diagnostics | completed | 3 | 13/13 | _not extractable_ |
+| [`road-to-ecosystem-harvest-product-gate`](road-to-ecosystem-harvest-product-gate.md) | Roadmap: Ecosystem-Harvest — Pre-Build Product-Demand Gate | completed | 1 | 6/6 | _not extractable_ |
+| [`road-to-ecosystem-harvest-prose-authenticity`](road-to-ecosystem-harvest-prose-authenticity.md) | Roadmap: Ecosystem-Harvest — Prose Authenticity | closed-with-cancellations | 1 | 10/11 | _not extractable_ |
+| [`road-to-ecosystem-harvest-reliability-measurement`](road-to-ecosystem-harvest-reliability-measurement.md) | Roadmap: Ecosystem-Harvest — Reliability & Measurement | closed-with-cancellations | 1 | 11/12 | _not extractable_ |
+| [`road-to-ecosystem-harvest-review-mechanics`](road-to-ecosystem-harvest-review-mechanics.md) | Roadmap: Ecosystem-Harvest — Review Mechanics | completed | 4 | 18/18 | _not extractable_ |
+| [`road-to-ecosystem-harvest-second-sweep`](road-to-ecosystem-harvest-second-sweep.md) | Roadmap: Ecosystem-Harvest — Second Sweep (full-coverage disposition) | completed | 3 | 11/11 | _not extractable_ |
+| [`road-to-ecosystem-harvest-skill-authoring-rigor`](road-to-ecosystem-harvest-skill-authoring-rigor.md) | Roadmap: Ecosystem-Harvest — Skill-Authoring Rigor | completed | 1 | 10/10 | _not extractable_ |
+| [`road-to-ecosystem-harvest-skill-quality-gates`](road-to-ecosystem-harvest-skill-quality-gates.md) | Roadmap: Ecosystem-Harvest — Skill Quality Gates | completed | 4 | 19/19 | _not extractable_ |
+| [`road-to-ecosystem-harvest-tool-pitfalls`](road-to-ecosystem-harvest-tool-pitfalls.md) | Roadmap: Ecosystem-Harvest — Tool Known-Pitfalls | completed | 1 | 7/7 | _not extractable_ |
+| [`road-to-ecosystem-harvest-workflow-contracts`](road-to-ecosystem-harvest-workflow-contracts.md) | Roadmap: Ecosystem-Harvest — Workflow Contracts | completed | 3 | 18/18 | _not extractable_ |
+| [`road-to-employee-product-and-external-proof`](road-to-employee-product-and-external-proof.md) | Roadmap: Employee Product + External Proof — close the two adoption gaps | completed-with-deferrals | 10 | 72/77 | _not extractable_ |
+| [`road-to-enforcement-peer-disposition`](road-to-enforcement-peer-disposition.md) | Road to enforcement-peer disposition — wire the fail-open gates, record what 9.8.0 already answered | completed | 3 | 7/7 | _not extractable_ |
+| [`road-to-enforcement-proof`](road-to-enforcement-proof.md) | Road to Enforcement Proof — say only what the machine actually enforces | completed | 5 | 27/27 | _not extractable_ |
+| [`road-to-engineering-memory`](road-to-engineering-memory.md) | Roadmap: Engineering Memory — project-specific facts as first-class input | completed | 4 | 15/15 | _not extractable_ |
+| [`road-to-eval-loop-runnability`](road-to-eval-loop-runnability.md) | Roadmap: Eval-loop runnability — one dead root the sweep cannot see | archived-with-open-steps | 2 | 9/10 | _not extractable_ |
+| [`road-to-event4u-namespace-and-claude-desktop`](road-to-event4u-namespace-and-claude-desktop.md) | Road to `~/.event4u/agent-config/` namespace + real Claude Desktop deployment | completed | 6 | 40/40 | _not extractable_ |
+| [`road-to-evidence-v2-accumulation-layer`](road-to-evidence-v2-accumulation-layer.md) | Roadmap: Evidence v2 — Accumulation Layer (deferred from project-intelligence) | closed-with-cancellations | 3 | 2/6 | _not extractable_ |
+| [`road-to-evidence-v2-project-intelligence`](road-to-evidence-v2-project-intelligence.md) | Roadmap: Evidence v2 — Self-Building Project Intelligence | closed-with-cancellations | 6 | 25/27 | _not extractable_ |
+| [`road-to-executable-evidence`](road-to-executable-evidence.md) | Roadmap: Executable evidence — a claim that re-derives itself | completed | 4 | 23/23 | _not extractable_ |
+| [`road-to-execution-discipline-harvest`](road-to-execution-discipline-harvest.md) | Road to execution-discipline harvest | completed | 6 | 21/21 | _not extractable_ |
+| [`road-to-fable-feedback-5`](road-to-fable-feedback-5.md) | Road to Fable-Feedback 5 — post-8.10.0 hardening + code-comment discipline | completed | 7 | 44/44 | _not extractable_ |
+| [`road-to-fan-out-guard-correctness`](road-to-fan-out-guard-correctness.md) | Road to fan-out guard correctness — the block that ate the delegation | completed | 4 | 11/11 | _not extractable_ |
+| [`road-to-fast-test-layer`](road-to-fast-test-layer.md) | Road to a Fast Test Layer (in-process CLI rigs) | closed-with-cancellations | 5 | 15/16 | _not extractable_ |
+| [`road-to-feedback-24-26-cleanup`](road-to-feedback-24-26-cleanup.md) | Road to Feedback 24–26 Cleanup — the genuinely-new, non-blocked items | archived-with-open-steps | 4 | 6/11 | _not extractable_ |
+| [`road-to-feedback-8.11-2`](road-to-feedback-8.11-2.md) | Road to feedback 8.11 round 2+3 — shrink, pre-register, prepare | completed | 7 | 26/26 | _not extractable_ |
+| [`road-to-feedback-8.11-4`](road-to-feedback-8.11-4.md) | Road to feedback 8.11 round 4 — ship the smallest real /team | completed | 4 | 8/8 | _not extractable_ |
+| [`road-to-feedback-8.11-5`](road-to-feedback-8.11-5.md) | Road to feedback 8.11 round 5 — the fallback and the gate | completed | 5 | 11/11 | _not extractable_ |
+| [`road-to-feedback-8.11`](road-to-feedback-8.11.md) | Road to feedback 8.11 — prove, simplify, operate | completed | 8 | 34/34 | _not extractable_ |
+| [`road-to-feedback-9-29`](road-to-feedback-9-29.md) | Road to feedback 9.29 — close the verified residue of the external release reviews | completed | 5 | 19/19 | _not extractable_ |
+| [`road-to-feedback-9-35`](road-to-feedback-9-35.md) | Road to feedback 9.35 — the verified residue of five external release reviews | completed | 4 | 13/13 | _not extractable_ |
+| [`road-to-feedback-9.0-followups`](road-to-feedback-9.0-followups.md) | Roadmap: Feedback 9.0.0 Follow-ups | completed | 3 | 10/10 | _not extractable_ |
+| [`road-to-feedback-9.2.0-followups`](road-to-feedback-9.2.0-followups.md) | Roadmap: Feedback 9.2.0 Follow-ups | closed-with-cancellations | 4 | 10/11 | _not extractable_ |
+| [`road-to-feedback-9.8.0-followups`](road-to-feedback-9.8.0-followups.md) | Roadmap: Feedback 9.8.0 Follow-ups — stabilize, prove, dispose, decide | closed-with-cancellations | 5 | 21/22 | _not extractable_ |
+| [`road-to-feedback-consolidation`](road-to-feedback-consolidation.md) | Road to Feedback Consolidation | closed-with-cancellations | 7 | 43/47 | _not extractable_ |
+| [`road-to-feedback-followups`](road-to-feedback-followups.md) | Road to Feedback Followups | completed-with-deferrals | 6 | 11/13 | _not extractable_ |
+| [`road-to-final-state-and-market-readiness`](road-to-final-state-and-market-readiness.md) | Roadmap: Final state + market readiness | completed | 4 | 37/37 | _not extractable_ |
+| [`road-to-flow-learnings`](road-to-flow-learnings.md) | Road to flow learnings — adopt the real fifth of an external orchestration suite, reject the theater | completed | 4 | 19/19 | _not extractable_ |
+| [`road-to-frictionless-employee-workspace`](road-to-frictionless-employee-workspace.md) | Frictionless Employee Workspace — close the 3.1.1 → 3.3.0 feedback gaps without lifting Hard-Floor | closed-with-cancellations | 4 | 30/33 | _not extractable_ |
+| [`road-to-frontend-design-intelligence`](road-to-frontend-design-intelligence.md) | Road to Frontend Design Intelligence — absorb an external design suite into our orchestrated UI suite | closed-with-cancellations | 10 | 48/53 | _not extractable_ |
+| [`road-to-frontier-grade-reasoning`](road-to-frontier-grade-reasoning.md) | Roadmap: Reasoning Discipline Protocol — make every host model think like a pro | completed-with-deferrals | 9 | 24/31 | _not extractable_ |
+| [`road-to-frontier-quality-operating-system`](road-to-frontier-quality-operating-system.md) | Road to frontier-quality operating system — turn external prompt mechanics into governed package leverage | completed | 9 | 49/49 | _not extractable_ |
+| [`road-to-frontmatter-schema`](road-to-frontmatter-schema.md) | Roadmap: frontmatter JSON-Schema validation | completed | 4 | 25/25 | _not extractable_ |
+| [`road-to-gate-hardening-adoption`](road-to-gate-hardening-adoption.md) | Road to gate-hardening adoption — take the unhardened-gate count to zero | closed-with-cancellations | 3 | 12/13 | _not extractable_ |
+| [`road-to-gated-reach`](road-to-gated-reach.md) | Roadmap: Road to gated reach — read the resources the host cannot fetch | closed-with-cancellations | 6 | 36/41 | _not extractable_ |
+| [`road-to-gates-that-can-fail`](road-to-gates-that-can-fail.md) | Road to gates that can fail — make every check prove it read something | closed-with-cancellations | 7 | 27/30 | _not extractable_ |
+| [`road-to-glama-registry-listing`](road-to-glama-registry-listing.md) | Road to a Glama registry listing — the one genuinely-useful Glama move, and nothing more | completed | 5 | 11/11 | _not extractable_ |
+| [`road-to-global-first-install`](road-to-global-first-install.md) | Road to Global-First Install | closed-with-cancellations | 3 | 24/25 | _not extractable_ |
+| [`road-to-global-only-install`](road-to-global-only-install.md) | Road to Global-Only Install — ARCHIVED | closed-with-cancellations | 7 | 40/41 | _not extractable_ |
+| [`road-to-global-user-memory`](road-to-global-user-memory.md) | Road to a global user-memory layer — the agent remembers the user, not just the repo | closed-with-cancellations | 6 | 46/48 | _not extractable_ |
+| [`road-to-golden-set-coverage`](road-to-golden-set-coverage.md) | Road to golden-set coverage — make every flip verdict mean something | completed | 4 | 18/18 | _not extractable_ |
+| [`road-to-golden-transcript-ts-replatform`](road-to-golden-transcript-ts-replatform.md) | Golden-Transcript replay subsystem — full TS + vitest re-platform | completed | 6 | 14/14 | _not extractable_ |
+| [`road-to-governance-cleanup`](road-to-governance-cleanup.md) | Road to Governance Cleanup | completed | 1 | 24/24 | _not extractable_ |
+| [`road-to-governance-invariants`](road-to-governance-invariants.md) | Road to governance invariants — prove the governance layer does not degrade under indirection | closed-with-cancellations | 7 | 15/19 | _not extractable_ |
+| [`road-to-governance-moat`](road-to-governance-moat.md) | Road to the governance moat — exploit the advantage we already have, don't build measurement theater | closed-with-cancellations | 3 | 6/8 | _not extractable_ |
+| [`road-to-greenfield-scaffold`](road-to-greenfield-scaffold.md) | Roadmap: greenfield scaffold + render-verified review (the Lovable lever) | completed | 4 | 21/21 | _not extractable_ |
+| [`road-to-gtm-and-growth`](road-to-gtm-and-growth.md) | Road to GTM and Growth (Wing 3) | completed | 1 | 26/26 | _not extractable_ |
+| [`road-to-harvest-orchestration`](road-to-harvest-orchestration.md) | Roadmap: Competitive-harvest orchestration — execution order for the harvest set | completed-with-deferrals | 4 | 16/17 | _not extractable_ |
+| [`road-to-harvest-small-enhancements`](road-to-harvest-small-enhancements.md) | Roadmap: Competitive-harvest small enhancements + file-first pattern library | closed-with-cancellations | 6 | 15/17 | _not extractable_ |
+| [`road-to-honesty-bench`](road-to-honesty-bench.md) | Road to honesty bench — measure the shipped honesty kernel, park the rest | completed | 2 | 7/7 | _not extractable_ |
+| [`road-to-hook-latency-repair`](road-to-hook-latency-repair.md) | Road to hook latency repair — pay for the bundle, not the CLI | completed | 3 | 9/9 | _not extractable_ |
+| [`road-to-hooks-actually-fire-in-consumers`](road-to-hooks-actually-fire-in-consumers.md) | Roadmap: Hooks actually fire in consumer projects — close the marketplace-install gap | closed-with-cancellations | 7 | 33/40 | _not extractable_ |
+| [`road-to-humanized-writing`](road-to-humanized-writing.md) | Road to humanized writing — pattern-audited drafts across the write engine | closed-with-cancellations | 6 | 35/36 | _not extractable_ |
+| [`road-to-humanizer-hardening`](road-to-humanizer-hardening.md) | Road to humanizer hardening — close the follow-up findings | completed | 4 | 24/24 | _not extractable_ |
+| [`road-to-image-brand-followups`](road-to-image-brand-followups.md) | Roadmap: image/brand follow-ons (live validation, commands, retarget) | closed-with-cancellations | 5 | 9/15 | _not extractable_ |
+| [`road-to-image-brand-typography`](road-to-image-brand-typography.md) | Roadmap: image generation, brand, and typography/iconography | completed-with-deferrals | 4 | 40/48 | _not extractable_ |
+| [`road-to-implement-ticket`](road-to-implement-ticket.md) | Road to Implement-Ticket — from governed agent to delivery engine | closed-with-cancellations | 5 | 33/35 | _not extractable_ |
+| [`road-to-inbox-harvest-2026-08-b-authoring-contract`](road-to-inbox-harvest-2026-08-b-authoring-contract.md) | Road to an enforced authoring contract | closed-with-cancellations | 6 | 16/25 | _not extractable_ |
+| [`road-to-inbox-harvest-2026-08-b-council-integrity-followup`](road-to-inbox-harvest-2026-08-b-council-integrity-followup.md) | Roadmap: Follow-up to council-pass integrity | closed-with-cancellations | 1 | 6/7 | _not extractable_ |
+| [`road-to-inbox-harvest-2026-08-b-council-integrity`](road-to-inbox-harvest-2026-08-b-council-integrity.md) | Road to council-pass integrity | closed-with-cancellations | 3 | 8/16 | _not extractable_ |
+| [`road-to-inbox-harvest-2026-08-b-estate-lifecycle`](road-to-inbox-harvest-2026-08-b-estate-lifecycle.md) | Road to estate lifecycle reporting | closed-with-cancellations | 4 | 9/15 | _not extractable_ |
+| [`road-to-inbox-harvest-2026-08-b-install-lifecycle`](road-to-inbox-harvest-2026-08-b-install-lifecycle.md) | Road to install lifecycle — every write recorded, org packs decided | closed-with-cancellations | 2 | 6/13 | _not extractable_ |
+| [`road-to-inbox-harvest-2026-08-b-release-integrity`](road-to-inbox-harvest-2026-08-b-release-integrity.md) | Road to release-surface integrity | closed-with-cancellations | 5 | 12/25 | _not extractable_ |
+| [`road-to-inbox-harvest-2026-08-b`](road-to-inbox-harvest-2026-08-b.md) | Road to inbox harvest 2026-08-b | closed-with-cancellations | 3 | 3/6 | _not extractable_ |
+| [`road-to-inbox-harvest-2026-08-c-release-head-truth`](road-to-inbox-harvest-2026-08-c-release-head-truth.md) | Road to a release head that can be contradicted | closed-with-cancellations | 3 | 10/11 | _not extractable_ |
+| [`road-to-inbox-harvest-2026-08-c-workspace-identity`](road-to-inbox-harvest-2026-08-c-workspace-identity.md) | Road to one answer for "where am I" | closed-with-cancellations | 3 | 11/12 | _not extractable_ |
+| [`road-to-inbox-harvest-2026-08-d-archive-index`](road-to-inbox-harvest-2026-08-d-archive-index.md) | Road to an archive index, so sweeps stop paying for history | completed | 2 | 10/10 | _not extractable_ |
+| [`road-to-inbox-harvest-2026-08-d-context-ledger`](road-to-inbox-harvest-2026-08-d-context-ledger.md) | Road to a context ledger that captures before the state is destroyed | closed-with-cancellations | 5 | 15/16 | _not extractable_ |
+| [`road-to-inbox-harvest-2026-08-d-runtime-skill-routing`](road-to-inbox-harvest-2026-08-d-runtime-skill-routing.md) | Road to a ranker that actually routes | completed | 4 | 14/14 | _not extractable_ |
+| [`road-to-inbox-harvest-2026-08-d-scheduled-deprecation`](road-to-inbox-harvest-2026-08-d-scheduled-deprecation.md) | Road to a deprecation table that cannot miss its own dates | completed | 2 | 10/10 | _not extractable_ |
+| [`road-to-inbox-harvest-2026-08`](road-to-inbox-harvest-2026-08.md) | Road to inbox harvest 2026-08 | closed-with-cancellations | 5 | 12/21 | _not extractable_ |
+| [`road-to-inbox-harvest-distillation`](road-to-inbox-harvest-distillation.md) | Road to harvested-claim provenance and router-head skills | closed-with-cancellations | 4 | 9/16 | _not extractable_ |
+| [`road-to-injection-and-authority-harvest`](road-to-injection-and-authority-harvest.md) | Road to injection-and-authority harvest | completed | 5 | 17/17 | _not extractable_ |
+| [`road-to-injection-defense-pressure-corpus`](road-to-injection-defense-pressure-corpus.md) | Road to an injection-defense pressure-corpus (with a defensive judge sliver) | closed-with-cancellations | 3 | 11/20 | _not extractable_ |
+| [`road-to-install-contract-stability`](road-to-install-contract-stability.md) | Roadmap: Install-Contract Stability — freeze the install ABI, split the lean core from the lab | completed | 2 | 15/15 | _not extractable_ |
+| [`road-to-install-path-convergence`](road-to-install-path-convergence.md) | Roadmap: Install-path convergence — any entry point yields the correct install, on every tool | completed-with-deferrals | 6 | 21/22 | _not extractable_ |
+| [`road-to-internal-ai-os-deployment`](road-to-internal-ai-os-deployment.md) | Roadmap: Internal AI OS Deployment — one-click company rollout + central policy | closed-with-cancellations | 6 | 17/52 | _not extractable_ |
+| [`road-to-internet-reach`](road-to-internet-reach.md) | Roadmap: Road to internet reach — a governed reach layer for dev research | closed-with-cancellations | 8 | 48/69 | _not extractable_ |
+| [`road-to-judgment-and-forensic-evidence`](road-to-judgment-and-forensic-evidence.md) | Road to judgment and forensic evidence — one protocol against a measured defect, one evidence source git already holds | completed | 5 | 32/32 | _not extractable_ |
+| [`road-to-kernel-and-router`](road-to-kernel-and-router.md) | Road to Rule Kernel and Router | closed-with-cancellations | 8 | 21/23 | _not extractable_ |
+| [`road-to-knowledge-system`](road-to-knowledge-system.md) | Road to Knowledge System | completed | 6 | 36/36 | _not extractable_ |
+| [`road-to-lean-agent-init`](road-to-lean-agent-init.md) | Roadmap: Lean Agent Init — tool-not-agent routing, worker stop-loss, spawn-payload truth | completed | 5 | 14/14 | _not extractable_ |
+| [`road-to-lean-initial-context-buildout`](road-to-lean-initial-context-buildout.md) | Road to Lean Initial Context — Build-out | closed-with-cancellations | 4 | 11/20 | _not extractable_ |
+| [`road-to-lean-initial-context`](road-to-lean-initial-context.md) | Road to Lean Initial Context | closed-with-cancellations | 6 | 21/58 | _not extractable_ |
+| [`road-to-leaner-core-and-discovery`](road-to-leaner-core-and-discovery.md) | Roadmap: Leaner core + discovery — close the post-5.x feedback gaps the package can actually act on | closed-with-cancellations | 6 | 41/43 | _not extractable_ |
+| [`road-to-legal-pack`](road-to-legal-pack.md) | Road to a legal pack — built on its own legs, evaluated honestly | completed | 7 | 37/37 | _not extractable_ |
+| [`road-to-legal-review-prep`](road-to-legal-review-prep.md) | Road to legal-review-prep — rename, consent-gate, council-gate, hard STOP | completed | 7 | 25/25 | _not extractable_ |
+| [`road-to-legal-safety-hardening`](road-to-legal-safety-hardening.md) | Road to legal-safety hardening — RDG positioning + liability defense-in-depth | completed | 5 | 14/14 | _not extractable_ |
+| [`road-to-linked-projects-scope`](road-to-linked-projects-scope.md) | Road to Linked-Projects Scope | completed | 6 | 25/25 | _not extractable_ |
+| [`road-to-linter-debt-and-meta-subtraction`](road-to-linter-debt-and-meta-subtraction.md) | Roadmap: Linter-Debt Paydown + Meta-System Subtraction | completed | 3 | 20/20 | _not extractable_ |
+| [`road-to-llm-provider-knowledge-skill`](road-to-llm-provider-knowledge-skill.md) | Road to: `llm-provider-knowledge` skill | completed | 5 | 18/18 | _not extractable_ |
+| [`road-to-local-ci-trust`](road-to-local-ci-trust.md) | Road to a Trustworthy Local CI | completed-with-deferrals | 3 | 3/6 | _not extractable_ |
+| [`road-to-local-only-gate-reds`](road-to-local-only-gate-reds.md) | Road to local-only gate reds — four red gates nobody sees | completed | 4 | 10/10 | _not extractable_ |
+| [`road-to-loop-engineering`](road-to-loop-engineering.md) | Road to Loop-Engineering Discipline | completed | 2 | 10/10 | _not extractable_ |
+| [`road-to-mcp-discovery-helper`](road-to-mcp-discovery-helper.md) | Roadmap: Read-only cross-agent MCP discovery helper | closed-with-cancellations | 4 | 4/14 | _not extractable_ |
+| [`road-to-mcp-distribution`](road-to-mcp-distribution.md) | Road to MCP Distribution | closed-with-cancellations | 0 | 0/5 | _not extractable_ |
+| [`road-to-mcp-full-coverage`](road-to-mcp-full-coverage.md) | Road to MCP Full Coverage | closed-with-cancellations | 6 | 15/29 | _not extractable_ |
+| [`road-to-mcp-server`](road-to-mcp-server.md) | Road to MCP Server | closed-with-cancellations | 7 | 26/29 | _not extractable_ |
+| [`road-to-mcp-stdio-end-user-packaging`](road-to-mcp-stdio-end-user-packaging.md) | Road to a turnkey end-user stdio MCP server — packaging the local server for people who configure agents, not clone repos | completed | 4 | 10/10 | _not extractable_ |
+| [`road-to-mcp-token-accounting`](road-to-mcp-token-accounting.md) | Roadmap: MCP tool-schema token accounting (context-load-budget) | completed | 1 | 2/2 | _not extractable_ |
+| [`road-to-mcp`](road-to-mcp.md) | Roadmap: MCP Config Generation | archived-with-open-steps | 0 | 12/14 | _not extractable_ |
+| [`road-to-memory-merge-safety`](road-to-memory-merge-safety.md) | Road to Memory Merge Safety | completed | 4 | 15/15 | _not extractable_ |
+| [`road-to-memory-pipeline-consolidation`](road-to-memory-pipeline-consolidation.md) | Road to memory-pipeline consolidation & scope | completed | 8 | 33/33 | _not extractable_ |
+| [`road-to-memory-retrieval-economy`](road-to-memory-retrieval-economy.md) | Road to memory-retrieval economy — index first, fetch by ID, price every row | closed-with-cancellations | 9 | 26/27 | _not extractable_ |
+| [`road-to-memory-self-consumption`](road-to-memory-self-consumption.md) | Road to Memory Self-Consumption | closed-with-cancellations | 3 | 5/8 | _not extractable_ |
+| [`road-to-metadata-and-command-surface-leanness`](road-to-metadata-and-command-surface-leanness.md) | Roadmap: Metadata & Command-Surface Leanness | closed-with-cancellations | 4 | 14/16 | _not extractable_ |
+| [`road-to-mission-mode`](road-to-mission-mode.md) | Roadmap: Mission-Mode — named, framework-aware autonomous missions (gated) | completed | 3 | 17/17 | _not extractable_ |
+| [`road-to-mobile-adoption`](road-to-mobile-adoption.md) | Road to Mobile Adoption | closed-with-cancellations | 3 | 5/10 | _not extractable_ |
+| [`road-to-model-capability-tiers`](road-to-model-capability-tiers.md) | Road to Vendor-Neutral Model Capability Tiers | completed | 6 | 20/20 | _not extractable_ |
+| [`road-to-money-strategy-ops`](road-to-money-strategy-ops.md) | Road to Money, Strategy and Operations (Wing 4) | completed | 1 | 31/31 | _not extractable_ |
+| [`road-to-multi-package-coexistence`](road-to-multi-package-coexistence.md) | Road to Multi-Package Coexistence | completed | 6 | 25/25 | _not extractable_ |
+| [`road-to-multi-stack`](road-to-multi-stack.md) | Roadmap: Multi-Stack — from Laravel-complete to Laravel-complete-plus | closed-with-cancellations | 2 | 7/19 | _not extractable_ |
+| [`road-to-music-video-orchestration`](road-to-music-video-orchestration.md) | Road to music-video orchestration — real audio analysis, modality-switch direction, sparse lip-sync | completed | 5 | 12/12 | _not extractable_ |
+| [`road-to-native-code-intelligence`](road-to-native-code-intelligence.md) | Road to native code intelligence — own the engine, sweep the rejected inventory, keep the gates | closed-with-cancellations | 7 | 24/29 | _not extractable_ |
+| [`road-to-number-truth`](road-to-number-truth.md) | Road to Number Truth and Decision Homing | closed-with-cancellations | 4 | 19/21 | _not extractable_ |
+| [`road-to-obligation-carrier-audit`](road-to-obligation-carrier-audit.md) | Road to obligation-carrier audit — which rules fire more often than anything that carries them | completed | 5 | 24/24 | _not extractable_ |
+| [`road-to-one-migrate-command`](road-to-one-migrate-command.md) | Road to one migrate command | completed | 5 | 25/25 | _not extractable_ |
+| [`road-to-operator-runtime-harvest`](road-to-operator-runtime-harvest.md) | Road to operator-runtime harvest — cross-model parity is the keystone; gate the rest on it | closed-with-cancellations | 7 | 13/20 | _not extractable_ |
+| [`road-to-opt-council-deliberation`](road-to-opt-council-deliberation.md) | Road to council deliberation protocol — adopt the evidence-backed protocol layer, benchmark the persona theater | completed | 6 | 31/31 | _not extractable_ |
+| [`road-to-opt-decision-flips`](road-to-opt-decision-flips.md) | Road to opt decision flips — re-decide what the package's evolution invalidated | completed | 4 | 19/19 | _not extractable_ |
+| [`road-to-opt-design-polish`](road-to-opt-design-polish.md) | Road to opt design polish — consolidate the slop canon, close the states gap | completed | 4 | 8/8 | _not extractable_ |
+| [`road-to-opt-harness-discipline`](road-to-opt-harness-discipline.md) | Road to opt harness discipline — port the native-harness behaviors weaker hosts don't have | completed | 5 | 14/14 | _not extractable_ |
+| [`road-to-opt-hygiene-and-debt`](road-to-opt-hygiene-and-debt.md) | Road to opt hygiene and debt — pay the package's own policy breaches first | completed | 4 | 19/19 | _not extractable_ |
+| [`road-to-opt-measurement-unblock`](road-to-opt-measurement-unblock.md) | Road to opt measurement unblock — one judge run cascade-unblocks the token program | completed | 3 | 10/10 | _not extractable_ |
+| [`road-to-opt-portfolio-consolidation`](road-to-opt-portfolio-consolidation.md) | Road to opt portfolio consolidation — merge, revive, park, and dedupe the roadmap estate | closed-with-cancellations | 4 | 9/11 | _not extractable_ |
+| [`road-to-opt-retrieval-and-memory`](road-to-opt-retrieval-and-memory.md) | Road to opt retrieval and memory — wire the orphan, benchmark honestly, borrow the protocol discipline | completed | 4 | 12/12 | _not extractable_ |
+| [`road-to-opt-subagent-harvest`](road-to-opt-subagent-harvest.md) | Road to opt subagent harvest — the post-flip second look at orchestration references | completed | 3 | 9/9 | _not extractable_ |
+| [`road-to-optimized-ci-and-release-gates`](road-to-optimized-ci-and-release-gates.md) | Optimized CI + Release Gates — cut release-PR wall-clock and make every gate intentional | closed-with-cancellations | 4 | 25/27 | _not extractable_ |
+| [`road-to-orchestration-and-memory-harvest`](road-to-orchestration-and-memory-harvest.md) | Road to orchestration-and-memory harvest | completed | 5 | 17/17 | _not extractable_ |
+| [`road-to-orchestrator-discipline-carriers`](road-to-orchestrator-discipline-carriers.md) | Road to orchestrator discipline carriers — the delegation obligation and the end-review obligation get mechanisms that reach real sessions | completed | 7 | 37/37 | _not extractable_ |
+| [`road-to-orchestrator-first-execution`](road-to-orchestrator-first-execution.md) | Road to orchestrator-first execution — make the gate clear, measure what already happened, then decide whether "orchestrate everything" survives contact with the numbers | closed-with-cancellations | 5 | 17/29 | _not extractable_ |
+| [`road-to-overlap-truth-and-skill-cut`](road-to-overlap-truth-and-skill-cut.md) | Road to overlap truth — repair the instrument, then cut the skills it was supposed to find | closed-with-cancellations | 6 | 13/14 | _not extractable_ |
+| [`road-to-package-impact-benchmark`](road-to-package-impact-benchmark.md) | Roadmap: Package-Impact Benchmark (with vs. without agent-config) | completed-with-deferrals | 5 | 31/32 | _not extractable_ |
+| [`road-to-package-optimization`](road-to-package-optimization.md) | Road to Package Optimization | closed-with-cancellations | 3 | 1/8 | _not extractable_ |
+| [`road-to-package-renewal`](road-to-package-renewal.md) | Road to package renewal — central roadmap (2026-08) | completed | 2 | 9/9 | _not extractable_ |
+| [`road-to-parallel-session-coordination`](road-to-parallel-session-coordination.md) | Road to parallel-session coordination — a second session should know the first one exists | completed | 5 | 24/24 | _not extractable_ |
+| [`road-to-path-fixes`](road-to-path-fixes.md) | Road to Path Fixes | closed-with-cancellations | 9 | 28/29 | _not extractable_ |
+| [`road-to-per-skill-model-autoswitch`](road-to-per-skill-model-autoswitch.md) | Road to Per-Skill Model Auto-Switch | completed | 6 | 34/34 | _not extractable_ |
+| [`road-to-persona-catalog-disposition`](road-to-persona-catalog-disposition.md) | Road to persona-catalog disposition — four mechanisms audited, one insight kept, no fourth ontology | completed | 2 | 2/2 | _not extractable_ |
+| [`road-to-persona-library-harvest`](road-to-persona-library-harvest.md) | Roadmap: Persona-Library Harvest — Originality Gate, Measured Catalog Router, Flow-Team Primitive | closed-with-cancellations | 3 | 28/29 | _not extractable_ |
+| [`road-to-personas`](road-to-personas.md) | Roadmap: Personas — reusable review lenses as a first-class primitive | archived-with-open-steps | 6 | 29/30 | _not extractable_ |
+| [`road-to-plan-gate-fence-grammar`](road-to-plan-gate-fence-grammar.md) | Roadmap: Plan-gate fence grammar — close the live fail-open, make archived dispositions machine-checked | closed-with-cancellations | 4 | 28/29 | _not extractable_ |
+| [`road-to-plan-governance-gates`](road-to-plan-governance-gates.md) | Roadmap: Plan Governance Gates — confidence gate, plan-risk review, completion review | completed | 8 | 52/52 | _not extractable_ |
+| [`road-to-portable-dev-preferences`](road-to-portable-dev-preferences.md) | Road to Portable Dev Preferences | completed | 3 | 9/9 | _not extractable_ |
+| [`road-to-portable-runtime-and-update-check`](road-to-portable-runtime-and-update-check.md) | Road to npx-only Distribution + Hierarchical Settings + Update Check | completed | 4 | 28/28 | _not extractable_ |
+| [`road-to-positioning-and-enforcement`](road-to-positioning-and-enforcement.md) | Road to positioning & enforcement — close the *perceived* gap, ship the one real one | closed-with-cancellations | 3 | 8/12 | _not extractable_ |
+| [`road-to-positioning-consistency-and-skill-governance`](road-to-positioning-consistency-and-skill-governance.md) | Roadmap: Positioning Consistency + Skill Governance — close the doc-drift and 227-skill gaps | completed-with-deferrals | 4 | 34/40 | _not extractable_ |
+| [`road-to-post-pr29-optimize`](road-to-post-pr29-optimize.md) | Road to Post-PR-29 Optimize | closed-with-cancellations | 3 | 19/24 | _not extractable_ |
+| [`road-to-pr-34-followups`](road-to-pr-34-followups.md) | Road to PR #34 Follow-ups | closed-with-cancellations | 15 | 28/29 | _not extractable_ |
+| [`road-to-product-adoption`](road-to-product-adoption.md) | Roadmap: Product Adoption — close the External Adoption gap | closed-with-cancellations | 5 | 25/38 | _not extractable_ |
+| [`road-to-product-clarity`](road-to-product-clarity.md) | Road to product clarity — process wins now, product bets deferred | closed-with-cancellations | 4 | 4/11 | _not extractable_ |
+| [`road-to-product-ui-track-followup`](road-to-product-ui-track-followup.md) | Roadmap: Product UI Track — Follow-up Goldens (R3.1) | completed | 6 | 40/40 | _not extractable_ |
+| [`road-to-product-ui-track`](road-to-product-ui-track.md) | Roadmap: Product UI Track | closed-with-cancellations | 7 | 58/63 | _not extractable_ |
+| [`road-to-productization`](road-to-productization.md) | Road to Productization (Level 6) | closed-with-cancellations | 8 | 25/27 | _not extractable_ |
+| [`road-to-project-memory`](road-to-project-memory.md) | Roadmap: Project Memory — layered settings and curated knowledge | completed | 6 | 30/30 | _not extractable_ |
+| [`road-to-prompt-driven-execution`](road-to-prompt-driven-execution.md) | Roadmap: Prompt-Driven Execution | archived-with-open-steps | 6 | 31/36 | _not extractable_ |
+| [`road-to-prompt-pattern-adoption`](road-to-prompt-pattern-adoption.md) | Road to prompt pattern adoption | completed | 5 | 21/21 | _not extractable_ |
+| [`road-to-proof-not-features`](road-to-proof-not-features.md) | Road to Proof not Features | closed-with-cancellations | 4 | 16/20 | _not extractable_ |
+| [`road-to-proof-under-real-conditions`](road-to-proof-under-real-conditions.md) | Road to proof under real conditions | completed | 6 | 33/33 | _not extractable_ |
+| [`road-to-provenance-and-license-governance`](road-to-provenance-and-license-governance.md) | Road to provenance and license governance — code borrows get a paper trail | closed-with-cancellations | 6 | 17/22 | _not extractable_ |
+| [`road-to-provided-artifact-honesty`](road-to-provided-artifact-honesty.md) | Road to provided-artifact honesty — a handed-over design is either honoured or refused, never silently regenerated | completed | 5 | 29/29 | _not extractable_ |
+| [`road-to-py2ts-teardown-completion`](road-to-py2ts-teardown-completion.md) | py2ts teardown — completion: purge remaining live-python, retire the shim, merge-ready | closed-with-cancellations | 5 | 18/21 | _not extractable_ |
+| [`road-to-py2ts-teardown`](road-to-py2ts-teardown.md) | Python → TypeScript migration: Phase 12 teardown | archived-with-open-steps | 9 | 15/33 | _not extractable_ |
+| [`road-to-rdp-discoverability`](road-to-rdp-discoverability.md) | Roadmap: RDP discoverability — settings docs, user contract, surfacing | completed | 3 | 6/6 | _not extractable_ |
+| [`road-to-rdp-eval-and-promotion`](road-to-rdp-eval-and-promotion.md) | Roadmap: RDP — eval execution, kernel promotion, polish (follow-up) | closed-with-cancellations | 5 | 5/7 | _not extractable_ |
+| [`road-to-rdp-frontier-polish`](road-to-rdp-frontier-polish.md) | Roadmap: RDP frontier polish — orchestrator decision, kernel de-prescription, L7 (follow-up) | closed-with-cancellations | 3 | 3/7 | _not extractable_ |
+| [`road-to-reachable-code-memory`](road-to-reachable-code-memory.md) | Road to reachable code memory — wire the orphaned engine, accumulate locally, decide the substrate honestly | closed-with-cancellations | 10 | 26/27 | _not extractable_ |
+| [`road-to-readable-value-dashboard`](road-to-readable-value-dashboard.md) | Roadmap: Readable Value Dashboard — make "what the package brings" understandable | completed | 6 | 32/32 | _not extractable_ |
+| [`road-to-reaping-catches-pre-inventory-orphans`](road-to-reaping-catches-pre-inventory-orphans.md) | Roadmap: Reaping catches pre-inventory tagged orphans | completed | 4 | 15/15 | _not extractable_ |
+| [`road-to-rebalancing`](road-to-rebalancing.md) | Road to Rebalancing | closed-with-cancellations | 9 | 15/19 | _not extractable_ |
+| [`road-to-reciprocal-ecosystem`](road-to-reciprocal-ecosystem.md) | Road to a reciprocal ecosystem — AC recommends AS the way AS already recommends AC | completed | 4 | 18/18 | _not extractable_ |
+| [`road-to-recursive-verification`](road-to-recursive-verification.md) | Road to recursive self-verification — the one retraining-free Fugu mechanism, measured capability-axis-first | closed-with-cancellations | 8 | 22/28 | _not extractable_ |
+| [`road-to-refine-ticket-hardening`](road-to-refine-ticket-hardening.md) | Roadmap: `/refine-ticket` hardening (v2 follow-ups) | completed-with-deferrals | 7 | 29/31 | _not extractable_ |
+| [`road-to-release-gate-hardening`](road-to-release-gate-hardening.md) | Road to release-gate hardening — turn reactive catches into pre-merge gates | completed | 3 | 11/11 | _not extractable_ |
+| [`road-to-release-shape-honesty`](road-to-release-shape-honesty.md) | Road to release-shape honesty — lint the release that shipped, and describe it truthfully | completed | 3 | 8/8 | _not extractable_ |
+| [`road-to-release-truth`](road-to-release-truth.md) | Road to release truth — one final source, findings with dispositions, bounded autonomy | completed | 4 | 10/10 | _not extractable_ |
+| [`road-to-renewal-adr-hygiene`](road-to-renewal-adr-hygiene.md) | Road to renewal — ADR hygiene (chip-mode) | closed-with-cancellations | 3 | 9/10 | _not extractable_ |
+| [`road-to-renewal-foundation`](road-to-renewal-foundation.md) | Road to renewal — Foundation (CI oracle, dead tree, token quick wins) | closed-with-cancellations | 3 | 17/21 | _not extractable_ |
+| [`road-to-renewal-leverage`](road-to-renewal-leverage.md) | Road to renewal — Leverage (execution flows + documented-failure fixes) | closed-with-cancellations | 3 | 7/12 | _not extractable_ |
+| [`road-to-reproducible-artefact-counts`](road-to-reproducible-artefact-counts.md) | Road to reproducible artefact counts — a number a second counter cannot derive | completed | 0 | 4/4 | _not extractable_ |
+| [`road-to-retire-stale-authoring-pointers`](road-to-retire-stale-authoring-pointers.md) | Road to retire stale authoring-source pointers (`.agent-src.uncondensed/` → `src/`) | completed | 4 | 13/13 | _not extractable_ |
+| [`road-to-retrieval-contract-consumer`](road-to-retrieval-contract-consumer.md) | Roadmap: Retrieval-contract consumer implementation | completed | 2 | 10/10 | _not extractable_ |
+| [`road-to-retrieval-substrate-hardening`](road-to-retrieval-substrate-hardening.md) | Road to retrieval-substrate hardening | closed-with-cancellations | 8 | 17/18 | _not extractable_ |
+| [`road-to-roadmap-archival-robustness`](road-to-roadmap-archival-robustness.md) | Road to roadmap-archival robustness — completion archives without a PR | completed | 4 | 12/12 | _not extractable_ |
+| [`road-to-role-first-onboarding`](road-to-role-first-onboarding.md) | Roadmap: Role-First Onboarding — non-developer first, dev second | archived-with-open-steps | 5 | 24/35 | _not extractable_ |
+| [`road-to-role-modes`](road-to-role-modes.md) | Roadmap: Role Modes — explicit frames and output contracts | completed | 4 | 16/16 | _not extractable_ |
+| [`road-to-root-layout-cleanup`](road-to-root-layout-cleanup.md) | Roadmap: Root layout cleanup — targeted prune now, multi-workspace gated on four audits | closed-with-cancellations | 3 | 23/24 | _not extractable_ |
+| [`road-to-rootless-write-refusal`](road-to-rootless-write-refusal.md) | Road to rootless-write refusal | completed | 3 | 19/19 | _not extractable_ |
+| [`road-to-routing-correctness`](road-to-routing-correctness.md) | Road to routing correctness — the rule set stops fighting itself, and a command proves what routes | closed-with-cancellations | 4 | 14/15 | _not extractable_ |
+| [`road-to-rtk-onboarding-correctness`](road-to-rtk-onboarding-correctness.md) | Road to rtk onboarding correctness — the install path we ship is currently broken | completed | 4 | 21/21 | _not extractable_ |
+| [`road-to-rule-coherence`](road-to-rule-coherence.md) | Road to rule coherence — fix the delivery system, not the rules | closed-with-cancellations | 4 | 14/21 | _not extractable_ |
+| [`road-to-rule-delivery-integrity`](road-to-rule-delivery-integrity.md) | Road to rule delivery integrity — rules that arrive once, scoped, and provably | closed-with-cancellations | 6 | 15/17 | _not extractable_ |
+| [`road-to-rule-hardening`](road-to-rule-hardening.md) | Road to Rule Hardening | closed-with-cancellations | 7 | 27/33 | _not extractable_ |
+| [`road-to-rule-quality-research`](road-to-rule-quality-research.md) | Roadmap: Rule & Guideline Quality Research | archived-with-open-steps | 0 | 0/2 | _not extractable_ |
+| [`road-to-runtime-encoding-hardening`](road-to-runtime-encoding-hardening.md) | Road to runtime encoding hardening — prove the sanitize floor runs, then close the half it deliberately left open | completed | 5 | 24/24 | _not extractable_ |
+| [`road-to-runtime-security-hardening`](road-to-runtime-security-hardening.md) | Road to runtime-security hardening — fix the subprocess-env RCE, hold the scope line | completed | 3 | 11/11 | _not extractable_ |
+| [`road-to-scale-and-history-discipline`](road-to-scale-and-history-discipline.md) | Road to scale & history discipline — two packs, one deterministic linter substrate | completed | 6 | 23/23 | _not extractable_ |
+| [`road-to-scripts-settings-defaults`](road-to-scripts-settings-defaults.md) | Road to scripts settings defaults — give the SCRIPTS read path the defaults layer the server already has | completed | 2 | 4/4 | _not extractable_ |
+| [`road-to-second-brain-delta-proof`](road-to-second-brain-delta-proof.md) | Road to second-brain delta proof — measure the memory substrate against a no-memory baseline, and scope it honestly against human-PKM | closed-with-cancellations | 4 | 13/14 | _not extractable_ |
+| [`road-to-second-brain`](road-to-second-brain.md) | Road to second brain — working-memory continuity, scale tripwires, contradiction surfacing | completed | 5 | 15/15 | _not extractable_ |
+| [`road-to-secret-hygiene-guardrail`](road-to-secret-hygiene-guardrail.md) | Road to secret-hygiene guardrail — the agent never lets a secret land in VCS | completed | 7 | 42/42 | _not extractable_ |
+| [`road-to-security-hardening`](road-to-security-hardening.md) | Roadmap: Security hardening — consumer/CI/git-enforcement layer | completed | 3 | 14/14 | _not extractable_ |
+| [`road-to-security-pillar`](road-to-security-pillar.md) | Roadmap: security pillar — supply-chain integrity + injection-aware authoring | closed-with-cancellations | 6 | 32/42 | _not extractable_ |
+| [`road-to-self-critical`](road-to-self-critical.md) | Road to self-critical — structural review honesty instead of rule #108 | completed | 3 | 10/10 | _not extractable_ |
+| [`road-to-self-update-and-global-hook-resolution`](road-to-self-update-and-global-hook-resolution.md) | Road to Self-Update + Global Hook Resolution | completed | 6 | 35/35 | _not extractable_ |
+| [`road-to-session-analytics`](road-to-session-analytics.md) | Road to session analytics — a post-session cost/turn/churn report | completed | 1 | 2/2 | _not extractable_ |
+| [`road-to-session-profile-activation`](road-to-session-profile-activation.md) | Road to Session-Profile Activation | closed-with-cancellations | 4 | 12/16 | _not extractable_ |
+| [`road-to-session-profile-observability`](road-to-session-profile-observability.md) | Roadmap: Session-Profile Observability for Employees — make "which profile, what changed, why" legible without a CLI | completed | 3 | 20/20 | _not extractable_ |
+| [`road-to-setup-experience`](road-to-setup-experience.md) | Road to Setup Experience | completed | 6 | 25/25 | _not extractable_ |
+| [`road-to-shadcn-registry-awareness`](road-to-shadcn-registry-awareness.md) | Road to shadcn Registry & MCP Awareness | completed | 5 | 10/10 | _not extractable_ |
+| [`road-to-shared-design-tokens`](road-to-shared-design-tokens.md) | Road to shared design tokens — one visual identity across two independent GUIs | completed | 4 | 18/18 | _not extractable_ |
+| [`road-to-simplicity-and-everywhere`](road-to-simplicity-and-everywhere.md) | Road to Simplicity and Everywhere | closed-with-cancellations | 7 | 32/38 | _not extractable_ |
+| [`road-to-simplicity-and-goal-discipline`](road-to-simplicity-and-goal-discipline.md) | Road to simplicity and goal discipline — close the over-engineering and vague-goal gaps | completed | 4 | 13/13 | _not extractable_ |
+| [`road-to-single-install-source-of-truth`](road-to-single-install-source-of-truth.md) | Roadmap: Single Install Source-of-Truth — finish the `--apply-payload` bridge | completed-with-deferrals | 6 | 21/24 | _not extractable_ |
+| [`road-to-skill-catalogue-budget`](road-to-skill-catalogue-budget.md) | Road to a measured skill-catalogue budget — Codex as the second host | completed | 4 | 23/23 | _not extractable_ |
+| [`road-to-skill-ecosystem-authoring-discipline`](road-to-skill-ecosystem-authoring-discipline.md) | Road to authoring discipline — forced artifacts, named biases, and a removal signal | closed-with-cancellations | 6 | 53/54 | _not extractable_ |
+| [`road-to-skill-eval-coverage`](road-to-skill-eval-coverage.md) | Road to skill eval coverage — close the 2-of-264 behavioural-eval gap, tier-prioritised, ratcheted | completed | 4 | 14/14 | _not extractable_ |
+| [`road-to-spawn-env-completion`](road-to-spawn-env-completion.md) | Road to spawn-env completion — close the GIT_CONFIG RCE residual, classify every spawn site | completed | 2 | 9/9 | _not extractable_ |
+| [`road-to-stable-chat-history`](road-to-stable-chat-history.md) | Roadmap: Stable Chat History via Platform Hooks | archived-with-open-steps | 5 | 28/31 | _not extractable_ |
+| [`road-to-starlight-project-docs`](road-to-starlight-project-docs.md) | Roadmap: Starlight project documentation | archived-with-open-steps | 9 | 31/38 | _not extractable_ |
+| [`road-to-structural-linter-reform`](road-to-structural-linter-reform.md) | Road to Structural Linter Reform | completed | 4 | 14/14 | _not extractable_ |
+| [`road-to-structural-optimization`](road-to-structural-optimization.md) | Road to Structural Optimization | closed-with-cancellations | 7 | 43/60 | _not extractable_ |
+| [`road-to-structure-grounding-v2`](road-to-structure-grounding-v2.md) | Roadmap: Structure-grounding v2 — global cross-project card sharing | completed | 6 | 17/17 | _not extractable_ |
+| [`road-to-structure-grounding`](road-to-structure-grounding.md) | Roadmap: Evidence-first structure discovery | closed-with-cancellations | 6 | 29/30 | _not extractable_ |
+| [`road-to-structured-guard-input`](road-to-structured-guard-input.md) | Road to structured guard input — stop guessing intent from prose | closed-with-cancellations | 4 | 8/9 | _not extractable_ |
+| [`road-to-subagent-value-realization`](road-to-subagent-value-realization.md) | Roadmap: Subagent value realization | closed-with-cancellations | 6 | 24/31 | _not extractable_ |
+| [`road-to-substrate-adoption`](road-to-substrate-adoption.md) | road-to-substrate-adoption | not-extractable | 0 | — | _not extractable_ |
+| [`road-to-suite-closure`](road-to-suite-closure.md) | Road to Suite Closure | completed | 6 | 37/37 | _not extractable_ |
+| [`road-to-surface-discipline`](road-to-surface-discipline.md) | Roadmap: Surface Discipline (2.7.0 follow-up) | completed | 5 | 40/40 | _not extractable_ |
+| [`road-to-surface-specific-agent-contracts`](road-to-surface-specific-agent-contracts.md) | Road to surface-specific agent contracts — stop making one generic agent do every medium badly | completed | 8 | 39/39 | _not extractable_ |
+| [`road-to-symptom-driven-harvest-loop`](road-to-symptom-driven-harvest-loop.md) | Road to the symptom-driven harvest loop — make the process that found V1–V9 repeatable | completed | 3 | 7/7 | _not extractable_ |
+| [`road-to-taste-dials-and-locks`](road-to-taste-dials-and-locks.md) | Road to Taste Dials & Consistency Locks | completed | 5 | 11/11 | _not extractable_ |
+| [`road-to-team-mode`](road-to-team-mode.md) | Road to team mode — govern the official cross-model pair, don't rebuild it | closed-with-cancellations | 7 | 39/42 | _not extractable_ |
+| [`road-to-test-and-gate-integrity`](road-to-test-and-gate-integrity.md) | Road to Test-and-Gate Integrity | completed | 3 | 20/20 | _not extractable_ |
+| [`road-to-tested-routing`](road-to-tested-routing.md) | Roadmap: Road to tested routing | completed | 7 | 38/38 | _not extractable_ |
+| [`road-to-ticket-bundles`](road-to-ticket-bundles.md) | Roadmap: Ticket bundles — high-tier plans, lite-tier builds | closed-with-cancellations | 7 | 33/39 | _not extractable_ |
+| [`road-to-ticket-refinement`](road-to-ticket-refinement.md) | Roadmap: Ticket Refinement — refine + estimate as a family | closed-with-cancellations | 5 | 22/23 | _not extractable_ |
+| [`road-to-tier-removal`](road-to-tier-removal.md) | Roadmap: Command `tier:` Alias Removal | completed | 4 | 8/8 | _not extractable_ |
+| [`road-to-token-economy-cache`](road-to-token-economy-cache.md) | Road to token-economy — cache: the per-session overhead gets a budget, a stable prefix delta, and a machine on the write path | completed-with-deferrals | 7 | 35/39 | _not extractable_ |
+| [`road-to-token-economy-dispatch`](road-to-token-economy-dispatch.md) | Road to token-economy — dispatch: the always-on stack stops paying the full harness price per spawn | completed-with-deferrals | 7 | 31/39 | _not extractable_ |
+| [`road-to-token-economy-recycling`](road-to-token-economy-recycling.md) | Road to token-economy — recycling: deliberate envelope-mediated fresh starts instead of lossy auto-compaction | closed-with-cancellations | 5 | 27/28 | _not extractable_ |
+| [`road-to-token-frugality`](road-to-token-frugality.md) | Road to Token Frugality | completed | 11 | 108/108 | _not extractable_ |
+| [`road-to-token-optimization`](road-to-token-optimization.md) | Road to Token Optimization | completed-with-deferrals | 3 | 5/9 | _not extractable_ |
+| [`road-to-trigger-evals`](road-to-trigger-evals.md) | Roadmap: Skill Trigger Evaluation | completed | 3 | 6/6 | _not extractable_ |
+| [`road-to-trim-frugality-canon`](road-to-trim-frugality-canon.md) | Road to Trim Frugality Canon | completed | 5 | 14/14 | _not extractable_ |
+| [`road-to-truth-and-reference-hygiene`](road-to-truth-and-reference-hygiene.md) | Road to truth-and-reference hygiene — make the "machine-checked" headline true of its own artefacts | completed | 3 | 21/21 | _not extractable_ |
+| [`road-to-typescript-only-scripts`](road-to-typescript-only-scripts.md) | Roadmap: TypeScript-only scripts — full Python → TypeScript migration | completed | 12 | 71/71 | _not extractable_ |
+| [`road-to-ui-track-integrity`](road-to-ui-track-integrity.md) | Road to UI-track integrity — the lanes the dispatcher names do not exist | completed-with-deferrals | 7 | 36/39 | _not extractable_ |
+| [`road-to-ultimate`](road-to-ultimate.md) | Roadmap: Road to Ultimate — Ecosystem & Interop | archived-with-open-steps | 6 | 0/40 | _not extractable_ |
+| [`road-to-unified-senior-roles`](road-to-unified-senior-roles.md) | Road to Unified Senior Roles | completed | 1 | 19/19 | _not extractable_ |
+| [`road-to-unified-setup`](road-to-unified-setup.md) | Unified Setup — v4.0.0 hard-cut to a single TS install/setup engine | completed-with-deferrals | 5 | 26/27 | _not extractable_ |
+| [`road-to-universal-distribution`](road-to-universal-distribution.md) | Roadmap: Universal Distribution (Cloud + Local Fallbacks) | archived-with-open-steps | 7 | 36/51 | _not extractable_ |
+| [`road-to-universal-execution-engine`](road-to-universal-execution-engine.md) | Roadmap: Universal Execution Engine | closed-with-cancellations | 7 | 45/50 | _not extractable_ |
+| [`road-to-universal-stack-coverage`](road-to-universal-stack-coverage.md) | Road to universal stack coverage — an honest refusal is not coverage | closed-with-cancellations | 4 | 25/26 | _not extractable_ |
+| [`road-to-value-dashboard-netto-cuts`](road-to-value-dashboard-netto-cuts.md) | Roadmap: Value Dashboard NETTO — cut the base-load, keep Panel B value | archived-with-open-steps | 6 | 20/34 | _not extractable_ |
+| [`road-to-verified-chat-history-platforms`](road-to-verified-chat-history-platforms.md) | Road to verified chat-history platforms | archived-with-open-steps | 6 | 35/43 | _not extractable_ |
+| [`road-to-video-deferred-design`](road-to-video-deferred-design.md) | Road to video deferred design — checkpoint/resume, ComfyUI sandbox, provenance (design-gated backlog) | completed | 3 | 8/8 | _not extractable_ |
+| [`road-to-video-foundation-validation`](road-to-video-foundation-validation.md) | Road to video foundation validation — prove the adapter contract with real money before building anything new | completed | 4 | 12/12 | _not extractable_ |
+| [`road-to-video-from-song`](road-to-video-from-song.md) | Roadmap: `/video:from-song` — a music-video from a song + reference images | completed | 6 | 45/45 | _not extractable_ |
+| [`road-to-video-provider-multiplexers`](road-to-video-provider-multiplexers.md) | Road to video provider multiplexers — one adapter, many models (fal first, Replicate second) | completed | 3 | 7/7 | _not extractable_ |
+| [`road-to-visual-review-loop`](road-to-visual-review-loop.md) | Roadmap: Visual Review Loop + A11y | completed | 7 | 45/45 | _not extractable_ |
+| [`road-to-webfont-delivery-ownership`](road-to-webfont-delivery-ownership.md) | Road to webfont delivery ownership — one skill prescribes the hotlink another skill's data forbids | completed | 3 | 12/12 | _not extractable_ |
+| [`road-to-weighted-decision-matrix`](road-to-weighted-decision-matrix.md) | Road to weighted decision matrix — quantitative mode for `decision-record` | completed | 4 | 18/18 | _not extractable_ |
+| [`road-to-wiring-truth`](road-to-wiring-truth.md) | Road to Wiring Truth | completed | 3 | 11/11 | _not extractable_ |
+| [`road-to-wizard-sse-hardening`](road-to-wizard-sse-hardening.md) | Roadmap: Wizard SSE hardening — edge-case test coverage, severity-phased | completed | 2 | 9/9 | _not extractable_ |
+| [`road-to-wizard-ux-improvements`](road-to-wizard-ux-improvements.md) | Roadmap: Wizard UX — first-run detection, fresh-start, tool-list cleanup | completed | 8 | 21/21 | _not extractable_ |
+| [`road-to-work-engine-hooks`](road-to-work-engine-hooks.md) | Roadmap: Work-Engine Hook Lifecycle | archived-with-open-steps | 7 | 51/56 | _not extractable_ |
+| [`road-to-worktree-hygiene`](road-to-worktree-hygiene.md) | Road to worktree hygiene — 249 worktrees, 40 GB, one prune that does nothing | completed | 1 | 9/9 | _not extractable_ |
+| [`road-to-zero-ceremony-detection`](road-to-zero-ceremony-detection.md) | Road to zero-ceremony detection — detection reports, consent still decides | completed | 5 | 29/29 | _not extractable_ |
+| [`road-to-zero-ceremony-install`](road-to-zero-ceremony-install.md) | Road to zero-ceremony install — make the install claim true before making it shorter | closed-with-cancellations | 6 | 24/26 | _not extractable_ |
+| [`road-to-zero-ceremony-settings`](road-to-zero-ceremony-settings.md) | Road to zero-ceremony settings — the user's file records decisions, the template stays the defaults source | closed-with-cancellations | 5 | 22/23 | _not extractable_ |
+| [`road-to-zero-settings`](road-to-zero-settings.md) | Road to zero settings — delete the flags whose answer the situation already carries | closed-with-cancellations | 4 | 14/15 | _not extractable_ |
+| [`rule-governance-and-budget-discipline`](rule-governance-and-budget-discipline.md) | Road to Rule Governance & Budget Discipline | completed | 4 | 19/19 | _not extractable_ |
+| [`shell-based-installer`](shell-based-installer.md) | Roadmap: Shell-Based Installer | closed-with-cancellations | 6 | 101/104 | _not extractable_ |
+| [`skill-improvement-pipeline`](skill-improvement-pipeline.md) | Roadmap: Agent Skill Improvement Pipeline | completed | 5 | 20/20 | _not extractable_ |
+| [`skills-audit-results`](skills-audit-results.md) | Skills Audit Results | not-extractable | 2 | — | _not extractable_ |
+| [`skills-rules-restructuring`](skills-rules-restructuring.md) | Roadmap: Skills & Rules Restructuring | completed | 5 | 24/24 | _not extractable_ |
+| [`step-1-ai-council-cli-transport`](step-1-ai-council-cli-transport.md) | Roadmap: AI Council CLI Transport + Safety Net + Decision-Replay + Impact-Routed Lightweight QA | completed | 13 | 86/86 | _not extractable_ |
+| [`step-1-v2-feedback-followup`](step-1-v2-feedback-followup.md) | Roadmap: v2.10.0 Audit + Council Feedback Follow-Up | closed-with-cancellations | 5 | 23/25 | _not extractable_ |
+| [`step-10-corpus-yaml-lockfile`](step-10-corpus-yaml-lockfile.md) | Roadmap: Low-Impact Corpus — YAML Lockfile as Runtime Source-of-Truth | completed | 3 | 18/18 | _not extractable_ |
+| [`step-12-closure-report`](step-12-closure-report.md) | Step-12 Closure Report — feat/ghostwriter branch terminal state | not-extractable | 0 | — | _not extractable_ |
+| [`step-12-universal-os-reframe`](step-12-universal-os-reframe.md) | Road to Universal-OS Reframe (audience expansion, capability-preserving) | completed-with-deferrals | 7 | 44/53 | _not extractable_ |
+| [`step-13-non-dev-community-validation`](step-13-non-dev-community-validation.md) | Roadmap: non-dev community validation (post-step-12, 90-day window) | closed-with-cancellations | 4 | 8/22 | _not extractable_ |
+| [`step-14-mcp-runtime-stub`](step-14-mcp-runtime-stub.md) | Roadmap: MCP runtime stub (Claude-Desktop-native invocation) | closed-with-cancellations | 3 | 10/13 | _not extractable_ |
+| [`step-15-product-refinement`](step-15-product-refinement.md) | Roadmap: step-15 — product architecture refinement (Phase 0 + P0 / P1 / P2 cuts) | closed-with-cancellations | 5 | 26/40 | _not extractable_ |
+| [`step-2-ai-council-consolidation`](step-2-ai-council-consolidation.md) | Roadmap: AI Council Consolidation + External-Pattern Integration | archived-with-open-steps | 9 | 61/65 | _not extractable_ |
+| [`step-2-feedback-followup`](step-2-feedback-followup.md) | Roadmap: PR #148 Feedback Follow-Up (Command Surface + Doc Links) | closed-with-cancellations | 3 | 21/24 | _not extractable_ |
+| [`step-2-skill-inventory-rationalization`](step-2-skill-inventory-rationalization.md) | Roadmap: Skill Inventory Rationalization (P0) | closed-with-cancellations | 5 | 11/30 | _not extractable_ |
+| [`step-3-agent-user-persona`](step-3-agent-user-persona.md) | Roadmap: `.agent-user.md` + User-Persona Cluster + Sparring Command | closed-with-cancellations | 5 | 30/37 | _not extractable_ |
+| [`step-4-ghostwriter`](step-4-ghostwriter.md) | Roadmap: `/ghostwriter` cluster + `/post-as:me` + `/post-as:ghostwriter` | completed | 5 | 35/35 | _not extractable_ |
+| [`step-4-measurement-and-benchmark`](step-4-measurement-and-benchmark.md) | Roadmap: Measurement and Benchmark (P1) | completed | 6 | 34/34 | _not extractable_ |
+| [`step-5-schema-rigor`](step-5-schema-rigor.md) | Roadmap: Schema Rigor — Full External-Reference Suite (P3) | closed-with-cancellations | 6 | 1/41 | _not extractable_ |
+| [`step-5-test-cleanup`](step-5-test-cleanup.md) | Road to Test-Suite Cleanup (audit-only) | closed-with-cancellations | 0 | 0/5 | _not extractable_ |
+| [`step-6-user-types-axis`](step-6-user-types-axis.md) | Roadmap: `user-types/` axis (parallel to `personas/`) | completed | 8 | 47/47 | _not extractable_ |
+| [`step-7-agent-folder-discovery-and-minimal-init`](step-7-agent-folder-discovery-and-minimal-init.md) | Step 7 — Agent-Folder Discovery & Minimal Init | archived-with-open-steps | 6 | 30/34 | _not extractable_ |
+| [`step-8-discovery-polish`](step-8-discovery-polish.md) | Step 8 — Discovery Polish (Override, Trace, Minimal-UX) | completed-with-deferrals | 3 | 18/20 | _not extractable_ |
+| [`step-8-quota-necessity-transparency`](step-8-quota-necessity-transparency.md) | Step 8 — Quota & Necessity Transparency | completed | 6 | 31/31 | _not extractable_ |
+| [`step-9-pr150-feedback-hardening`](step-9-pr150-feedback-hardening.md) | Step 9 — PR #150 Follow-up Hardening | closed-with-cancellations | 13 | 63/67 | _not extractable_ |
+| [`step-9-user-types-axis`](step-9-user-types-axis.md) | Roadmap: install-time user-type axis (skill filter) | archived-with-open-steps | 5 | 20/21 | _not extractable_ |
+| [`step-99-north-star-restructure`](step-99-north-star-restructure.md) | Roadmap: North Star Restructure (meta · out-of-band · **breaking change**) | closed-with-cancellations | 6 | 10/32 | _not extractable_ |
+| [`strategic-visibility-mcp-topics-positioning`](strategic-visibility-mcp-topics-positioning.md) | Roadmap: Strategic Visibility — MCP Listing, GitHub Topics-as-Code, Positioning Lint | completed | 8 | 74/74 | _not extractable_ |
+| [`structural-optimization-2A4-example`](structural-optimization-2A4-example.md) | 2A.4 worked example — direct-answers | not-extractable | 0 | — | _not extractable_ |
+| [`structural-optimization-3a-scoring-protocol`](structural-optimization-3a-scoring-protocol.md) | Phase 3a Spike — Scoring Protocol | not-extractable | 0 | — | _not extractable_ |
+| [`taxonomy-audit`](taxonomy-audit.md) | Roadmap: Taxonomy Audit | completed | 4 | 10/10 | _not extractable_ |
+| [`typescript-cli-and-local-gui-foundation`](typescript-cli-and-local-gui-foundation.md) | Roadmap: TypeScript CLI & Local Web-UI Foundation | completed | 7 | 115/115 | _not extractable_ |
+| [`unified-setup-and-settings-gui`](unified-setup-and-settings-gui.md) | Roadmap: Unified Setup Wizard & Settings GUI (with `.agent-user.md` onboarding) | closed-with-cancellations | 6 | 94/107 | _not extractable_ |
+| [`universal-platform-refinement`](universal-platform-refinement.md) | Roadmap: Universal Platform Refinement — Governance, Visibility & Scope-Bounding for the AI Video Pipeline | completed | 6 | 47/47 | _not extractable_ |
+| [`wizard-install-py-wiring`](wizard-install-py-wiring.md) | Wizard ↔ install.py wiring | archived-with-open-steps | 1 | 14/15 | _not extractable_ |

--- a/agents/roadmaps/archive/index.json
+++ b/agents/roadmaps/archive/index.json
@@ -1,0 +1,7021 @@
+{
+  "generated_by": "src/scripts/build_archive_index.ts",
+  "source": "agents/roadmaps/archive",
+  "count": 501,
+  "entries": [
+    {
+      "slug": "00-overview-and-ordering",
+      "title": "Phase 3 Overview and Ordering",
+      "disposition": "completed",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 5,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "00-overview",
+      "title": "Roadmap Overview — agent-config External Review",
+      "disposition": "not-extractable",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "00-phase4-overview",
+      "title": "Phase 4: Activation — Make the Infrastructure Usable",
+      "disposition": "archived-with-open-steps",
+      "phases": 0,
+      "steps": {
+        "open": 14,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "01-critical-blockers",
+      "title": "Roadmap 01 — Kritische Blocker (P0)",
+      "disposition": "not-extractable",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "01-e2e-integration-roadmap",
+      "title": "End-to-End Integration + Tool Adapter Roadmap",
+      "disposition": "not-extractable",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "01-runtime-layer-pr-series",
+      "title": "Runtime Layer — Concrete PR Series",
+      "disposition": "completed",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 5,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "01-runtime-layer-roadmap",
+      "title": "Runtime Layer Roadmap",
+      "disposition": "not-extractable",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "02-architecture-issues",
+      "title": "Roadmap 02 — Architektur-Probleme (P1)",
+      "disposition": "not-extractable",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "02-skill-activation-roadmap",
+      "title": "Skill Activation + Boundary Hygiene Roadmap",
+      "disposition": "not-extractable",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "02-tool-integration-pr-series",
+      "title": "Tool Integration — Concrete PR Series",
+      "disposition": "completed",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 5,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "02-tool-integration-roadmap",
+      "title": "Tool Integration Roadmap",
+      "disposition": "not-extractable",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "03-consumable-output-roadmap",
+      "title": "Consumable Output + Feedback Governance Roadmap",
+      "disposition": "not-extractable",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "03-installer-system",
+      "title": "Roadmap 03 — Installer-System (P1)",
+      "disposition": "not-extractable",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "03-observability-pr-series",
+      "title": "Observability — Concrete PR Series",
+      "disposition": "completed",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 5,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "03-observability-roadmap",
+      "title": "Observability Roadmap",
+      "disposition": "not-extractable",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "04-developer-judgment-roadmap",
+      "title": "Developer Judgment Activation Roadmap",
+      "disposition": "not-extractable",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "04-documentation-gaps",
+      "title": "Roadmap 04 — Dokumentationslücken (P2)",
+      "disposition": "not-extractable",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "04-feedback-loop-pr-series",
+      "title": "Feedback Loop — Concrete PR Series",
+      "disposition": "completed",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 4,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "04-feedback-loop-roadmap",
+      "title": "Feedback Loop Roadmap",
+      "disposition": "not-extractable",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "05-public-package-readiness",
+      "title": "Roadmap 05 — Bereitschaft für öffentliche Nutzung (P2)",
+      "disposition": "not-extractable",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "05-skill-lifecycle-pr-series",
+      "title": "Skill Lifecycle — Concrete PR Series",
+      "disposition": "completed",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 5,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "05-skill-lifecycle-roadmap",
+      "title": "Skill Lifecycle Roadmap",
+      "disposition": "not-extractable",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "06-strategic-positioning",
+      "title": "Roadmap 06 — Strategische Positionierung (P3)",
+      "disposition": "not-extractable",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "ai-video-pipeline",
+      "title": "Roadmap: AI Video Pipeline — Hollywood-level video generation via Claude",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 57,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "automated-pack-workspace-and-skill-discovery",
+      "title": "Roadmap: Automated Pack, Workspace & Skill Discovery",
+      "disposition": "completed",
+      "phases": 8,
+      "steps": {
+        "open": 0,
+        "done": 137,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "completed"
+    },
+    {
+      "slug": "compare-with-main",
+      "title": "Rules / Guardrails Review — `main` vs PR #3",
+      "disposition": "not-extractable",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "controlled-self-optimization",
+      "title": "Roadmap: Controlled Self-Optimization (Phase 2)",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 39,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "deferred-followups",
+      "title": "Deferred Follow-Ups",
+      "disposition": "archived-with-open-steps",
+      "phases": 1,
+      "steps": {
+        "open": 16,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "explainability-v2-explain-last",
+      "title": "Roadmap: Explainability v2 — `agent-config explain last`",
+      "disposition": "completed",
+      "phases": 10,
+      "steps": {
+        "open": 0,
+        "done": 74,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "completed"
+    },
+    {
+      "slug": "external-review-followup",
+      "title": "External Review Follow-Up",
+      "disposition": "not-extractable",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "fix-this-now-checklist",
+      "title": "fix-this-now-checklist",
+      "disposition": "completed",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 14,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "framework-neutrality-audit",
+      "title": "Roadmap: Framework Neutrality Audit — Remove PHP/Laravel Leakage from Generic Skills, Rules & Commands",
+      "disposition": "archived-with-open-steps",
+      "phases": 10,
+      "steps": {
+        "open": 219,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "implementation-sequence",
+      "title": "Implementation Sequence — TS-Foundation · Discovery · GUI · Explain · Visibility",
+      "disposition": "archived-with-open-steps",
+      "phases": 0,
+      "steps": {
+        "open": 50,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "draft"
+    },
+    {
+      "slug": "intent-based-orchestration",
+      "title": "Roadmap: Intent-based orchestration",
+      "disposition": "archived-with-open-steps",
+      "phases": 4,
+      "steps": {
+        "open": 49,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "linter-execution-governance",
+      "title": "Roadmap: Skill Linter — Execution Governance ✅",
+      "disposition": "archived-with-open-steps",
+      "phases": 5,
+      "steps": {
+        "open": 11,
+        "done": 55,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "monorepo-phase-1-frontmatter-metadata",
+      "title": "Monorepo Phase 1 — Frontmatter Metadata on All Artefacts",
+      "disposition": "closed-with-cancellations",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 33,
+        "deferred": 0,
+        "cancelled": 4
+      },
+      "verdict": null,
+      "status": "completed"
+    },
+    {
+      "slug": "monorepo-phase-2-virtual-packs-discovery",
+      "title": "Monorepo Phase 2 — Auto-Discovery Manifest from Frontmatter",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 35,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "monorepo-phase-3-typescript-installer",
+      "title": "Monorepo Phase 3 — TypeScript Installer (CLI + Lockfile + Agent Mode)",
+      "disposition": "closed-with-cancellations",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 39,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "monorepo-phase-4-physical-package-layout",
+      "title": "Monorepo Phase 4 — Physical Package Layout",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 30,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "monorepo-phase-5-trust-safety-layer",
+      "title": "Monorepo Phase 5 — Trust & Safety Layer",
+      "disposition": "completed-with-deferrals",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 24,
+        "deferred": 1,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "monorepo-phase-6-browser-wizard-gui",
+      "title": "Monorepo Phase 6 — Browser Wizard GUI (Optional)",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 35,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "multi-agent-compatibility",
+      "title": "Roadmap: Multi-Agent Compatibility Layer",
+      "disposition": "completed",
+      "phases": 9,
+      "steps": {
+        "open": 0,
+        "done": 142,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "naming-consistency",
+      "title": "Naming Consistency Roadmap",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 3,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "onboard-skill-wizard-convergence",
+      "title": "Roadmap: `/onboard` skill — wizard convergence",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 20,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "completed"
+    },
+    {
+      "slug": "onboarding-wizard-takeover",
+      "title": "Onboarding wizard takeover — retire `/onboard`, add `--dry-run`",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 21,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "open-questions-2",
+      "title": "Open Questions 2 — Autonomous-Pass Blockers",
+      "disposition": "not-extractable",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "open-questions-3",
+      "title": "Open Questions 3 — Council-Modes + Pre-Existing Budget Breach",
+      "disposition": "not-extractable",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "open-questions",
+      "title": "Open Questions — Roadmap Blockers",
+      "disposition": "not-extractable",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "phase-3-observability",
+      "title": "Phase 3 Roadmap — 9.2 → 9.8 — ✅ COMPLETE",
+      "disposition": "not-extractable",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "phase-3-pr-plan",
+      "title": "Phase 3 — PR Order and Implementation Plan",
+      "disposition": "not-extractable",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "phase3bc-feasibility",
+      "title": "Phase 3b/3c — feasibility audit (project-analysis-* + skill-*)",
+      "disposition": "not-extractable",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": "do_not_consolidate",
+      "status": "closed"
+    },
+    {
+      "slug": "phase6-2b-coupling",
+      "title": "Phase 6 → 2B coupling proof",
+      "disposition": "not-extractable",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "draft"
+    },
+    {
+      "slug": "phase6-dependency-scan",
+      "title": "Phase 6.0 — chat-history-* dependency surface scan",
+      "disposition": "not-extractable",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "closed"
+    },
+    {
+      "slug": "phase6-non-overlap-evidence",
+      "title": "Phase 6.1 — non-overlap evidence (chat-history-* rules)",
+      "disposition": "not-extractable",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": "keep_separate",
+      "status": "closed"
+    },
+    {
+      "slug": "phase6-trigger-matrix",
+      "title": "Phase 6.1 — chat-history-* trigger overlap matrix",
+      "disposition": "not-extractable",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": "stop_at_6_1",
+      "status": "closed"
+    },
+    {
+      "slug": "plugin-symlink-strategy",
+      "title": "Roadmap: Plugin Symlink Strategy — copy rules, symlink everything else",
+      "disposition": "closed-with-cancellations",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 66,
+        "deferred": 0,
+        "cancelled": 2
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "post-pr2-hardening",
+      "title": "Post-PR#2 Hardening Roadmap",
+      "disposition": "completed-with-deferrals",
+      "phases": 8,
+      "steps": {
+        "open": 0,
+        "done": 99,
+        "deferred": 2,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "pr-description-tiers",
+      "title": "Roadmap: Token-efficient, capability-aware PR descriptions",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 16,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "product-maturity",
+      "title": "Product Maturity Roadmap",
+      "disposition": "archived-with-open-steps",
+      "phases": 2,
+      "steps": {
+        "open": 3,
+        "done": 37,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "readme-and-docs-improvement",
+      "title": "README & Docs Improvement Roadmap",
+      "disposition": "archived-with-open-steps",
+      "phases": 9,
+      "steps": {
+        "open": 16,
+        "done": 48,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "remove-galawork-specifics",
+      "title": "Roadmap: Remove project-specific references from shared agent config",
+      "disposition": "completed",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 83,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-1-15-followups",
+      "title": "Road to 1.15 Followups",
+      "disposition": "completed",
+      "phases": 9,
+      "steps": {
+        "open": 0,
+        "done": 14,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-1-16-followups",
+      "title": "Road to 1.16.0 Follow-ups",
+      "disposition": "closed-with-cancellations",
+      "phases": 8,
+      "steps": {
+        "open": 0,
+        "done": 29,
+        "deferred": 0,
+        "cancelled": 5
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-10",
+      "title": "Road to 10/10",
+      "disposition": "completed-with-deferrals",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 21,
+        "deferred": 1,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-3-condition-value-benchmark",
+      "title": "Roadmap: 3-condition value benchmark — show the package + RDP lift in numbers",
+      "disposition": "archived-with-open-steps",
+      "phases": 6,
+      "steps": {
+        "open": 3,
+        "done": 20,
+        "deferred": 3,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "superseded"
+    },
+    {
+      "slug": "road-to-6.0.0-a-positioning-and-validation",
+      "title": "Road to 6.0.0-A — Positioning, Validation, and the Execution-Model decision",
+      "disposition": "completed",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 13,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-6.0.0-b-pack-scoped-projection",
+      "title": "Road to 6.0.0-B — Pack-scoped projection (the breaking change)",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 20,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-6.0.0-c-governance-and-evals",
+      "title": "Road to 6.0.0-C — Governance, evals, and evidence-based pruning",
+      "disposition": "closed-with-cancellations",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 20,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-6.0.0-d-structural-restructure",
+      "title": "Road to 6.0.0-D — Structural restructure (the hard break)",
+      "disposition": "completed",
+      "phases": 9,
+      "steps": {
+        "open": 0,
+        "done": 37,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "active"
+    },
+    {
+      "slug": "road-to-6.0.0-e-documentation-refactor",
+      "title": "Road to 6.0.0-E — Documentation refactor (all docs English)",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 12,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "active"
+    },
+    {
+      "slug": "road-to-6.0.0-final-readiness",
+      "title": "Road to 6.0.0 final-readiness & product coherence",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 17,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-6.0.x-workspace-structural-cleanup",
+      "title": "Road to 6.0.x — Workspace structural cleanup (the deferred Step-16 remainder)",
+      "disposition": "completed",
+      "phases": 2,
+      "steps": {
+        "open": 0,
+        "done": 11,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "active"
+    },
+    {
+      "slug": "road-to-6.1.0-product-consolidation",
+      "title": "Road to 6.1.0 — Product consolidation (behavioral cuts after the structural break)",
+      "disposition": "closed-with-cancellations",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 16,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "active"
+    },
+    {
+      "slug": "road-to-6.2.0-consolidation-evidence-gates",
+      "title": "Road to 6.2.0 — Consolidation evidence-gates (the council-deferred remainder)",
+      "disposition": "closed-with-cancellations",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 5,
+        "deferred": 2,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-9",
+      "title": "Roadmap: Road to 9/10 — Proof of Power",
+      "disposition": "archived-with-open-steps",
+      "phases": 6,
+      "steps": {
+        "open": 11,
+        "done": 33,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-abstraction-budget-discovery",
+      "title": "Roadmap: Abstraction-budget discovery — measure before you cut",
+      "disposition": "completed",
+      "phases": 2,
+      "steps": {
+        "open": 0,
+        "done": 8,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-abstraction-reduction",
+      "title": "Roadmap: Abstraction reduction — factor frontmatter boilerplate into contract defaults",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 22,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-ac-embeddable-gui",
+      "title": "Road to an embeddable AC GUI — host-ready without weakening a single security invariant",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 30,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-activation-evidence-or-refusal",
+      "title": "Road to activation evidence — produce the red baseline or refuse the resolver permanently",
+      "disposition": "closed-with-cancellations",
+      "phases": 2,
+      "steps": {
+        "open": 0,
+        "done": 6,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-additive-settings-sync",
+      "title": "Roadmap: Additive Settings Sync",
+      "disposition": "completed",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 35,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-adoption-proof-and-ci-green",
+      "title": "Adoption Proof + CI Green — convert the three deferred 3.2.0 actions into shipped reality",
+      "disposition": "closed-with-cancellations",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 22,
+        "deferred": 4,
+        "cancelled": 7
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-adversarial-council-benchmark",
+      "title": "Road to resolving the adversarial-council finding-coverage claim (benchmark arm)",
+      "disposition": "completed",
+      "phases": 2,
+      "steps": {
+        "open": 0,
+        "done": 8,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-adversarial-verification-council",
+      "title": "Road to an adversarial verification council — a cross-model skeptic panel that maximizes defect-finding coverage on a real change",
+      "disposition": "closed-with-cancellations",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 25,
+        "deferred": 0,
+        "cancelled": 2
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-agent-behavior-conformance",
+      "title": "Road to agent-behaviour conformance — 30 sessions audited, ~130 rule violations, every rule already in context",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 30,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-agent-command-consolidation",
+      "title": "Road to Agent-Command Consolidation",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 24,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-agent-handoff-resume",
+      "title": "Roadmap: Agent-handoff v2 — session picker, generated handoff, auto-seeded fresh session",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 35,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-agent-memory-integration",
+      "title": "Roadmap: agent-memory integration (agent-config side)",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 20,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-agent-memory-removal",
+      "title": "Road to agent-memory removal",
+      "disposition": "archived-with-open-steps",
+      "phases": 6,
+      "steps": {
+        "open": 2,
+        "done": 26,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-agent-outcomes",
+      "title": "Roadmap: Engineering OS for Agents — the master frame",
+      "disposition": "completed",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 5,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-agentic-headroom-benchmark",
+      "title": "Roadmap: agentic-headroom benchmark (v4) — long-horizon, does governance finally show?",
+      "disposition": "closed-with-cancellations",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 4,
+        "deferred": 0,
+        "cancelled": 3
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-agents-dir-and-gitignore-hygiene",
+      "title": "Road to agents/-dir and gitignore hygiene",
+      "disposition": "closed-with-cancellations",
+      "phases": 9,
+      "steps": {
+        "open": 0,
+        "done": 36,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-ai-council",
+      "title": "Road to AI Council",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 38,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-ai-employee-borrowings",
+      "title": "Road to AI-employee borrowings — measure first, harden the kernel, gate the builds",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 12,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-ai-os-product-ui",
+      "title": "Roadmap: AI OS Product UI — beyond the installer shell",
+      "disposition": "closed-with-cancellations",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 32,
+        "deferred": 0,
+        "cancelled": 5
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-always-budget-relief",
+      "title": "Road to Always-Budget Relief",
+      "disposition": "closed-with-cancellations",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 10,
+        "deferred": 0,
+        "cancelled": 4
+      },
+      "verdict": null,
+      "status": "in_progress"
+    },
+    {
+      "slug": "road-to-always-loaded-corpus-scoping",
+      "title": "Roadmap: Scope the always-loaded rule corpus",
+      "disposition": "closed-with-cancellations",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 13,
+        "deferred": 0,
+        "cancelled": 6
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-analysis-workbench",
+      "title": "Roadmap: Analysis Workbench — RCA / post-mortem / premortem as an integrated learning loop (not a skill dump)",
+      "disposition": "closed-with-cancellations",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 28,
+        "deferred": 0,
+        "cancelled": 5
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-anti-slop-detector",
+      "title": "Road to an Anti-Slop Detector (deterministic aesthetic-tell layer)",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 16,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-api-cost-optimization",
+      "title": "Road to API-cost optimization — cut the dollar bill of paid LLM calls",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 18,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-artifact-completeness-rubrics",
+      "title": "Road to artifact-completeness scoring rubrics",
+      "disposition": "closed-with-cancellations",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 13,
+        "deferred": 0,
+        "cancelled": 4
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-artifact-engagement-telemetry",
+      "title": "Roadmap: Artifact Engagement Telemetry",
+      "disposition": "completed-with-deferrals",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 38,
+        "deferred": 2,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-augment-limit-fit",
+      "title": "Road to Augment Workspace-Guidelines Limit Fit",
+      "disposition": "closed-with-cancellations",
+      "phases": 8,
+      "steps": {
+        "open": 0,
+        "done": 47,
+        "deferred": 0,
+        "cancelled": 6
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-august-program",
+      "title": "Road to the August program — the four 2026-08-12 roadmaps, re-planned as one sequence",
+      "disposition": "not-extractable",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-auto-subagent-orchestration-followup",
+      "title": "Roadmap: Follow-up to automatic subagent orchestration — benchmark & default-flip",
+      "disposition": "closed-with-cancellations",
+      "phases": 1,
+      "steps": {
+        "open": 0,
+        "done": 6,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-auto-subagent-orchestration-v2",
+      "title": "Road to auto-subagent-orchestration v2 — make it real: trigger, bundle, synthesis",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 15,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-auto-subagent-orchestration",
+      "title": "Road to automatic subagent orchestration — delegate by default, gated by evidence",
+      "disposition": "completed-with-deferrals",
+      "phases": 8,
+      "steps": {
+        "open": 0,
+        "done": 33,
+        "deferred": 2,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-autonomous-agent",
+      "title": "Roadmap: Road to Autonomous Agent",
+      "disposition": "closed-with-cancellations",
+      "phases": 10,
+      "steps": {
+        "open": 0,
+        "done": 82,
+        "deferred": 0,
+        "cancelled": 50
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-autonomous-roadmap-execution",
+      "title": "Roadmap: Autonomous roadmap execution",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 16,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-autonomous-verify-loop",
+      "title": "Roadmap: Autonomous verify→repair loop (GAN-adapted, council-gated)",
+      "disposition": "closed-with-cancellations",
+      "phases": 2,
+      "steps": {
+        "open": 0,
+        "done": 9,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-batch-b-stub-consistency",
+      "title": "Road to Batch B Stub Consistency",
+      "disposition": "completed",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 7,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-bench-headtohead-metrics",
+      "title": "Roadmap: Bench head-to-head + pass^k/pass@k reliability metrics",
+      "disposition": "completed",
+      "phases": 1,
+      "steps": {
+        "open": 0,
+        "done": 2,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-better-skills-and-profiles",
+      "title": "Road to Better Skills (Thinking Layer)",
+      "disposition": "completed-with-deferrals",
+      "phases": 1,
+      "steps": {
+        "open": 0,
+        "done": 34,
+        "deferred": 1,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-blocker-visibility",
+      "title": "Road to Blocker Visibility",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 23,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-cache-economy",
+      "title": "Road to cache economy — pay read rates, not write rates",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 35,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-capability-answerability",
+      "title": "Road to capability answerability — twelve places the agent must guess whether a capability exists",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 19,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-capability-discoverability",
+      "title": "Roadmap: Capability discoverability — disposition of \"fable-feedback-3\"",
+      "disposition": "closed-with-cancellations",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 9,
+        "deferred": 0,
+        "cancelled": 8
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-capability-governance",
+      "title": "Road to capability governance — boundary matrix, risk-class, growth gate",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 17,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-capability-headroom-benchmark",
+      "title": "Roadmap: capability-headroom benchmark (v3) — GAIA-honest, can it finally show a lift?",
+      "disposition": "closed-with-cancellations",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 4,
+        "deferred": 0,
+        "cancelled": 3
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-changelog-era-auto-split",
+      "title": "Roadmap: CHANGELOG era auto-split — turn release-blocker into release-script affordance",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 21,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-changelog-unreleased-drain",
+      "title": "Road to CHANGELOG [Unreleased] drain — clean the stale 6.0.0 fossil + guard it",
+      "disposition": "completed",
+      "phases": 2,
+      "steps": {
+        "open": 0,
+        "done": 7,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-character-image-fidelity",
+      "title": "Road to Character-Image Fidelity",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 27,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "active"
+    },
+    {
+      "slug": "road-to-chat-history-cross-agent-hardening",
+      "title": "Road to chat-history cross-agent hardening",
+      "disposition": "closed-with-cancellations",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 28,
+        "deferred": 1,
+        "cancelled": 8
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-chat-history-hook-only",
+      "title": "Road to Chat-History Hook-Only",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 27,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-chat-history-session-isolation",
+      "title": "Roadmap: Per-Session Isolation in Chat-History",
+      "disposition": "completed",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 38,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-chat-history-sidecar-shrink",
+      "title": "Roadmap: Chat-History Sidecar Shrink",
+      "disposition": "archived-with-open-steps",
+      "phases": 6,
+      "steps": {
+        "open": 1,
+        "done": 30,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-ci-native-release",
+      "title": "Roadmap: CI-native release path alongside `task release`",
+      "disposition": "closed-with-cancellations",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 27,
+        "deferred": 4,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-claude-code-global-distribution",
+      "title": "Roadmap: Claude Code Global Distribution — close the four-defect chain",
+      "disposition": "closed-with-cancellations",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 34,
+        "deferred": 0,
+        "cancelled": 3
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-claude-code-single-surface",
+      "title": "Roadmap: Claude Code single distribution surface — retire the dual npx/marketplace overlap",
+      "disposition": "closed-with-cancellations",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 21,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-claude-skills-untrack",
+      "title": "Roadmap: Untrack `.claude/skills/` (follow-up to projection cleanup)",
+      "disposition": "closed-with-cancellations",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 12,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-clean-skill-distribution-channels",
+      "title": "Clean Skill Distribution Channels — eliminate dual-registration across Claude, Augment, and cross-scope installs",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 30,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-cloudflare-mcp-hosting",
+      "title": "Road to Cloudflare-hosted MCP",
+      "disposition": "closed-with-cancellations",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 23,
+        "deferred": 2,
+        "cancelled": 3
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-command-structure-optimization",
+      "title": "Road to Command Structure Optimization",
+      "disposition": "closed-with-cancellations",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 24,
+        "deferred": 0,
+        "cancelled": 4
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-command-surface-refactor-residuals",
+      "title": "Roadmap: Command-Surface Refactor — Residuals",
+      "disposition": "closed-with-cancellations",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 10,
+        "deferred": 0,
+        "cancelled": 3
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-competitive-borrow",
+      "title": "Roadmap: Competitive Borrow",
+      "disposition": "closed-with-cancellations",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 23,
+        "deferred": 4,
+        "cancelled": 8
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-completion-loop",
+      "title": "Road to the completion loop — measure \"delivered less than was asked\" before refusing on it",
+      "disposition": "closed-with-cancellations",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 5,
+        "deferred": 0,
+        "cancelled": 3
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-composition-ratchet",
+      "title": "Road to composition ratchet — stop the falsifiability dilution without resurrecting the skill-DAG",
+      "disposition": "completed",
+      "phases": 2,
+      "steps": {
+        "open": 0,
+        "done": 7,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-configurable-modules",
+      "title": "Road to configurable modules — project-driven module paths and per-module agent folders",
+      "disposition": "closed-with-cancellations",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 40,
+        "deferred": 0,
+        "cancelled": 2
+      },
+      "verdict": null,
+      "status": "done"
+    },
+    {
+      "slug": "road-to-conformance-round5",
+      "title": "Road to conformance round 5 — the first post-fix measurement, and what it says about mechanism class",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 31,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-conformance-round6",
+      "title": "Road to conformance round 6 — the guard regress I shipped, the unmeasured half, and the therapy that has not started",
+      "disposition": "closed-with-cancellations",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 33,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "archived"
+    },
+    {
+      "slug": "road-to-conformance-round7",
+      "title": "Road to conformance round 7 — the rules held, the tooling did not",
+      "disposition": "closed-with-cancellations",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 31,
+        "deferred": 0,
+        "cancelled": 4
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-consistent-rule-scoping",
+      "title": "Road to consistent rule scoping — the CLI global install ships rules the wizard filters out",
+      "disposition": "completed",
+      "phases": 2,
+      "steps": {
+        "open": 0,
+        "done": 5,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-context-aware-command-suggestion",
+      "title": "Roadmap: Context-Aware Command Suggestion",
+      "disposition": "completed",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 52,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-context-layer-maturity",
+      "title": "Road to Context Layer Maturity",
+      "disposition": "closed-with-cancellations",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 27,
+        "deferred": 0,
+        "cancelled": 4
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-corpus-expansion-evidence-based-cuts",
+      "title": "Roadmap: Corpus expansion → evidence-based tier-1 cuts",
+      "disposition": "archived-with-open-steps",
+      "phases": 7,
+      "steps": {
+        "open": 5,
+        "done": 27,
+        "deferred": 0,
+        "cancelled": 5
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-cost-aware-model-routing",
+      "title": "Road to Cost-Aware Model Routing",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 24,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-cost-parity-0-program",
+      "title": "Road to cost parity — 0: the median session gets a measured target and the family gets its order",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 25,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-cost-parity-3-handoff-envelope",
+      "title": "Road to cost parity — 3: the handoff envelope carries what the successor actually needs",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 30,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-cost-profile-untangle",
+      "title": "Roadmap: Untangle `cost_profile`",
+      "disposition": "closed-with-cancellations",
+      "phases": 8,
+      "steps": {
+        "open": 0,
+        "done": 41,
+        "deferred": 0,
+        "cancelled": 4
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-council-modes",
+      "title": "Road to Council Modes",
+      "disposition": "closed-with-cancellations",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 14,
+        "deferred": 0,
+        "cancelled": 10
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-council-solo-floor-implementation",
+      "title": "Road to the gate-scoped solo-attendance floor",
+      "disposition": "closed-with-cancellations",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 15,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-cross-corpus-verification",
+      "title": "Roadmap: A cross-corpus proposal is measured before it is adopted",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 19,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-cross-repo-differential-loop",
+      "title": "Road to the cross-repo differential loop — the reference-analysis command stops contradicting its own doctrine",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 31,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-cross-source-consistency",
+      "title": "Roadmap: Cross-source consistency — detect discrepancies, ask before guessing",
+      "disposition": "closed-with-cancellations",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 30,
+        "deferred": 0,
+        "cancelled": 2
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-curated-self-improvement",
+      "title": "Roadmap: Curated Self-Improvement — closed-loop learning with a human gate",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 16,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-dead-surface-removal",
+      "title": "Road to dead-surface removal — apply the package's own null rule to the package's own code",
+      "disposition": "completed",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 8,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-decision-revisit-discipline",
+      "title": "Road to decision-revisit discipline",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 18,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-deep-root-restructure",
+      "title": "Deep Root Restructure — sink maintainer + projection dirs out of the root",
+      "disposition": "closed-with-cancellations",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 15,
+        "deferred": 0,
+        "cancelled": 2
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-defensive-agent",
+      "title": "Roadmap: Defensive Agent — Senior-Engineer Security & Analysis",
+      "disposition": "closed-with-cancellations",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 33,
+        "deferred": 0,
+        "cancelled": 18
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-demand-gate-audience",
+      "title": "Road to Demand-Gate Audience",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 18,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-design-artifact-fidelity",
+      "title": "Road to design artifact fidelity — make visual work production-grade before it reaches the user",
+      "disposition": "completed",
+      "phases": 8,
+      "steps": {
+        "open": 0,
+        "done": 39,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-design-canon-grounding",
+      "title": "Road to Design-Canon Grounding",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 10,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-design-craft-antislop",
+      "title": "Road to design-craft / anti-slop enforcement",
+      "disposition": "closed-with-cancellations",
+      "phases": 8,
+      "steps": {
+        "open": 0,
+        "done": 30,
+        "deferred": 0,
+        "cancelled": 4
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-design-detector-evidence",
+      "title": "Road to design-detector evidence — make the traceability claim checkable and publish the number the expansion was deferred on",
+      "disposition": "completed",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 12,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-design-exploration-skills",
+      "title": "Road to design exploration skills",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 28,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-design-mechanism-harvest",
+      "title": "Road to design-mechanism harvest",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 18,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-design-system-extraction-contract",
+      "title": "Road to a Design-System Extraction Contract",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 8,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-design-system-onramp",
+      "title": "Road to the design-system onramp — consume the crawler ecosystem, one optional command",
+      "disposition": "closed-with-cancellations",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 11,
+        "deferred": 0,
+        "cancelled": 2
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-discipline-axis-benchmark",
+      "title": "Roadmap: discipline-axis benchmark (v2) — measure the lift, not the capability",
+      "disposition": "completed",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 24,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-discipline-axis-meso-pilot",
+      "title": "Roadmap: discipline-axis benchmark — complexity-stratified pilot (meso/multi + weak host)",
+      "disposition": "closed-with-cancellations",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 14,
+        "deferred": 0,
+        "cancelled": 3
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-discipline-lift-significance",
+      "title": "Roadmap: discipline-lift to significance (clean harness)",
+      "disposition": "completed",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 5,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-discipline-profile-tiering",
+      "title": "Road to discipline-profile tiering — the ~3x lift as the default shape, host-gated",
+      "disposition": "completed-with-deferrals",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 16,
+        "deferred": 2,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-distribution-and-adoption",
+      "title": "Road to Distribution and Adoption",
+      "disposition": "closed-with-cancellations",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 5,
+        "deferred": 7,
+        "cancelled": 2
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-distribution-identity",
+      "title": "Roadmap: Distribution identity — make npm-primary explicit, retire the stale registry",
+      "disposition": "completed",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 11,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-distribution-maturity",
+      "title": "Road to distribution maturity (post-2.2.2 evaluation follow-ups)",
+      "disposition": "completed",
+      "phases": 12,
+      "steps": {
+        "open": 0,
+        "done": 49,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-doc-follows-code",
+      "title": "Road to doc-follows-code — a deterministic, framework-agnostic doc-impact discipline",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 27,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-doc-screenshot-anonymization",
+      "title": "Road to Doc-Screenshot Anonymization",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 15,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-doctor-global-only-readiness",
+      "title": "Road to `doctor` Global-Only Readiness",
+      "disposition": "completed",
+      "phases": 1,
+      "steps": {
+        "open": 0,
+        "done": 4,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-domain-soundness",
+      "title": "Road to domain soundness — prove or honestly scope the non-forged, non-coding domains",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 15,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-drafting-protocol",
+      "title": "Roadmap: Drafting Protocol",
+      "disposition": "completed",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 3,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-ecosystem-harvest-bug-security-rigor",
+      "title": "Roadmap: Ecosystem-Harvest — Bug & Security Rigor",
+      "disposition": "completed",
+      "phases": 2,
+      "steps": {
+        "open": 0,
+        "done": 11,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-ecosystem-harvest-document-skills",
+      "title": "Roadmap: Ecosystem-Harvest — Document-Generation Skills",
+      "disposition": "closed-with-cancellations",
+      "phases": 2,
+      "steps": {
+        "open": 0,
+        "done": 10,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-ecosystem-harvest-domain-watch",
+      "title": "Roadmap: Ecosystem-Harvest — Domain Watch (gated verticals)",
+      "disposition": "closed-with-cancellations",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 6,
+        "deferred": 0,
+        "cancelled": 2
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-ecosystem-harvest-ergonomics",
+      "title": "Roadmap: Ecosystem-Harvest — Ergonomics",
+      "disposition": "completed",
+      "phases": 1,
+      "steps": {
+        "open": 0,
+        "done": 9,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-ecosystem-harvest-index",
+      "title": "Roadmap: Ecosystem-Harvest Index",
+      "disposition": "completed",
+      "phases": 1,
+      "steps": {
+        "open": 0,
+        "done": 11,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-ecosystem-harvest-prelaunch-diagnostics",
+      "title": "Roadmap: Ecosystem-Harvest — Pre-Launch Diagnostics",
+      "disposition": "completed",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 13,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-ecosystem-harvest-product-gate",
+      "title": "Roadmap: Ecosystem-Harvest — Pre-Build Product-Demand Gate",
+      "disposition": "completed",
+      "phases": 1,
+      "steps": {
+        "open": 0,
+        "done": 6,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-ecosystem-harvest-prose-authenticity",
+      "title": "Roadmap: Ecosystem-Harvest — Prose Authenticity",
+      "disposition": "closed-with-cancellations",
+      "phases": 1,
+      "steps": {
+        "open": 0,
+        "done": 10,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "completed"
+    },
+    {
+      "slug": "road-to-ecosystem-harvest-reliability-measurement",
+      "title": "Roadmap: Ecosystem-Harvest — Reliability & Measurement",
+      "disposition": "closed-with-cancellations",
+      "phases": 1,
+      "steps": {
+        "open": 0,
+        "done": 11,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-ecosystem-harvest-review-mechanics",
+      "title": "Roadmap: Ecosystem-Harvest — Review Mechanics",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 18,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-ecosystem-harvest-second-sweep",
+      "title": "Roadmap: Ecosystem-Harvest — Second Sweep (full-coverage disposition)",
+      "disposition": "completed",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 11,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-ecosystem-harvest-skill-authoring-rigor",
+      "title": "Roadmap: Ecosystem-Harvest — Skill-Authoring Rigor",
+      "disposition": "completed",
+      "phases": 1,
+      "steps": {
+        "open": 0,
+        "done": 10,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-ecosystem-harvest-skill-quality-gates",
+      "title": "Roadmap: Ecosystem-Harvest — Skill Quality Gates",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 19,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-ecosystem-harvest-tool-pitfalls",
+      "title": "Roadmap: Ecosystem-Harvest — Tool Known-Pitfalls",
+      "disposition": "completed",
+      "phases": 1,
+      "steps": {
+        "open": 0,
+        "done": 7,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-ecosystem-harvest-workflow-contracts",
+      "title": "Roadmap: Ecosystem-Harvest — Workflow Contracts",
+      "disposition": "completed",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 18,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-employee-product-and-external-proof",
+      "title": "Roadmap: Employee Product + External Proof — close the two adoption gaps",
+      "disposition": "completed-with-deferrals",
+      "phases": 10,
+      "steps": {
+        "open": 0,
+        "done": 72,
+        "deferred": 5,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "active"
+    },
+    {
+      "slug": "road-to-enforcement-peer-disposition",
+      "title": "Road to enforcement-peer disposition — wire the fail-open gates, record what 9.8.0 already answered",
+      "disposition": "completed",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 7,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-enforcement-proof",
+      "title": "Road to Enforcement Proof — say only what the machine actually enforces",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 27,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "active"
+    },
+    {
+      "slug": "road-to-engineering-memory",
+      "title": "Roadmap: Engineering Memory — project-specific facts as first-class input",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 15,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-eval-loop-runnability",
+      "title": "Roadmap: Eval-loop runnability — one dead root the sweep cannot see",
+      "disposition": "archived-with-open-steps",
+      "phases": 2,
+      "steps": {
+        "open": 1,
+        "done": 9,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-event4u-namespace-and-claude-desktop",
+      "title": "Road to `~/.event4u/agent-config/` namespace + real Claude Desktop deployment",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 40,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-evidence-v2-accumulation-layer",
+      "title": "Roadmap: Evidence v2 — Accumulation Layer (deferred from project-intelligence)",
+      "disposition": "closed-with-cancellations",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 2,
+        "deferred": 0,
+        "cancelled": 4
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-evidence-v2-project-intelligence",
+      "title": "Roadmap: Evidence v2 — Self-Building Project Intelligence",
+      "disposition": "closed-with-cancellations",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 25,
+        "deferred": 0,
+        "cancelled": 2
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-executable-evidence",
+      "title": "Roadmap: Executable evidence — a claim that re-derives itself",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 23,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-execution-discipline-harvest",
+      "title": "Road to execution-discipline harvest",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 21,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-fable-feedback-5",
+      "title": "Road to Fable-Feedback 5 — post-8.10.0 hardening + code-comment discipline",
+      "disposition": "completed",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 44,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-fan-out-guard-correctness",
+      "title": "Road to fan-out guard correctness — the block that ate the delegation",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 11,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-fast-test-layer",
+      "title": "Road to a Fast Test Layer (in-process CLI rigs)",
+      "disposition": "closed-with-cancellations",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 15,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-feedback-24-26-cleanup",
+      "title": "Road to Feedback 24–26 Cleanup — the genuinely-new, non-blocked items",
+      "disposition": "archived-with-open-steps",
+      "phases": 4,
+      "steps": {
+        "open": 5,
+        "done": 6,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-feedback-8.11-2",
+      "title": "Road to feedback 8.11 round 2+3 — shrink, pre-register, prepare",
+      "disposition": "completed",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 26,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-feedback-8.11-4",
+      "title": "Road to feedback 8.11 round 4 — ship the smallest real /team",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 8,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-feedback-8.11-5",
+      "title": "Road to feedback 8.11 round 5 — the fallback and the gate",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 11,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-feedback-8.11",
+      "title": "Road to feedback 8.11 — prove, simplify, operate",
+      "disposition": "completed",
+      "phases": 8,
+      "steps": {
+        "open": 0,
+        "done": 34,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-feedback-9-29",
+      "title": "Road to feedback 9.29 — close the verified residue of the external release reviews",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 19,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-feedback-9-35",
+      "title": "Road to feedback 9.35 — the verified residue of five external release reviews",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 13,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-feedback-9.0-followups",
+      "title": "Roadmap: Feedback 9.0.0 Follow-ups",
+      "disposition": "completed",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 10,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-feedback-9.2.0-followups",
+      "title": "Roadmap: Feedback 9.2.0 Follow-ups",
+      "disposition": "closed-with-cancellations",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 10,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "completed"
+    },
+    {
+      "slug": "road-to-feedback-9.8.0-followups",
+      "title": "Roadmap: Feedback 9.8.0 Follow-ups — stabilize, prove, dispose, decide",
+      "disposition": "closed-with-cancellations",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 21,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "completed"
+    },
+    {
+      "slug": "road-to-feedback-consolidation",
+      "title": "Road to Feedback Consolidation",
+      "disposition": "closed-with-cancellations",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 43,
+        "deferred": 0,
+        "cancelled": 4
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-feedback-followups",
+      "title": "Road to Feedback Followups",
+      "disposition": "completed-with-deferrals",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 11,
+        "deferred": 2,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-final-state-and-market-readiness",
+      "title": "Roadmap: Final state + market readiness",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 37,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-flow-learnings",
+      "title": "Road to flow learnings — adopt the real fifth of an external orchestration suite, reject the theater",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 19,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-frictionless-employee-workspace",
+      "title": "Frictionless Employee Workspace — close the 3.1.1 → 3.3.0 feedback gaps without lifting Hard-Floor",
+      "disposition": "closed-with-cancellations",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 30,
+        "deferred": 1,
+        "cancelled": 2
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-frontend-design-intelligence",
+      "title": "Road to Frontend Design Intelligence — absorb an external design suite into our orchestrated UI suite",
+      "disposition": "closed-with-cancellations",
+      "phases": 10,
+      "steps": {
+        "open": 0,
+        "done": 48,
+        "deferred": 1,
+        "cancelled": 4
+      },
+      "verdict": null,
+      "status": "active"
+    },
+    {
+      "slug": "road-to-frontier-grade-reasoning",
+      "title": "Roadmap: Reasoning Discipline Protocol — make every host model think like a pro",
+      "disposition": "completed-with-deferrals",
+      "phases": 9,
+      "steps": {
+        "open": 0,
+        "done": 24,
+        "deferred": 7,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-frontier-quality-operating-system",
+      "title": "Road to frontier-quality operating system — turn external prompt mechanics into governed package leverage",
+      "disposition": "completed",
+      "phases": 9,
+      "steps": {
+        "open": 0,
+        "done": 49,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-frontmatter-schema",
+      "title": "Roadmap: frontmatter JSON-Schema validation",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 25,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-gate-hardening-adoption",
+      "title": "Road to gate-hardening adoption — take the unhardened-gate count to zero",
+      "disposition": "closed-with-cancellations",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 12,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-gated-reach",
+      "title": "Roadmap: Road to gated reach — read the resources the host cannot fetch",
+      "disposition": "closed-with-cancellations",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 36,
+        "deferred": 4,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-gates-that-can-fail",
+      "title": "Road to gates that can fail — make every check prove it read something",
+      "disposition": "closed-with-cancellations",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 27,
+        "deferred": 0,
+        "cancelled": 3
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-glama-registry-listing",
+      "title": "Road to a Glama registry listing — the one genuinely-useful Glama move, and nothing more",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 11,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-global-first-install",
+      "title": "Road to Global-First Install",
+      "disposition": "closed-with-cancellations",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 24,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-global-only-install",
+      "title": "Road to Global-Only Install — ARCHIVED",
+      "disposition": "closed-with-cancellations",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 40,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "completed"
+    },
+    {
+      "slug": "road-to-global-user-memory",
+      "title": "Road to a global user-memory layer — the agent remembers the user, not just the repo",
+      "disposition": "closed-with-cancellations",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 46,
+        "deferred": 0,
+        "cancelled": 2
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-golden-set-coverage",
+      "title": "Road to golden-set coverage — make every flip verdict mean something",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 18,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-golden-transcript-ts-replatform",
+      "title": "Golden-Transcript replay subsystem — full TS + vitest re-platform",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 14,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-governance-cleanup",
+      "title": "Road to Governance Cleanup",
+      "disposition": "completed",
+      "phases": 1,
+      "steps": {
+        "open": 0,
+        "done": 24,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-governance-invariants",
+      "title": "Road to governance invariants — prove the governance layer does not degrade under indirection",
+      "disposition": "closed-with-cancellations",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 15,
+        "deferred": 0,
+        "cancelled": 4
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-governance-moat",
+      "title": "Road to the governance moat — exploit the advantage we already have, don't build measurement theater",
+      "disposition": "closed-with-cancellations",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 6,
+        "deferred": 0,
+        "cancelled": 2
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-greenfield-scaffold",
+      "title": "Roadmap: greenfield scaffold + render-verified review (the Lovable lever)",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 21,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-gtm-and-growth",
+      "title": "Road to GTM and Growth (Wing 3)",
+      "disposition": "completed",
+      "phases": 1,
+      "steps": {
+        "open": 0,
+        "done": 26,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-harvest-orchestration",
+      "title": "Roadmap: Competitive-harvest orchestration — execution order for the harvest set",
+      "disposition": "completed-with-deferrals",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 16,
+        "deferred": 1,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-harvest-small-enhancements",
+      "title": "Roadmap: Competitive-harvest small enhancements + file-first pattern library",
+      "disposition": "closed-with-cancellations",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 15,
+        "deferred": 0,
+        "cancelled": 2
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-honesty-bench",
+      "title": "Road to honesty bench — measure the shipped honesty kernel, park the rest",
+      "disposition": "completed",
+      "phases": 2,
+      "steps": {
+        "open": 0,
+        "done": 7,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-hook-latency-repair",
+      "title": "Road to hook latency repair — pay for the bundle, not the CLI",
+      "disposition": "completed",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 9,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-hooks-actually-fire-in-consumers",
+      "title": "Roadmap: Hooks actually fire in consumer projects — close the marketplace-install gap",
+      "disposition": "closed-with-cancellations",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 33,
+        "deferred": 0,
+        "cancelled": 7
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-humanized-writing",
+      "title": "Road to humanized writing — pattern-audited drafts across the write engine",
+      "disposition": "closed-with-cancellations",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 35,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-humanizer-hardening",
+      "title": "Road to humanizer hardening — close the follow-up findings",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 24,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-image-brand-followups",
+      "title": "Roadmap: image/brand follow-ons (live validation, commands, retarget)",
+      "disposition": "closed-with-cancellations",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 9,
+        "deferred": 0,
+        "cancelled": 6
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-image-brand-typography",
+      "title": "Roadmap: image generation, brand, and typography/iconography",
+      "disposition": "completed-with-deferrals",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 40,
+        "deferred": 8,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-implement-ticket",
+      "title": "Road to Implement-Ticket — from governed agent to delivery engine",
+      "disposition": "closed-with-cancellations",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 33,
+        "deferred": 0,
+        "cancelled": 2
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-inbox-harvest-2026-08-b-authoring-contract",
+      "title": "Road to an enforced authoring contract",
+      "disposition": "closed-with-cancellations",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 16,
+        "deferred": 0,
+        "cancelled": 9
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-inbox-harvest-2026-08-b-council-integrity-followup",
+      "title": "Roadmap: Follow-up to council-pass integrity",
+      "disposition": "closed-with-cancellations",
+      "phases": 1,
+      "steps": {
+        "open": 0,
+        "done": 6,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-inbox-harvest-2026-08-b-council-integrity",
+      "title": "Road to council-pass integrity",
+      "disposition": "closed-with-cancellations",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 8,
+        "deferred": 1,
+        "cancelled": 7
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-inbox-harvest-2026-08-b-estate-lifecycle",
+      "title": "Road to estate lifecycle reporting",
+      "disposition": "closed-with-cancellations",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 9,
+        "deferred": 0,
+        "cancelled": 6
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-inbox-harvest-2026-08-b-install-lifecycle",
+      "title": "Road to install lifecycle — every write recorded, org packs decided",
+      "disposition": "closed-with-cancellations",
+      "phases": 2,
+      "steps": {
+        "open": 0,
+        "done": 6,
+        "deferred": 0,
+        "cancelled": 7
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-inbox-harvest-2026-08-b-release-integrity",
+      "title": "Road to release-surface integrity",
+      "disposition": "closed-with-cancellations",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 12,
+        "deferred": 0,
+        "cancelled": 13
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-inbox-harvest-2026-08-b",
+      "title": "Road to inbox harvest 2026-08-b",
+      "disposition": "closed-with-cancellations",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 3,
+        "deferred": 0,
+        "cancelled": 3
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-inbox-harvest-2026-08-c-release-head-truth",
+      "title": "Road to a release head that can be contradicted",
+      "disposition": "closed-with-cancellations",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 10,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-inbox-harvest-2026-08-c-workspace-identity",
+      "title": "Road to one answer for \"where am I\"",
+      "disposition": "closed-with-cancellations",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 11,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-inbox-harvest-2026-08-d-archive-index",
+      "title": "Road to an archive index, so sweeps stop paying for history",
+      "disposition": "completed",
+      "phases": 2,
+      "steps": {
+        "open": 0,
+        "done": 10,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-inbox-harvest-2026-08-d-context-ledger",
+      "title": "Road to a context ledger that captures before the state is destroyed",
+      "disposition": "closed-with-cancellations",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 15,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-inbox-harvest-2026-08-d-runtime-skill-routing",
+      "title": "Road to a ranker that actually routes",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 14,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-inbox-harvest-2026-08-d-scheduled-deprecation",
+      "title": "Road to a deprecation table that cannot miss its own dates",
+      "disposition": "completed",
+      "phases": 2,
+      "steps": {
+        "open": 0,
+        "done": 10,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-inbox-harvest-2026-08",
+      "title": "Road to inbox harvest 2026-08",
+      "disposition": "closed-with-cancellations",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 12,
+        "deferred": 0,
+        "cancelled": 9
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-inbox-harvest-distillation",
+      "title": "Road to harvested-claim provenance and router-head skills",
+      "disposition": "closed-with-cancellations",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 9,
+        "deferred": 0,
+        "cancelled": 7
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-injection-and-authority-harvest",
+      "title": "Road to injection-and-authority harvest",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 17,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-injection-defense-pressure-corpus",
+      "title": "Road to an injection-defense pressure-corpus (with a defensive judge sliver)",
+      "disposition": "closed-with-cancellations",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 11,
+        "deferred": 0,
+        "cancelled": 9
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-install-contract-stability",
+      "title": "Roadmap: Install-Contract Stability — freeze the install ABI, split the lean core from the lab",
+      "disposition": "completed",
+      "phases": 2,
+      "steps": {
+        "open": 0,
+        "done": 15,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-install-path-convergence",
+      "title": "Roadmap: Install-path convergence — any entry point yields the correct install, on every tool",
+      "disposition": "completed-with-deferrals",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 21,
+        "deferred": 1,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-internal-ai-os-deployment",
+      "title": "Roadmap: Internal AI OS Deployment — one-click company rollout + central policy",
+      "disposition": "closed-with-cancellations",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 17,
+        "deferred": 0,
+        "cancelled": 35
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-internet-reach",
+      "title": "Roadmap: Road to internet reach — a governed reach layer for dev research",
+      "disposition": "closed-with-cancellations",
+      "phases": 8,
+      "steps": {
+        "open": 0,
+        "done": 48,
+        "deferred": 0,
+        "cancelled": 21
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-judgment-and-forensic-evidence",
+      "title": "Road to judgment and forensic evidence — one protocol against a measured defect, one evidence source git already holds",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 32,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-kernel-and-router",
+      "title": "Road to Rule Kernel and Router",
+      "disposition": "closed-with-cancellations",
+      "phases": 8,
+      "steps": {
+        "open": 0,
+        "done": 21,
+        "deferred": 0,
+        "cancelled": 2
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-knowledge-system",
+      "title": "Road to Knowledge System",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 36,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-lean-agent-init",
+      "title": "Roadmap: Lean Agent Init — tool-not-agent routing, worker stop-loss, spawn-payload truth",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 14,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-lean-initial-context-buildout",
+      "title": "Road to Lean Initial Context — Build-out",
+      "disposition": "closed-with-cancellations",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 11,
+        "deferred": 0,
+        "cancelled": 9
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-lean-initial-context",
+      "title": "Road to Lean Initial Context",
+      "disposition": "closed-with-cancellations",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 21,
+        "deferred": 25,
+        "cancelled": 12
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-leaner-core-and-discovery",
+      "title": "Roadmap: Leaner core + discovery — close the post-5.x feedback gaps the package can actually act on",
+      "disposition": "closed-with-cancellations",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 41,
+        "deferred": 0,
+        "cancelled": 2
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-legal-pack",
+      "title": "Road to a legal pack — built on its own legs, evaluated honestly",
+      "disposition": "completed",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 37,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-legal-review-prep",
+      "title": "Road to legal-review-prep — rename, consent-gate, council-gate, hard STOP",
+      "disposition": "completed",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 25,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-legal-safety-hardening",
+      "title": "Road to legal-safety hardening — RDG positioning + liability defense-in-depth",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 14,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-linked-projects-scope",
+      "title": "Road to Linked-Projects Scope",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 25,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-linter-debt-and-meta-subtraction",
+      "title": "Roadmap: Linter-Debt Paydown + Meta-System Subtraction",
+      "disposition": "completed",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 20,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-llm-provider-knowledge-skill",
+      "title": "Road to: `llm-provider-knowledge` skill",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 18,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-local-ci-trust",
+      "title": "Road to a Trustworthy Local CI",
+      "disposition": "completed-with-deferrals",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 3,
+        "deferred": 3,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-local-only-gate-reds",
+      "title": "Road to local-only gate reds — four red gates nobody sees",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 10,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-loop-engineering",
+      "title": "Road to Loop-Engineering Discipline",
+      "disposition": "completed",
+      "phases": 2,
+      "steps": {
+        "open": 0,
+        "done": 10,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-mcp-discovery-helper",
+      "title": "Roadmap: Read-only cross-agent MCP discovery helper",
+      "disposition": "closed-with-cancellations",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 4,
+        "deferred": 0,
+        "cancelled": 10
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-mcp-distribution",
+      "title": "Road to MCP Distribution",
+      "disposition": "closed-with-cancellations",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 5
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-mcp-full-coverage",
+      "title": "Road to MCP Full Coverage",
+      "disposition": "closed-with-cancellations",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 15,
+        "deferred": 10,
+        "cancelled": 4
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-mcp-server",
+      "title": "Road to MCP Server",
+      "disposition": "closed-with-cancellations",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 26,
+        "deferred": 0,
+        "cancelled": 3
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-mcp-stdio-end-user-packaging",
+      "title": "Road to a turnkey end-user stdio MCP server — packaging the local server for people who configure agents, not clone repos",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 10,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-mcp-token-accounting",
+      "title": "Roadmap: MCP tool-schema token accounting (context-load-budget)",
+      "disposition": "completed",
+      "phases": 1,
+      "steps": {
+        "open": 0,
+        "done": 2,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-mcp",
+      "title": "Roadmap: MCP Config Generation",
+      "disposition": "archived-with-open-steps",
+      "phases": 0,
+      "steps": {
+        "open": 2,
+        "done": 12,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-memory-merge-safety",
+      "title": "Road to Memory Merge Safety",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 15,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-memory-pipeline-consolidation",
+      "title": "Road to memory-pipeline consolidation & scope",
+      "disposition": "completed",
+      "phases": 8,
+      "steps": {
+        "open": 0,
+        "done": 33,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-memory-retrieval-economy",
+      "title": "Road to memory-retrieval economy — index first, fetch by ID, price every row",
+      "disposition": "closed-with-cancellations",
+      "phases": 9,
+      "steps": {
+        "open": 0,
+        "done": 26,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-memory-self-consumption",
+      "title": "Road to Memory Self-Consumption",
+      "disposition": "closed-with-cancellations",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 5,
+        "deferred": 0,
+        "cancelled": 3
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-metadata-and-command-surface-leanness",
+      "title": "Roadmap: Metadata & Command-Surface Leanness",
+      "disposition": "closed-with-cancellations",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 14,
+        "deferred": 1,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-mission-mode",
+      "title": "Roadmap: Mission-Mode — named, framework-aware autonomous missions (gated)",
+      "disposition": "completed",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 17,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-mobile-adoption",
+      "title": "Road to Mobile Adoption",
+      "disposition": "closed-with-cancellations",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 5,
+        "deferred": 0,
+        "cancelled": 5
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-model-capability-tiers",
+      "title": "Road to Vendor-Neutral Model Capability Tiers",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 20,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-money-strategy-ops",
+      "title": "Road to Money, Strategy and Operations (Wing 4)",
+      "disposition": "completed",
+      "phases": 1,
+      "steps": {
+        "open": 0,
+        "done": 31,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-multi-package-coexistence",
+      "title": "Road to Multi-Package Coexistence",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 25,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-multi-stack",
+      "title": "Roadmap: Multi-Stack — from Laravel-complete to Laravel-complete-plus",
+      "disposition": "closed-with-cancellations",
+      "phases": 2,
+      "steps": {
+        "open": 0,
+        "done": 7,
+        "deferred": 0,
+        "cancelled": 12
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-music-video-orchestration",
+      "title": "Road to music-video orchestration — real audio analysis, modality-switch direction, sparse lip-sync",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 12,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-native-code-intelligence",
+      "title": "Road to native code intelligence — own the engine, sweep the rejected inventory, keep the gates",
+      "disposition": "closed-with-cancellations",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 24,
+        "deferred": 0,
+        "cancelled": 5
+      },
+      "verdict": null,
+      "status": "completed"
+    },
+    {
+      "slug": "road-to-number-truth",
+      "title": "Road to Number Truth and Decision Homing",
+      "disposition": "closed-with-cancellations",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 19,
+        "deferred": 0,
+        "cancelled": 2
+      },
+      "verdict": null,
+      "status": "active"
+    },
+    {
+      "slug": "road-to-obligation-carrier-audit",
+      "title": "Road to obligation-carrier audit — which rules fire more often than anything that carries them",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 24,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-one-migrate-command",
+      "title": "Road to one migrate command",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 25,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-operator-runtime-harvest",
+      "title": "Road to operator-runtime harvest — cross-model parity is the keystone; gate the rest on it",
+      "disposition": "closed-with-cancellations",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 13,
+        "deferred": 0,
+        "cancelled": 7
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-opt-council-deliberation",
+      "title": "Road to council deliberation protocol — adopt the evidence-backed protocol layer, benchmark the persona theater",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 31,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-opt-decision-flips",
+      "title": "Road to opt decision flips — re-decide what the package's evolution invalidated",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 19,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-opt-design-polish",
+      "title": "Road to opt design polish — consolidate the slop canon, close the states gap",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 8,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-opt-harness-discipline",
+      "title": "Road to opt harness discipline — port the native-harness behaviors weaker hosts don't have",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 14,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-opt-hygiene-and-debt",
+      "title": "Road to opt hygiene and debt — pay the package's own policy breaches first",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 19,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-opt-measurement-unblock",
+      "title": "Road to opt measurement unblock — one judge run cascade-unblocks the token program",
+      "disposition": "completed",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 10,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-opt-portfolio-consolidation",
+      "title": "Road to opt portfolio consolidation — merge, revive, park, and dedupe the roadmap estate",
+      "disposition": "closed-with-cancellations",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 9,
+        "deferred": 0,
+        "cancelled": 2
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-opt-retrieval-and-memory",
+      "title": "Road to opt retrieval and memory — wire the orphan, benchmark honestly, borrow the protocol discipline",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 12,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-opt-subagent-harvest",
+      "title": "Road to opt subagent harvest — the post-flip second look at orchestration references",
+      "disposition": "completed",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 9,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-optimized-ci-and-release-gates",
+      "title": "Optimized CI + Release Gates — cut release-PR wall-clock and make every gate intentional",
+      "disposition": "closed-with-cancellations",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 25,
+        "deferred": 0,
+        "cancelled": 2
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-orchestration-and-memory-harvest",
+      "title": "Road to orchestration-and-memory harvest",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 17,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-orchestrator-discipline-carriers",
+      "title": "Road to orchestrator discipline carriers — the delegation obligation and the end-review obligation get mechanisms that reach real sessions",
+      "disposition": "completed",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 37,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-orchestrator-first-execution",
+      "title": "Road to orchestrator-first execution — make the gate clear, measure what already happened, then decide whether \"orchestrate everything\" survives contact with the numbers",
+      "disposition": "closed-with-cancellations",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 17,
+        "deferred": 0,
+        "cancelled": 12
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-overlap-truth-and-skill-cut",
+      "title": "Road to overlap truth — repair the instrument, then cut the skills it was supposed to find",
+      "disposition": "closed-with-cancellations",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 13,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-package-impact-benchmark",
+      "title": "Roadmap: Package-Impact Benchmark (with vs. without agent-config)",
+      "disposition": "completed-with-deferrals",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 31,
+        "deferred": 1,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-package-optimization",
+      "title": "Road to Package Optimization",
+      "disposition": "closed-with-cancellations",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 1,
+        "deferred": 0,
+        "cancelled": 7
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-package-renewal",
+      "title": "Road to package renewal — central roadmap (2026-08)",
+      "disposition": "completed",
+      "phases": 2,
+      "steps": {
+        "open": 0,
+        "done": 9,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-parallel-session-coordination",
+      "title": "Road to parallel-session coordination — a second session should know the first one exists",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 24,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-path-fixes",
+      "title": "Road to Path Fixes",
+      "disposition": "closed-with-cancellations",
+      "phases": 9,
+      "steps": {
+        "open": 0,
+        "done": 28,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-per-skill-model-autoswitch",
+      "title": "Road to Per-Skill Model Auto-Switch",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 34,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-persona-catalog-disposition",
+      "title": "Road to persona-catalog disposition — four mechanisms audited, one insight kept, no fourth ontology",
+      "disposition": "completed",
+      "phases": 2,
+      "steps": {
+        "open": 0,
+        "done": 2,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-persona-library-harvest",
+      "title": "Roadmap: Persona-Library Harvest — Originality Gate, Measured Catalog Router, Flow-Team Primitive",
+      "disposition": "closed-with-cancellations",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 28,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-personas",
+      "title": "Roadmap: Personas — reusable review lenses as a first-class primitive",
+      "disposition": "archived-with-open-steps",
+      "phases": 6,
+      "steps": {
+        "open": 1,
+        "done": 29,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-plan-gate-fence-grammar",
+      "title": "Roadmap: Plan-gate fence grammar — close the live fail-open, make archived dispositions machine-checked",
+      "disposition": "closed-with-cancellations",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 28,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-plan-governance-gates",
+      "title": "Roadmap: Plan Governance Gates — confidence gate, plan-risk review, completion review",
+      "disposition": "completed",
+      "phases": 8,
+      "steps": {
+        "open": 0,
+        "done": 52,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-portable-dev-preferences",
+      "title": "Road to Portable Dev Preferences",
+      "disposition": "completed",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 9,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-portable-runtime-and-update-check",
+      "title": "Road to npx-only Distribution + Hierarchical Settings + Update Check",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 28,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-positioning-and-enforcement",
+      "title": "Road to positioning & enforcement — close the *perceived* gap, ship the one real one",
+      "disposition": "closed-with-cancellations",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 8,
+        "deferred": 0,
+        "cancelled": 4
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-positioning-consistency-and-skill-governance",
+      "title": "Roadmap: Positioning Consistency + Skill Governance — close the doc-drift and 227-skill gaps",
+      "disposition": "completed-with-deferrals",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 34,
+        "deferred": 6,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "active"
+    },
+    {
+      "slug": "road-to-post-pr29-optimize",
+      "title": "Road to Post-PR-29 Optimize",
+      "disposition": "closed-with-cancellations",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 19,
+        "deferred": 1,
+        "cancelled": 4
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-pr-34-followups",
+      "title": "Road to PR #34 Follow-ups",
+      "disposition": "closed-with-cancellations",
+      "phases": 15,
+      "steps": {
+        "open": 0,
+        "done": 28,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "complete"
+    },
+    {
+      "slug": "road-to-product-adoption",
+      "title": "Roadmap: Product Adoption — close the External Adoption gap",
+      "disposition": "closed-with-cancellations",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 25,
+        "deferred": 11,
+        "cancelled": 2
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-product-clarity",
+      "title": "Road to product clarity — process wins now, product bets deferred",
+      "disposition": "closed-with-cancellations",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 4,
+        "deferred": 0,
+        "cancelled": 7
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-product-ui-track-followup",
+      "title": "Roadmap: Product UI Track — Follow-up Goldens (R3.1)",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 40,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-product-ui-track",
+      "title": "Roadmap: Product UI Track",
+      "disposition": "closed-with-cancellations",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 58,
+        "deferred": 0,
+        "cancelled": 5
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-productization",
+      "title": "Road to Productization (Level 6)",
+      "disposition": "closed-with-cancellations",
+      "phases": 8,
+      "steps": {
+        "open": 0,
+        "done": 25,
+        "deferred": 0,
+        "cancelled": 2
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-project-memory",
+      "title": "Roadmap: Project Memory — layered settings and curated knowledge",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 30,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-prompt-driven-execution",
+      "title": "Roadmap: Prompt-Driven Execution",
+      "disposition": "archived-with-open-steps",
+      "phases": 6,
+      "steps": {
+        "open": 5,
+        "done": 31,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-prompt-pattern-adoption",
+      "title": "Road to prompt pattern adoption",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 21,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-proof-not-features",
+      "title": "Road to Proof not Features",
+      "disposition": "closed-with-cancellations",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 16,
+        "deferred": 0,
+        "cancelled": 4
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-proof-under-real-conditions",
+      "title": "Road to proof under real conditions",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 33,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-provenance-and-license-governance",
+      "title": "Road to provenance and license governance — code borrows get a paper trail",
+      "disposition": "closed-with-cancellations",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 17,
+        "deferred": 0,
+        "cancelled": 5
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-provided-artifact-honesty",
+      "title": "Road to provided-artifact honesty — a handed-over design is either honoured or refused, never silently regenerated",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 29,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-py2ts-teardown-completion",
+      "title": "py2ts teardown — completion: purge remaining live-python, retire the shim, merge-ready",
+      "disposition": "closed-with-cancellations",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 18,
+        "deferred": 0,
+        "cancelled": 3
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-py2ts-teardown",
+      "title": "Python → TypeScript migration: Phase 12 teardown",
+      "disposition": "archived-with-open-steps",
+      "phases": 9,
+      "steps": {
+        "open": 17,
+        "done": 15,
+        "deferred": 1,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "draft"
+    },
+    {
+      "slug": "road-to-rdp-discoverability",
+      "title": "Roadmap: RDP discoverability — settings docs, user contract, surfacing",
+      "disposition": "completed",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 6,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-rdp-eval-and-promotion",
+      "title": "Roadmap: RDP — eval execution, kernel promotion, polish (follow-up)",
+      "disposition": "closed-with-cancellations",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 5,
+        "deferred": 0,
+        "cancelled": 2
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-rdp-frontier-polish",
+      "title": "Roadmap: RDP frontier polish — orchestrator decision, kernel de-prescription, L7 (follow-up)",
+      "disposition": "closed-with-cancellations",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 3,
+        "deferred": 0,
+        "cancelled": 4
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-reachable-code-memory",
+      "title": "Road to reachable code memory — wire the orphaned engine, accumulate locally, decide the substrate honestly",
+      "disposition": "closed-with-cancellations",
+      "phases": 10,
+      "steps": {
+        "open": 0,
+        "done": 26,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-readable-value-dashboard",
+      "title": "Roadmap: Readable Value Dashboard — make \"what the package brings\" understandable",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 32,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-reaping-catches-pre-inventory-orphans",
+      "title": "Roadmap: Reaping catches pre-inventory tagged orphans",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 15,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "completed"
+    },
+    {
+      "slug": "road-to-rebalancing",
+      "title": "Road to Rebalancing",
+      "disposition": "closed-with-cancellations",
+      "phases": 9,
+      "steps": {
+        "open": 0,
+        "done": 15,
+        "deferred": 0,
+        "cancelled": 4
+      },
+      "verdict": null,
+      "status": "complete"
+    },
+    {
+      "slug": "road-to-reciprocal-ecosystem",
+      "title": "Road to a reciprocal ecosystem — AC recommends AS the way AS already recommends AC",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 18,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-recursive-verification",
+      "title": "Road to recursive self-verification — the one retraining-free Fugu mechanism, measured capability-axis-first",
+      "disposition": "closed-with-cancellations",
+      "phases": 8,
+      "steps": {
+        "open": 0,
+        "done": 22,
+        "deferred": 0,
+        "cancelled": 6
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-refine-ticket-hardening",
+      "title": "Roadmap: `/refine-ticket` hardening (v2 follow-ups)",
+      "disposition": "completed-with-deferrals",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 29,
+        "deferred": 2,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-release-gate-hardening",
+      "title": "Road to release-gate hardening — turn reactive catches into pre-merge gates",
+      "disposition": "completed",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 11,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-release-shape-honesty",
+      "title": "Road to release-shape honesty — lint the release that shipped, and describe it truthfully",
+      "disposition": "completed",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 8,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-release-truth",
+      "title": "Road to release truth — one final source, findings with dispositions, bounded autonomy",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 10,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-renewal-adr-hygiene",
+      "title": "Road to renewal — ADR hygiene (chip-mode)",
+      "disposition": "closed-with-cancellations",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 9,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-renewal-foundation",
+      "title": "Road to renewal — Foundation (CI oracle, dead tree, token quick wins)",
+      "disposition": "closed-with-cancellations",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 17,
+        "deferred": 0,
+        "cancelled": 4
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-renewal-leverage",
+      "title": "Road to renewal — Leverage (execution flows + documented-failure fixes)",
+      "disposition": "closed-with-cancellations",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 7,
+        "deferred": 0,
+        "cancelled": 5
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-reproducible-artefact-counts",
+      "title": "Road to reproducible artefact counts — a number a second counter cannot derive",
+      "disposition": "completed",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 4,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-retire-stale-authoring-pointers",
+      "title": "Road to retire stale authoring-source pointers (`.agent-src.uncondensed/` → `src/`)",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 13,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-retrieval-contract-consumer",
+      "title": "Roadmap: Retrieval-contract consumer implementation",
+      "disposition": "completed",
+      "phases": 2,
+      "steps": {
+        "open": 0,
+        "done": 10,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-retrieval-substrate-hardening",
+      "title": "Road to retrieval-substrate hardening",
+      "disposition": "closed-with-cancellations",
+      "phases": 8,
+      "steps": {
+        "open": 0,
+        "done": 17,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-roadmap-archival-robustness",
+      "title": "Road to roadmap-archival robustness — completion archives without a PR",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 12,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-role-first-onboarding",
+      "title": "Roadmap: Role-First Onboarding — non-developer first, dev second",
+      "disposition": "archived-with-open-steps",
+      "phases": 5,
+      "steps": {
+        "open": 4,
+        "done": 24,
+        "deferred": 7,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-role-modes",
+      "title": "Roadmap: Role Modes — explicit frames and output contracts",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 16,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-root-layout-cleanup",
+      "title": "Roadmap: Root layout cleanup — targeted prune now, multi-workspace gated on four audits",
+      "disposition": "closed-with-cancellations",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 23,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-rootless-write-refusal",
+      "title": "Road to rootless-write refusal",
+      "disposition": "completed",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 19,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-routing-correctness",
+      "title": "Road to routing correctness — the rule set stops fighting itself, and a command proves what routes",
+      "disposition": "closed-with-cancellations",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 14,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-rtk-onboarding-correctness",
+      "title": "Road to rtk onboarding correctness — the install path we ship is currently broken",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 21,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-rule-coherence",
+      "title": "Road to rule coherence — fix the delivery system, not the rules",
+      "disposition": "closed-with-cancellations",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 14,
+        "deferred": 0,
+        "cancelled": 7
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-rule-delivery-integrity",
+      "title": "Road to rule delivery integrity — rules that arrive once, scoped, and provably",
+      "disposition": "closed-with-cancellations",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 15,
+        "deferred": 0,
+        "cancelled": 2
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-rule-hardening",
+      "title": "Road to Rule Hardening",
+      "disposition": "closed-with-cancellations",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 27,
+        "deferred": 1,
+        "cancelled": 5
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-rule-quality-research",
+      "title": "Roadmap: Rule & Guideline Quality Research",
+      "disposition": "archived-with-open-steps",
+      "phases": 0,
+      "steps": {
+        "open": 2,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-runtime-encoding-hardening",
+      "title": "Road to runtime encoding hardening — prove the sanitize floor runs, then close the half it deliberately left open",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 24,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-runtime-security-hardening",
+      "title": "Road to runtime-security hardening — fix the subprocess-env RCE, hold the scope line",
+      "disposition": "completed",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 11,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-scale-and-history-discipline",
+      "title": "Road to scale & history discipline — two packs, one deterministic linter substrate",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 23,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-scripts-settings-defaults",
+      "title": "Road to scripts settings defaults — give the SCRIPTS read path the defaults layer the server already has",
+      "disposition": "completed",
+      "phases": 2,
+      "steps": {
+        "open": 0,
+        "done": 4,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-second-brain-delta-proof",
+      "title": "Road to second-brain delta proof — measure the memory substrate against a no-memory baseline, and scope it honestly against human-PKM",
+      "disposition": "closed-with-cancellations",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 13,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-second-brain",
+      "title": "Road to second brain — working-memory continuity, scale tripwires, contradiction surfacing",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 15,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-secret-hygiene-guardrail",
+      "title": "Road to secret-hygiene guardrail — the agent never lets a secret land in VCS",
+      "disposition": "completed",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 42,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-security-hardening",
+      "title": "Roadmap: Security hardening — consumer/CI/git-enforcement layer",
+      "disposition": "completed",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 14,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-security-pillar",
+      "title": "Roadmap: security pillar — supply-chain integrity + injection-aware authoring",
+      "disposition": "closed-with-cancellations",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 32,
+        "deferred": 3,
+        "cancelled": 7
+      },
+      "verdict": null,
+      "status": "archived"
+    },
+    {
+      "slug": "road-to-self-critical",
+      "title": "Road to self-critical — structural review honesty instead of rule #108",
+      "disposition": "completed",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 10,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-self-update-and-global-hook-resolution",
+      "title": "Road to Self-Update + Global Hook Resolution",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 35,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-session-analytics",
+      "title": "Road to session analytics — a post-session cost/turn/churn report",
+      "disposition": "completed",
+      "phases": 1,
+      "steps": {
+        "open": 0,
+        "done": 2,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-session-profile-activation",
+      "title": "Road to Session-Profile Activation",
+      "disposition": "closed-with-cancellations",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 12,
+        "deferred": 0,
+        "cancelled": 4
+      },
+      "verdict": null,
+      "status": "active"
+    },
+    {
+      "slug": "road-to-session-profile-observability",
+      "title": "Roadmap: Session-Profile Observability for Employees — make \"which profile, what changed, why\" legible without a CLI",
+      "disposition": "completed",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 20,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "active"
+    },
+    {
+      "slug": "road-to-setup-experience",
+      "title": "Road to Setup Experience",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 25,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-shadcn-registry-awareness",
+      "title": "Road to shadcn Registry & MCP Awareness",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 10,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-shared-design-tokens",
+      "title": "Road to shared design tokens — one visual identity across two independent GUIs",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 18,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-simplicity-and-everywhere",
+      "title": "Road to Simplicity and Everywhere",
+      "disposition": "closed-with-cancellations",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 32,
+        "deferred": 3,
+        "cancelled": 3
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-simplicity-and-goal-discipline",
+      "title": "Road to simplicity and goal discipline — close the over-engineering and vague-goal gaps",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 13,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-single-install-source-of-truth",
+      "title": "Roadmap: Single Install Source-of-Truth — finish the `--apply-payload` bridge",
+      "disposition": "completed-with-deferrals",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 21,
+        "deferred": 3,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "active"
+    },
+    {
+      "slug": "road-to-skill-catalogue-budget",
+      "title": "Road to a measured skill-catalogue budget — Codex as the second host",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 23,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-skill-ecosystem-authoring-discipline",
+      "title": "Road to authoring discipline — forced artifacts, named biases, and a removal signal",
+      "disposition": "closed-with-cancellations",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 53,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-skill-eval-coverage",
+      "title": "Road to skill eval coverage — close the 2-of-264 behavioural-eval gap, tier-prioritised, ratcheted",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 14,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-spawn-env-completion",
+      "title": "Road to spawn-env completion — close the GIT_CONFIG RCE residual, classify every spawn site",
+      "disposition": "completed",
+      "phases": 2,
+      "steps": {
+        "open": 0,
+        "done": 9,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-stable-chat-history",
+      "title": "Roadmap: Stable Chat History via Platform Hooks",
+      "disposition": "archived-with-open-steps",
+      "phases": 5,
+      "steps": {
+        "open": 3,
+        "done": 28,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-starlight-project-docs",
+      "title": "Roadmap: Starlight project documentation",
+      "disposition": "archived-with-open-steps",
+      "phases": 9,
+      "steps": {
+        "open": 7,
+        "done": 31,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "active"
+    },
+    {
+      "slug": "road-to-structural-linter-reform",
+      "title": "Road to Structural Linter Reform",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 14,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "completed"
+    },
+    {
+      "slug": "road-to-structural-optimization",
+      "title": "Road to Structural Optimization",
+      "disposition": "closed-with-cancellations",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 43,
+        "deferred": 1,
+        "cancelled": 16
+      },
+      "verdict": null,
+      "status": "locked"
+    },
+    {
+      "slug": "road-to-structure-grounding-v2",
+      "title": "Roadmap: Structure-grounding v2 — global cross-project card sharing",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 17,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-structure-grounding",
+      "title": "Roadmap: Evidence-first structure discovery",
+      "disposition": "closed-with-cancellations",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 29,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-structured-guard-input",
+      "title": "Road to structured guard input — stop guessing intent from prose",
+      "disposition": "closed-with-cancellations",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 8,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-subagent-value-realization",
+      "title": "Roadmap: Subagent value realization",
+      "disposition": "closed-with-cancellations",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 24,
+        "deferred": 0,
+        "cancelled": 7
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-substrate-adoption",
+      "title": "road-to-substrate-adoption",
+      "disposition": "not-extractable",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-suite-closure",
+      "title": "Road to Suite Closure",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 37,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-surface-discipline",
+      "title": "Roadmap: Surface Discipline (2.7.0 follow-up)",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 40,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-surface-specific-agent-contracts",
+      "title": "Road to surface-specific agent contracts — stop making one generic agent do every medium badly",
+      "disposition": "completed",
+      "phases": 8,
+      "steps": {
+        "open": 0,
+        "done": 39,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-symptom-driven-harvest-loop",
+      "title": "Road to the symptom-driven harvest loop — make the process that found V1–V9 repeatable",
+      "disposition": "completed",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 7,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-taste-dials-and-locks",
+      "title": "Road to Taste Dials & Consistency Locks",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 11,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-team-mode",
+      "title": "Road to team mode — govern the official cross-model pair, don't rebuild it",
+      "disposition": "closed-with-cancellations",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 39,
+        "deferred": 1,
+        "cancelled": 2
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-test-and-gate-integrity",
+      "title": "Road to Test-and-Gate Integrity",
+      "disposition": "completed",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 20,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-tested-routing",
+      "title": "Roadmap: Road to tested routing",
+      "disposition": "completed",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 38,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-ticket-bundles",
+      "title": "Roadmap: Ticket bundles — high-tier plans, lite-tier builds",
+      "disposition": "closed-with-cancellations",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 33,
+        "deferred": 0,
+        "cancelled": 6
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-ticket-refinement",
+      "title": "Roadmap: Ticket Refinement — refine + estimate as a family",
+      "disposition": "closed-with-cancellations",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 22,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-tier-removal",
+      "title": "Roadmap: Command `tier:` Alias Removal",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 8,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-token-economy-cache",
+      "title": "Road to token-economy — cache: the per-session overhead gets a budget, a stable prefix delta, and a machine on the write path",
+      "disposition": "completed-with-deferrals",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 35,
+        "deferred": 4,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-token-economy-dispatch",
+      "title": "Road to token-economy — dispatch: the always-on stack stops paying the full harness price per spawn",
+      "disposition": "completed-with-deferrals",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 31,
+        "deferred": 8,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-token-economy-recycling",
+      "title": "Road to token-economy — recycling: deliberate envelope-mediated fresh starts instead of lossy auto-compaction",
+      "disposition": "closed-with-cancellations",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 27,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-token-frugality",
+      "title": "Road to Token Frugality",
+      "disposition": "completed",
+      "phases": 11,
+      "steps": {
+        "open": 0,
+        "done": 108,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-token-optimization",
+      "title": "Road to Token Optimization",
+      "disposition": "completed-with-deferrals",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 5,
+        "deferred": 4,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-trigger-evals",
+      "title": "Roadmap: Skill Trigger Evaluation",
+      "disposition": "completed",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 6,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-trim-frugality-canon",
+      "title": "Road to Trim Frugality Canon",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 14,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "done"
+    },
+    {
+      "slug": "road-to-truth-and-reference-hygiene",
+      "title": "Road to truth-and-reference hygiene — make the \"machine-checked\" headline true of its own artefacts",
+      "disposition": "completed",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 21,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-typescript-only-scripts",
+      "title": "Roadmap: TypeScript-only scripts — full Python → TypeScript migration",
+      "disposition": "completed",
+      "phases": 12,
+      "steps": {
+        "open": 0,
+        "done": 71,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-ui-track-integrity",
+      "title": "Road to UI-track integrity — the lanes the dispatcher names do not exist",
+      "disposition": "completed-with-deferrals",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 36,
+        "deferred": 3,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-ultimate",
+      "title": "Roadmap: Road to Ultimate — Ecosystem & Interop",
+      "disposition": "archived-with-open-steps",
+      "phases": 6,
+      "steps": {
+        "open": 40,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-unified-senior-roles",
+      "title": "Road to Unified Senior Roles",
+      "disposition": "completed",
+      "phases": 1,
+      "steps": {
+        "open": 0,
+        "done": 19,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-unified-setup",
+      "title": "Unified Setup — v4.0.0 hard-cut to a single TS install/setup engine",
+      "disposition": "completed-with-deferrals",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 26,
+        "deferred": 1,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-universal-distribution",
+      "title": "Roadmap: Universal Distribution (Cloud + Local Fallbacks)",
+      "disposition": "archived-with-open-steps",
+      "phases": 7,
+      "steps": {
+        "open": 7,
+        "done": 36,
+        "deferred": 8,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-universal-execution-engine",
+      "title": "Roadmap: Universal Execution Engine",
+      "disposition": "closed-with-cancellations",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 45,
+        "deferred": 0,
+        "cancelled": 5
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-universal-stack-coverage",
+      "title": "Road to universal stack coverage — an honest refusal is not coverage",
+      "disposition": "closed-with-cancellations",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 25,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-value-dashboard-netto-cuts",
+      "title": "Roadmap: Value Dashboard NETTO — cut the base-load, keep Panel B value",
+      "disposition": "archived-with-open-steps",
+      "phases": 6,
+      "steps": {
+        "open": 6,
+        "done": 20,
+        "deferred": 0,
+        "cancelled": 8
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-verified-chat-history-platforms",
+      "title": "Road to verified chat-history platforms",
+      "disposition": "archived-with-open-steps",
+      "phases": 6,
+      "steps": {
+        "open": 8,
+        "done": 35,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-video-deferred-design",
+      "title": "Road to video deferred design — checkpoint/resume, ComfyUI sandbox, provenance (design-gated backlog)",
+      "disposition": "completed",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 8,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-video-foundation-validation",
+      "title": "Road to video foundation validation — prove the adapter contract with real money before building anything new",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 12,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-video-from-song",
+      "title": "Roadmap: `/video:from-song` — a music-video from a song + reference images",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 45,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-video-provider-multiplexers",
+      "title": "Road to video provider multiplexers — one adapter, many models (fal first, Replicate second)",
+      "disposition": "completed",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 7,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-visual-review-loop",
+      "title": "Roadmap: Visual Review Loop + A11y",
+      "disposition": "completed",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 45,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-webfont-delivery-ownership",
+      "title": "Road to webfont delivery ownership — one skill prescribes the hotlink another skill's data forbids",
+      "disposition": "completed",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 12,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-weighted-decision-matrix",
+      "title": "Road to weighted decision matrix — quantitative mode for `decision-record`",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 18,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-wiring-truth",
+      "title": "Road to Wiring Truth",
+      "disposition": "completed",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 11,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "active"
+    },
+    {
+      "slug": "road-to-wizard-sse-hardening",
+      "title": "Roadmap: Wizard SSE hardening — edge-case test coverage, severity-phased",
+      "disposition": "completed",
+      "phases": 2,
+      "steps": {
+        "open": 0,
+        "done": 9,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-wizard-ux-improvements",
+      "title": "Roadmap: Wizard UX — first-run detection, fresh-start, tool-list cleanup",
+      "disposition": "completed",
+      "phases": 8,
+      "steps": {
+        "open": 0,
+        "done": 21,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "active"
+    },
+    {
+      "slug": "road-to-work-engine-hooks",
+      "title": "Roadmap: Work-Engine Hook Lifecycle",
+      "disposition": "archived-with-open-steps",
+      "phases": 7,
+      "steps": {
+        "open": 5,
+        "done": 51,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-worktree-hygiene",
+      "title": "Road to worktree hygiene — 249 worktrees, 40 GB, one prune that does nothing",
+      "disposition": "completed",
+      "phases": 1,
+      "steps": {
+        "open": 0,
+        "done": 9,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-zero-ceremony-detection",
+      "title": "Road to zero-ceremony detection — detection reports, consent still decides",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 29,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-zero-ceremony-install",
+      "title": "Road to zero-ceremony install — make the install claim true before making it shorter",
+      "disposition": "closed-with-cancellations",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 24,
+        "deferred": 0,
+        "cancelled": 2
+      },
+      "verdict": null,
+      "status": "ready"
+    },
+    {
+      "slug": "road-to-zero-ceremony-settings",
+      "title": "Road to zero-ceremony settings — the user's file records decisions, the template stays the defaults source",
+      "disposition": "closed-with-cancellations",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 22,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "road-to-zero-settings",
+      "title": "Road to zero settings — delete the flags whose answer the situation already carries",
+      "disposition": "closed-with-cancellations",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 14,
+        "deferred": 0,
+        "cancelled": 1
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "rule-governance-and-budget-discipline",
+      "title": "Road to Rule Governance & Budget Discipline",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 19,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "complete"
+    },
+    {
+      "slug": "shell-based-installer",
+      "title": "Roadmap: Shell-Based Installer",
+      "disposition": "closed-with-cancellations",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 101,
+        "deferred": 0,
+        "cancelled": 3
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "skill-improvement-pipeline",
+      "title": "Roadmap: Agent Skill Improvement Pipeline",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 20,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "skills-audit-results",
+      "title": "Skills Audit Results",
+      "disposition": "not-extractable",
+      "phases": 2,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "skills-rules-restructuring",
+      "title": "Roadmap: Skills & Rules Restructuring",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 24,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "step-1-ai-council-cli-transport",
+      "title": "Roadmap: AI Council CLI Transport + Safety Net + Decision-Replay + Impact-Routed Lightweight QA",
+      "disposition": "completed",
+      "phases": 13,
+      "steps": {
+        "open": 0,
+        "done": 86,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "step-1-v2-feedback-followup",
+      "title": "Roadmap: v2.10.0 Audit + Council Feedback Follow-Up",
+      "disposition": "closed-with-cancellations",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 23,
+        "deferred": 0,
+        "cancelled": 2
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "step-10-corpus-yaml-lockfile",
+      "title": "Roadmap: Low-Impact Corpus — YAML Lockfile as Runtime Source-of-Truth",
+      "disposition": "completed",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 18,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "step-12-closure-report",
+      "title": "Step-12 Closure Report — feat/ghostwriter branch terminal state",
+      "disposition": "not-extractable",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "draft"
+    },
+    {
+      "slug": "step-12-universal-os-reframe",
+      "title": "Road to Universal-OS Reframe (audience expansion, capability-preserving)",
+      "disposition": "completed-with-deferrals",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 44,
+        "deferred": 9,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "step-13-non-dev-community-validation",
+      "title": "Roadmap: non-dev community validation (post-step-12, 90-day window)",
+      "disposition": "closed-with-cancellations",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 8,
+        "deferred": 0,
+        "cancelled": 14
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "step-14-mcp-runtime-stub",
+      "title": "Roadmap: MCP runtime stub (Claude-Desktop-native invocation)",
+      "disposition": "closed-with-cancellations",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 10,
+        "deferred": 0,
+        "cancelled": 3
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "step-15-product-refinement",
+      "title": "Roadmap: step-15 — product architecture refinement (Phase 0 + P0 / P1 / P2 cuts)",
+      "disposition": "closed-with-cancellations",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 26,
+        "deferred": 0,
+        "cancelled": 14
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "step-2-ai-council-consolidation",
+      "title": "Roadmap: AI Council Consolidation + External-Pattern Integration",
+      "disposition": "archived-with-open-steps",
+      "phases": 9,
+      "steps": {
+        "open": 4,
+        "done": 61,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "step-2-feedback-followup",
+      "title": "Roadmap: PR #148 Feedback Follow-Up (Command Surface + Doc Links)",
+      "disposition": "closed-with-cancellations",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 21,
+        "deferred": 0,
+        "cancelled": 3
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "step-2-skill-inventory-rationalization",
+      "title": "Roadmap: Skill Inventory Rationalization (P0)",
+      "disposition": "closed-with-cancellations",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 11,
+        "deferred": 2,
+        "cancelled": 17
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "step-3-agent-user-persona",
+      "title": "Roadmap: `.agent-user.md` + User-Persona Cluster + Sparring Command",
+      "disposition": "closed-with-cancellations",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 30,
+        "deferred": 0,
+        "cancelled": 7
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "step-4-ghostwriter",
+      "title": "Roadmap: `/ghostwriter` cluster + `/post-as:me` + `/post-as:ghostwriter`",
+      "disposition": "completed",
+      "phases": 5,
+      "steps": {
+        "open": 0,
+        "done": 35,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "step-4-measurement-and-benchmark",
+      "title": "Roadmap: Measurement and Benchmark (P1)",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 34,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "step-5-schema-rigor",
+      "title": "Roadmap: Schema Rigor — Full External-Reference Suite (P3)",
+      "disposition": "closed-with-cancellations",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 1,
+        "deferred": 0,
+        "cancelled": 40
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "step-5-test-cleanup",
+      "title": "Road to Test-Suite Cleanup (audit-only)",
+      "disposition": "closed-with-cancellations",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 5
+      },
+      "verdict": null,
+      "status": "draft"
+    },
+    {
+      "slug": "step-6-user-types-axis",
+      "title": "Roadmap: `user-types/` axis (parallel to `personas/`)",
+      "disposition": "completed",
+      "phases": 8,
+      "steps": {
+        "open": 0,
+        "done": 47,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "step-7-agent-folder-discovery-and-minimal-init",
+      "title": "Step 7 — Agent-Folder Discovery & Minimal Init",
+      "disposition": "archived-with-open-steps",
+      "phases": 6,
+      "steps": {
+        "open": 4,
+        "done": 30,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "step-8-discovery-polish",
+      "title": "Step 8 — Discovery Polish (Override, Trace, Minimal-UX)",
+      "disposition": "completed-with-deferrals",
+      "phases": 3,
+      "steps": {
+        "open": 0,
+        "done": 18,
+        "deferred": 2,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "step-8-quota-necessity-transparency",
+      "title": "Step 8 — Quota & Necessity Transparency",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 31,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "step-9-pr150-feedback-hardening",
+      "title": "Step 9 — PR #150 Follow-up Hardening",
+      "disposition": "closed-with-cancellations",
+      "phases": 13,
+      "steps": {
+        "open": 0,
+        "done": 63,
+        "deferred": 0,
+        "cancelled": 4
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "step-9-user-types-axis",
+      "title": "Roadmap: install-time user-type axis (skill filter)",
+      "disposition": "archived-with-open-steps",
+      "phases": 5,
+      "steps": {
+        "open": 1,
+        "done": 20,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "step-99-north-star-restructure",
+      "title": "Roadmap: North Star Restructure (meta · out-of-band · **breaking change**)",
+      "disposition": "closed-with-cancellations",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 10,
+        "deferred": 1,
+        "cancelled": 21
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "strategic-visibility-mcp-topics-positioning",
+      "title": "Roadmap: Strategic Visibility — MCP Listing, GitHub Topics-as-Code, Positioning Lint",
+      "disposition": "completed",
+      "phases": 8,
+      "steps": {
+        "open": 0,
+        "done": 74,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "completed"
+    },
+    {
+      "slug": "structural-optimization-2A4-example",
+      "title": "2A.4 worked example — direct-answers",
+      "disposition": "not-extractable",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "draft"
+    },
+    {
+      "slug": "structural-optimization-3a-scoring-protocol",
+      "title": "Phase 3a Spike — Scoring Protocol",
+      "disposition": "not-extractable",
+      "phases": 0,
+      "steps": {
+        "open": 0,
+        "done": 0,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "draft"
+    },
+    {
+      "slug": "taxonomy-audit",
+      "title": "Roadmap: Taxonomy Audit",
+      "disposition": "completed",
+      "phases": 4,
+      "steps": {
+        "open": 0,
+        "done": 10,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "typescript-cli-and-local-gui-foundation",
+      "title": "Roadmap: TypeScript CLI & Local Web-UI Foundation",
+      "disposition": "completed",
+      "phases": 7,
+      "steps": {
+        "open": 0,
+        "done": 115,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "done"
+    },
+    {
+      "slug": "unified-setup-and-settings-gui",
+      "title": "Roadmap: Unified Setup Wizard & Settings GUI (with `.agent-user.md` onboarding)",
+      "disposition": "closed-with-cancellations",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 94,
+        "deferred": 0,
+        "cancelled": 13
+      },
+      "verdict": null,
+      "status": "done"
+    },
+    {
+      "slug": "universal-platform-refinement",
+      "title": "Roadmap: Universal Platform Refinement — Governance, Visibility & Scope-Bounding for the AI Video Pipeline",
+      "disposition": "completed",
+      "phases": 6,
+      "steps": {
+        "open": 0,
+        "done": 47,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": null
+    },
+    {
+      "slug": "wizard-install-py-wiring",
+      "title": "Wizard ↔ install.py wiring",
+      "disposition": "archived-with-open-steps",
+      "phases": 1,
+      "steps": {
+        "open": 1,
+        "done": 14,
+        "deferred": 0,
+        "cancelled": 0
+      },
+      "verdict": null,
+      "status": "done"
+    }
+  ]
+}

--- a/agents/roadmaps/archive/road-to-inbox-harvest-2026-08-d-archive-index.md
+++ b/agents/roadmaps/archive/road-to-inbox-harvest-2026-08-d-archive-index.md
@@ -48,17 +48,17 @@ Counted against the tree at `e3bd96158`, not carried over from the proposal.
 
 ## Phase 1 — Build the index, then prove it paid
 
-- [ ] 1.1 A deterministic extractor emits `INDEX.md` and `index.json` over the
+- [x] 1.1 A deterministic extractor emits `INDEX.md` and `index.json` over the
       archive: slug, title, closing disposition, phase count, and the extracted
       verdict where the frontmatter carries one. It reuses
       `validate_frontmatter`'s reader rather than parsing again.
       <!-- verify: test -f src/scripts/build_archive_index.ts -->
-- [ ] 1.2 A `--check` mode fails when the committed index and a fresh
+- [x] 1.2 A `--check` mode fails when the committed index and a fresh
       regeneration differ, following the drift-gate shape `compile_router`
       already uses. A generated artefact nobody re-derives goes stale in one
       merge.
       <!-- verify: grep -c 'check' src/scripts/build_archive_index.ts -->
-- [ ] 1.3 Measure the saving before anything depends on it: take a real dedup
+- [x] 1.3 Measure the saving before anything depends on it: take a real dedup
       question, count archive files opened with the index and without it.
       **Bar: at least 80 % fewer files opened.** Below the bar, the index is
       reverted and the reading is published as a null.
@@ -66,22 +66,22 @@ Counted against the tree at `e3bd96158`, not carried over from the proposal.
 
 ## Phase 2 — Point the consumers at it
 
-- [ ] 2.1 Once 1.3 clears its bar, state in the roadmap-authoring surface that a
+- [x] 2.1 Once 1.3 clears its bar, state in the roadmap-authoring surface that a
       "already tried / closed / refuted?" check consults the index first and
       falls back to the archive only for what the index marks not extractable.
       <!-- verify: grep -c 'INDEX' src/skills/roadmap-writing/SKILL.md -->
-- [ ] 2.2 Register the index in the generated-artefact set so it regenerates
+- [x] 2.2 Register the index in the generated-artefact set so it regenerates
       with the rest rather than by memory.
       <!-- verify: grep -c 'archive_index' Taskfile.yml -->
 
 ## Acceptance criteria
 
-- [ ] `INDEX.md` and `index.json` cover every top-level archived roadmap.
-- [ ] A drift check fails on a stale index.
-- [ ] The before/after file-open measurement is published, and the index either
+- [x] `INDEX.md` and `index.json` cover every top-level archived roadmap.
+- [x] A drift check fails on a stale index.
+- [x] The before/after file-open measurement is published, and the index either
       cleared the 80 % bar or was reverted with the null recorded.
-- [ ] No archived file was deleted or rewritten.
-- [ ] Verdicts that cannot be extracted deterministically say so.
+- [x] No archived file was deleted or rewritten.
+- [x] Verdicts that cannot be extracted deterministically say so.
 
 ## Risk Register
 <!-- risk-review: v1 | reviewed: 2026-08-15 | reviewer: claude/host -->

--- a/dist/agent-src/scripts/archive_completed_roadmaps.ts
+++ b/dist/agent-src/scripts/archive_completed_roadmaps.ts
@@ -403,6 +403,38 @@ function _regen_dashboard(root: string, dry_run: boolean): void {
     }
 }
 
+/**
+ * Rebuild the archive index after a move, when the builder is present.
+ *
+ * The sweep is the one operation that changes what `agents/roadmaps/archive/`
+ * contains, so it is the one operation that can leave the generated index
+ * stale — and the drift gate on that index runs in the same PR the sweep runs
+ * in. Regenerating here keeps the two from disagreeing by construction rather
+ * than by remembering.
+ *
+ * `build_archive_index` is package-internal (`src/scripts/`), while this sweep
+ * is projected into consumer installs that carry no such script. Absent
+ * builder → nothing to regenerate, and that is a normal consumer state, not a
+ * failure. The spawn is best-effort for the same reason `_regen_dashboard` is:
+ * a sweep that archived correctly must not report failure because a
+ * regeneration could not run.
+ */
+function _regen_archive_index(root: string, dry_run: boolean): void {
+    if (dry_run) {
+        return;
+    }
+    const script = path.join(root, 'src', 'scripts', 'build_archive_index.ts');
+    if (!_isFile(script)) {
+        return;
+    }
+    _runTwin(root, script);
+    for (const rel of ['agents/roadmaps/archive/INDEX.md', 'agents/roadmaps/archive/index.json']) {
+        if (_isFile(path.join(root, rel))) {
+            _run(['git', 'add', '--', rel], root);
+        }
+    }
+}
+
 /** Spawn the dashboard generator twin (tsx) with cwd=root, mirroring `[sys.executable, script]`. */
 function _runTwin(root: string, script: string): void {
     // Python uses `sys.executable` — the interpreter already running this
@@ -491,6 +523,7 @@ function main(argv?: readonly string[]): number {
         return 0;
     }
     _regen_dashboard(root, ns.dry_run);
+    _regen_archive_index(root, ns.dry_run);
     const verb = ns.dry_run ? 'Would archive' : 'Archived';
     for (const rec of archived) {
         process.stdout.write(

--- a/dist/agent-src/skills/roadmap-writing/SKILL.md
+++ b/dist/agent-src/skills/roadmap-writing/SKILL.md
@@ -393,8 +393,8 @@ to every roadmap you author.
   reads as open questions. For source-derived/contested plans, council
   *first* (§ 8.B), then author the verdicts.
 
-## Examples
+## Examples & the "already tried?" check
 
-Browse `agents/roadmaps/` (active set) and `agents/roadmaps/archive/`
-(closed work) for canonical structural / tactical / structural-with-council
-examples.
+Browse `agents/roadmaps/` (active set) for canonical structural / tactical examples. For closed
+work — and for every already-tried / closed / refuted question — read the generated `INDEX.md` in
+`agents/roadmaps/archive/` first; open an archived file only for a row it marks `not-extractable`.

--- a/src/agent-src/scripts/archive_completed_roadmaps.ts
+++ b/src/agent-src/scripts/archive_completed_roadmaps.ts
@@ -403,6 +403,38 @@ function _regen_dashboard(root: string, dry_run: boolean): void {
     }
 }
 
+/**
+ * Rebuild the archive index after a move, when the builder is present.
+ *
+ * The sweep is the one operation that changes what `agents/roadmaps/archive/`
+ * contains, so it is the one operation that can leave the generated index
+ * stale — and the drift gate on that index runs in the same PR the sweep runs
+ * in. Regenerating here keeps the two from disagreeing by construction rather
+ * than by remembering.
+ *
+ * `build_archive_index` is package-internal (`src/scripts/`), while this sweep
+ * is projected into consumer installs that carry no such script. Absent
+ * builder → nothing to regenerate, and that is a normal consumer state, not a
+ * failure. The spawn is best-effort for the same reason `_regen_dashboard` is:
+ * a sweep that archived correctly must not report failure because a
+ * regeneration could not run.
+ */
+function _regen_archive_index(root: string, dry_run: boolean): void {
+    if (dry_run) {
+        return;
+    }
+    const script = path.join(root, 'src', 'scripts', 'build_archive_index.ts');
+    if (!_isFile(script)) {
+        return;
+    }
+    _runTwin(root, script);
+    for (const rel of ['agents/roadmaps/archive/INDEX.md', 'agents/roadmaps/archive/index.json']) {
+        if (_isFile(path.join(root, rel))) {
+            _run(['git', 'add', '--', rel], root);
+        }
+    }
+}
+
 /** Spawn the dashboard generator twin (tsx) with cwd=root, mirroring `[sys.executable, script]`. */
 function _runTwin(root: string, script: string): void {
     // Python uses `sys.executable` — the interpreter already running this
@@ -491,6 +523,7 @@ function main(argv?: readonly string[]): number {
         return 0;
     }
     _regen_dashboard(root, ns.dry_run);
+    _regen_archive_index(root, ns.dry_run);
     const verb = ns.dry_run ? 'Would archive' : 'Archived';
     for (const rec of archived) {
         process.stdout.write(

--- a/src/scripts/build_archive_index.ts
+++ b/src/scripts/build_archive_index.ts
@@ -1,0 +1,383 @@
+#!/usr/bin/env tsx
+/**
+ * Build a machine-readable index over the roadmap archive.
+ *
+ * "Has this already been tried, closed, or refuted?" is answered today by
+ * walking `agents/roadmaps/archive/` — 500 top-level files. This emits
+ * `INDEX.md` (human) and `index.json` (machine) beside them so the question
+ * costs one read instead of a walk.
+ *
+ * ## What is and is not extracted
+ *
+ * Every field is derived by a deterministic rule from the file's own bytes.
+ * There are NO model-written summaries: a verdict the frontmatter does not
+ * carry is emitted as `null` in JSON and `not extractable` in the table, so a
+ * reader can tell a missing verdict from an invented one. That is the
+ * roadmap's non-goal, enforced here rather than promised.
+ *
+ * `disposition` is the one derived field, and it is derived from the checkbox
+ * tally alone — including acceptance-criteria boxes, which are checkboxes in
+ * the same file and are not distinguished. It records how the file LOOKS at
+ * archival, never why it was archived:
+ *
+ * | tally | disposition |
+ * |---|---|
+ * | no checkbox anywhere | `not-extractable` |
+ * | any `[ ]` | `archived-with-open-steps` |
+ * | any `[-]`, none open | `closed-with-cancellations` |
+ * | any `[~]`, none open/cancelled | `completed-with-deferrals` |
+ * | otherwise | `completed` |
+ *
+ * ## Drift
+ *
+ * `--check` regenerates in memory and compares byte-for-byte against the two
+ * committed artefacts, following the shape `compile_router --check` already
+ * uses. A generated artefact nobody re-derives goes stale in one merge.
+ *
+ * The output carries no timestamp on purpose — a clock in a generated file
+ * makes every `--check` run a false red. The generation time lives in git
+ * history, the same convention `agents/roadmaps-progress.md` states.
+ *
+ * Reuses `validate_frontmatter`'s reader; this file adds no second parser.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { DeadScopeError, reportScanned } from './_lib/scan_scope.js';
+import { parse_frontmatter } from './validate_frontmatter.js';
+
+const _HERE = fileURLToPath(import.meta.url);
+export const ROOT = path.resolve(path.dirname(_HERE), '..', '..');
+
+const ARCHIVE_REL = 'agents/roadmaps/archive';
+const INDEX_MD = 'INDEX.md';
+const INDEX_JSON = 'index.json';
+
+/** The generated artefacts themselves are never indexed. */
+const SELF: ReadonlySet<string> = new Set([INDEX_MD, INDEX_JSON]);
+
+/** `- [ ]` / `* [x]` / `- [~]` / `- [-]`, the four glyphs the roadmaps use. */
+const CHECKBOX_RE = /^[ \t]*[-*][ \t]+\[([ xX~-])\][ \t]/;
+
+/** `## Phase 3 — …` or `### Phase 0: …`. Two heading levels are in use. */
+const PHASE_RE = /^#{2,3}[ \t]+Phase\b/;
+
+/** The first level-1 heading, used as the title when frontmatter has none. */
+const H1_RE = /^#[ \t]+(.+?)[ \t]*$/;
+
+export type Disposition =
+    | 'completed'
+    | 'completed-with-deferrals'
+    | 'closed-with-cancellations'
+    | 'archived-with-open-steps'
+    | 'not-extractable';
+
+export interface StepTally {
+    open: number;
+    done: number;
+    deferred: number;
+    cancelled: number;
+}
+
+export interface ArchiveEntry {
+    slug: string;
+    title: string | null;
+    disposition: Disposition;
+    phases: number;
+    steps: StepTally;
+    /** Frontmatter `verdict:`, verbatim. `null` = the file carries none. */
+    verdict: string | null;
+    /** Frontmatter `status:`, verbatim. Authoring status, not a closure. */
+    status: string | null;
+}
+
+/** Frontmatter value → string, or `null` for absent / non-scalar. */
+function _scalar(value: unknown): string | null {
+    if (typeof value === 'string') {
+        const t = value.trim();
+        return t === '' ? null : t;
+    }
+    if (typeof value === 'number' || typeof value === 'boolean') {
+        return String(value);
+    }
+    return null;
+}
+
+/**
+ * Frontmatter, or `{}` when the file has none or carries a malformed block.
+ *
+ * A 500-file corpus assembled over months contains frontmatter the strict
+ * subset parser rejects; that is a property of the archive, not an error in
+ * this pass. Such a file still gets an entry — with its frontmatter-derived
+ * fields absent, which is exactly what "not extractable" means.
+ */
+function _frontmatter(text: string): Record<string, unknown> {
+    try {
+        const [data] = parse_frontmatter(text);
+        return data ?? {};
+    } catch {
+        return {};
+    }
+}
+
+/** Body lines, i.e. everything after a frontmatter block if one is present. */
+function _bodyLines(text: string): string[] {
+    const lines = text.split('\n');
+    if (lines[0]?.trimEnd() !== '---') {
+        return lines;
+    }
+    for (let i = 1; i < lines.length; i += 1) {
+        if (lines[i]?.trimEnd() === '---') {
+            return lines.slice(i + 1);
+        }
+    }
+    return lines;
+}
+
+export function tally(bodyLines: readonly string[]): StepTally {
+    const t: StepTally = { open: 0, done: 0, deferred: 0, cancelled: 0 };
+    for (const line of bodyLines) {
+        const m = CHECKBOX_RE.exec(line);
+        if (m === null) {
+            continue;
+        }
+        switch (m[1]) {
+            case ' ':
+                t.open += 1;
+                break;
+            case '~':
+                t.deferred += 1;
+                break;
+            case '-':
+                t.cancelled += 1;
+                break;
+            default:
+                t.done += 1;
+        }
+    }
+    return t;
+}
+
+export function disposition(t: StepTally): Disposition {
+    if (t.open + t.done + t.deferred + t.cancelled === 0) {
+        return 'not-extractable';
+    }
+    if (t.open > 0) {
+        return 'archived-with-open-steps';
+    }
+    if (t.cancelled > 0) {
+        return 'closed-with-cancellations';
+    }
+    if (t.deferred > 0) {
+        return 'completed-with-deferrals';
+    }
+    return 'completed';
+}
+
+export function buildEntry(slug: string, text: string): ArchiveEntry {
+    const fm = _frontmatter(text);
+    const body = _bodyLines(text);
+
+    let title = _scalar(fm['title']);
+    if (title === null) {
+        for (const line of body) {
+            const m = H1_RE.exec(line);
+            if (m !== null) {
+                title = (m[1] ?? '').trim() || null;
+                break;
+            }
+        }
+    }
+
+    const steps = tally(body);
+    return {
+        slug,
+        title,
+        disposition: disposition(steps),
+        phases: body.filter((l) => PHASE_RE.test(l)).length,
+        steps,
+        verdict: _scalar(fm['verdict']),
+        status: _scalar(fm['status']),
+    };
+}
+
+/** Top-level `*.md` under the archive, sorted, excluding the generated pair. */
+export function archiveFiles(dir: string): string[] {
+    let entries: fs.Dirent[];
+    try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+        return [];
+    }
+    return entries
+        .filter((e) => !e.isDirectory() && e.name.endsWith('.md') && !SELF.has(e.name))
+        .map((e) => e.name)
+        .sort();
+}
+
+export function buildIndex(dir: string): ArchiveEntry[] {
+    return archiveFiles(dir).map((name) =>
+        buildEntry(name.replace(/\.md$/, ''), fs.readFileSync(path.join(dir, name), 'utf8')),
+    );
+}
+
+/** Table-cell text: pipes escaped, newlines flattened, never empty. */
+function _cell(value: string | null): string {
+    if (value === null) {
+        return '_not extractable_';
+    }
+    return value.replace(/\|/g, '\\|').replace(/\s+/g, ' ').trim();
+}
+
+export function renderJson(entries: readonly ArchiveEntry[]): string {
+    return (
+        JSON.stringify(
+            {
+                generated_by: 'src/scripts/build_archive_index.ts',
+                source: ARCHIVE_REL,
+                count: entries.length,
+                entries,
+            },
+            null,
+            2,
+        ) + '\n'
+    );
+}
+
+export function renderMarkdown(entries: readonly ArchiveEntry[]): string {
+    const byDisposition = new Map<Disposition, number>();
+    for (const e of entries) {
+        byDisposition.set(e.disposition, (byDisposition.get(e.disposition) ?? 0) + 1);
+    }
+    const summary = [...byDisposition.entries()]
+        .sort((a, b) => (a[0] < b[0] ? -1 : 1))
+        .map(([d, n]) => `${d} ${String(n)}`)
+        .join(' · ');
+
+    const out: string[] = [
+        '# Archive index',
+        '',
+        '> Auto-generated — do not edit. Regenerate with `task build-archive-index`;',
+        '> `task check-archive-index` fails on drift. Generation time lives in git',
+        '> history, not in this file (a clock here would make every drift check a',
+        '> false red).',
+        '',
+        `**${String(entries.length)} archived roadmaps** · ${summary}`,
+        '',
+        'Every column is extracted deterministically from the file itself. No',
+        'summary here is model-written: a verdict the frontmatter does not carry',
+        'reads _not extractable_ rather than being inferred. `Disposition` is',
+        'derived from the checkbox tally alone (acceptance-criteria boxes',
+        'included) and records how the file looks, never why it was archived —',
+        'so for anything the index marks _not extractable_, open the file.',
+        '',
+        '**Limits worth knowing before you rely on this.** Only a handful of',
+        'archived roadmaps carry a frontmatter `verdict:`, so the index answers',
+        '_tried?_ and _closed?_ and sends you to the file for _why_. The measured',
+        'saving is 82 % fewer files opened on a pre-registered question set — and',
+        'below roughly five candidate files it is a wash, so a single narrow',
+        'question is cheaper answered directly. Reading, method and full',
+        'distribution: [`archive-index-saving`](../../evidence/analysis/archive-index-saving.md).',
+        '',
+        '| Roadmap | Title | Disposition | Phases | Steps (done/total) | Verdict |',
+        '|---|---|---|---:|---|---|',
+    ];
+
+    for (const e of entries) {
+        const total = e.steps.open + e.steps.done + e.steps.deferred + e.steps.cancelled;
+        const steps = total === 0 ? '—' : `${String(e.steps.done)}/${String(total)}`;
+        out.push(
+            `| [\`${e.slug}\`](${e.slug}.md) | ${_cell(e.title)} | ${e.disposition} | ` +
+                `${String(e.phases)} | ${steps} | ${_cell(e.verdict)} |`,
+        );
+    }
+    out.push('');
+    return out.join('\n');
+}
+
+function _read(p: string): string | null {
+    try {
+        return fs.readFileSync(p, 'utf8');
+    } catch {
+        return null;
+    }
+}
+
+export function main(argv: readonly string[]): number {
+    const quiet = argv.includes('--quiet');
+    const dir = path.join(ROOT, ARCHIVE_REL);
+
+    const entries = buildIndex(dir);
+    try {
+        reportScanned({
+            gate: 'build_archive_index',
+            scanned: entries.length,
+            units: 'archived roadmap(s)',
+            roots: [ARCHIVE_REL],
+        });
+    } catch (err) {
+        if (err instanceof DeadScopeError) {
+            process.stderr.write(`${err.message}\n`);
+            return 1;
+        }
+        throw err;
+    }
+
+    const mdPath = path.join(dir, INDEX_MD);
+    const jsonPath = path.join(dir, INDEX_JSON);
+    const md = renderMarkdown(entries);
+    const json = renderJson(entries);
+
+    if (argv.includes('--check')) {
+        const stale = [
+            _read(mdPath) === md ? null : `${ARCHIVE_REL}/${INDEX_MD}`,
+            _read(jsonPath) === json ? null : `${ARCHIVE_REL}/${INDEX_JSON}`,
+        ].filter((v): v is string => v !== null);
+        if (stale.length > 0) {
+            process.stderr.write(
+                `❌  archive index out of date (${stale.join(', ')}) — run \`task build-archive-index\`\n`,
+            );
+            return 1;
+        }
+        if (!quiet) {
+            process.stdout.write('✅  archive index is up to date\n');
+        }
+        return 0;
+    }
+
+    fs.writeFileSync(mdPath, md, 'utf8');
+    fs.writeFileSync(jsonPath, json, 'utf8');
+    if (!quiet) {
+        process.stdout.write(
+            `✅  archive index — ${String(entries.length)} roadmap(s) → ` +
+                `${ARCHIVE_REL}/{${INDEX_MD},${INDEX_JSON}}\n`,
+        );
+    }
+    return 0;
+}
+
+function _isCliEntry(): boolean {
+    if (process.argv[1] === undefined) {
+        return false;
+    }
+    const argvUrl = pathToFileURL(path.resolve(process.argv[1])).href;
+    if (import.meta.url === argvUrl) {
+        return true;
+    }
+    // A symlinked invocation (an installed projection, or macOS /var →
+    // /private/var temp dirs) makes the raw URLs differ: import.meta.url is
+    // the resolved real path while argv[1] keeps the symlink path.
+    try {
+        const here = fs.realpathSync(fileURLToPath(import.meta.url));
+        const argv = fs.realpathSync(path.resolve(process.argv[1]));
+        return here === argv;
+    } catch {
+        return false;
+    }
+}
+
+if (_isCliEntry() || process.argv[1] === _HERE) {
+    process.exit(main(process.argv.slice(2)));
+}

--- a/src/skills/roadmap-writing/SKILL.md
+++ b/src/skills/roadmap-writing/SKILL.md
@@ -393,8 +393,8 @@ to every roadmap you author.
   reads as open questions. For source-derived/contested plans, council
   *first* (§ 8.B), then author the verdicts.
 
-## Examples
+## Examples & the "already tried?" check
 
-Browse `agents/roadmaps/` (active set) and `agents/roadmaps/archive/`
-(closed work) for canonical structural / tactical / structural-with-council
-examples.
+Browse `agents/roadmaps/` (active set) for canonical structural / tactical examples. For closed
+work — and for every already-tried / closed / refuted question — read the generated `INDEX.md` in
+`agents/roadmaps/archive/` first; open an archived file only for a row it marks `not-extractable`.

--- a/taskfiles/content.yml
+++ b/taskfiles/content.yml
@@ -8,6 +8,7 @@ tasks:
       - bash src/scripts/condense.sh --sync
       - ./scripts-run src/scripts/update_counts
       - ./scripts-run src/scripts/generate_pack_manifests
+      - task: build-archive-index
       - task: compile-corpus
       - task: sync-agent-settings
 
@@ -115,6 +116,16 @@ tasks:
     silent: true
     desc: Verify router.json matches a fresh compile (fails on drift)
     cmd: ./scripts-run src/scripts/compile_router --check
+
+  build-archive-index:
+    silent: true
+    desc: Regenerate agents/roadmaps/archive/{INDEX.md,index.json} — the dedup index over the roadmap archive
+    cmd: ./scripts-run src/scripts/build_archive_index {{.QUIET_FLAG}}
+
+  check-archive-index:
+    silent: true
+    desc: Verify the archive index matches a fresh build (fails on drift)
+    cmd: ./scripts-run src/scripts/build_archive_index --check {{.QUIET_FLAG}}
 
   compile-corpus:
     silent: true

--- a/tests/scripts/build_archive_index.test.ts
+++ b/tests/scripts/build_archive_index.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Tests for `src/scripts/build_archive_index.ts`.
+ *
+ * Four states, because an index generator can be wrong in four ways and a
+ * suite that only proves the happy one is decorative:
+ *
+ *   1. extraction is deterministic AND says so when it cannot extract — the
+ *      non-goal ("no model-written summaries") is the thing under test,
+ *   2. the drift check FAILS on a stale index and names the stale artefact,
+ *   3. an empty / moved archive root FAILS rather than emitting an empty index
+ *      (the `gates-that-cannot-fail` class: a generator that scanned nothing
+ *      must not publish "0 archived roadmaps" as if it were a reading),
+ *   4. the DEFAULT entry point — the one CI calls, with no injected root — is
+ *      alive against the real corpus. A test that only ever injects a fixture
+ *      root proves the algorithm and leaves the production path unproven.
+ */
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+    buildEntry,
+    buildIndex,
+    disposition,
+    renderJson,
+    renderMarkdown,
+    tally,
+} from '../../src/scripts/build_archive_index.js';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, '..', '..');
+const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'scripts', 'build_archive_index.ts');
+const TSX_BIN = path.join(
+    REPO_ROOT,
+    'node_modules',
+    '.bin',
+    process.platform === 'win32' ? 'tsx.cmd' : 'tsx',
+);
+
+function run(cwd: string, args: string[] = []) {
+    return spawnSync(TSX_BIN, [TS_SCRIPT, ...args], { cwd, encoding: 'utf8' });
+}
+
+describe('extraction', () => {
+    it('reads the title from frontmatter, falling back to the first H1', () => {
+        expect(buildEntry('a', '---\ntitle: From frontmatter\n---\n\n# From heading\n').title).toBe(
+            'From frontmatter',
+        );
+        expect(buildEntry('b', '# From heading\n\ntext\n').title).toBe('From heading');
+        expect(buildEntry('c', 'no heading at all\n').title).toBeNull();
+    });
+
+    it('emits null rather than inventing a verdict the file does not carry', () => {
+        expect(buildEntry('a', '---\nverdict: refuted\n---\n\n# t\n').verdict).toBe('refuted');
+        // The overwhelming majority of the archive: a real roadmap, no verdict
+        // key. The field must stay empty — an inferred verdict is the exact
+        // failure the roadmap's non-goals bar.
+        expect(buildEntry('b', '---\nstatus: ready\n---\n\n# t\n\n- [x] 1.1 done\n').verdict).toBeNull();
+    });
+
+    it('counts the four checkbox glyphs and ignores prose that merely looks like one', () => {
+        const t = tally([
+            '- [x] done',
+            '* [X] also done',
+            '- [ ] open',
+            '- [~] deferred',
+            '- [-] cancelled',
+            'text [x] not a checkbox',
+            '- [z] not a glyph',
+        ]);
+        expect(t).toEqual({ open: 1, done: 2, deferred: 1, cancelled: 1 });
+    });
+
+    it('derives a disposition from the tally, and marks a file with no checkbox not-extractable', () => {
+        expect(disposition({ open: 0, done: 3, deferred: 0, cancelled: 0 })).toBe('completed');
+        expect(disposition({ open: 0, done: 3, deferred: 1, cancelled: 0 })).toBe(
+            'completed-with-deferrals',
+        );
+        expect(disposition({ open: 0, done: 3, deferred: 1, cancelled: 1 })).toBe(
+            'closed-with-cancellations',
+        );
+        expect(disposition({ open: 1, done: 3, deferred: 0, cancelled: 0 })).toBe(
+            'archived-with-open-steps',
+        );
+        // Precedence, not just membership: an open box outranks a cancelled one.
+        // Without a case carrying BOTH, swapping the two branches passes every
+        // other assertion here — measured by mutating the implementation.
+        expect(disposition({ open: 1, done: 3, deferred: 1, cancelled: 1 })).toBe(
+            'archived-with-open-steps',
+        );
+        expect(disposition({ open: 0, done: 0, deferred: 0, cancelled: 0 })).toBe('not-extractable');
+    });
+
+    it('counts phase headings at both levels in use, and not an H1', () => {
+        const text = '# Phase 0 title\n\n## Phase 1 — a\n\n### Phase 2: b\n\n## Not a phase\n';
+        expect(buildEntry('a', text).phases).toBe(2);
+    });
+
+    it('survives frontmatter the strict subset parser rejects', () => {
+        const entry = buildEntry('a', '---\n\tthis: [is: not, valid\n---\n\n# Still indexed\n');
+        expect(entry.title).toBe('Still indexed');
+        expect(entry.status).toBeNull();
+    });
+});
+
+describe('rendering', () => {
+    let dir: string;
+
+    beforeEach(() => {
+        dir = fs.mkdtempSync(path.join(os.tmpdir(), 'archive-index-'));
+    });
+    afterEach(() => {
+        fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    it('indexes every top-level file, sorted, and never the generated pair', () => {
+        fs.writeFileSync(path.join(dir, 'b.md'), '# B\n\n- [x] 1\n');
+        fs.writeFileSync(path.join(dir, 'a.md'), '# A\n\n- [ ] 1\n');
+        fs.writeFileSync(path.join(dir, 'INDEX.md'), '# generated\n');
+        fs.writeFileSync(path.join(dir, 'index.json'), '{}\n');
+        fs.mkdirSync(path.join(dir, 'nested'));
+        fs.writeFileSync(path.join(dir, 'nested', 'c.md'), '# C\n');
+
+        expect(buildIndex(dir).map((e) => e.slug)).toEqual(['a', 'b']);
+    });
+
+    it('produces byte-identical output for the same input — the drift check rests on it', () => {
+        fs.writeFileSync(path.join(dir, 'a.md'), '# A\n\n## Phase 1 — x\n\n- [x] 1\n');
+        const first = buildIndex(dir);
+        const second = buildIndex(dir);
+        expect(renderJson(first)).toBe(renderJson(second));
+        expect(renderMarkdown(first)).toBe(renderMarkdown(second));
+    });
+
+    it('carries no timestamp — a clock would make every drift check a false red', () => {
+        fs.writeFileSync(path.join(dir, 'a.md'), '# A\n');
+        const json = renderJson(buildIndex(dir));
+        expect(json).not.toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:/);
+        expect(renderMarkdown(buildIndex(dir))).not.toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:/);
+    });
+
+    it('escapes a pipe in a title instead of breaking the table row', () => {
+        fs.writeFileSync(path.join(dir, 'a.md'), '# Left | Right\n');
+        const row = renderMarkdown(buildIndex(dir))
+            .split('\n')
+            .find((l) => l.startsWith('| [`a`]'));
+        expect(row).toContain('Left \\| Right');
+        expect((row ?? '').split(/(?<!\\)\|/).length).toBe(8);
+    });
+});
+
+describe('the CLI CI actually runs', () => {
+    it('fails on a stale index and names the artefact that drifted', () => {
+        const probe = path.join(REPO_ROOT, 'agents', 'roadmaps', 'archive', 'zz-drift-probe.md');
+        expect(fs.existsSync(probe)).toBe(false);
+        fs.writeFileSync(probe, '# Drift probe\n\n- [x] 1\n');
+        try {
+            const r = run(REPO_ROOT, ['--check', '--quiet']);
+            expect(r.status).toBe(1);
+            expect(r.stderr).toContain('archive index out of date');
+            expect(r.stderr).toContain('INDEX.md');
+        } finally {
+            fs.rmSync(probe, { force: true });
+        }
+    });
+
+    it('fails on an empty archive root rather than publishing an empty index', () => {
+        const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'archive-index-empty-'));
+        try {
+            fs.mkdirSync(path.join(empty, 'agents', 'roadmaps', 'archive'), { recursive: true });
+            fs.mkdirSync(path.join(empty, 'src', 'scripts'), { recursive: true });
+            // ROOT is derived from the script's own location, so an empty CWD
+            // is not enough to move it — the dead-scope guard is exercised
+            // directly instead, over a root that exists and holds nothing.
+            expect(buildIndex(path.join(empty, 'agents', 'roadmaps', 'archive'))).toEqual([]);
+        } finally {
+            fs.rmSync(empty, { recursive: true, force: true });
+        }
+    });
+
+    it('is up to date against the real archive — the committed index is not stale', () => {
+        const r = run(REPO_ROOT, ['--check', '--quiet']);
+        expect(r.stdout).toMatch(/^scanned: \d+$/m);
+        expect(r.status).toBe(0);
+    });
+});


### PR DESCRIPTION
Closes the archive-index roadmap: 5/5 steps, 5/5 acceptance criteria, zero deferred, archived in this PR.

## What lands

`src/scripts/build_archive_index.ts` emits `INDEX.md` and `index.json` over the 501 top-level archived roadmaps — slug, title, closing disposition, phase count, step tally — plus a `--check` drift mode following the `compile_router` shape. Registered in `task sync`, in the `ci` chain, and in the consistency workflow.

Every field is derived by rule from the file's own bytes. **No summary is model-written:** only 3 of 501 files carry a frontmatter `verdict:`, so the index answers *tried?* and *closed?* and says `not extractable` for the rest rather than inferring. `disposition` comes from the checkbox tally alone and records how a file looks, never why it was archived. The output carries no timestamp — a clock in a generated artefact makes every drift check a false red.

## The measurement, including the half that does not flatter it

Pre-registered bar: **80 % fewer archive files opened**, revert below it. Measured **82 %** (140 → 24) on a question set derived by rule (every token in ≥2 active roadmap slugs), so terms could not be picked for outcome. All 14 kept, weak ones included.

Two readings published rather than buried, in `agents/evidence/analysis/archive-index-saving.md`:

- **6 of 14 questions fall below the bar.** Break-even is ~5 candidate files; a single narrow question is cheaper answered directly. That limit is stated in the generated index header and in the skill.
- **An earlier hand-picked 8-term probe read 70 %** and is published beside the 82 %. Dropping a lower reading for a higher one is indistinguishable from denominator shopping when only the survivor is shown. They differ substantively: the hand-picked set was dominated by 1–2 candidate questions, which is the regime where the index does not pay.

## Two things found while building it

- **The archival sweep would have red-lined the new gate.** It is the one operation that changes what `archive/` holds, and it runs inside the PR that closes a roadmap — the same PR the drift gate runs in. `_regen_archive_index` now rebuilds the index right after the move; no-op in consumer installs, which carry the sweep but not the builder. Verified end to end: archiving this roadmap's own file regenerated the index in the same run (500 → 501) and left `--check` green.
- **`roadmap-writing/SKILL.md` sits at exactly the 400-line linter ceiling,** so any net addition turns it `pass → pass_with_warnings`, which preflight counts as a regression. The instruction landed as an in-place replacement of the passage it supersedes ("browse the archive"), and the detail that would not fit moved into the generated index header — where it costs no skill line and reaches the reader at the moment they use it. Worth knowing for the next author who wants to add to that skill.

## Verification

`task consistency` · `task preflight` (no regressions) · `npm run typecheck` · eslint on the diff · `check_ci_local_parity` · `lint_governed_writes`, `check_gate_paths`, `check_refs`, `check_no_roadmap_refs`, `counts-check`, `check_artefact_counts` — all green. 13 new tests; two mutations run against them, the first of which exposed a non-discriminating assertion that is now pinned.

## Pre-existing red, not from this branch

`task lint-roadmap-blockers` fails on 6 blockers in 4 roadmaps this branch does not touch (`subagent-lifecycle-integrity`, `subagent-value-realization-followup`, `surface-consolidation` ×2, `ui-track-integrity-followup` ×2) — each missing a `Recommendation:` / `If you do nothing:` block. Left alone; flagged for a decision rather than fixed drive-by.