### PR TITLE
feat(roadmaps): adopt rule-stub-projection and apply the performance-regression residue

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -2,11 +2,11 @@
 
 > Auto-generated — do not edit. Regenerate with `task roadmap-progress` or by running the `update_roadmap_progress` script for your install; rewritten on every roadmap create / execute / completion change (timestamp lives in git history).
 >
-> 38 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **47** open blockers, **21** need you → `agent-config gates`
+> 39 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **50** open blockers, **22** need you → `agent-config gates`
 
 ## Overall
 
-**267 / 575 steps done · 46%**
+**271 / 591 steps done · 46%**
 
 ```text
 ██████████████████░░░░░░░░░░░░░░░░░░░░░░   46%
@@ -28,7 +28,7 @@ These roadmaps have `count_open == 0` but carry `[~]` deferred items. Per `roadm
 | 2 | [road-to-carrier-layer-convergence.md](roadmaps/road-to-carrier-layer-convergence.md) | 3 | 8 | 2 | 3 | 0 | 3 | [1](#blockers-road-to-carrier-layer-convergence) | ██████░░░░ 60% |
 | 3 | [road-to-catalogue-host-fit.md](roadmaps/road-to-catalogue-host-fit.md) | 4 | 8 | 7 | 0 | 1 | 0 | [1](#blockers-road-to-catalogue-host-fit) | ░░░░░░░░░░ 0% |
 | 4 | [road-to-ci-native-release-first-run.md](roadmaps/road-to-ci-native-release-first-run.md) | 2 | 8 | 8 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
-| 5 | [road-to-context-fidelity.md](roadmaps/road-to-context-fidelity.md) | 5 | 24 | 24 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 5 | [road-to-context-fidelity.md](roadmaps/road-to-context-fidelity.md) | 5 | 24 | 19 | 4 | 0 | 1 | [3](#blockers-road-to-context-fidelity) | ██░░░░░░░░ 17% |
 | 6 | [road-to-cost-parity-1-rule-payload-diet.md](roadmaps/road-to-cost-parity-1-rule-payload-diet.md) | 6 | 49 | 49 | 0 | 0 | 0 | [2](#blockers-road-to-cost-parity-1-rule-payload-diet) | ░░░░░░░░░░ 0% |
 | 7 | [road-to-council-blind-review.md](roadmaps/road-to-council-blind-review.md) | 3 | 6 | 2 | 3 | 0 | 1 | [1](#blockers-road-to-council-blind-review) | ██████░░░░ 60% |
 | 8 | [road-to-distillation-followups.md](roadmaps/road-to-distillation-followups.md) | 2 | 2 | 2 | 0 | 0 | 0 | [2](#blockers-road-to-distillation-followups) | ░░░░░░░░░░ 0% |
@@ -49,19 +49,20 @@ These roadmaps have `count_open == 0` but carry `[~]` deferred items. Per `roadm
 | 23 | [road-to-per-turn-hook-economy.md](roadmaps/road-to-per-turn-hook-economy.md) | 6 | 16 | 15 | 0 | 1 | 0 | [1](#blockers-road-to-per-turn-hook-economy) | ░░░░░░░░░░ 0% |
 | 24 | [road-to-release-review-p0.md](roadmaps/road-to-release-review-p0.md) | 3 | 17 | 7 | 10 | 0 | 0 | 0 | ██████░░░░ 59% |
 | 25 | [road-to-rule-coherence-followup.md](roadmaps/road-to-rule-coherence-followup.md) | 5 | 9 | 7 | 2 | 0 | 0 | [2](#blockers-road-to-rule-coherence-followup) | ██░░░░░░░░ 22% |
-| 26 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | [1](#blockers-road-to-scale-history-bench-run) | ░░░░░░░░░░ 0% |
-| 27 | [road-to-skill-description-measurement.md](roadmaps/road-to-skill-description-measurement.md) | 1 | 4 | 4 | 0 | 0 | 0 | [1](#blockers-road-to-skill-description-measurement) | ░░░░░░░░░░ 0% |
-| 28 | [road-to-skill-ecosystem-executable-payloads.md](roadmaps/road-to-skill-ecosystem-executable-payloads.md) | 6 | 21 | 14 | 6 | 0 | 1 | [1](#blockers-road-to-skill-ecosystem-executable-payloads) | ███░░░░░░░ 30% |
-| 29 | [road-to-skill-ecosystem-gate-integrity.md](roadmaps/road-to-skill-ecosystem-gate-integrity.md) | 5 | 43 | 3 | 40 | 0 | 0 | [1](#blockers-road-to-skill-ecosystem-gate-integrity) | █████████░ 93% |
-| 30 | [road-to-solution-minimalism.md](roadmaps/road-to-solution-minimalism.md) | 4 | 36 | 6 | 29 | 0 | 1 | [1](#blockers-road-to-solution-minimalism) | ████████░░ 83% |
-| 31 | [road-to-source-first-frontend.md](roadmaps/road-to-source-first-frontend.md) | 6 | 18 | 6 | 11 | 1 | 0 | 0 | ██████░░░░ 65% |
-| 32 | [road-to-standing-context-40k.md](roadmaps/road-to-standing-context-40k.md) | 5 | 9 | 8 | 0 | 1 | 0 | [1](#blockers-road-to-standing-context-40k) | ░░░░░░░░░░ 0% |
-| 33 | [road-to-stop-gate-honesty.md](roadmaps/road-to-stop-gate-honesty.md) | 3 | 7 | 6 | 0 | 1 | 0 | [1](#blockers-road-to-stop-gate-honesty) | ░░░░░░░░░░ 0% |
-| 34 | [road-to-subagent-lifecycle-integrity.md](roadmaps/road-to-subagent-lifecycle-integrity.md) | 7 | 21 | 9 | 10 | 0 | 2 | [1](#blockers-road-to-subagent-lifecycle-integrity) | █████░░░░░ 53% |
-| 35 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
-| 36 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 3 | 14 | 1 | 12 | 1 | 0 | [2](#blockers-road-to-surface-consolidation) | █████████░ 92% |
-| 37 | [road-to-ui-track-integrity-followup.md](roadmaps/road-to-ui-track-integrity-followup.md) | 1 | 10 | 10 | 0 | 0 | 0 | [2](#blockers-road-to-ui-track-integrity-followup) | ░░░░░░░░░░ 0% |
-| 38 | [road-to-user-out-of-the-loop.md](roadmaps/road-to-user-out-of-the-loop.md) | 9 | 40 | 31 | 9 | 0 | 0 | [2](#blockers-road-to-user-out-of-the-loop) | ██░░░░░░░░ 22% |
+| 26 | [road-to-rule-stub-projection.md](roadmaps/road-to-rule-stub-projection.md) | 4 | 17 | 17 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 27 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | [1](#blockers-road-to-scale-history-bench-run) | ░░░░░░░░░░ 0% |
+| 28 | [road-to-skill-description-measurement.md](roadmaps/road-to-skill-description-measurement.md) | 1 | 4 | 4 | 0 | 0 | 0 | [1](#blockers-road-to-skill-description-measurement) | ░░░░░░░░░░ 0% |
+| 29 | [road-to-skill-ecosystem-executable-payloads.md](roadmaps/road-to-skill-ecosystem-executable-payloads.md) | 6 | 21 | 14 | 6 | 0 | 1 | [1](#blockers-road-to-skill-ecosystem-executable-payloads) | ███░░░░░░░ 30% |
+| 30 | [road-to-skill-ecosystem-gate-integrity.md](roadmaps/road-to-skill-ecosystem-gate-integrity.md) | 5 | 43 | 3 | 40 | 0 | 0 | [1](#blockers-road-to-skill-ecosystem-gate-integrity) | █████████░ 93% |
+| 31 | [road-to-solution-minimalism.md](roadmaps/road-to-solution-minimalism.md) | 4 | 36 | 6 | 29 | 0 | 1 | [1](#blockers-road-to-solution-minimalism) | ████████░░ 83% |
+| 32 | [road-to-source-first-frontend.md](roadmaps/road-to-source-first-frontend.md) | 6 | 18 | 6 | 11 | 1 | 0 | 0 | ██████░░░░ 65% |
+| 33 | [road-to-standing-context-40k.md](roadmaps/road-to-standing-context-40k.md) | 5 | 9 | 8 | 0 | 1 | 0 | [1](#blockers-road-to-standing-context-40k) | ░░░░░░░░░░ 0% |
+| 34 | [road-to-stop-gate-honesty.md](roadmaps/road-to-stop-gate-honesty.md) | 3 | 7 | 6 | 0 | 1 | 0 | [1](#blockers-road-to-stop-gate-honesty) | ░░░░░░░░░░ 0% |
+| 35 | [road-to-subagent-lifecycle-integrity.md](roadmaps/road-to-subagent-lifecycle-integrity.md) | 7 | 21 | 9 | 10 | 0 | 2 | [1](#blockers-road-to-subagent-lifecycle-integrity) | █████░░░░░ 53% |
+| 36 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
+| 37 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 3 | 14 | 1 | 12 | 1 | 0 | [2](#blockers-road-to-surface-consolidation) | █████████░ 92% |
+| 38 | [road-to-ui-track-integrity-followup.md](roadmaps/road-to-ui-track-integrity-followup.md) | 1 | 10 | 10 | 0 | 0 | 0 | [2](#blockers-road-to-ui-track-integrity-followup) | ░░░░░░░░░░ 0% |
+| 39 | [road-to-user-out-of-the-loop.md](roadmaps/road-to-user-out-of-the-loop.md) | 9 | 40 | 31 | 9 | 0 | 0 | [2](#blockers-road-to-user-out-of-the-loop) | ██░░░░░░░░ 22% |
 
 ---
 
@@ -732,9 +733,12 @@ _1 blocker resolved._
   - **Recommendation:** **option (b) — register the row observe-only for one release.** No prior exists for a per-turn composite in this tree, so any number named today would be invented, and an invented bar on a summed metric is the flappiest possible gate. One release of observation produces the distribution the bar should come from. Option (a) is right afterwards, not now; option (c) leaves D-1 permanently unmeasurable, which is the defect itself.
   - **If you do nothing:** the per-turn cost stays structurally invisible — every slot green, the number the user feels unrepresented — and Phases 1, 2, 3 and 5 land with no bar to prove they helped. The budget-ownership discipline this repo follows says the bar precedes the lever, so the phases would be shipping against no registered target at all.
   - **What to do:**
-    pre-register the per-turn composite bar. Options: (a) adopt a
-    composite p50 ceiling at a representative tool-call count on CI hardware, naming
-    the number; (b) register the row as **observe-only** for one release and set the
+    pre-register the per-turn composite bar. The composite itself is
+    defined in step 4.1 — `(pre + post) × 10 + ups + stop` — so only the ceiling is
+    open. Options: (a) adopt a composite p50 ceiling on CI hardware, naming the
+    number; the source draft proposed **p50 ≤ 1.5 s at ten tool calls** and that is
+    a candidate to accept or reject, not a measurement — no run in this tree
+    produced it; (b) register the row as **observe-only** for one release and set the
     bar from the observed distribution, which is the honest choice if no prior exists;
     (c) decline the composite, in which case D-1 stays an unmeasured structural cost
     and this phase closes with that recorded. Note the latency file's existing
@@ -781,6 +785,17 @@ _1 blocker resolved._
     human-judged production measurement, so a real claim needs human judging at
     adequate N.
   - **Resolved when:** thresholds are pre-registered here and the run is authorized, or F2.1 is cancelled and the preset ships documentation-only.
+
+### [road-to-rule-stub-projection.md](roadmaps/road-to-rule-stub-projection.md)
+
+**Road to rule-stub projection — hold a migrated rule at the size its pointer claims** — 0 / 17 done (0%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 0 | Size the migrated corpus, do not reclassify it | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 1 | Make the pointer machine-checked | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
+| 2 | Per-rule shrink-only ceilings | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 3 | Hand the sized residue to its owner | ⬜ not started | 9 | 0 | 0 | 0 | 0% |
 
 ### [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md)
 

--- a/agents/roadmaps/road-to-mixed-trigger-activation-cost.md
+++ b/agents/roadmaps/road-to-mixed-trigger-activation-cost.md
@@ -106,6 +106,9 @@ this tree can settle it).
 | 13 | `trigger-coverage.yaml` independently pins the same pre-contact reach the amendment retires | **still-true, found during execution** | its `ui-component` case expected `ui-audit-gate` from a file-less prompt. `fired_rules` in `src/scripts/trigger_coverage.ts` matches only `keyword` / `phrase`, so that corpus cannot express a path-backed positive at all — the reach was moved to the routing matrix and the case re-pointed to the only rule still firing on that prompt. A second pin the roadmap did not know about when it was written |
 | 14 | `ui_rule_triggers.test.ts` asserted the keyword triggers MUST exist ("host-independent fallback") | **overtaken, and measured before retiring** | its stated reason was that the rules once had only two Laravel path prefixes, leaving keywords as the whole routing surface — a gap closed by the `components/` · `src/components/` · `pages/` prefixes the same file pins. Measured: no host activation surface reads a keyword (Cursor `.mdc` → `description` + `globs`; Windsurf → `trigger: glob` + `globs`; Claude → `paths:`), so "host-independent" did not hold. Retired as a `decision-revisit-gate` mechanism-match miss and replaced by the inverse assertion |
 | 12 | The three PRs the delta doc analysed as open (#1391, #1393, #1395) | **overtaken** | all three merged into `main` (`097ab6549`, `01ec331ab`, `f0675de95`); #1393's twelfth `pre_tool_use` concern is live, not pending |
+| 15 | **Pre-guard emitter arm:** running `_claude_paths_plan` at `12.0.0` yields **25** scoped · **85** unconditional · **340,028** bytes, against **6** · 105 · 421,719 at the guard-active tree | **draft-reported, not re-verified here** | the source draft's own census, method = importing the emitter's plan function at each tag. Recorded because step 3.1 requires exactly this arm ("one projection generated with the pre-guard plan") and nothing else in this file states what that arm should produce. **Method caveat, also from the draft:** `12.0.0` predates the export split, so confirm the symbol is exported at both tags before trusting the import. Re-derive before use; a number quoted from a draft is not a measurement |
+| 16 | The only other change in the 12.0→12.1 window is the frontier tier added to `model-recommendations` — agent-visible, opt-in, not a loop-maker | **draft-reported alternative-cause elimination** | `git diff 12.0.0..12.1.0 -- src/agent-src/contexts/model-recommendations.md`. Recorded because § 0's causal story is exclusive ("the mechanism that *does* reproduce is rule activation") and an exclusive claim needs its co-change closed, not omitted |
+| 17 | **17 of 19** flipped rules have routing-matrix positives that fire with no file in context; 2 have no matrix at all | **negative half verified (claim 6), positive half OPEN** | claim 6 confirms the two matrix-less rules. Nobody has confirmed a surviving file-less positive for each of the other 17, and **AC-2 lets a rule close on exactly that** — so 15 of the 17 dispositions currently rest on an unverified premise. Phase 2's disposition table gains a column for it |
 
 ## Phases
 
@@ -311,7 +314,9 @@ the obligation does not need.
       into `matcher` / `if` groups is `road-to-per-turn-hook-economy` Phase 5.1,
       whose own text sequences it FIRST because it changes the denominator every
       later benchmark divides by. Verified in this tree: `hooks/hooks.json` uses no
-      `matcher` and no `if` today (§ 1 claim 9), so this is a new mechanism rather
+      `matcher` and no `if` today (`road-to-per-turn-hook-economy` § 1 claim 9 —
+      NOT this file's claim 9, which is about rule-content churn in the window),
+      so this is a new mechanism rather
       than an extension of one — and building it here is exactly the
       spawn-a-sibling-for-owned-scope that
       `agents/evidence/analysis/mixed-trigger-cleanup-ownership-map.md` forbids.
@@ -323,7 +328,10 @@ the obligation does not need.
 - **AC-2:** every one of the 17 has a terminal disposition citing the amendment, a
   surviving pre-contact positive, **or** an `if`-gated carrier with its condensed
   payload committed; the scoped count and the unconditional-token census are
-  re-measured and recorded.
+  re-measured and recorded. **The middle branch is not free** (claim 17): a
+  "surviving pre-contact positive" is verified per rule, in a column of the
+  disposition table, naming the matrix case — never assumed from the fact that a
+  matrix exists.
 - **Interlock — do not duplicate an existing owner.** The 5 maintainer-only rules
   in the set (`augment-edit-discipline`, `framework-neutrality-in-generic-skills`,
   `persona-governance`, `domain-adoption-policy`,
@@ -373,7 +381,9 @@ latency claim would get: pre-registered, paired, refutable.
       forbid, and the same shape as the unverified-host-capability claims this
       package has had to correct before.
 
-      This does NOT refute the roadmap's § 1 claim 12 — that claim is marked
+      This does NOT refute `road-to-per-turn-hook-economy` § 1 claim 12 (the
+      `async`/`asyncRewake` row — NOT this file's claim 12, which is the three
+      merged PRs) — that claim is marked
       "still-true, external", sourced from host documentation read at one version,
       and external docs and the extracted binary token set can legitimately
       disagree if the event is newer than 2.1.229 or is not hook-bindable at all.
@@ -571,7 +581,14 @@ owner, and the colleague's report returns to Phase 0 of
 - **`road-to-standing-context-40k`** gains the window pin: the 6-scoped state is
   not "structural since forever" — nineteen of the unconditional rules became
   unconditional *at 12.1.0*, and its condensation priority list starts with those
-  nineteen, largest body first.
+  nineteen, largest body first. Measured at `86cdbf652` so step 2.1 does not have
+  to re-derive the head of the list: `design-review-after-ui-write` 10,569 B ·
+  `design-fidelity` 10,544 B · `settings-ask-protocol` 9,374 B · `ui-audit-gate`
+  8,209 B. Bytes, deliberately — the exact-BPE ordering is Phase 4's tokenizer
+  path, and a byte figure quoted as a token figure is the claim-11 error. Two of
+  these four grew since the source draft measured them, so re-measure rather than
+  cite. `road-to-rule-stub-projection` Phase 0 produces the exact-BPE table for
+  the whole migrated corpus and hands it to step 2.1.
 - **`road-to-stop-gate-honesty`** Phase 2 gains a causal link: detector-C refusal
   rates are predicted to correlate with the flip date on affected machines, so its
   Phase-1 counter should be split before and after the local 12.1 install date.

--- a/agents/roadmaps/road-to-per-turn-hook-economy.md
+++ b/agents/roadmaps/road-to-per-turn-hook-economy.md
@@ -82,7 +82,14 @@ transcript size, and the delta between the two tags is approximately zero.
 
 The reported "fast before 12.\*, slow since 12.1.\*" **does not reproduce at the
 dispatcher level** between 11.0.0 and 13.0.0 in that environment. The hot-slot
-binding deltas across the window are small and named. Every fix below is
+binding deltas across the window are small, and here they are actually named —
+the sentence used to assert "named" while listing none, which is the shape risk 6
+below gates against: `tool-result-bytes` added to `post_tool_use` and
+`hot-context` added to `pre_compact`, both in `bc20d3e6c` ("feat(context): meter
+tool results, and capture before compaction", verified present in this tree); and
+`skill-route` first binding on `user_prompt_submit` — the binding is live at
+`86cdbf652`, while "first appears at 13.0.0" is the source draft's tag-level
+claim and is not re-verified here. Every fix below is
 justified by the **structural** cost, not by a version regression. Phase 0 exists
 to find what the colleague actually hit — and the current best candidate is not in
 this file at all, it is the activation flip owned by
@@ -115,6 +122,15 @@ This phase is a blocker on citing "a 12.1 latency regression" anywhere.
       investigation moves to turn shape (`road-to-stop-gate-honesty`) and context
       (`road-to-standing-context-40k`).
       `verify:` the matrix table, both versions, at least three runs per cell.
+      **Fixture sizes, so the run is reproducible rather than merely instructed**
+      (from the source draft's own container run): a `post_tool_use` event with a
+      2,000,000-character `tool_response`; a `stop` event against a 3.5 MB
+      synthetic JSONL transcript; a `user_prompt_submit` against a workspace
+      carrying the full projected skill set. The draft's absolute cell values are
+      deliberately **not** carried over — § 2's verdict already refuses to treat
+      one container's milliseconds as a repo fact — but a comparison needs the
+      same fixtures on both arms, and those are specifiable without claiming a
+      number.
 - [ ] **0.3** Read the turn-end-gate refusal state for the affected sessions and
       count refusals per session. A median above one refusal per session means the
       perceived slowness is extra model turns rather than hook wall clock.
@@ -136,6 +152,16 @@ This phase is a blocker on citing "a 12.1 latency regression" anywhere.
       contract is unchanged — the same bundle runs, it just runs on fewer events.
       `verify:` the dispatcher receives no event for a non-matching payload, proven
       by an absent invocation record rather than by a fast one.
+      <!-- starting assignment, verified against hook_manifest.yaml at 86cdbf652
+      rather than carried from the source draft, which mis-slotted one of them.
+      `pre_tool_use` (12 concerns): `block-no-verify` and `block-unauthorized-git`
+      are git-command-shaped → `if: "Bash(git *)"`; `rtk-wrap` is Bash-only;
+      `design-slop` and `ui-route-nudge` are write-shaped → `matcher: Edit|Write`.
+      `post_tool_use` (11 concerns): `edit-shape` is write-shaped → `matcher:
+      Edit|Write`. The draft placed `edit-shape` on the pre slot; it binds post,
+      so its matcher is a post-slot matcher. Treat this as the input to 5.1, not
+      its output — each row still needs its own absent-invocation proof. -->
+
 - [ ] **5.2** Safety invariant, stated because claim 11 demands it: `if` is a
       **prefilter, never the enforcement**. It fails open on unparseable commands —
       which is exactly right for fail-closed guards, because unparseable means the
@@ -148,6 +174,20 @@ This phase is a blocker on citing "a 12.1 latency regression" anywhere.
       synchronous until measured otherwise.
       `verify:` artifact diff against a synchronous run — every async concern still
       produces its disk artefact.
+      <!-- the set membership IS the risky decision here — mis-classifying a
+      gating concern as non-gating is the failure mode — so it is named, measured
+      at 86cdbf652, and the draft's version of it is corrected on both sides.
+      `stop` binds TEN concerns on claude, not the draft's six: chat-history,
+      hot-context, verify-before-complete, team-review-gate, end-review-nudge,
+      turn-end-gate, self-repair, session-register, session-eol,
+      interruption-ledger. Of those, exactly ONE carries `severity: blocking` —
+      `turn-end-gate`. The draft named `team-review-gate` as a second refuser; it
+      is `severity: advisory`. Async candidates the draft named and this tree
+      confirms as advisory and stop-bound: chat-history, hot-context,
+      session-register, self-repair. `session-eol` and `interruption-ledger`
+      postdate the draft and are unclassified — classify all ten here, from the
+      manifest, rather than inheriting a six-row list. -->
+
 - **AC-5:** on the § 2 matrix, a `PreToolUse` with a non-matching payload costs no
   dispatcher spawn at all, and the Stop cell drops materially on the large-transcript
   payload with every async concern still producing its artefacts.
@@ -176,7 +216,13 @@ This phase is a blocker on citing "a 12.1 latency regression" anywhere.
       body; absent means the envelope arrives **without** the result and input
       bodies, with a name-and-sizes stub in their place. Audit every post concern
       against its source before flipping, and record the per-concern verdict in the
-      PR — this audit is a merge precondition, not a follow-up.
+      PR — this audit is a merge precondition, not a follow-up. **Start from the
+      source draft's first-pass read, which survives verification:** of the 11
+      concerns bound to `post_tool_use` at `86cdbf652`, only `tool-result-bytes`
+      (a byte count), `edit-shape`, `injection-scan` and `context-hygiene`
+      plausibly read result content. All four bind that slot in this tree. The
+      audit still covers all 11 — a shortlist orders the work, it does not bound
+      it — but four rows already have a hypothesis to confirm or refute.
       `verify:` a counter in the dispatcher records every stub served, so a concern
       that silently depended on the body shows up as a number rather than as a bug
       report.
@@ -216,7 +262,12 @@ This phase is a blocker on citing "a 12.1 latency regression" anywhere.
       pre and post chains across a representative tool-call count plus the prompt
       and stop slots, benchmarked in CI. Register it **before** Phases 1–3 merge —
       the bar precedes the lever, which is this repo's own budget-ownership
-      discipline.
+      discipline. **"Representative tool-call count" is specified, not left open** —
+      the source draft's definition is `(pre + post) × 10 + ups + stop`, i.e. ten
+      tool calls per turn, and it is a *definition* rather than a bar, so it lands
+      here rather than in the blocker below. Without it the step is not
+      implementable: two people would compute two different composites and both
+      would call the row green.
       `verify:` the composite appears in the latency bench output and its CI gate.
 - [~] **4.2** The bar itself is the maintainer's to pre-register, not this
       document's. Blocked on `b-per-turn-composite-bar`.
@@ -234,9 +285,12 @@ This phase is a blocker on citing "a 12.1 latency regression" anywhere.
 - **Owner:** user
 - **Blocks:** Phase 4 step 4.2 only. Step 4.1 registers the composite as a measured
   row and 4.3 refreshes the census; both proceed without the bar.
-- **What to do:** pre-register the per-turn composite bar. Options: (a) adopt a
-  composite p50 ceiling at a representative tool-call count on CI hardware, naming
-  the number; (b) register the row as **observe-only** for one release and set the
+- **What to do:** pre-register the per-turn composite bar. The composite itself is
+  defined in step 4.1 — `(pre + post) × 10 + ups + stop` — so only the ceiling is
+  open. Options: (a) adopt a composite p50 ceiling on CI hardware, naming the
+  number; the source draft proposed **p50 ≤ 1.5 s at ten tool calls** and that is
+  a candidate to accept or reject, not a measurement — no run in this tree
+  produced it; (b) register the row as **observe-only** for one release and set the
   bar from the observed distribution, which is the honest choice if no prior exists;
   (c) decline the composite, in which case D-1 stays an unmeasured structural cost
   and this phase closes with that recorded. Note the latency file's existing

--- a/agents/roadmaps/road-to-rule-stub-projection.md
+++ b/agents/roadmaps/road-to-rule-stub-projection.md
@@ -1,0 +1,305 @@
+---
+complexity: lightweight
+execution:
+  mode: autonomous
+---
+
+# Road to rule-stub projection — hold a migrated rule at the size its pointer claims
+
+> **Source:** `agents/tmp.old/performance-regression/road-to-rule-stub-projection.md`
+> — external analysis session, 2026-08-17, drafted against `de76c38b`. Adopted
+> 2026-08-17 via `/analyze:inbox` after per-claim verification against
+> `origin/main` @ `86cdbf652`. The draft's status line said PROPOSAL and its IDs
+> were proposal IDs; § 1 records which claims survived, which were overtaken, and
+> the two that are refuted as written. § 2 records what was kept, folded, and cut.
+
+> **Why the scope is narrower than the draft's.** The draft proposed building a
+> stub tier: a generated one-liner per rule, a three-class delivery taxonomy, and
+> a new emitter phase. Verification found that **most of that already shipped** —
+> the stub form exists and 42 rules carry it, the projection mechanism exists
+> (`type: manual`, ADR-004), and the per-rule classification exists and is closed.
+> What does not exist is the invariant that keeps a migrated rule *at* stub size.
+> This roadmap owns exactly that, and hands the one remaining body-moving job to
+> the roadmap that already owns it.
+
+## Goal
+
+Every rule whose body declares itself migrated is held at a machine-checked
+per-rule size ceiling, so the always-on corpus cannot re-grow past a pointer that
+says the body left — measured against the committed census baseline of **103,265**
+exact-BPE tokens.
+
+---
+
+## 0. The defect, stated first
+
+The stub pattern is in production. 42 of the 117 rules in `src/rules/` carry a
+line of the shape *"Body migrated to `guideline:X` … Trigger-set above activates
+this routing on demand"* — norm line, binds line, pointer, which is the form the
+draft proposed building. The projection half is in production too:
+`_is_manual_rule` (`src/scripts/condense.ts:1086`) excludes a `type: manual` rule
+from every per-tool tree (filter sites at `:1114`, `:1613`, `:1635`) and
+`compile_router` omits it from `dist/router.json`, so such a rule costs zero
+workspace budget by construction. Five rules use it today:
+`analysis-skill-routing`, `brand-consistency`, `guidelines`, `package-ci-checks`,
+`size-enforcement`.
+
+**Nothing asserts that a migrated rule stays small.** Migration was executed as an
+event and never encoded as a state, so the 42 pointers are hand-authored prose
+that no gate reads. Measured at `origin/main`, the 42 span **~300 bytes to 10,988
+bytes** and total **128,261 bytes**; the largest four are
+`design-review-after-ui-write` (10,569 B), `design-fidelity` (10,544 B),
+`settings-ask-protocol` (9,374 B) and `ui-audit-gate` (8,209 B) — every one of
+them carrying a pointer that says the body moved.
+
+The sharpest single case: `src/rules/context-hygiene.md` is **10,988 bytes** and
+declares its body migrated to
+`docs/guidelines/agent-infra/context-hygiene-mechanics.md`, which is **3,491
+bytes**. The rule is three times the size of the file it migrated into. That is
+the "second truth that drifts" the draft predicted for hand-authored stubs —
+already realized, in the pointer itself.
+
+The aggregate census ratchet does not catch this and is not meant to.
+`src/config/rule-activation-census.json` pins the *corpus* token total and walks
+it down only; one rule growing while another shrinks is a green run. Per-rule
+re-growth under an aggregate cap is precisely the gap.
+
+---
+
+## 1. Per-claim verification of the draft
+
+| # | Draft claim | Verdict | Evidence |
+|---|---|---|---|
+| 1 | Corpus baseline 107,194 exact-BPE tokens; 6 scoped · 19 mixed | **overtaken** | `src/config/rule-activation-census.json` @ `86cdbf652`: **103,265** tokens, **8** scoped, **17** mixed. `baseline_history` 2026-08-17 records the authorized move (mixed-trigger Phase 2 restored `paths:` on two rules, −3,929) |
+| 2 | 116 rules | **overtaken** | `ls src/rules/*.md \| wc -l` = **117** |
+| 3 | Rules have no "description always, body on demand" tier; the emitter's only choices are unconditional or `paths:` | **refuted as written** | a third choice ships: `type: manual` → `_is_manual_rule`, `condense.ts:1086`, honoured by the per-tool projection and by `compile_router`. Five rules use it |
+| 4 | The stub form (norm line + binds line + pointer) must be built | **refuted as written** | it exists in 42 rules as the P4 migration pointer of `road-to-kernel-and-router`. What is missing is not the form but its enforcement |
+| 5 | A three-class taxonomy (hook-enforced / contact-bound / guidance) must be authored per rule | **overtaken** | `agents/decisions/rule-activation-dispositions.yml` holds 76 rows with four adjudicated dispositions — `digest` 30, `keep` 46, `skill` 0, `drop` 0. Its line 1 marks the record **CLOSED**: "the migration this file drove is complete … New dispositions belong in the emitting rule's own frontmatter and the rule-migrations ledger, not here" |
+| 6 | Class A (hook-enforced) is the risk-free half and covers a large share | **narrower than claimed** | of the 33 rules declaring `enforced_by:`, the values split **16 validator · 9 hook · 9 none · 1 observer**. Only the 9 hook rows deliver an explanation at violation time; a CI validator does not reach the session. 84 rules declare no `enforced_by:` at all |
+| 7 | `paths:` loads a rule mid-turn on file contact | **still-true** | `archive/road-to-rule-delivery-integrity.md` P3.1 done-note, "VERIFIED FIRST-PARTY … the host injected `.claude/rules/augment-edit-discipline.md` on its own" |
+| 8 | The `if`-gated carrier is available for class B | **not yet** | `road-to-mixed-trigger-activation-cost` step 2.3 is open and gated on `road-to-per-turn-hook-economy` 5.1 landing the matcher/if split. Only the `paths:` carrier is live |
+| 9 | Non-goal: no keyword hook injecting rule bodies | **still-true** | `archive/road-to-rule-delivery-integrity.md` § Non-goals, line 93 |
+| 10 | P3.2 chose rule→skill conversion 0 times | **still-true** | same file, P3.2 done-note: `skill` = 0 rows, because P2.1 measured 5 of 8 sampled catalogue entries reaching the model with no description |
+| 11 | Norm line per rule under a drift lint is owned work | **still-true, unbuilt** | `road-to-cost-parity-1-rule-payload-diet` steps 3.1 (`norm:` field) and 3.2 (drift lint) are both `- [ ]`. The draft's invariant "rides the cost-parity-1 drift lint" has no lint to ride yet |
+| 12 | `rules_efficiency` gate at 0.2 owns runtime retrieval | **still-true** | `later/road-to-deferred-rule-retriever.md`: "Phase 1.3 registered `rules_efficiency` … low-quota bar 0.2" in `src/config/dispatch-economy-metrics.json` |
+| 13 | `InstructionsLoaded` measures actual per-session rule loads | **still-true, already owned twice** | `road-to-mixed-trigger-activation-cost` 3.3 and `road-to-standing-context-40k` 3.0 both register the observer. Not this roadmap's to build |
+| 14 | ~80 tokens/skill catalogue median; ~50 % baseline / ~84 % forced-eval pointer compliance | **unverifiable here** | external figures with no in-tree derivation. Indicative only; nothing in this roadmap is gated on them |
+
+The two `refuted as written` rows are the reason the scope changed. Neither
+refutes the draft's *reasoning* — the mechanism it asked for is right, and it is
+the mechanism the repo already chose. It refutes the draft's assumption that the
+mechanism has to be built.
+
+---
+
+## 2. Disposition of the draft's proposals
+
+| Proposal | Disposition | Reason |
+|---|---|---|
+| A generated stub form per rule | **FOLD** | into Phase 1 as a check on the 42 existing pointers, not a new emitter tier |
+| A new emitter projection phase | **CUT** | `type: manual` is the tier (claim 3) |
+| Three-class taxonomy authored per rule | **CUT** | the disposition record is closed with four dispositions already adjudicated (claim 5); a second classification of one corpus drifts with nothing to reconcile it — the record's own done-note says so |
+| Phase-0 classification sweep over 116 rules | **FOLD** | into Phase 0 as a *measurement* of the 42 migrated rules, reconciled against the closed record |
+| Class-A-ships-first | **CUT** | 9 hook-backed rules (claim 6) is not a half, and their bodies are not what the corpus is made of |
+| Class-B carrier verification before stubbing | **CUT** | the `if` carrier is not available (claim 8); `paths:` scoping is owned by mixed-trigger Phase 2 and already executed for two rules |
+| Class C measured, never assumed | **CUT** | the model-compliance question is `later/road-to-deferred-rule-retriever`'s behind its registered gate (claim 12). This roadmap never asks a model to follow a pointer |
+| Norm-line byte-identity invariant | **KEEP, deferred** | needs cost-parity-1 3.1/3.2 (claim 11). Phase 1 checks the pointer's *target*, which needs no norm line |
+| Census re-baseline in the same commit as any flip | **KEEP** | already the documented procedure; Phase 2 follows it |
+| Hand-authored stubs are drift by construction | **KEEP** | verified realized, `context-hygiene` vs its own guideline (§ 0) |
+
+---
+
+## 3. The invariant this roadmap adds
+
+A rule that declares its body migrated is making a checkable claim about itself.
+Three parts, none of which exists today:
+
+1. **The target resolves.** The path or `guideline:`/`skill:` reference in the
+   pointer names a file that exists.
+2. **The rule is under its own ceiling.** A per-rule, shrink-only byte budget
+   derived from the rule's measured size at adoption — the same posture as the
+   census ratchet's token axis and the rich-class ceiling, one level finer.
+3. **A raise is a stated decision.** Raising a per-rule ceiling needs a
+   `reason` sentence in the baseline file, exactly as
+   `rule-activation-census.json` requires for its token axis. Raising a ceiling
+   to clear a red is the config-weakening move this repo blocks by construction.
+
+What it deliberately does **not** add: any judgment about which prose should
+move. That is `road-to-standing-context-40k` step 2.2, and Phase 3 feeds it.
+
+---
+
+## Prerequisites
+
+- [ ] Read `AGENTS.md`, `docs/contracts/kernel-membership.md`, and
+      `src/rules/preservation-guard.md` — the last one binds every later phase:
+      Iron Law headings and fenced blocks survive verbatim, so they are floor,
+      not residue.
+- [ ] Read `agents/decisions/rule-activation-dispositions.yml` header. It is a
+      closed record; this roadmap reads it and never adds a row.
+
+## Context
+
+Traces to the same operator report as `road-to-mixed-trigger-activation-cost`
+("slow since 12.1"). That roadmap found and priced the activation flip; this one
+covers the orthogonal half its § 0 exposed — the corpus that stayed
+unconditional is body-heavy, and 42 of those bodies already declare that they
+should not be.
+
+Siblings and their boundaries, so no step here duplicates an owner:
+
+- `road-to-standing-context-40k` — owns the 40k destination, the condense pass
+  (2.1) and the rationale-extraction pass (2.2). **Owns the moving.**
+- `road-to-cost-parity-1-rule-payload-diet` — owns the `norm:` field and its
+  drift lint (3.1/3.2, both open).
+- `road-to-mixed-trigger-activation-cost` — owns the trigger axis, the census
+  ratchet (4.1, landed) and the `if` carrier (2.3, open).
+- `later/road-to-deferred-rule-retriever` — owns runtime retrieval behind
+  `rules_efficiency ≤ 0.2`.
+
+## Phase 0 — Size the migrated corpus, do not reclassify it
+
+- [ ] **0.1** Enumerate the rules carrying a migration pointer and measure each
+      one in exact BPE via the tokenizer path `rule_activation_census.ts` already
+      uses — never bytes ÷ 4, which is the proxy error `road-to-mixed-trigger-activation-cost`
+      claim 11 exists to record. Emit one row per rule: name, exact tokens,
+      pointer target, target exists yes/no.
+      <!-- verify: ./scripts-run src/scripts/rule_activation_census.ts --help -->
+- [ ] **0.2** Split each migrated rule's retained body into **floor** and
+      **residue**. Floor = what `preservation-guard` requires to stay (Iron Law
+      headings at their level, their fenced blocks byte-for-byte, negation
+      clauses) plus the pointer itself. Residue = everything else. Report both
+      totals; the split is the input Phase 3 hands on, and the reason no step
+      here proposes a deletion.
+- [ ] **0.3** Reconcile the row set against the closed disposition record: for
+      each migrated rule, note its recorded disposition (`digest` / `keep` /
+      absent) without changing it. A `keep` row that also carries a migration
+      pointer is a contradiction worth reporting — `keep` means "stays always-on
+      and monolithic, deliberately", and a pointer says the opposite.
+- **Pre-registered expectation, to falsify:** residue ≥ 25 % of the 103,265-token
+  baseline. Priors that make this a measurement rather than a hope: the 42
+  migrated rules total 128,261 bytes, and the four largest each exceed 8 KB while
+  the fully-migrated ones sit near 300–1,400 B. **If residue < 10 %**, the
+  stub-ceiling lever is small, Phase 2 ships as pure regression protection, and
+  § Honest-null consequence is the finding.
+- **Exit:** a committed table covering every migrated rule with both totals.
+- **Rollback:** the table is an evidence artifact; deleting it reverts the phase.
+
+## Phase 1 — Make the pointer machine-checked
+
+- [ ] **1.1** A gate that reads every rule declaring a migration pointer and
+      fails when the pointer's target does not resolve. Fail-closed on an
+      unparseable pointer, and report the pointer form it matched so a reworded
+      pointer surfaces as a finding rather than as silence.
+      <!-- verify: the gate exits non-zero on a fixture rule whose pointer names a missing file -->
+- [ ] **1.2** Register the gate in the gate ledger under CI-identical argv, with
+      the skip reason drawn from the existing closed union. A gate that scans
+      nothing exits green, so its green line publishes the count of rules it
+      actually read.
+      <!-- verify: the gate's green line names a non-zero rule count -->
+- **Exit:** gate registered, red on the fixture, green on the tree.
+- **Rollback:** de-register the gate; no rule content changed in this phase.
+
+## Phase 2 — Per-rule shrink-only ceilings
+
+- [ ] **2.1** Extend the Phase-1 gate with a per-rule token ceiling read from a
+      committed baseline, generated from Phase 0's measurement — never
+      hand-edited, regenerated by an explicit `--write-baseline` flag, same
+      posture as `rule-activation-census.json`.
+      <!-- verify: the gate exits non-zero on a fixture rule padded past its baseline -->
+- [ ] **2.2** Require a `reason` sentence per raise in the baseline's history
+      array, and make the gate refuse a raise whose reason is empty or a
+      restatement of the number. The census baseline's own comment carries the
+      sentence to mirror.
+      <!-- verify: the gate exits non-zero on a fixture raise with an empty reason -->
+- [ ] **2.3** Record in the baseline that the ceilings are a floor-plus-residue
+      snapshot, not a target: a rule at its ceiling is not thereby correct, only
+      not worse.
+- **Exit:** both fixtures red, tree green, baseline committed with its generation
+  command.
+- **Rollback:** revert the baseline and the ceiling check; Phase 1's
+  target-resolution half stands on its own.
+
+## Phase 3 — Hand the sized residue to its owner
+
+- [ ] **3.1** Write Phase 0's residue table into `road-to-standing-context-40k`
+      step 2.1 as its prioritisation input. That step says "prioritised by body
+      size" and no measurement exists for it; this supplies one, in exact BPE,
+      largest residue first.
+- [ ] **3.2** Note in the same place that 2.2's moves land against per-rule
+      ceilings from Phase 2, so each move's effect is visible per rule instead of
+      only in the aggregate census. Do not restate 2.2's method — it already
+      binds `preservation-guard`.
+- [ ] **3.3** Report the contradictions from 0.3 (pointer-carrying `keep` rows,
+      if any) as findings on this roadmap, not as edits to the closed record.
+- **Exit:** the receiving roadmap carries the table; this roadmap owns no
+  body-moving step.
+- **Rollback:** revert the edit to the sibling roadmap; the table survives in
+  Phase 0's artifact.
+
+## Acceptance Criteria
+
+- [ ] Every rule carrying a migration pointer has an exact-BPE measurement and a
+      floor/residue split in a committed table.
+- [ ] A pointer naming a missing target fails CI; the gate's green line reports
+      how many rules it read.
+- [ ] A migrated rule padded past its per-rule ceiling fails CI; a raise without
+      a real reason sentence fails CI.
+- [ ] The aggregate census baseline is unchanged by Phases 1–2, and any change in
+      Phase 3's wake is re-baselined in the same commit with its reason.
+- [ ] `road-to-standing-context-40k` step 2.1 carries the prioritisation table;
+      no step in this roadmap moves prose out of a rule body.
+- [ ] The closed disposition record has the same row count and the same
+      dispositions it had at adoption.
+
+## Risk Register
+
+<!-- risk-review: v1 | reviewed: 2026-08-17 | reviewer: claude/host -->
+
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | A per-rule ceiling freezes a rule that legitimately needs to grow | product | Several of the 42 are kernel-adjacent and gain material when a measured finding lands; a ceiling that reads as a prohibition would suppress the finding instead of the bloat | The ceiling is shrink-only with an explicit raise path, and 2.2 requires a real reason rather than refusing the raise; the same mechanism the census token axis already runs under | Phase 2 — Per-rule shrink-only ceilings |
+| 2 | Phase 0's floor/residue split is a judgment dressed as a measurement | implementation | "What `preservation-guard` requires" is decidable for Iron Law headings and fenced blocks and much less so for a table or a marker list, and 46 rules were already adjudicated `keep` on exactly that ambiguity | The split reports floor and residue separately with the criterion per rule, so a reader can disagree with a row without discarding the total; 0.3 surfaces the `keep` overlap rather than resolving it | Phase 0 — Size the migrated corpus |
+| 3 | The pointer gate hardens a hand-authored prose convention into a contract | implementation | 42 pointers were written by hand over months in at least two phrasings; a gate keyed to one phrasing silently stops seeing the others | 1.1 fails closed on an unparseable pointer and 1.2 publishes the count it read, so a phrasing the gate cannot see shows up as a falling number instead of as silence | Phase 1 — Make the pointer machine-checked |
+| 4 | The residue is small and the roadmap's premise is thin | product | If the 42 rules' retained bodies are mostly Iron Law floor, the lever is regression protection only and the corpus problem lies elsewhere | Phase 0 pre-registers the band and § Honest-null consequence states the outcome in advance; Phases 1–2 keep their value as protection even at a null | Phase 0 — Size the migrated corpus |
+| 5 | Phase 3's edit to a sibling roadmap goes stale | implementation | A table written into another roadmap ages with the corpus, and a stale prioritisation is worse than none because it looks authoritative | 3.1 writes the table with its generation command and its measurement commit, so a reader can regenerate rather than trust it | Phase 3 — Hand the sized residue to its owner |
+
+## CUT list — do not re-litigate
+
+- **A new emitter projection tier.** `type: manual` is it (claim 3). Cut.
+- **Re-opening the disposition record.** Line 1 marks it closed and names where
+  new dispositions go. Cut.
+- **A three-class taxonomy over 117 rules.** A second classification of one
+  corpus drifts with nothing to reconcile it — the record's own done-note.
+  Cut.
+- **Any model-compliance bet on pointer-following.** Owned by
+  `later/road-to-deferred-rule-retriever` behind `rules_efficiency ≤ 0.2`. This
+  roadmap asks no model to follow a pointer. Cut.
+- **A keyword hook injecting rule bodies.** Recorded non-goal (claim 9). Cut.
+- **Deleting a rule body to hit a ceiling.** `preservation-guard`: every passage
+  moves, none is deleted. The ceiling is satisfied by moving, and the moving has
+  an owner. Cut.
+- **Bulk deletion of low-usage rules framed as stubbing.** A different decision
+  with a different owner; the census refuses a rate. Cut.
+
+## Honest-null consequence
+
+If Phase 0 measures residue under 10 % of the 103,265-token baseline, the finding
+is that the migration pointers are honest and the always-on corpus is Iron Law
+floor rather than stranded prose. Then this roadmap closes at its measured size:
+Phases 1–2 ship as regression protection for a state that is already good, the
+prioritisation table Phase 3 hands over says "little to prioritise", and the
+remaining reduction against the 40k destination belongs to
+`road-to-standing-context-40k` Phase 2 condensing floor material — a harder job
+than moving residue, and one this roadmap should not pretend to have made easier.
+
+## Notes
+
+- The draft's own risk row "stub tier becomes a second truth that drifts" is the
+  one thing verification found **already realized** rather than prospective
+  (`context-hygiene` at 10,988 B against a 3,491 B target). That inversion is why
+  the roadmap enforces the existing pointer instead of generating a new one.
+- Two of the draft's four cited body sizes had moved by adoption
+  (`design-review-after-ui-write` 9.2 → 10.6 KB, `ui-audit-gate` 6.9 → 8.2 KB),
+  measured fresh in § 0. A size quoted from a draft is a stale number by the time
+  it is read; Phase 0 regenerates rather than cites.


### PR DESCRIPTION
Consumes `agents/tmp/performance-regression/` (5 files) via `/analyze:inbox`, verified against `origin/main` @ `86cdbf652`.

## Triage

| File | Genre | Drafted against | Disposition |
|---|---|---|---|
| `00-INDEX.md` | index | `de76c38b` | reference only — 7 of the 8 roadmaps it indexes are already on `main` |
| `chat.txt` | transcript | — | source of the one new idea; no roadmap of its own |
| `road-to-mixed-trigger-activation-cost.md` | draft, 2nd revision | `de76c38b` | overtaken — residue applied in place |
| `road-to-per-turn-hook-economy.md` | draft, 2nd revision | `de76c38b` | overtaken — residue applied in place |
| `road-to-rule-stub-projection.md` | feature spec | `de76c38b` | **survives → one new roadmap** |

The index claimed five corrections were "uncommitted pending authorization". All five had already landed *and been executed further*: the census baseline moved 107,194 → 103,265 with scoped 6 → 8 and mixed 19 → 17, so the two roadmap drafts were re-presentations of a state the tree had passed.

## What is new

`agents/roadmaps/road-to-rule-stub-projection.md` — and its scope is materially narrower than the draft asked for, because verification found most of the proposal already shipped:

- the stub form exists; **42 of 117** rules carry it as the P4 migration pointer;
- the projection tier exists as `type: manual` (`condense.ts:1086` `_is_manual_rule`, honoured by `compile_router`), in use by five rules;
- the per-rule classification exists — `agents/decisions/rule-activation-dispositions.yml`, 76 rows, `digest` 30 / `keep` 46 / `skill` 0 / `drop` 0 — and its line 1 marks the record **closed**.

What does not exist is the invariant holding a migrated rule *at* stub size. The migration ran as an event, never as a state, so the 42 pointers are prose no gate reads and they span **300 B to 10,988 B**. Sharpest case: `context-hygiene.md` is 10,988 B and declares its body migrated to a guideline that is 3,491 B — three times the size of the file it migrated into. That is the second-truth drift the draft predicted for hand-authored stubs, already realized, in the pointer itself. The aggregate census ratchet cannot catch it: one rule growing while another shrinks is a green run.

So the roadmap owns the post-migration invariant (measure in exact BPE, split floor from residue under `preservation-guard`, machine-check the pointer target, per-rule shrink-only ceiling) and hands the body-moving job to `road-to-standing-context-40k` step 2.1, which already owns it and had no measurement to prioritise by.

Two draft claims are **refuted as written**, six **overtaken**; § 1 records all fourteen with evidence, § 2 records KEEP / FOLD / CUT. Class C — the pointer-following model-compliance bet — is cut outright; it belongs to `later/road-to-deferred-rule-retriever` behind its registered `rules_efficiency ≤ 0.2` gate.

## What was applied to the two overtaken roadmaps

Item-by-item comparison found residue the earlier adoption pass dropped, plus two places where the committed text asserted something it no longer backed:

- **`per-turn-hook-economy` § 3** said the binding deltas are "small and named" and named none. Now named: `tool-result-bytes` → `post_tool_use` and `hot-context` → `pre_compact`, both in `bc20d3e6c`, verified present.
- **step 5.3** gained the named Stop set — **corrected on both sides**: the slot binds ten concerns, not the draft's six, and exactly one carries `severity: blocking`. The draft named `team-review-gate` as a second refuser; it is advisory.
- **step 5.1** gained the per-concern matcher map, corrected: `edit-shape` binds `post_tool_use`, so its matcher is a post-slot matcher.
- **step 4.1** gained the composite definition `(pre + post) × 10 + ups + stop`. Without it two people compute two composites and both call the row green. Its candidate ceiling went into the blocker as a candidate, not a measurement.
- **step 2.1** gained the four-concern shortlist; **step 0.2** gained its fixture sizes. Container cell values stayed out — § 2 already refuses to treat one container as a repo fact.
- **`mixed-trigger` claim 15** records the pre-guard emitter arm that step 3.1 requires and nothing described; marked draft-reported with its export-split caveat, not as a measurement. **Claim 16** closes the one co-change in the window. **Claim 17** exposes that AC-2's middle branch rested on an unverified premise for 15 of 17 rules; AC-2 now requires the positive per rule.
- **two dangling cross-file claim citations** fixed — both pointed at the sibling file's claim numbers after a renumbering.
- the condensation head-of-list for `standing-context-40k`, measured fresh; two of the draft's four sizes had grown.

## Verification

Green on this diff: `lint_roadmap_complexity` (45 clean), `lint_plan_risk_register`, `lint_roadmap_blockers` (all three touched files ✅), `lint_roadmap_later_disposition`, `check_references`, `check_md_language`, `check_no_roadmap_refs`, `lint_hidden_unicode`, `check_branch_freshness`. Remote CI is the authoritative gate.

Two notes, neither introduced here:

1. `lint_roadmap_blockers` reports **28 decidability violations against a baseline of 26 — 2 new**, in twelve roadmaps this PR does not touch. Pre-existing red on `origin/main`; left alone rather than folded in.
2. The dashboard regen also picks up a pre-existing staleness — the `road-to-context-fidelity` rows were never regenerated after that merge.

The consumed inbox directory moved to `agents/tmp.old/performance-regression/` (gitignored, so outside this diff); `agents/tmp/council-quota/` was left untouched.
