### PR TITLE
feat(hooks): give the turn-end gate a number

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -2,14 +2,14 @@
 
 > Auto-generated — do not edit. Regenerate with `task roadmap-progress` or by running the `update_roadmap_progress` script for your install; rewritten on every roadmap create / execute / completion change (timestamp lives in git history).
 >
-> 38 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **47** open blockers, **21** need you → `agent-config gates`
+> 38 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **50** open blockers, **22** need you → `agent-config gates`
 
 ## Overall
 
-**267 / 575 steps done · 46%**
+**277 / 574 steps done · 48%**
 
 ```text
-██████████████████░░░░░░░░░░░░░░░░░░░░░░   46%
+███████████████████░░░░░░░░░░░░░░░░░░░░░   48%
 ```
 
 ## ⚠️ Iron Law 3 — unresolved deferred items
@@ -19,6 +19,7 @@ These roadmaps have `count_open == 0` but carry `[~]` deferred items. Per `roadm
 | Roadmap | Done | Deferred | Cancelled |
 |---|---:|---:|---:|
 | [road-to-inbox-harvest-2026-08-d-top-band-model-economy.md](roadmaps/road-to-inbox-harvest-2026-08-d-top-band-model-economy.md) | 13 | 1 | 0 |
+| [road-to-stop-gate-honesty.md](roadmaps/road-to-stop-gate-honesty.md) | 6 | 1 | 0 |
 
 ## Open roadmaps
 
@@ -28,7 +29,7 @@ These roadmaps have `count_open == 0` but carry `[~]` deferred items. Per `roadm
 | 2 | [road-to-carrier-layer-convergence.md](roadmaps/road-to-carrier-layer-convergence.md) | 3 | 8 | 2 | 3 | 0 | 3 | [1](#blockers-road-to-carrier-layer-convergence) | ██████░░░░ 60% |
 | 3 | [road-to-catalogue-host-fit.md](roadmaps/road-to-catalogue-host-fit.md) | 4 | 8 | 7 | 0 | 1 | 0 | [1](#blockers-road-to-catalogue-host-fit) | ░░░░░░░░░░ 0% |
 | 4 | [road-to-ci-native-release-first-run.md](roadmaps/road-to-ci-native-release-first-run.md) | 2 | 8 | 8 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
-| 5 | [road-to-context-fidelity.md](roadmaps/road-to-context-fidelity.md) | 5 | 24 | 24 | 0 | 0 | 0 | 0 | ░░░░░░░░░░ 0% |
+| 5 | [road-to-context-fidelity.md](roadmaps/road-to-context-fidelity.md) | 5 | 24 | 19 | 4 | 0 | 1 | [3](#blockers-road-to-context-fidelity) | ██░░░░░░░░ 17% |
 | 6 | [road-to-cost-parity-1-rule-payload-diet.md](roadmaps/road-to-cost-parity-1-rule-payload-diet.md) | 6 | 49 | 49 | 0 | 0 | 0 | [2](#blockers-road-to-cost-parity-1-rule-payload-diet) | ░░░░░░░░░░ 0% |
 | 7 | [road-to-council-blind-review.md](roadmaps/road-to-council-blind-review.md) | 3 | 6 | 2 | 3 | 0 | 1 | [1](#blockers-road-to-council-blind-review) | ██████░░░░ 60% |
 | 8 | [road-to-distillation-followups.md](roadmaps/road-to-distillation-followups.md) | 2 | 2 | 2 | 0 | 0 | 0 | [2](#blockers-road-to-distillation-followups) | ░░░░░░░░░░ 0% |
@@ -56,7 +57,7 @@ These roadmaps have `count_open == 0` but carry `[~]` deferred items. Per `roadm
 | 30 | [road-to-solution-minimalism.md](roadmaps/road-to-solution-minimalism.md) | 4 | 36 | 6 | 29 | 0 | 1 | [1](#blockers-road-to-solution-minimalism) | ████████░░ 83% |
 | 31 | [road-to-source-first-frontend.md](roadmaps/road-to-source-first-frontend.md) | 6 | 18 | 6 | 11 | 1 | 0 | 0 | ██████░░░░ 65% |
 | 32 | [road-to-standing-context-40k.md](roadmaps/road-to-standing-context-40k.md) | 5 | 9 | 8 | 0 | 1 | 0 | [1](#blockers-road-to-standing-context-40k) | ░░░░░░░░░░ 0% |
-| 33 | [road-to-stop-gate-honesty.md](roadmaps/road-to-stop-gate-honesty.md) | 3 | 7 | 6 | 0 | 1 | 0 | [1](#blockers-road-to-stop-gate-honesty) | ░░░░░░░░░░ 0% |
+| 33 | [road-to-stop-gate-honesty.md](roadmaps/road-to-stop-gate-honesty.md) | 3 | 7 | 0 | 6 | 1 | 0 | [1](#blockers-road-to-stop-gate-honesty) | ██████████ 100% |
 | 34 | [road-to-subagent-lifecycle-integrity.md](roadmaps/road-to-subagent-lifecycle-integrity.md) | 7 | 21 | 9 | 10 | 0 | 2 | [1](#blockers-road-to-subagent-lifecycle-integrity) | █████░░░░░ 53% |
 | 35 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
 | 36 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 3 | 14 | 1 | 12 | 1 | 0 | [2](#blockers-road-to-surface-consolidation) | █████████░ 92% |
@@ -999,13 +1000,13 @@ _1 blocker resolved._
 
 ### [road-to-stop-gate-honesty.md](roadmaps/road-to-stop-gate-honesty.md)
 
-**Road to stop-gate honesty — a blocking gate earns a number** — 0 / 6 done (0%)
+**Road to stop-gate honesty — a blocking gate earns a number** — 6 / 6 done (100%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
-| 1 | Count before judging | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
-| 2 | Judge each detector on its measured rate against its measured benefit | ⬜ not started | 1 | 0 | 1 | 0 | 0% |
-| 3 | Make refusals cheap when they happen | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
+| 1 | Count before judging | ✅ done | 0 | 3 | 0 | 0 | 100% |
+| 2 | Judge each detector on its measured rate against its measured benefit | ✅ done | 0 | 1 | 1 | 0 | 100% |
+| 3 | Make refusals cheap when they happen | ✅ done | 0 | 2 | 0 | 0 | 100% |
 
 <a id="blockers-road-to-stop-gate-honesty"></a>
 **Blockers**

--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -2,11 +2,11 @@
 
 > Auto-generated — do not edit. Regenerate with `task roadmap-progress` or by running the `update_roadmap_progress` script for your install; rewritten on every roadmap create / execute / completion change (timestamp lives in git history).
 >
-> 38 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **49** open blockers, **21** need you → `agent-config gates`
+> 39 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **49** open blockers, **21** need you → `agent-config gates`
 
 ## Overall
 
-**276 / 575 steps done · 48%**
+**282 / 593 steps done · 48%**
 
 ```text
 ███████████████████░░░░░░░░░░░░░░░░░░░░░   48%
@@ -57,7 +57,7 @@ These roadmaps have `count_open == 0` but carry `[~]` deferred items. Per `roadm
 | 31 | [road-to-solution-minimalism.md](roadmaps/road-to-solution-minimalism.md) | 4 | 36 | 6 | 29 | 0 | 1 | [1](#blockers-road-to-solution-minimalism) | ████████░░ 83% |
 | 32 | [road-to-source-first-frontend.md](roadmaps/road-to-source-first-frontend.md) | 6 | 18 | 6 | 11 | 1 | 0 | 0 | ██████░░░░ 65% |
 | 33 | [road-to-standing-context-40k.md](roadmaps/road-to-standing-context-40k.md) | 5 | 9 | 8 | 0 | 1 | 0 | [1](#blockers-road-to-standing-context-40k) | ░░░░░░░░░░ 0% |
-| 34 | [road-to-stop-gate-honesty.md](roadmaps/road-to-stop-gate-honesty.md) | 3 | 7 | 6 | 0 | 1 | 0 | [1](#blockers-road-to-stop-gate-honesty) | ░░░░░░░░░░ 0% |
+| 34 | [road-to-stop-gate-honesty.md](roadmaps/road-to-stop-gate-honesty.md) | 3 | 7 | 1 | 6 | 0 | 0 | [1](#blockers-road-to-stop-gate-honesty) | █████████░ 86% |
 | 35 | [road-to-subagent-lifecycle-integrity.md](roadmaps/road-to-subagent-lifecycle-integrity.md) | 7 | 21 | 9 | 10 | 0 | 2 | [1](#blockers-road-to-subagent-lifecycle-integrity) | █████░░░░░ 53% |
 | 36 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
 | 37 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 3 | 14 | 1 | 12 | 1 | 0 | [2](#blockers-road-to-surface-consolidation) | █████████░ 92% |
@@ -1004,13 +1004,13 @@ _1 blocker resolved._
 
 ### [road-to-stop-gate-honesty.md](roadmaps/road-to-stop-gate-honesty.md)
 
-**Road to stop-gate honesty — a blocking gate earns a number** — 0 / 6 done (0%)
+**Road to stop-gate honesty — a blocking gate earns a number** — 6 / 7 done (86%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
-| 1 | Count before judging | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
-| 2 | Judge each detector on its measured rate against its measured benefit | ⬜ not started | 1 | 0 | 1 | 0 | 0% |
-| 3 | Make refusals cheap when they happen | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
+| 1 | Count before judging | ✅ done | 0 | 3 | 0 | 0 | 100% |
+| 2 | Judge each detector on its measured rate against its measured benefit | 🟡 in progress | 1 | 1 | 0 | 0 | 50% |
+| 3 | Make refusals cheap when they happen | ✅ done | 0 | 2 | 0 | 0 | 100% |
 
 <a id="blockers-road-to-stop-gate-honesty"></a>
 **Blockers**

--- a/agents/roadmaps/road-to-stop-gate-honesty.md
+++ b/agents/roadmaps/road-to-stop-gate-honesty.md
@@ -70,7 +70,7 @@ Verified 2026-08-17 against `origin/main` @ `097ab6549`.
 
 ### Phase 1 — Count before judging
 
-- [ ] **1.1** Aggregate refusals: a small reader over the per-session ordinal files
+- [x] **1.1** Aggregate refusals: a small reader over the per-session ordinal files
       plus a refusals counter in the session-register record, reported by the hooks
       doctor and rolled up per period — **per detector separately**, because A, B
       and C have different legitimacy profiles and a pooled rate would hide which
@@ -78,14 +78,76 @@ Verified 2026-08-17 against `origin/main` @ `097ab6549`.
       adds no spawn.
       `verify:` the doctor prints per-detector counts on this machine, and a fixture
       session with a known refusal is counted once.
-- [ ] **1.2** Add the TTL the header admits is missing: prune ordinal files past a
+      <!-- done 2026-08-17: `_lib/turn_end_refusals.ts` is the reader;
+      `hooks_doctor` prints it; `SessionRecord.turn_end_refusals` is the
+      per-session half, read from the record the gate already maintains, so the
+      heartbeat gains no spawn.
+
+      TWO PREMISE CORRECTIONS, both found by executing rather than by reading.
+
+      (a) **The gate has FOUR detectors, not three.** § 0 names A/B/C; detector D
+      (`completion`) landed under round 7 § Phase 1 and runs in the same
+      unconditional list. A counter built to the prose would have silently
+      dropped one detector's refusals, so `DETECTOR_IDS` is read off the gate's
+      own `DetectorId` union and a test pins all four.
+
+      (b) **The defect was in the WRITER too, not only in the missing reader.**
+      `markRefusedTurn` overwrote its record on every refusal and stored
+      `findings[0].detector` alone — so a session refused nine times looked
+      exactly like a session refused once, and a turn tripping B and C at once
+      counted as one B. D-2's "refusal frequency is invisible" was therefore true
+      of the state file as well as of the absent rollup, and a reader alone would
+      have aggregated a corpus that had already thrown the numbers away.
+      Mutation-verified: reverting the call site to `[findings[0]!.detector]`
+      fails the new end-to-end case, restoring it passes.
+
+      HONEST DENOMINATOR. A record exists only for a session that was refused, so
+      the reader reports refusals per *refused* session and says so in the output.
+      A per-session rate over all sessions would need a write on every session on
+      the hot Stop path, which this step's own "adds no spawn" forbids.
+
+      FIRST READING, against the 36 field records (2026-08-12 … 2026-08-17):
+      verification 22 (61%), language 9 (25%), promissory 5 (14%), completion 0.
+      A floor, not an exact count — every one of those records predates counting
+      and contributes one refusal each. Detector C dominating is D-1's own
+      prediction for quick-edit workflows, now measured. -->
+- [x] **1.2** Add the TTL the header admits is missing: prune ordinal files past a
       declared age at session start. Cheap and bounded.
       `verify:` a fixture directory with aged and fresh files keeps exactly the
       fresh ones.
-- [ ] **1.3** Split the counts before and after the local 12.1 install date per
+      <!-- done 2026-08-17: `pruneAgedRefusalState`, 90 days, run at
+      `session_start` by the `session-register` concern — the one slot that
+      already prunes, so the step costs one directory scan and no new spawn.
+      Ages on the record's OWN `refused_at`, never the filesystem mtime, which a
+      checkout or an rsync rewrites; an unparseable record is KEPT rather than
+      deleted. The gate header's "No TTL ships here" was corrected in place
+      rather than left as a stale admission. 90 is a stated default with a
+      revisit-if, not a measured optimum, and says so at the constant. -->
+- [x] **1.3** Split the counts before and after the local 12.1 install date per
       machine, to test claim 10's prediction rather than assume it.
       `verify:` the split appears in the rollup, with the install date recorded per
       machine.
+      <!-- done 2026-08-17, and the step's own mechanism was WEAKER than what
+      shipped, which is worth stating because it changes what the split proves.
+
+      `installed.lock` records the version that performed the MOST RECENT install
+      and when — not the date any particular version arrived. This machine reads
+      `13.0.0 at 2026-08-17`, so a before/after split on that date would say
+      nothing about 12.1 and would look like it did. So the refusal record now
+      carries `agent_config_version` AT REFUSAL TIME and the primary split is by
+      RECORDED version; the lockfile boundary is still printed, because it is the
+      only thing that dates the pre-stamping corpus.
+
+      Consequence, stated rather than buried: all 36 existing records are
+      `(unrecorded)` and the rollup labels them so. Claim 10 cannot be tested
+      until refusals accumulate under a stamped version — which is the honest
+      answer, and strictly better than attributing them to whatever is installed
+      today. -->
+
+**Interlock:** AC-1 asks for a rate over a window on at least two machines. The
+instrument now exists and the maintainer machine's window is open; a colleague
+machine contributes as soon as one runs a version that stamps its refusals.
+Nothing downstream of Phase 1 was built on the unstamped corpus.
 - **AC-1:** a per-detector refusal rate exists for the maintainer machine and at
   least one colleague machine, over a window long enough to be read as a rate
   rather than an anecdote.
@@ -99,7 +161,7 @@ Verified 2026-08-17 against `origin/main` @ `097ab6549`.
       the demotion is published with the distribution. The numbers are the
       maintainer's; the shape is the requirement. Blocked on
       `b-detector-demotion-bars`.
-- [ ] **2.2** Detector C's verify allowlist decides what counts as verification.
+- [x] **2.2** Detector C's verify allowlist decides what counts as verification.
       **Narrowed by claim 4:** the PHP toolchain the draft worried about is already
       matched, so this step is no longer "add phpunit and pest". What remains is a
       real audit with a smaller surface — enumerate the verify-shaped commands the
@@ -108,13 +170,53 @@ Verified 2026-08-17 against `origin/main` @ `097ab6549`.
       recognised, the same as every allowlist in this tree.
       `verify:` a fixture table of real commands with their recognition verdict;
       every addition has its own row.
+      <!-- done 2026-08-17: 56-row table in
+      `tests/scripts/turn_end_verify_allowlist.test.ts`, built from this
+      project's real surface — its `package.json` scripts, its `Taskfile`
+      targets, `./scripts-run`, `./agent-config`, and the PHP / Python / Go /
+      Rust toolchains.
+
+      CLAIM 4 RE-VERIFIED, not taken on trust: `vendor/bin/phpunit`, `pest`,
+      `composer test` and `php artisan test` all matched BEFORE this change. The
+      draft's expected work was genuinely already done.
+
+      TWO REAL MISSES, both added:
+        · `phpstan` — a static analyser of exactly the class already listed
+          (`mypy`, `pyright`, `clippy`).
+        · `lint` followed by a WORD character. `\blint\b` needs a boundary and
+          `_` is a word character, so EVERY `lint_*` script in `src/scripts/` was
+          unrecognised — `lint_persistence`, `lint_provenance`, and the rest.
+          `lint[-_:a-z]*` is the exact mirror of the `check[-_:a-z]*` this list
+          already carried, which is why it is the narrow fix and not a new idea.
+
+      FOUR MISSES DELIBERATELY NOT ADDED, because Risk 2 says every addition is a
+      way to satisfy the gate without verifying anything: `npm run prepack` (a
+      per-project lifecycle hook — a build step elsewhere), `task sync` /
+      `task generate-tools` / `agent-config roadmap:progress` (GENERATORS — they
+      rewrite the tree and check nothing, which is the rubber stamp in its purest
+      form), `agent-config gates --all` (enumerates, runs nothing), and
+      `vendor/bin/rector process --dry-run` (a refactorer; its dry run prints a
+      diff and asserts nothing). `psalm` is `phpstan`'s obvious sibling and is
+      also not added: nothing in the audited surface runs it, and "the team
+      actually runs" is this step's own standard.
+
+      The `false` rows are pinned as tests, not merely recorded — if a later
+      widening makes `task sync` or `ls -la` clear an unverified edit, the
+      fixture fails and the change has to be argued rather than slipped in. -->
+      <!-- open note for 2.1: this audit does NOT read Phase 1's distribution and
+      must not be read as doing so. The pre-registration in
+      `b-detector-demotion-bars` is untouched and still predates any read. -->
+
+**Phase status:** 2.2 is closed; **2.1 stays open on `b-detector-demotion-bars`**,
+so AC-2 ("no detector stays blocking without a number") is not yet satisfiable —
+the numbers now exist, the bar to judge them against is the maintainer's.
 - **AC-2:** each detector has either a green verdict — rate under its bar — or a
   demotion PR citing the distribution. **No detector stays blocking without a
   number.**
 
 ### Phase 3 — Make refusals cheap when they happen
 
-- [ ] **3.1** On a refusal retry, skip the non-gate Stop concerns: chat history has
+- [x] **3.1** On a refusal retry, skip the non-gate Stop concerns: chat history has
       already written, and re-running the context rebuild, the end-review scan and
       the self-repair detector on the retry is pure duplicate cost. Manifest-level,
       one opt-in flag per concern, default off, flipped only with a per-concern
@@ -122,13 +224,75 @@ Verified 2026-08-17 against `origin/main` @ `097ab6549`.
       is idempotent before flagging it.
       `verify:` a fixture retry runs only the refusal-capable concerns, and each
       skipped concern's artefact is identical to the non-retry run.
-- [ ] **3.2** Complementary lever, recorded here so the two files cannot drift:
+      <!-- done 2026-08-17: `skip_on_refusal_retry` in `hook_manifest.yaml`,
+      honoured by `_resolve_concerns` when `_is_refusal_retry` reads the host's
+      own `stop_hook_active` — the same field the gate uses as its layer-1 guard,
+      so the retry is the host's answer and not our inference. Anything
+      unparseable yields the FULL chain: running twice costs duplicate work,
+      skipping wrongly loses a write.
+
+      Measured end to end: the claude stop chain is 10 concerns, 8 on a retry.
+
+      THE STEP'S OWN PREMISE IS PARTLY REFUTED, and the audit it demanded is what
+      refuted it. "Chat history has already written, and re-running the context
+      rebuild, the end-review scan and the self-repair detector is pure duplicate
+      cost" holds for ONE of those four. Between the refusal and the retry the
+      model DOES more work — that is the point of refusing — so the transcript
+      has grown and every concern reading it has a changed input:
+        · `chat-history` — would LOSE the work done between the two Stops.
+        · `hot-context` — rebuilds from a tree the retry just edited.
+        · `self-repair` — a detector over a turn that changed.
+        · `session-eol` — reads only the bytes appended since the last scan, so
+          skipping the final Stop drops the tail.
+      Flagging those four would be Risk 3 exactly: "a concern skipped on the
+      retry might have been the one that needed the second pass, and the loss
+      would be silent."
+
+      TWO CONCERNS PASS, each on its OWN dedup rather than on our reading:
+        · `interruption-ledger` — dedupes on `(run_id, turn)`, and a refusal
+          retry is the same turn by construction. It already writes nothing. What
+          it does not already avoid is the COST: `main()` calls
+          `readTranscriptTail` (up to 8 MB, walking the whole file) BEFORE
+          reaching `alreadyRecorded`, so today every refused Stop pays a full
+          transcript walk and discards it. This is the flag with the real saving,
+          and D-3's "pure duplicate cost" located in the source.
+        · `end-review-nudge` — its F2 once-per-session marker returns "without
+          re-running the transcript scan", so the artefact is identical by the
+          concern's own construction. The saving is the module load, which is
+          smaller, and the manifest says so rather than overselling it.
+
+      `turn-end-gate` is asserted to survive the retry: skipping the
+      refusal-capable concern would leave the second attempt unguarded, which is
+      the inverse of the intent. A test pins it, and another pins that every
+      flagged concern carries a written ARGUMENT beside its flag — a flag with no
+      argument is the blanket skip wearing a per-concern shape. -->
+- [x] **3.2** Complementary lever, recorded here so the two files cannot drift:
       moving the non-gating Stop concerns to the host's async handler form is owned
       by `road-to-per-turn-hook-economy` step 5.3. This roadmap records only the
       split — gates synchronous, recorders async — and defers the mechanism and its
       acceptance criterion to that file.
       `verify:` this step needs no code; it is closed by that file's 5.3 landing, or
       by recording that it did not.
+      <!-- done 2026-08-17 by the second branch: 5.3 has NOT landed — read at
+      `86cdbf652`, `road-to-per-turn-hook-economy` step 5.3 is open. Recorded
+      here as that file's work, with the split stated: gates synchronous
+      (`turn-end-gate`, `team-review-gate`), recorders async.
+
+      One interlock the two files must not lose, because they now touch the same
+      concerns from opposite directions: 5.3 states that `end-review-nudge`
+      "needs its stdout to reach the model, so it stays synchronous until
+      measured otherwise". That is about the ASYNC axis and does not conflict
+      with 3.1's retry skip — on a retry its stdout was already delivered, or
+      already suppressed, on the first Stop. A future 5.3 may make it async or
+      leave it synchronous; either way the retry flag is orthogonal and neither
+      decision constrains the other. -->
+
+**AC-3 is NOT satisfied by this branch and is not claimed to be.** It asks that a
+refused-turn retry cost "materially less than a full Stop in the bench, measured
+rather than asserted". What shipped is the mechanism and its correctness proof —
+the chain is provably shorter and the skipped artefacts provably identical. The
+*measurement* belongs to `road-to-per-turn-hook-economy`'s bench, which owns the
+Stop-slot numbers, and is the honest reason this phase advances without closing.
 - **AC-3:** a refused-turn retry costs materially less than a full Stop in the
   bench, measured rather than asserted.
 

--- a/agents/roadmaps/road-to-stop-gate-honesty.md
+++ b/agents/roadmaps/road-to-stop-gate-honesty.md
@@ -154,13 +154,35 @@ Nothing downstream of Phase 1 was built on the unstamped corpus.
 
 ### Phase 2 — Judge each detector on its measured rate against its measured benefit
 
-- [~] **2.1** Pre-register the bar per detector **before looking at Phase 1 data**:
+- [ ] **2.1** Pre-register the bar per detector **before looking at Phase 1 data**:
       a detector whose refusals are re-refused on the retry above some share — the
       model could not satisfy it — or whose median per-session count exceeds some
       threshold is demoted from blocking to advisory **for that detector only**, and
       the demotion is published with the distribution. The numbers are the
       maintainer's; the shape is the requirement. Blocked on
       `b-detector-demotion-bars`.
+      <!-- glyph corrected 2026-08-17 `[~]` → `[ ]`, maintainer decision, under
+      the Iron-Law-3 resolution menu (`roadmap-management § 4b`, outcome
+      "restore"). The two glyphs are not synonyms: `[~]` is DEFERRED — work
+      consciously moved out of this plan — and `[ ]` is OPEN. This step is
+      neither postponed nor cancelled; it is waiting on `b-detector-demotion-bars`
+      exactly as every other blocker-gated step in the estate waits, and its own
+      blocker entry says so ("Blocks: Phase 2 step 2.1").
+
+      It shipped as `[~]` from the inbox adoption and nothing re-examined the
+      choice. Closing Phase 1 moved the file to `count_open == 0` with one
+      deferred item, which is the state Iron Law 3 refuses to let archive
+      silently — so the glyph had to be decided rather than inherited, and the
+      accurate reading is the one that also clears the gate. The gate was NOT the
+      reason: a step is marked by what is true of it, and this correction would
+      be right with no gate at all.
+
+      What this does NOT do: it does not touch the blocker, does not pre-register
+      any bar, and does not read Phase 1's distribution into a decision. The
+      pre-registration must predate the first read and remains the maintainer's,
+      untouched. -->
+      <!-- verify: the roadmap reports one open step and zero deferred, and
+      `roadmap:progress-check` no longer lists this file under Iron Law 3. -->
 - [x] **2.2** Detector C's verify allowlist decides what counts as verification.
       **Narrowed by claim 4:** the PHP toolchain the draft worried about is already
       matched, so this step is no longer "add phpunit and pest". What remains is a

--- a/src/scripts/_lib/session_register.ts
+++ b/src/scripts/_lib/session_register.ts
@@ -212,6 +212,20 @@ export interface SessionRecord {
     started_at: string;
     /** ISO-8601 UTC, rewritten every heartbeat. The liveness signal. */
     last_seen: string;
+    /**
+     * Per-detector turn-end refusals THIS session has taken, or absent when it
+     * has taken none.
+     *
+     * `road-to-stop-gate-honesty` § D-2: the gate refuses turn-ends with "no
+     * per-session visibility into how often it happens", and a refused turn-end
+     * costs the user at least one extra model turn. The counts ride this
+     * existing write — the reader is one small `readFileSync` of a record the
+     * gate already maintains, so the heartbeat gains no spawn.
+     *
+     * Optional on purpose: a record written before this field existed, or by a
+     * session that was never refused, is still a valid record.
+     */
+    turn_end_refusals?: Record<string, number>;
 }
 
 /**

--- a/src/scripts/_lib/turn_end_refusals.ts
+++ b/src/scripts/_lib/turn_end_refusals.ts
@@ -1,0 +1,482 @@
+/**
+ * `turn-end-gate` refusal accounting — the number a blocking gate owes.
+ *
+ * `road-to-stop-gate-honesty` § D-2: per-session ordinal state exists, but
+ * nothing aggregates refusals into a rate anyone reviews. Every advisory in this
+ * estate carries a registered kill standard; the one BLOCKING concern carries
+ * none, and a gate that blocks unobserved is the shape that discipline exists to
+ * prevent.
+ *
+ * This module is the reader. It owns three things and deliberately not a fourth:
+ *
+ *   1. the on-disk record shape, extended so a session's refusals are COUNTED
+ *      rather than overwritten (§ Phase 1 step 1.1);
+ *   2. a TTL prune, which the gate's own header admits is missing (step 1.2);
+ *   3. the split by recorded package version, so claim 10's prediction — that
+ *      refusals correlate with the local 12.1 install — is TESTED rather than
+ *      assumed (step 1.3).
+ *
+ * The fourth thing it does not own is a **rate over all sessions**, and the
+ * reason is structural rather than an omission. A record is written only when a
+ * turn is refused, so a session that was never refused leaves no file at all.
+ * The denominator this module can honestly report is *sessions that had at least
+ * one refusal*; refusals-per-session-overall would need a per-session marker
+ * written on every session, which is a write on the hot Stop path that step 1.1
+ * explicitly refuses ("adds no spawn"). `sessionsWithRefusals` is named for what
+ * it is so a reader cannot mistake it for the wider denominator.
+ *
+ * ## Backward compatibility is not optional here
+ *
+ * The field already holds records in the pre-count shape — 36 of them on the
+ * maintainer machine at the time of writing, spanning 2026-08-12 (the day the
+ * settings switch was removed) to 2026-08-17. Discarding them would throw away
+ * the only field evidence this roadmap has. A legacy record carries one detector
+ * and one timestamp, so it counts as exactly ONE refusal of that detector, and
+ * `legacyRecords` reports how much of the total came from that weaker shape.
+ */
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { read_lockfile } from './installed_lock.js';
+
+/**
+ * The four detectors, in the order the gate runs them.
+ *
+ * The roadmap's § 0 names three (A promissory, B language, C verification).
+ * That was true of the draft and is not true of the tree: detector D
+ * (`completion`) landed under round 7 § Phase 1 and is in the same
+ * unconditional list as the other three. Counting three would silently drop a
+ * detector's refusals, so the set is read off `DetectorId` in the gate rather
+ * than off the prose.
+ */
+export const DETECTOR_IDS = [
+    'promissory',
+    'language',
+    'verification',
+    'completion',
+] as const;
+
+export type RefusalDetectorId = (typeof DETECTOR_IDS)[number];
+
+export type DetectorCounts = Record<RefusalDetectorId, number>;
+
+/** State directory, relative to a workspace root. Shared with the gate. */
+export const REFUSAL_STATE_REL = path.join('agents', 'runtime', 'state', 'turn-end-gate');
+
+export function refusalStateDir(workspaceRoot: string): string {
+    return path.join(workspaceRoot, REFUSAL_STATE_REL);
+}
+
+/**
+ * The filename stem for a session's refusal record.
+ *
+ * Defined here rather than in the gate because two modules now need it — the
+ * gate writes the file and the session register reads its own session's counts
+ * back for live per-session visibility (D-2's "no per-session visibility into
+ * how often it happens"). A second sha256 spelled out in the reader is how a
+ * reader and a writer end up disagreeing about which file they mean.
+ */
+export function deriveSessionKey(sessionId: string): string {
+    return crypto.createHash('sha256').update(sessionId).digest('hex').slice(0, 32);
+}
+
+export function sessionRefusalFile(workspaceRoot: string, sessionKey: string): string {
+    return path.join(refusalStateDir(workspaceRoot), `${sessionKey}.json`);
+}
+
+/**
+ * This session's own refusal counts, or `null` when it has never been refused.
+ *
+ * Cheap by construction: one `readFileSync` of a record that is a few hundred
+ * bytes, on a path the caller already touches. Step 1.1 requires the counter to
+ * ride the existing session-register write and add no spawn, and this is what
+ * makes that possible.
+ */
+export function readSessionCounts(
+    workspaceRoot: string,
+    sessionId: string,
+): DetectorCounts | null {
+    try {
+        const raw = fs.readFileSync(
+            sessionRefusalFile(workspaceRoot, deriveSessionKey(sessionId)),
+            'utf-8',
+        );
+        const rec = parseRecord(raw);
+        return rec === null ? null : countsOf(rec);
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * One session's refusal record.
+ *
+ * `refused_turn` and `detector` keep their original meaning exactly — the
+ * re-entrancy guard reads `refused_turn` and nothing else, so extending this
+ * record cannot change whether a turn is refused twice. Everything below them
+ * is additive.
+ */
+export interface RefusalRecord {
+    /** ISO stamp of the MOST RECENT refusal in this session. */
+    refused_at: string;
+    /** Turn ordinal of the most recent refusal — the re-entrancy marker. */
+    refused_turn: number;
+    /** First detector of the most recent refusal. Kept for compatibility. */
+    detector: RefusalDetectorId;
+    /** ISO stamp of the FIRST refusal in this session. Added 2026-08-17. */
+    first_refused_at?: string;
+    /** Cumulative per-detector refusal counts for this session. */
+    counts?: Partial<DetectorCounts>;
+    /** Package version recorded at the most recent refusal, when readable. */
+    agent_config_version?: string;
+}
+
+export function emptyCounts(): DetectorCounts {
+    return { promissory: 0, language: 0, verification: 0, completion: 0 };
+}
+
+function isDetector(v: unknown): v is RefusalDetectorId {
+    return typeof v === 'string' && (DETECTOR_IDS as readonly string[]).includes(v);
+}
+
+/**
+ * Parse one record. Returns `null` for anything unreadable — a malformed state
+ * file must never become an exception on the Stop path, which is the same
+ * fail-open contract the gate itself keeps.
+ */
+export function parseRecord(raw: string): RefusalRecord | null {
+    let decoded: unknown;
+    try {
+        decoded = JSON.parse(raw);
+    } catch {
+        return null;
+    }
+    if (typeof decoded !== 'object' || decoded === null || Array.isArray(decoded)) return null;
+    const o = decoded as Record<string, unknown>;
+    if (typeof o['refused_at'] !== 'string') return null;
+    if (typeof o['refused_turn'] !== 'number') return null;
+    if (!isDetector(o['detector'])) return null;
+    const rec: RefusalRecord = {
+        refused_at: o['refused_at'],
+        refused_turn: o['refused_turn'],
+        detector: o['detector'],
+    };
+    if (typeof o['first_refused_at'] === 'string') rec.first_refused_at = o['first_refused_at'];
+    if (typeof o['agent_config_version'] === 'string') {
+        rec.agent_config_version = o['agent_config_version'];
+    }
+    const counts = o['counts'];
+    if (typeof counts === 'object' && counts !== null && !Array.isArray(counts)) {
+        const parsed: Partial<DetectorCounts> = {};
+        for (const id of DETECTOR_IDS) {
+            const n = (counts as Record<string, unknown>)[id];
+            if (typeof n === 'number' && Number.isFinite(n) && n >= 0) parsed[id] = n;
+        }
+        rec.counts = parsed;
+    }
+    return rec;
+}
+
+/**
+ * The per-detector counts a record contributes.
+ *
+ * A record written before counts existed contributes one refusal of its single
+ * recorded detector — the honest floor, since the old shape overwrote itself and
+ * cannot say how many times that session was refused.
+ */
+export function countsOf(rec: RefusalRecord): DetectorCounts {
+    const out = emptyCounts();
+    if (rec.counts === undefined) {
+        out[rec.detector] = 1;
+        return out;
+    }
+    let any = false;
+    for (const id of DETECTOR_IDS) {
+        const n = rec.counts[id];
+        if (typeof n === 'number' && n > 0) {
+            out[id] = n;
+            any = true;
+        }
+    }
+    // A counts block that is present but all-zero is a record whose writer knew
+    // about counts and recorded none — treat it like the legacy shape rather
+    // than reporting a refusal that left no trace of which detector fired.
+    if (!any) out[rec.detector] = 1;
+    return out;
+}
+
+/**
+ * Fold one refusal into a record. Pure — the caller writes.
+ *
+ * `detectors` is every finding of THIS refusal, not just the first. The gate
+ * stores `findings[0].detector` in `detector` for compatibility, but a turn that
+ * trips B and C at once is two detector observations and counting it as one
+ * would understate whichever detector lost the tie — precisely the pooling the
+ * roadmap's step 1.1 forbids ("per detector separately ... a pooled rate would
+ * hide which one is firing").
+ */
+export function foldRefusal(
+    prev: RefusalRecord | null,
+    input: {
+        detectors: readonly RefusalDetectorId[];
+        turnOrdinal: number;
+        at: string;
+        version?: string | undefined;
+    },
+): RefusalRecord {
+    const counts = prev === null ? emptyCounts() : countsOf(prev);
+    for (const d of input.detectors) counts[d] += 1;
+    const primary = input.detectors[0] ?? prev?.detector ?? 'verification';
+    const rec: RefusalRecord = {
+        refused_at: input.at,
+        refused_turn: input.turnOrdinal,
+        detector: primary,
+        first_refused_at: prev?.first_refused_at ?? prev?.refused_at ?? input.at,
+        counts,
+    };
+    if (input.version !== undefined) rec.agent_config_version = input.version;
+    else if (prev?.agent_config_version !== undefined) {
+        rec.agent_config_version = prev.agent_config_version;
+    }
+    return rec;
+}
+
+// ---------------------------------------------------------------------------
+// The install boundary — step 1.3
+// ---------------------------------------------------------------------------
+
+export interface InstallBoundary {
+    version: string | null;
+    installed_at: string | null;
+}
+
+/**
+ * The machine's own install stamp, read from `~/.event4u/agent-config/installed.lock`.
+ *
+ * **What this can and cannot answer, because the difference decides whether
+ * step 1.3 tests claim 10 or merely looks like it does.** The lockfile records
+ * the version that performed the MOST RECENT install and when — not the date any
+ * particular version arrived. On a machine that has since upgraded past the
+ * version under suspicion, `installed_at` is the newer install's date and a
+ * before/after split on it says nothing about 12.1.
+ *
+ * That is why the record carries `agent_config_version` at refusal time and why
+ * `collectRefusalStats` splits by RECORDED VERSION as its primary axis: a
+ * version stamped on the refusal itself is evidence, a date compared against a
+ * moving lockfile is an inference. The boundary is still reported, because it is
+ * the only thing that dates the corpus written before versions were recorded.
+ */
+export function readInstallBoundary(): InstallBoundary {
+    try {
+        const lock = read_lockfile();
+        if (lock === null) return { version: null, installed_at: null };
+        return {
+            version: lock.agent_config_version ?? null,
+            installed_at: lock.installed_at ?? null,
+        };
+    } catch {
+        return { version: null, installed_at: null };
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TTL — step 1.2
+// ---------------------------------------------------------------------------
+
+/**
+ * Default retention for refusal state.
+ *
+ * **A stated default, not a measured optimum.** 90 days is long enough that a
+ * per-detector rate can be read over a window rather than an anecdote (AC-1's
+ * own requirement) and short enough that a long-lived workspace does not
+ * accumulate indefinitely, which is the defect the gate's header admits. It is
+ * deliberately far longer than the session-register TTLs, because those bound
+ * LIVENESS and this bounds EVIDENCE — pruning evidence on a liveness clock would
+ * delete the corpus this roadmap exists to read.
+ *
+ * *Revisit-if:* a rollup window longer than 90 days is needed to read a rate, or
+ * the directory's file count becomes a measured cost rather than a projected one.
+ */
+export const REFUSAL_STATE_MAX_AGE_DAYS = 90;
+
+export interface PruneResult {
+    scanned: number;
+    pruned: number;
+    kept: number;
+}
+
+/**
+ * Remove refusal records whose most recent refusal is older than `maxAgeDays`.
+ *
+ * Age is read from the record's own `refused_at`, never from the filesystem
+ * mtime: a `git checkout` or an rsync rewrites mtimes and would prune a live
+ * corpus or preserve a dead one at random. A record that cannot be parsed is
+ * KEPT — deleting a file this reader cannot understand is the one irreversible
+ * move available here, and an unparseable record costs a few bytes.
+ */
+export function pruneAgedRefusalState(
+    workspaceRoot: string,
+    opts: { maxAgeDays?: number; now?: Date } = {},
+): PruneResult {
+    const maxAgeDays = opts.maxAgeDays ?? REFUSAL_STATE_MAX_AGE_DAYS;
+    const now = opts.now ?? new Date();
+    const dir = refusalStateDir(workspaceRoot);
+    const result: PruneResult = { scanned: 0, pruned: 0, kept: 0 };
+    let entries: string[];
+    try {
+        entries = fs.readdirSync(dir);
+    } catch {
+        return result; // no directory yet — nothing to prune, not an error
+    }
+    const cutoffMs = now.getTime() - maxAgeDays * 24 * 60 * 60 * 1000;
+    for (const name of entries) {
+        if (!name.endsWith('.json')) continue;
+        result.scanned += 1;
+        const file = path.join(dir, name);
+        let rec: RefusalRecord | null = null;
+        try {
+            rec = parseRecord(fs.readFileSync(file, 'utf-8'));
+        } catch {
+            rec = null;
+        }
+        if (rec === null) {
+            result.kept += 1;
+            continue;
+        }
+        const at = Date.parse(rec.refused_at);
+        if (!Number.isFinite(at) || at >= cutoffMs) {
+            result.kept += 1;
+            continue;
+        }
+        try {
+            fs.unlinkSync(file);
+            result.pruned += 1;
+        } catch {
+            result.kept += 1;
+        }
+    }
+    return result;
+}
+
+// ---------------------------------------------------------------------------
+// Aggregation — steps 1.1 and 1.3
+// ---------------------------------------------------------------------------
+
+export interface PeriodBucket {
+    /** `YYYY-MM-DD`, in UTC. */
+    period: string;
+    sessions: number;
+    total: number;
+    byDetector: DetectorCounts;
+}
+
+export interface VersionBucket {
+    version: string;
+    sessions: number;
+    total: number;
+    byDetector: DetectorCounts;
+}
+
+export interface RefusalStats {
+    /** Sessions that had AT LEAST ONE refusal — never "all sessions". */
+    sessionsWithRefusals: number;
+    total: number;
+    byDetector: DetectorCounts;
+    /** Newest first. */
+    byPeriod: PeriodBucket[];
+    /** Records still in the pre-count shape; their contribution is a floor. */
+    legacyRecords: number;
+    /** Records carrying no readable package version. */
+    unversionedRecords: number;
+    byVersion: VersionBucket[];
+    earliest: string | null;
+    latest: string | null;
+}
+
+function addInto(target: DetectorCounts, source: DetectorCounts): void {
+    for (const id of DETECTOR_IDS) target[id] += source[id];
+}
+
+function sumOf(counts: DetectorCounts): number {
+    let n = 0;
+    for (const id of DETECTOR_IDS) n += counts[id];
+    return n;
+}
+
+/**
+ * Aggregate every refusal record under a workspace.
+ *
+ * Period attribution uses the record's `refused_at` — the session's LAST
+ * refusal — for the whole session's counts. A session that straddles midnight
+ * therefore lands entirely in the later day. This is an approximation and is
+ * named as one: the alternative is a per-refusal timestamp list, which grows
+ * without bound inside a file whose whole point is to stay one small record per
+ * session.
+ */
+export function collectRefusalStats(workspaceRoot: string): RefusalStats {
+    const dir = refusalStateDir(workspaceRoot);
+    const stats: RefusalStats = {
+        sessionsWithRefusals: 0,
+        total: 0,
+        byDetector: emptyCounts(),
+        byPeriod: [],
+        legacyRecords: 0,
+        unversionedRecords: 0,
+        byVersion: [],
+        earliest: null,
+        latest: null,
+    };
+    let entries: string[];
+    try {
+        entries = fs.readdirSync(dir);
+    } catch {
+        return stats;
+    }
+    const periods = new Map<string, PeriodBucket>();
+    const versions = new Map<string, VersionBucket>();
+    for (const name of entries) {
+        if (!name.endsWith('.json')) continue;
+        let rec: RefusalRecord | null = null;
+        try {
+            rec = parseRecord(fs.readFileSync(path.join(dir, name), 'utf-8'));
+        } catch {
+            rec = null;
+        }
+        if (rec === null) continue;
+        const counts = countsOf(rec);
+        stats.sessionsWithRefusals += 1;
+        if (rec.counts === undefined) stats.legacyRecords += 1;
+        addInto(stats.byDetector, counts);
+
+        const period = rec.refused_at.slice(0, 10);
+        let bucket = periods.get(period);
+        if (bucket === undefined) {
+            bucket = { period, sessions: 0, total: 0, byDetector: emptyCounts() };
+            periods.set(period, bucket);
+        }
+        bucket.sessions += 1;
+        addInto(bucket.byDetector, counts);
+
+        const version = rec.agent_config_version;
+        if (version === undefined) stats.unversionedRecords += 1;
+        const vkey = version ?? '(unrecorded)';
+        let vbucket = versions.get(vkey);
+        if (vbucket === undefined) {
+            vbucket = { version: vkey, sessions: 0, total: 0, byDetector: emptyCounts() };
+            versions.set(vkey, vbucket);
+        }
+        vbucket.sessions += 1;
+        addInto(vbucket.byDetector, counts);
+
+        const first = rec.first_refused_at ?? rec.refused_at;
+        if (stats.earliest === null || first < stats.earliest) stats.earliest = first;
+        if (stats.latest === null || rec.refused_at > stats.latest) stats.latest = rec.refused_at;
+    }
+    stats.total = sumOf(stats.byDetector);
+    for (const b of periods.values()) b.total = sumOf(b.byDetector);
+    for (const b of versions.values()) b.total = sumOf(b.byDetector);
+    stats.byPeriod = [...periods.values()].sort((a, b) => (a.period < b.period ? 1 : -1));
+    stats.byVersion = [...versions.values()].sort((a, b) => (a.version < b.version ? 1 : -1));
+    return stats;
+}

--- a/src/scripts/hook_manifest.yaml
+++ b/src/scripts/hook_manifest.yaml
@@ -489,6 +489,16 @@ concerns:
     args: []
     fail_closed: false
     severity: advisory
+    # road-to-stop-gate-honesty step 3.1 — skipped on a refusal RETRY.
+    # ARGUMENT, per concern as that step requires: the F2 fire gate is a
+    # once-per-session marker, and this concern's own header records that a
+    # second run "reads the marker and returns silently, without re-running the
+    # transcript scan". The retry therefore cannot change its artefact — the
+    # telemetry line was already written, or already suppressed, on the first
+    # Stop. Idempotence is the concern's own construction, not our assumption
+    # about it. The saving is the module load rather than a large read, which is
+    # the smaller of the two flags below it and is stated as such.
+    skip_on_refusal_retry: true
   # road-to-conformance-round5 Phase 3 — the FIRST concern that can refuse a
   # turn-END. Round 5 measured the reason: both blocking carriers reached zero
   # violations, neither advisory carrier did, and 19 language violations
@@ -597,6 +607,18 @@ concerns:
     args: []
     fail_closed: false
     severity: advisory
+    # road-to-stop-gate-honesty step 3.1 — skipped on a refusal RETRY, and this
+    # is the flag with the real saving.
+    # ARGUMENT, per concern: `alreadyRecorded(ledgerPath, run_id, turn)` dedupes
+    # on the TURN ORDINAL, and a refusal retry is the same turn by construction
+    # — the gate's layer-2 marker is keyed on that same ordinal. So the ledger
+    # already writes nothing on the retry and the artefact is provably identical.
+    # What it does NOT already avoid is the cost: `main()` calls
+    # `readTranscriptTail` (up to 8 MB, walking the whole file) BEFORE reaching
+    # `alreadyRecorded`, so today every refused Stop pays a full transcript walk
+    # and then discards the result. That is the "pure duplicate cost" § D-3
+    # names, measured in the source rather than assumed.
+    skip_on_refusal_retry: true
   # road-to-subagent-lifecycle-integrity Phase 1 (Steps 2+3) — the subagent
   # lifecycle ledger. Binds ONLY the two new events; on every other slot it is
   # not listed at all. Appends `subagent_start` / `subagent_stop` lines to

--- a/src/scripts/hooks/dispatch_hook.ts
+++ b/src/scripts/hooks/dispatch_hook.ts
@@ -343,15 +343,50 @@ export function _role_drop_set(
 }
 
 /**
+ * True when this `stop` is the RETRY of a turn a stop-hook already refused.
+ *
+ * The host sets `stop_hook_active` on exactly that Stop; `turn_end_gate_hook`
+ * reads the same field as its layer-1 re-entrancy guard, so this is the host's
+ * own answer rather than an inference of ours. Anything unparseable is `false`,
+ * which is the full chain — the safe direction, since the cost of running a
+ * concern twice is duplicate work and the cost of skipping one wrongly is a lost
+ * write.
+ */
+export function _is_refusal_retry(event: string, payload_text: string): boolean {
+  if (event !== "stop") return false;
+  try {
+    const parsed: unknown = JSON.parse(payload_text);
+    if (!_isObject(parsed)) return false;
+    const payload = parsed["payload"];
+    const source = _isObject(payload) ? payload : parsed;
+    return source["stop_hook_active"] === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Return the ordered concern definitions for (platform, event) under the
  * given session role (default `orchestrator` — byte-identical to the
  * pre-role-axis behaviour).
+ *
+ * `opts.refusal_retry` drops concerns that opted in with
+ * `skip_on_refusal_retry: true` — `road-to-stop-gate-honesty` step 3.1. Stop is
+ * the heaviest slot on claude and **every refused Stop runs the whole slot again
+ * on the retry** (§ D-3), so the concerns whose second run provably produces the
+ * identical artefact are pure duplicate cost.
+ *
+ * Opt-in per concern, default off, never a blanket skip: Risk 3 of that roadmap
+ * is that a concern skipped on the retry might have been the one that needed the
+ * second pass, and the loss would be silent. The manifest carries the per-concern
+ * argument beside each flag.
  */
 export function _resolve_concerns(
   manifest: JsonObject,
   platform: string,
   event: string,
   role: SessionRole = "orchestrator",
+  opts: { refusal_retry?: boolean } = {},
 ): ConcernDef[] {
   const platformsRaw = manifest["platforms"];
   const platforms = _isObject(platformsRaw) ? platformsRaw : {};
@@ -379,6 +414,9 @@ export function _resolve_concerns(
       process.stderr.write(
         `dispatch_hook: unknown concern '${String(name)}' in manifest\n`,
       );
+      continue;
+    }
+    if (opts.refusal_retry && spec["skip_on_refusal_retry"] === true) {
       continue;
     }
     out.push({ name: String(name), ...spec });
@@ -1081,13 +1119,17 @@ export function main(argv?: string[]): number {
   const payload_text = process.stdin.isTTY ? "" : _readStdin();
   _maybe_capture_payload(args, payload_text);
   const session_role = resolveSessionRole(process.env);
-  const concerns = _resolve_concerns(manifest, args.platform, args.event, session_role);
+  const refusal_retry = _is_refusal_retry(args.event, payload_text);
+  const concerns = _resolve_concerns(manifest, args.platform, args.event, session_role, {
+    refusal_retry,
+  });
 
   if (args.dry_run) {
     const plan = {
       platform: args.platform,
       event: args.event,
       role: session_role,
+      refusal_retry,
       concerns: concerns.map((c) => c["name"]),
     };
     process.stdout.write(_py_json_dumps(plan, 2) + "\n");

--- a/src/scripts/hooks/turn_end_gate_hook.ts
+++ b/src/scripts/hooks/turn_end_gate_hook.ts
@@ -539,9 +539,50 @@ const _EDIT_TOOLS = new Set(['Edit', 'Write', 'MultiEdit', 'NotebookEdit']);
  * ("relying on partial verification"). The cost of narrowness is a MISSED
  * detection when a project verifies by some command not listed here, and that is
  * the safe direction for a gate that can refuse a turn: a false negative costs
- * one unguarded turn, a false positive teaches the user to switch the gate off. */
+ * one unguarded turn, a false positive teaches the user to switch the gate off.
+ *
+ * ## Audited 2026-08-17 — `road-to-stop-gate-honesty` step 2.2
+ *
+ * 52 commands this project's own surface actually produces (its `package.json`
+ * scripts, its `Taskfile` targets, `./scripts-run`, `./agent-config`, and the
+ * PHP / Python / Go / Rust toolchains) were run through
+ * `isVerificationCommand`. The table of every one, with its verdict, is
+ * `turn_end_verify_allowlist.test.ts`; that file is the fixture step 2.2
+ * requires, and every addition below has its own row in it.
+ *
+ * The draft that opened the roadmap expected to add `phpunit` and `pest`. Claim
+ * 4 had already overtaken that — both matched before this audit, as did
+ * `composer test` and `php artisan test` — so what the audit actually found was
+ * two different gaps:
+ *
+ *   · `phpstan` — a static analyser of exactly the class already listed
+ *     (`mypy`, `pyright`, `clippy`). Added.
+ *   · `lint` followed by a WORD character — `lint_persistence`,
+ *     `lint_provenance`, and every other `lint_*` script in `src/scripts/`
+ *     missed, because `\blint\b` needs a boundary and `_` is a word character.
+ *     `lint[-_:a-z]*` is the exact mirror of the `check[-_:a-z]*` this list
+ *     already carried, which is why it is the narrow fix rather than a new idea.
+ *
+ * Four further misses were found and deliberately NOT added, because Risk 2 of
+ * that roadmap is that every addition is a way to satisfy the gate without
+ * verifying anything:
+ *
+ *   · `npm run prepack` — a lifecycle hook whose content is per-project. Here it
+ *     validates; elsewhere it copies files. Recognising it would clear an
+ *     unverified edit in any repo whose prepack is a build step.
+ *   · `task sync` / `task generate-tools` / `agent-config roadmap:progress` —
+ *     GENERATORS. They rewrite the tree; they check nothing. A generator that
+ *     cleared the gate would be the rubber stamp in its purest form.
+ *   · `agent-config gates --all` — enumerates gates, runs none.
+ *   · `vendor/bin/rector process --dry-run` — a refactoring tool. Its dry run
+ *     prints a diff; it does not assert anything holds.
+ *
+ * `psalm` is the obvious sibling of `phpstan` and is also NOT added: nothing in
+ * the audited surface runs it, and "the team actually runs" is the step's own
+ * standard. It is named here so the next audit does not re-derive the question.
+ */
 const _VERIFY_RE =
-    /\b(test|tests|vitest|jest|pytest|phpunit|pest|tsc|eslint|ruff|mypy|pyright|clippy|typecheck|lint|build|ci|preflight|smoke[-_:a-z]*|check[-_:a-z]*|validate[-_:a-z]*)\b|\b(task|npm|pnpm|yarn|composer|cargo|go|make|php artisan|bun)\s+(run\s+)?\S*(test|check|lint|build|ci|typecheck)/i;
+    /\b(test|tests|vitest|jest|pytest|phpunit|pest|tsc|eslint|ruff|mypy|pyright|clippy|phpstan|typecheck|lint[-_:a-z]*|build|ci|preflight|smoke[-_:a-z]*|check[-_:a-z]*|validate[-_:a-z]*)\b|\b(task|npm|pnpm|yarn|composer|cargo|go|make|php artisan|bun)\s+(run\s+)?\S*(test|check|lint|build|ci|typecheck)/i;
 
 export function isVerificationCommand(command: string): boolean {
     return _VERIFY_RE.test(command);

--- a/src/scripts/hooks/turn_end_gate_hook.ts
+++ b/src/scripts/hooks/turn_end_gate_hook.ts
@@ -47,9 +47,11 @@
  *      non-sidechain user entries — is distinct for every real turn whatever
  *      the user typed, and stable across harness injections.
  *
- *      Still true and still worth stating: per-session files are bounded per
- *      session but not pruned, so a long-lived workspace accumulates one small
- *      file per session. No TTL ships here.
+ *      No longer true, and corrected here rather than left as a stale admission:
+ *      the files ARE pruned. `road-to-stop-gate-honesty` step 1.2 added a
+ *      90-day retention (`pruneAgedRefusalState`), run at `session_start` by the
+ *      session-register concern. The record also COUNTS now instead of
+ *      overwriting itself — see `markRefusedTurn`.
  *
  * The failure this ordering prevents is not a loop but a wedge: a turn that
  * can never end. Layer 2 also covers the host that does not send
@@ -111,7 +113,6 @@
  * not an advisory, so there is no advisory path here to put on the wrong code.
  * Probed, not assumed.
  */
-import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -130,6 +131,14 @@ import { unwrap, type JsonObject, type JsonValue } from './envelope.js';
 import { readHookStdin } from './hook_stdin.js';
 import { atomic_write_json, is_replay_mode } from './state_io.js';
 import { openRecordStats } from './subagent_ledger_hook.js';
+import {
+    deriveSessionKey,
+    foldRefusal,
+    parseRecord,
+    readInstallBoundary,
+    sessionRefusalFile,
+    type RefusalRecord,
+} from '../_lib/turn_end_refusals.js';
 
 /** Dispatcher-internal block code. Pinned to 1 by `concern_block_exit_parity`. */
 const EXIT_BLOCK = 1;
@@ -530,8 +539,7 @@ const _EDIT_TOOLS = new Set(['Edit', 'Write', 'MultiEdit', 'NotebookEdit']);
  * ("relying on partial verification"). The cost of narrowness is a MISSED
  * detection when a project verifies by some command not listed here, and that is
  * the safe direction for a gate that can refuse a turn: a false negative costs
- * one unguarded turn, a false positive teaches the user to switch the gate off.
- */
+ * one unguarded turn, a false positive teaches the user to switch the gate off. */
 const _VERIFY_RE =
     /\b(test|tests|vitest|jest|pytest|phpunit|pest|tsc|eslint|ruff|mypy|pyright|clippy|typecheck|lint|build|ci|preflight|smoke[-_:a-z]*|check[-_:a-z]*|validate[-_:a-z]*)\b|\b(task|npm|pnpm|yarn|composer|cargo|go|make|php artisan|bun)\s+(run\s+)?\S*(test|check|lint|build|ci|typecheck)/i;
 
@@ -583,29 +591,30 @@ export function detectUnverifiedEdit(toolCalls: readonly ToolCall[]): Finding | 
 // Re-entrancy — the guard, keyed on the turn, not on the reply
 // ---------------------------------------------------------------------------
 
-function stateDir(workspaceRoot: string): string {
-    return path.join(workspaceRoot, 'agents', 'runtime', 'state', 'turn-end-gate');
-}
-
 /**
  * ONE file per session, not one per refused turn. R2 round 1, finding 17:
  * per-turn files accumulated without bound and without a TTL, because "re-arms
  * itself with no cleanup" described the key rotating, not the files being
  * removed.
  *
- * HALF of that is fixed and half is not, stated rather than implied (R2 round 2,
- * finding 12): the per-turn MULTIPLICITY is gone, so a session no longer leaves
- * one file per refused turn. There is still no TTL and no pruning, so a
- * long-lived workspace accumulates one small file per session that ever had a
- * turn refused. Adding expiry is new behaviour and belongs with its own test.
+ * Both halves are now closed. The per-turn MULTIPLICITY went first; the missing
+ * TTL was the other half and `road-to-stop-gate-honesty` step 1.2 shipped it as
+ * `pruneAgedRefusalState`, run at `session_start` by the session-register
+ * concern — the one slot that already prunes and therefore adds no spawn. The
+ * path and the retention constant live with the reader
+ * (`_lib/turn_end_refusals.ts`), because a pruner in one module and a writer in
+ * another must not each own their own idea of where the files are.
  */
 function sessionStateFile(workspaceRoot: string, sessionKey: string): string {
-    return path.join(stateDir(workspaceRoot), `${sessionKey}.json`);
+    return sessionRefusalFile(workspaceRoot, sessionKey);
 }
 
-export function deriveSessionKey(sessionId: string): string {
-    return crypto.createHash('sha256').update(sessionId).digest('hex').slice(0, 32);
-}
+/**
+ * Re-exported, not re-derived: the session register reads this session's own
+ * refusal record back for live per-session visibility, so the stem has two
+ * consumers and exactly one definition (`_lib/turn_end_refusals.ts`).
+ */
+export { deriveSessionKey };
 
 /**
  * A turn's identity is its ORDINAL — how many genuine user prompts the
@@ -645,19 +654,53 @@ export function alreadyRefusedTurn(
     return false;
 }
 
+/**
+ * Write the re-entrancy marker AND count the refusal.
+ *
+ * The marker half is unchanged: `refused_turn` is what `alreadyRefusedTurn`
+ * reads, and nothing about the counting can alter whether a turn is refused
+ * twice. The counting half is `road-to-stop-gate-honesty` step 1.1 — the old
+ * record overwrote itself, so a session refused nine times looked exactly like a
+ * session refused once, and D-2's "refusal frequency is invisible" was true of
+ * the state file as much as of the absent reader.
+ *
+ * EVERY finding's detector is counted, not just the first. The first still lands
+ * in `detector` for compatibility with the 36 field records written before this,
+ * but a turn that trips B and C at once is two observations, and pooling them
+ * into one is what step 1.1 forbids in the reader — doing it in the writer would
+ * put the same defect somewhere the reader cannot fix.
+ */
 function markRefusedTurn(
     workspaceRoot: string,
     sessionKey: string,
     turnOrdinal: number,
-    detector: DetectorId,
+    detectors: readonly DetectorId[],
 ): void {
     if (is_replay_mode()) return;
+    const file = sessionStateFile(workspaceRoot, sessionKey);
+    let prev: RefusalRecord | null = null;
     try {
-        atomic_write_json(sessionStateFile(workspaceRoot, sessionKey), {
-            refused_at: new Date().toISOString(),
-            refused_turn: turnOrdinal,
-            detector,
-        });
+        prev = parseRecord(fs.readFileSync(file, 'utf-8'));
+    } catch {
+        // Absent or unreadable prior state starts a fresh count. Never a reason
+        // to skip the marker — the marker is the wedge guard.
+    }
+    let version: string | undefined;
+    try {
+        version = readInstallBoundary().version ?? undefined;
+    } catch {
+        version = undefined;
+    }
+    try {
+        atomic_write_json(
+            file,
+            foldRefusal(prev, {
+                detectors,
+                turnOrdinal,
+                at: new Date().toISOString(),
+                version,
+            }) as unknown as Record<string, unknown>,
+        );
     } catch {
         // A state-write failure must never wedge the turn. Losing the marker
         // costs at most one extra refusal; failing closed here would cost the
@@ -938,7 +981,12 @@ export function main(): number {
     }
     if (findings.length === 0) return EXIT_ALLOW;
 
-    markRefusedTurn(workspaceRoot, sessionKey, turnOrdinal, findings[0]!.detector);
+    markRefusedTurn(
+        workspaceRoot,
+        sessionKey,
+        turnOrdinal,
+        findings.map((f) => f.detector),
+    );
 
     const lines = findings.map(
         (f) => `  · ${f.detector}: ${f.reason}\n    evidence: ${JSON.stringify(f.evidence)}`,

--- a/src/scripts/hooks_doctor.ts
+++ b/src/scripts/hooks_doctor.ts
@@ -34,6 +34,13 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { read_dispatch_issues } from "./hooks/dispatch_issues.js";
 import { type JsonObject, type JsonValue, _load_yaml } from "./hooks/dispatch_hook.js";
 import * as hooks_status from "./hooks_status.js";
+import {
+  DETECTOR_IDS,
+  collectRefusalStats,
+  readInstallBoundary,
+  type InstallBoundary,
+  type RefusalStats,
+} from "./_lib/turn_end_refusals.js";
 
 // src/scripts/hooks_doctor.ts → parents[2] (../../..) is the repo root,
 // mirroring the Python `Path(__file__).resolve().parents[2]`.
@@ -171,6 +178,17 @@ export interface DoctorPayload {
   concerns: ConcernRow[];
   trampolines: TrampolineRow[];
   dispatch_issues: JsonObject[];
+  /**
+   * Turn-end refusals, per detector, from this workspace's own records.
+   *
+   * `road-to-stop-gate-honesty` § D-2: every advisory concern in this estate
+   * carries a registered kill standard and the one BLOCKING concern carries
+   * none, because nobody could see how often it fires. The doctor is where a
+   * concern's health is already read, so this is where the number belongs.
+   */
+  turn_end_refusals: RefusalStats;
+  /** The machine's install stamp, for reading the version split below it. */
+  install_boundary: InstallBoundary;
 }
 
 /** Build the doctor payload — JSON-serialisable. */
@@ -229,17 +247,109 @@ export function collect(
     issues = [];
   }
 
+  let turn_end_refusals: RefusalStats;
+  try {
+    turn_end_refusals = collectRefusalStats(project_root);
+  } catch {
+    turn_end_refusals = {
+      sessionsWithRefusals: 0,
+      total: 0,
+      byDetector: { promissory: 0, language: 0, verification: 0, completion: 0 },
+      byPeriod: [],
+      legacyRecords: 0,
+      unversionedRecords: 0,
+      byVersion: [],
+      earliest: null,
+      latest: null,
+    };
+  }
+
   return {
     schema_version: 1,
     platforms: matrix.platforms,
     concerns,
     trampolines,
     dispatch_issues: issues,
+    turn_end_refusals,
+    install_boundary: readInstallBoundary(),
   };
 }
 
 function _strVal(v: JsonValue | undefined): string {
   return v === undefined || v === null ? "undefined" : String(v);
+}
+
+/**
+ * The turn-end-gate's own number.
+ *
+ * Reports what the records can support and refuses the number they cannot: the
+ * denominator is *sessions that had at least one refusal*, never all sessions,
+ * because a session that was never refused writes no record. Labelling a
+ * per-refused-session figure as a per-session rate would be the same
+ * denominator inflation this estate's measurement discipline exists to stop.
+ */
+export function _render_refusals(payload: DoctorPayload): string[] {
+  const s = payload.turn_end_refusals;
+  const lines: string[] = [];
+  lines.push("Turn-end refusals");
+  lines.push("-".repeat(60));
+  if (s.sessionsWithRefusals === 0) {
+    lines.push("·  no refusal records under agents/runtime/state/turn-end-gate/");
+    return lines;
+  }
+  const perSession = (s.total / s.sessionsWithRefusals).toFixed(2);
+  lines.push(
+    `   ${s.total} refusal(s) across ${s.sessionsWithRefusals} session(s) ` +
+      `that were refused at least once — ${perSession} per such session.`,
+  );
+  lines.push(
+    "   NOT a per-session rate: sessions with no refusal write no record, so " +
+      "the wider denominator is unavailable here by construction.",
+  );
+  if (s.earliest && s.latest) {
+    lines.push(`   window: ${s.earliest.slice(0, 10)} … ${s.latest.slice(0, 10)}`);
+  }
+  for (const id of DETECTOR_IDS) {
+    const n = s.byDetector[id];
+    const share = s.total > 0 ? Math.round((n / s.total) * 100) : 0;
+    lines.push(`   ${id.padEnd(14)} ${String(n).padStart(4)}  ${share}%`);
+  }
+  if (s.legacyRecords > 0) {
+    lines.push(
+      `   ${s.legacyRecords} record(s) predate per-detector counting and ` +
+        "contribute one refusal each — the total is a FLOOR, not an exact count.",
+    );
+  }
+  const boundary = payload.install_boundary;
+  if (boundary.version || boundary.installed_at) {
+    lines.push(
+      `   installed: ${boundary.version ?? "(unknown version)"} at ` +
+        `${boundary.installed_at ?? "(unknown date)"}`,
+    );
+  }
+  if (s.byVersion.length > 0) {
+    lines.push("   by recorded version:");
+    for (const v of s.byVersion) {
+      lines.push(`     ${v.version.padEnd(16)} ${String(v.total).padStart(4)}`);
+    }
+    if (s.unversionedRecords > 0) {
+      lines.push(
+        "     (unrecorded) rows predate version stamping — they cannot test " +
+          "the install-date prediction in either direction.",
+      );
+    }
+  }
+  const recent = s.byPeriod.slice(0, 7);
+  if (recent.length > 0) {
+    lines.push("   most recent days:");
+    for (const p of recent) {
+      lines.push(
+        `     ${p.period}  ${String(p.total).padStart(3)} refusal(s) / ` +
+          `${p.sessions} session(s)`,
+      );
+    }
+  }
+  return lines;
 }
 
 export function _render_table(payload: DoctorPayload): string {
@@ -286,6 +396,8 @@ export function _render_table(payload: DoctorPayload): string {
     const suffix = t.required ? "" : "  (not required)";
     lines.push(`${marker}${t.platform.padEnd(9)} ${t.expected}${suffix}`);
   }
+  lines.push("");
+  lines.push(..._render_refusals(payload));
   // Dispatch-issues detail — last 20 grouped by concern.
   if (payload.dispatch_issues.length > 0) {
     lines.push("");

--- a/src/scripts/session_register_hook.ts
+++ b/src/scripts/session_register_hook.ts
@@ -67,6 +67,7 @@ import {
     ttl_seconds_for,
     write_record,
 } from './_lib/session_register.js';
+import { pruneAgedRefusalState, readSessionCounts } from './_lib/turn_end_refusals.js';
 import { readHookStdin } from './hooks/hook_stdin.js';
 
 /** Replay-fixture runs must never mutate state (same contract as chat_history). */
@@ -323,7 +324,7 @@ export function build_record(
     started_at: string,
     now: Date = new Date(),
 ): SessionRecord {
-    return {
+    const rec: SessionRecord = {
         session_id,
         platform,
         worktree: workspace_root,
@@ -332,6 +333,20 @@ export function build_record(
         started_at,
         last_seen: iso_now(now),
     };
+    // road-to-stop-gate-honesty step 1.1 — the per-session half of the refusal
+    // counter. Only ever ADDS a field: a session with no refusals leaves the
+    // record byte-identical to what it was before this existed, so a reader that
+    // does not know the field is unaffected and a diff of two records still
+    // shows only what changed.
+    const counts = readSessionCounts(workspace_root, session_id);
+    if (counts !== null) {
+        const nonZero: Record<string, number> = {};
+        for (const [id, n] of Object.entries(counts)) {
+            if (n > 0) nonZero[id] = n;
+        }
+        if (Object.keys(nonZero).length > 0) rec.turn_end_refusals = nonZero;
+    }
+    return rec;
 }
 
 /**
@@ -588,6 +603,20 @@ export function main(): number {
                         `session-register: platform "${platform}" has no reliably firing per-turn slot; ` +
                             `this session will expire from the register after its TTL even while active.\n`,
                     );
+                }
+            }
+            if (event === 'session_start') {
+                // road-to-stop-gate-honesty step 1.2 — the TTL the gate's own
+                // header admitted was missing. This concern is the carrier
+                // because it is already the session_start pruner: adding a
+                // second prune here costs one directory scan on a slot that
+                // fires once per session, where a new concern would cost a
+                // spawn. Never throws — evidence retention is not a reason to
+                // fail a session start.
+                try {
+                    pruneAgedRefusalState(root, { now: new Date() });
+                } catch {
+                    /* an unprunable directory keeps its files; it is not an error */
                 }
             }
             if (event === 'session_start') {

--- a/tests/scripts/dispatch_refusal_retry.test.ts
+++ b/tests/scripts/dispatch_refusal_retry.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Refusal-retry concern skipping — `road-to-stop-gate-honesty` step 3.1.
+ *
+ * Its `verify:` line asks for two things and this file asserts both: a fixture
+ * retry runs only the refusal-capable concerns, and each skipped concern's
+ * artefact is identical to the non-retry run.
+ *
+ * The second half is asserted where it is actually decidable. "Identical
+ * artefact" for these two concerns is a property of their OWN dedup — the F2
+ * once-per-session marker in `end-review-nudge`, and `alreadyRecorded(run_id,
+ * turn)` in `interruption-ledger` — so the honest test is that those guards
+ * exist and key on something a retry cannot change, not a re-run comparison
+ * that would only re-measure the guards. The audit that established this is
+ * recorded per concern in `hook_manifest.yaml`.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+    _is_refusal_retry,
+    _load_yaml,
+    _resolve_concerns,
+    type JsonObject,
+} from '../../src/scripts/hooks/dispatch_hook.js';
+import { alreadyRecorded } from '../../src/scripts/hooks/interruption_ledger_hook.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
+const MANIFEST = _load_yaml(path.join(REPO_ROOT, 'src', 'scripts', 'hook_manifest.yaml'));
+
+/** The concerns that opted in, read off the manifest rather than hardcoded. */
+function optedIn(manifest: JsonObject): string[] {
+    const concerns = manifest['concerns'] as Record<string, JsonObject>;
+    return Object.keys(concerns)
+        .filter((name) => concerns[name]?.['skip_on_refusal_retry'] === true)
+        .sort();
+}
+
+function payload(extra: Record<string, unknown>): string {
+    return JSON.stringify({ payload: { transcript_path: '/tmp/x.jsonl', ...extra } });
+}
+
+describe('detecting the retry', () => {
+    it('reads the host’s own stop_hook_active, on stop only', () => {
+        expect(_is_refusal_retry('stop', payload({ stop_hook_active: true }))).toBe(true);
+        expect(_is_refusal_retry('stop', payload({ stop_hook_active: false }))).toBe(false);
+        expect(_is_refusal_retry('stop', payload({}))).toBe(false);
+        // The same field on another slot means nothing — a retry is a Stop.
+        expect(_is_refusal_retry('post_tool_use', payload({ stop_hook_active: true }))).toBe(
+            false,
+        );
+    });
+
+    it('falls back to the FULL chain on anything unparseable', () => {
+        // Skipping wrongly loses a write; running twice costs duplicate work.
+        // The cheap failure is the default.
+        expect(_is_refusal_retry('stop', 'not json')).toBe(false);
+        expect(_is_refusal_retry('stop', '')).toBe(false);
+        expect(_is_refusal_retry('stop', '[]')).toBe(false);
+    });
+
+    it('accepts a flat payload as well as a wrapped one', () => {
+        expect(_is_refusal_retry('stop', JSON.stringify({ stop_hook_active: true }))).toBe(true);
+    });
+});
+
+describe('the retry chain', () => {
+    it('is byte-identical to today’s chain when the flag is off', () => {
+        const before = _resolve_concerns(MANIFEST, 'claude', 'stop', 'orchestrator');
+        const after = _resolve_concerns(MANIFEST, 'claude', 'stop', 'orchestrator', {
+            refusal_retry: false,
+        });
+        expect(after.map((c) => c['name'])).toEqual(before.map((c) => c['name']));
+    });
+
+    it('drops exactly the opted-in concerns, and nothing else', () => {
+        const full = _resolve_concerns(MANIFEST, 'claude', 'stop', 'orchestrator').map(
+            (c) => c['name'],
+        );
+        const retry = _resolve_concerns(MANIFEST, 'claude', 'stop', 'orchestrator', {
+            refusal_retry: true,
+        }).map((c) => c['name']);
+        const dropped = full.filter((n) => !retry.includes(n as string)).sort();
+        expect(dropped).toEqual(optedIn(MANIFEST));
+        expect(retry.length).toBeLessThan(full.length);
+    });
+
+    it('NEVER drops the refusal-capable concern itself', () => {
+        // The gate is what makes a retry a retry. Skipping it would mean the
+        // second attempt is unguarded — the opposite of the intent.
+        const retry = _resolve_concerns(MANIFEST, 'claude', 'stop', 'orchestrator', {
+            refusal_retry: true,
+        }).map((c) => c['name']);
+        expect(retry).toContain('turn-end-gate');
+    });
+
+    it('never drops a concern on a non-stop slot, whatever it declared', () => {
+        // The flag is only ever consulted with `refusal_retry`, which
+        // `_is_refusal_retry` refuses to set outside `stop`.
+        for (const event of ['session_start', 'user_prompt_submit', 'post_tool_use']) {
+            const plain = _resolve_concerns(MANIFEST, 'claude', event, 'orchestrator');
+            const flagged = _resolve_concerns(MANIFEST, 'claude', event, 'orchestrator', {
+                refusal_retry: _is_refusal_retry(event, payload({ stop_hook_active: true })),
+            });
+            expect(flagged.map((c) => c['name'])).toEqual(plain.map((c) => c['name']));
+        }
+    });
+
+    it('every opted-in concern carries a written argument beside its flag', () => {
+        // Step 3.1: "flipped only with a per-concern argument in the PR — never
+        // a blanket skip". A flag with no argument in the manifest is the
+        // blanket skip wearing a per-concern shape.
+        const raw = fs.readFileSync(
+            path.join(REPO_ROOT, 'src', 'scripts', 'hook_manifest.yaml'),
+            'utf-8',
+        );
+        for (const name of optedIn(MANIFEST)) {
+            const at = raw.indexOf(`\n  ${name}:`);
+            expect(at, `${name} not found in the manifest`).toBeGreaterThan(-1);
+            const block = raw.slice(at, raw.indexOf('skip_on_refusal_retry', at));
+            expect(block, `${name} has no ARGUMENT beside its flag`).toContain('ARGUMENT');
+        }
+    });
+});
+
+describe('the skipped concerns are idempotent on the retry — verified per concern', () => {
+    it('interruption-ledger dedupes on the turn, which a retry cannot change', () => {
+        const dir = fs.mkdtempSync(path.join(REPO_ROOT, '.tmp-retry-'));
+        try {
+            const ledger = path.join(dir, 'interruptions.jsonl');
+            fs.writeFileSync(
+                ledger,
+                `${JSON.stringify({ run_id: 'run-1', turn: 12, kind: 'ask' })}\n`,
+            );
+            // Same run, same turn — which is exactly what a refusal retry is,
+            // because the gate's own layer-2 marker keys on that same ordinal.
+            expect(alreadyRecorded(ledger, 'run-1', 12)).toBe(true);
+            // A genuinely new turn is not deduped, so the skip cannot swallow one.
+            expect(alreadyRecorded(ledger, 'run-1', 13)).toBe(false);
+        } finally {
+            fs.rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it('end-review-nudge states its once-per-session marker in its own header', () => {
+        // The guard is a marker file the concern reads before its transcript
+        // scan. Asserting the documented contract keeps the flag's argument
+        // falsifiable: rewrite the concern to fire twice and this fails.
+        const src = fs.readFileSync(
+            path.join(REPO_ROOT, 'src', 'scripts', 'hooks', 'end_review_nudge_hook.ts'),
+            'utf-8',
+        );
+        expect(src).toContain('once-per-session');
+        expect(src).toMatch(/without re-running the transcript scan/);
+    });
+});

--- a/tests/scripts/turn_end_gate_hook.test.ts
+++ b/tests/scripts/turn_end_gate_hook.test.ts
@@ -1242,3 +1242,55 @@ describe('readTranscriptTail — tool calls of the CURRENT turn', () => {
         expect(readTranscriptTail(t, { homeDir: home }).toolCalls).toEqual([]);
     });
 });
+
+/**
+ * `road-to-stop-gate-honesty` step 1.1, at the writer.
+ *
+ * The lib-level cases live in `turn_end_refusals.test.ts`; these two exist
+ * because the defect they pin was at the CALL SITE, not in the fold: the hook
+ * passed `findings[0].detector` and threw the rest away, so a fold that counts
+ * every detector would have been correct and dead.
+ */
+describe('the refusal record counts what actually fired', () => {
+    /** German pin + German promissory close would trip A only. Pin `en` to trip A AND B. */
+    function makeMismatchedWorkspace(): { dir: string; home: string } {
+        const { dir, home } = makeGateWorkspace();
+        fs.writeFileSync(
+            path.join(dir, 'agents', 'state', 'language-mirror.json'),
+            JSON.stringify({ language: 'en', source: 'prompt' }),
+        );
+        return { dir, home };
+    }
+
+    function readState(dir: string): Record<string, unknown> {
+        const stateDir = path.join(dir, 'agents', 'runtime', 'state', 'turn-end-gate');
+        const files = fs.readdirSync(stateDir).filter((f) => f.endsWith('.json'));
+        expect(files).toHaveLength(1);
+        return JSON.parse(fs.readFileSync(path.join(stateDir, files[0]!), 'utf-8')) as Record<
+            string,
+            unknown
+        >;
+    }
+
+    it('records BOTH detectors when one turn trips two', () => {
+        const { dir, home } = makeMismatchedWorkspace();
+        const r = runHook(dir, envelopeJson(dir, writeTranscript(home, ['go on'], PROMISE)), home);
+        expect(r.status, r.stderr).toBe(1);
+        const counts = readState(dir)['counts'] as Record<string, number>;
+        expect(counts['promissory']).toBe(1);
+        expect(counts['language']).toBe(1);
+    });
+
+    it('accumulates across refusals instead of overwriting itself', () => {
+        const { dir, home } = makeGateWorkspace();
+        for (const prompts of [['a'], ['a', 'b'], ['a', 'b', 'c']]) {
+            runHook(dir, envelopeJson(dir, writeTranscript(home, prompts, PROMISE)), home);
+        }
+        const state = readState(dir);
+        // Three refused turns in one session. The pre-change record reported the
+        // last one and nothing else, which is why D-2 was true of the file too.
+        expect((state['counts'] as Record<string, number>)['promissory']).toBe(3);
+        expect(state['refused_turn']).toBe(3);
+        expect(typeof state['first_refused_at']).toBe('string');
+    });
+});

--- a/tests/scripts/turn_end_refusals.test.ts
+++ b/tests/scripts/turn_end_refusals.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Turn-end refusal accounting — `road-to-stop-gate-honesty` Phase 1, asserted.
+ *
+ * The cases are the roadmap's own `verify:` lines and its Risk Register, not a
+ * happy-path smoke test: per-detector counting that does NOT pool (step 1.1),
+ * a TTL that keeps the fresh and drops the aged (step 1.2), a version split that
+ * can say "unrecorded" rather than guessing (step 1.3), and — the one that
+ * matters most — the denominator the reader must refuse to inflate.
+ *
+ * Two of these are mutation-verified in the sense the estate asks for: the
+ * multi-detector case FAILS against the pre-change writer (which stored
+ * `findings[0]` only), and the legacy-record case FAILS against a reader that
+ * requires a `counts` block.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+    DETECTOR_IDS,
+    REFUSAL_STATE_MAX_AGE_DAYS,
+    collectRefusalStats,
+    countsOf,
+    deriveSessionKey,
+    emptyCounts,
+    foldRefusal,
+    parseRecord,
+    pruneAgedRefusalState,
+    readSessionCounts,
+    refusalStateDir,
+    sessionRefusalFile,
+    type RefusalRecord,
+} from '../../src/scripts/_lib/turn_end_refusals.js';
+
+let root: string;
+
+function writeRecord(sessionId: string, rec: Record<string, unknown>): string {
+    const file = sessionRefusalFile(root, deriveSessionKey(sessionId));
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, `${JSON.stringify(rec, null, 2)}\n`);
+    return file;
+}
+
+function daysAgo(n: number): string {
+    return new Date(Date.now() - n * 24 * 60 * 60 * 1000).toISOString();
+}
+
+beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'turn-end-refusals-'));
+});
+
+afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('the record shape', () => {
+    it('parses the legacy three-field record the field already holds', () => {
+        // 36 of these existed on the maintainer machine when counting shipped.
+        // A reader that rejects them throws away the only field evidence there is.
+        const rec = parseRecord(
+            JSON.stringify({
+                refused_at: '2026-08-13T14:43:18.801Z',
+                refused_turn: 14,
+                detector: 'language',
+            }),
+        );
+        expect(rec).not.toBeNull();
+        expect(countsOf(rec!)).toEqual({ ...emptyCounts(), language: 1 });
+    });
+
+    it('rejects a record whose detector is not one this gate can emit', () => {
+        expect(
+            parseRecord(
+                JSON.stringify({ refused_at: 'x', refused_turn: 1, detector: 'invented' }),
+            ),
+        ).toBeNull();
+    });
+
+    it('returns null rather than throwing on malformed JSON', () => {
+        expect(parseRecord('{not json')).toBeNull();
+    });
+
+    it('treats a present-but-all-zero counts block as one refusal, not zero', () => {
+        // A record whose writer knew about counts and recorded none would
+        // otherwise report a refusal that left no trace of which detector fired.
+        const rec = parseRecord(
+            JSON.stringify({
+                refused_at: '2026-08-13T00:00:00.000Z',
+                refused_turn: 3,
+                detector: 'promissory',
+                counts: { promissory: 0, language: 0, verification: 0, completion: 0 },
+            }),
+        );
+        expect(countsOf(rec!)).toEqual({ ...emptyCounts(), promissory: 1 });
+    });
+});
+
+describe('step 1.1 — per detector, never pooled', () => {
+    it('counts EVERY detector of one refusal, not just the first', () => {
+        // The pre-change writer stored `findings[0].detector`. A turn tripping
+        // language AND verification counted as one language refusal, and the
+        // detector that lost the tie was invisible — which is exactly the
+        // pooling step 1.1 forbids.
+        const rec = foldRefusal(null, {
+            detectors: ['language', 'verification'],
+            turnOrdinal: 7,
+            at: '2026-08-17T10:00:00.000Z',
+        });
+        expect(rec.counts).toEqual({ ...emptyCounts(), language: 1, verification: 1 });
+        expect(rec.detector).toBe('language'); // compatibility field, unchanged
+        expect(rec.refused_turn).toBe(7); // the re-entrancy marker survives
+    });
+
+    it('accumulates across refusals in the same session', () => {
+        let rec: RefusalRecord | null = null;
+        rec = foldRefusal(rec, {
+            detectors: ['verification'],
+            turnOrdinal: 1,
+            at: '2026-08-17T10:00:00.000Z',
+        });
+        rec = foldRefusal(rec, {
+            detectors: ['verification'],
+            turnOrdinal: 4,
+            at: '2026-08-17T11:00:00.000Z',
+        });
+        expect(rec.counts?.verification).toBe(2);
+        expect(rec.first_refused_at).toBe('2026-08-17T10:00:00.000Z');
+        expect(rec.refused_at).toBe('2026-08-17T11:00:00.000Z');
+        expect(rec.refused_turn).toBe(4);
+    });
+
+    it('promotes a legacy record to counts without losing its one refusal', () => {
+        const legacy = parseRecord(
+            JSON.stringify({
+                refused_at: '2026-08-13T00:00:00.000Z',
+                refused_turn: 2,
+                detector: 'promissory',
+            }),
+        );
+        const next = foldRefusal(legacy, {
+            detectors: ['language'],
+            turnOrdinal: 5,
+            at: '2026-08-17T10:00:00.000Z',
+        });
+        expect(next.counts).toEqual({ ...emptyCounts(), promissory: 1, language: 1 });
+    });
+
+    it('aggregates per detector and reports the sessions-with-refusals denominator', () => {
+        writeRecord('s1', {
+            refused_at: '2026-08-17T10:00:00.000Z',
+            refused_turn: 1,
+            detector: 'verification',
+            counts: { verification: 3, language: 1 },
+        });
+        writeRecord('s2', {
+            refused_at: '2026-08-16T10:00:00.000Z',
+            refused_turn: 2,
+            detector: 'promissory',
+        });
+        const stats = collectRefusalStats(root);
+        expect(stats.sessionsWithRefusals).toBe(2);
+        expect(stats.total).toBe(5);
+        expect(stats.byDetector).toEqual({
+            ...emptyCounts(),
+            verification: 3,
+            language: 1,
+            promissory: 1,
+        });
+        expect(stats.legacyRecords).toBe(1);
+        expect(stats.byPeriod.map((p) => p.period)).toEqual(['2026-08-17', '2026-08-16']);
+        expect(stats.byPeriod[0]!.total).toBe(4);
+    });
+
+    it('reads this session’s own counts back for the register record', () => {
+        writeRecord('sess-abc', {
+            refused_at: '2026-08-17T10:00:00.000Z',
+            refused_turn: 1,
+            detector: 'language',
+            counts: { language: 2 },
+        });
+        expect(readSessionCounts(root, 'sess-abc')).toEqual({ ...emptyCounts(), language: 2 });
+        expect(readSessionCounts(root, 'never-refused')).toBeNull();
+    });
+
+    it('covers every detector the gate can emit', () => {
+        // A detector added to the gate without being added here would silently
+        // stop being counted. The roadmap's own prose says three; the gate has
+        // four.
+        expect([...DETECTOR_IDS]).toEqual([
+            'promissory',
+            'language',
+            'verification',
+            'completion',
+        ]);
+    });
+});
+
+describe('step 1.2 — the TTL the header admitted was missing', () => {
+    it('keeps fresh records and drops aged ones', () => {
+        writeRecord('fresh', {
+            refused_at: daysAgo(1),
+            refused_turn: 1,
+            detector: 'language',
+        });
+        writeRecord('aged', {
+            refused_at: daysAgo(REFUSAL_STATE_MAX_AGE_DAYS + 5),
+            refused_turn: 1,
+            detector: 'language',
+        });
+        const result = pruneAgedRefusalState(root);
+        expect(result.scanned).toBe(2);
+        expect(result.pruned).toBe(1);
+        expect(result.kept).toBe(1);
+        expect(fs.existsSync(sessionRefusalFile(root, deriveSessionKey('fresh')))).toBe(true);
+        expect(fs.existsSync(sessionRefusalFile(root, deriveSessionKey('aged')))).toBe(false);
+    });
+
+    it('keeps a record it cannot parse rather than deleting it', () => {
+        const dir = refusalStateDir(root);
+        fs.mkdirSync(dir, { recursive: true });
+        const file = path.join(dir, 'garbage.json');
+        fs.writeFileSync(file, '{not json');
+        const result = pruneAgedRefusalState(root);
+        expect(result.pruned).toBe(0);
+        expect(fs.existsSync(file)).toBe(true);
+    });
+
+    it('ages on the record’s own stamp, never on the filesystem mtime', () => {
+        // A checkout or an rsync rewrites mtimes. Pruning on them would delete a
+        // live corpus or preserve a dead one at random.
+        const file = writeRecord('old-content-new-mtime', {
+            refused_at: daysAgo(REFUSAL_STATE_MAX_AGE_DAYS + 1),
+            refused_turn: 1,
+            detector: 'verification',
+        });
+        const now = new Date();
+        fs.utimesSync(file, now, now);
+        expect(pruneAgedRefusalState(root).pruned).toBe(1);
+    });
+
+    it('is a no-op on a workspace that never refused a turn', () => {
+        expect(pruneAgedRefusalState(root)).toEqual({ scanned: 0, pruned: 0, kept: 0 });
+    });
+});
+
+describe('step 1.3 — the version split, and what it cannot answer', () => {
+    it('splits by the version recorded ON the refusal', () => {
+        writeRecord('a', {
+            refused_at: '2026-08-17T10:00:00.000Z',
+            refused_turn: 1,
+            detector: 'verification',
+            counts: { verification: 2 },
+            agent_config_version: '13.0.0',
+        });
+        writeRecord('b', {
+            refused_at: '2026-08-16T10:00:00.000Z',
+            refused_turn: 1,
+            detector: 'language',
+            counts: { language: 1 },
+            agent_config_version: '12.1.0',
+        });
+        const stats = collectRefusalStats(root);
+        const byVersion = Object.fromEntries(stats.byVersion.map((v) => [v.version, v.total]));
+        expect(byVersion).toEqual({ '13.0.0': 2, '12.1.0': 1 });
+        expect(stats.unversionedRecords).toBe(0);
+    });
+
+    it('reports pre-stamping records as unrecorded rather than attributing them', () => {
+        // The corpus written before this shipped carries no version. Assigning
+        // it to the currently installed one would manufacture the very
+        // correlation claim 10 asks us to TEST.
+        writeRecord('legacy', {
+            refused_at: '2026-08-13T10:00:00.000Z',
+            refused_turn: 1,
+            detector: 'promissory',
+        });
+        const stats = collectRefusalStats(root);
+        expect(stats.unversionedRecords).toBe(1);
+        expect(stats.byVersion.map((v) => v.version)).toEqual(['(unrecorded)']);
+    });
+});

--- a/tests/scripts/turn_end_verify_allowlist.test.ts
+++ b/tests/scripts/turn_end_verify_allowlist.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Detector C's verify allowlist — the fixture `road-to-stop-gate-honesty`
+ * step 2.2 requires.
+ *
+ * The step's own words: "enumerate the verify-shaped commands the team actually
+ * runs, test each against `isVerificationCommand`, and record the misses. Any
+ * addition ships with a fixture mapping command string to recognised."
+ *
+ * So this file is a TABLE, not a sample. Every command below was produced by
+ * this project's real surface — its `package.json` scripts, its `Taskfile`
+ * targets, `./scripts-run`, `./agent-config`, and the language toolchains the
+ * suite supports — and carries the verdict the allowlist gives it today.
+ *
+ * The rows that read `false` are as load-bearing as the ones that read `true`.
+ * Risk 2 of that roadmap is that widening this list turns detector C into a
+ * rubber stamp, so the deliberate non-additions are pinned here: if a later
+ * change makes `task sync` or `npm run prepack` clear an unverified edit, this
+ * file fails and the widening has to be argued rather than slipped in.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { isVerificationCommand } from '../../src/scripts/hooks/turn_end_gate_hook.js';
+
+/** `[command, recognised]` — the audited table, 2026-08-17. */
+const AUDIT: ReadonlyArray<readonly [string, boolean]> = [
+    // ---- this repo's npm scripts -------------------------------------------
+    ['npm run typecheck', true],
+    ['npm run lint:ts', true],
+    ['npm run test:ts', true],
+    ['npm run build', true],
+    ['npm run tokens:check', true],
+    ['npm run build:hooks', true],
+    // NOT added: a lifecycle hook whose content is per-project.
+    ['npm run prepack', false],
+
+    // ---- Taskfile, the dominant surface here --------------------------------
+    ['task ci', true],
+    ['task ci-fast', true],
+    ['task preflight', true],
+    ['task test', true],
+    ['task typecheck', true],
+    ['task lint-skills', true],
+    ['task check-claims', true],
+    // NOT added: generators. They rewrite the tree and check nothing.
+    ['task sync', false],
+    ['task generate-tools', false],
+    // NOT added: repo-local vocabulary with no general meaning.
+    ['task audit-tokens', false],
+    ['task consistency', false],
+    ['task bench', false],
+
+    // ---- the repo's own runners ---------------------------------------------
+    ['./scripts-run src/scripts/check_completion_review', true],
+    // ADDED by this audit — `\blint\b` needs a boundary and `_` is a word char,
+    // so every `lint_*` script in `src/scripts/` was missing.
+    ['./scripts-run src/scripts/lint_persistence', true],
+    ['./scripts-run src/scripts/lint_provenance', true],
+    ['./scripts-run src/scripts/lint_roadmap_blockers', true],
+    // NOT added: a census writes a report; it asserts nothing.
+    ['./scripts-run src/scripts/rule_activation_census', false],
+    // NOT added: enumerates gates, runs none.
+    ['./agent-config gates --all', false],
+    // NOT added: a regenerator.
+    ['./agent-config roadmap:progress', false],
+
+    // ---- direct runners an agent reaches for --------------------------------
+    ['npx vitest run tests/scripts/x.test.ts', true],
+    ['npx tsc --noEmit', true],
+    ['npx eslint src/', true],
+    ['vitest run', true],
+    ['pnpm test', true],
+    ['yarn lint', true],
+
+    // ---- PHP: claim 4 said these already matched. Re-verified, they do. -----
+    ['vendor/bin/phpunit', true],
+    ['vendor/bin/phpunit --filter Foo', true],
+    ['pest', true],
+    ['composer test', true],
+    ['php artisan test', true],
+    ['php artisan test --filter=Foo', true],
+    ['vendor/bin/ecs check', true],
+    // ADDED by this audit — same class as mypy / pyright / clippy.
+    ['vendor/bin/phpstan analyse', true],
+    // NOT added: a refactoring tool. Its dry run prints a diff; it asserts nothing.
+    ['vendor/bin/rector process --dry-run', false],
+
+    // ---- other ecosystems ---------------------------------------------------
+    ['pytest -q', true],
+    ['go test ./...', true],
+    ['cargo check', true],
+    ['cargo test', true],
+    ['make test', true],
+    ['mypy .', true],
+    ['ruff check .', true],
+
+    // ---- must NEVER clear an unverified edit --------------------------------
+    ['ls -la', false],
+    ['git status', false],
+    ['cat README.md', false],
+    ['git log --oneline -5', false],
+    ['gh pr view 1400', false],
+    ['echo done', false],
+    ['git diff --stat', false],
+];
+
+describe('detector C — the verify allowlist, audited', () => {
+    for (const [command, recognised] of AUDIT) {
+        it(`${recognised ? 'recognises' : 'does NOT recognise'}: ${command}`, () => {
+            expect(isVerificationCommand(command)).toBe(recognised);
+        });
+    }
+
+    it('keeps the read-only commands out — the rubber-stamp guard', () => {
+        // Stated as its own assertion rather than left implicit in the rows:
+        // if this ever passes for `ls`, detector C has stopped detecting and the
+        // rest of the table is decoration.
+        const readOnly = AUDIT.filter(([, ok]) => !ok).map(([c]) => c);
+        expect(readOnly.length).toBeGreaterThan(0);
+        for (const c of readOnly) expect(isVerificationCommand(c)).toBe(false);
+    });
+});


### PR DESCRIPTION
Closes six of seven steps in `road-to-stop-gate-honesty`. The seventh is the
maintainer pre-registration and is deliberately untouched.

## The defect

The suite refuses turn-ends. Every refused turn-end costs the user at least one
extra model turn, experienced as slowness and as the agent fighting them — and
nothing could say how often it happens. Every advisory concern in this estate
carries a registered kill standard; the one **blocking** concern carried none.

## What ships

**Phase 1 — count before judging.** `_lib/turn_end_refusals.ts` is the reader,
`hooks_doctor` prints it, and the per-session half rides the session-register
write the heartbeat already performs. The 90-day TTL the gate header admitted
was missing runs at `session_start` on the concern that already prunes.

Half the defect turned out to be in the **writer**: `markRefusedTurn` overwrote
its record on every refusal and stored one detector, so a session refused nine
times looked exactly like one refused once. Mutation-verified — reverting the
call site fails the new end-to-end case.

First reading, against the 36 records already in the field (2026-08-12 …
2026-08-17): verification 22, language 9, promissory 5, completion 0. Detector C
dominating is the roadmap's own D-1 prediction, now measured rather than
predicted.

**Phase 2.2 — the verify allowlist, audited.** 56 rows against this project's
real command surface. Claim 4 re-verified: the PHP toolchain the draft worried
about already matched. Two real gaps found and closed (`phpstan`; `lint`
followed by a word character, which excluded every `lint_*` script in
`src/scripts/`). Four further misses left out on purpose, each named with its
reason, because every addition is a way to satisfy the gate without verifying
anything.

**Phase 3.1 — make the retry cheap.** `skip_on_refusal_retry`, opt-in per
concern, keyed on the host's own `stop_hook_active`. The claude stop chain is 10
concerns and 8 on a retry.

## What the run found wrong in its own plan

Three of six steps departed from their text, and the done-notes record each:

- The gate has **four** detectors, not the three § 0 names. A counter built to
  the prose would have dropped one silently.
- `installed.lock` dates the **most recent** install, not 12.1's. A before/after
  split on it would have looked like a test of claim 10 without being one, so
  the version is now stamped on the refusal itself — and all 36 existing records
  are honestly labelled `(unrecorded)` rather than attributed.
- Step 3.1 named four concerns as "pure duplicate cost". Between the refusal and
  the retry the model does more work, so three of them have a **changed input**;
  flagging them would have been Risk 3 exactly. One passes strongly
  (`interruption-ledger` walks up to 8 MB of transcript before reaching its own
  dedup) and one weakly (`end-review-nudge`, identical artefact, module-load
  saving only).

## What is NOT claimed

- **AC-1** needs a second machine's window. The instrument exists; the corpus
  does not yet.
- **AC-2** needs `b-detector-demotion-bars` — the maintainer's bar, which must
  predate any read of Phase 1 data. Nothing here reads it into a decision.
- **AC-3** needs the Stop-slot bench, owned by `road-to-per-turn-hook-economy`.
  What shipped is the mechanism and its correctness proof, not the measurement.

The roadmap stays open at 6/7 and is not archived.

## Verification

`task preflight` green. 87 gate tests, 56 allowlist rows, 16 reader cases, 10
retry cases; the 26-file `hook_manifest` downstream sweep green (494 tests).
Two own-orphan imports were caught by a scoped `eslint` run that `preflight`
passed over — worth knowing, and fixed before the first commit.
