### PR TITLE
fix(bench): let the spend cap reach the task runner on paid targets

### DIFF
--- a/taskfiles/bench-ab.yml
+++ b/taskfiles/bench-ab.yml
@@ -95,10 +95,15 @@ tasks:
       `claude --print` against the variant clone). Cost-bearing —
       use only when you want a real measurement. Set CLAUDE_CLI env
       var to override the binary path.
+
+      Trailing args reach the task runner, so `-- --budget <N>` caps
+      per-task spend. Without the passthrough the flag was accepted by
+      the shell and silently dropped, and the run fell back to the
+      runner's own default — see the note in bench_ab_task_runner.
     cmds:
       - task: bench:ab:track-a
       - ./scripts-run src/scripts/bench_ab_clone --variant both
-      - ./scripts-run src/scripts/bench_ab_task_runner --variant both --mode live
+      - ./scripts-run src/scripts/bench_ab_task_runner --variant both --mode live {{.CLI_ARGS}}
       - task: bench:ab:diff
 
   bench:ab:value:
@@ -121,7 +126,7 @@ tasks:
       # plugin; with-rdp = + injected RDP rules), not via clone files. The runner
       # resets a fixture working dir per task itself.
       - ./scripts-run src/scripts/bench_ab_clone --variant without --refresh
-      - ./scripts-run src/scripts/bench_ab_task_runner --variant all --mode live
+      - ./scripts-run src/scripts/bench_ab_task_runner --variant all --mode live {{.CLI_ARGS}}
       - task: bench:ab:diff
 
   bench:ab:value:quick:

--- a/taskfiles/value.yml
+++ b/taskfiles/value.yml
@@ -47,8 +47,13 @@ tasks:
       Run the cost-bearing live Track-B + behaviour run (uses the
       `claude --print` CLI per task — needs ANTHROPIC_API_KEY), then
       assemble + render. Cost-bearing.
+
+      Trailing args reach the task runner, so `-- --budget <N>` bounds the
+      spend. Before that passthrough existed this target could not be
+      bounded at all — it took the runner's own default and there was no
+      flag an operator could pass.
     cmds:
-      - ./scripts-run src/scripts/bench_ab_task_runner --variant both --mode live
+      - ./scripts-run src/scripts/bench_ab_task_runner --variant both --mode live {{.CLI_ARGS}}
       - task: value
 
   value:lint:

--- a/tests/scripts/bench_ab_taskfile.test.ts
+++ b/tests/scripts/bench_ab_taskfile.test.ts
@@ -1,0 +1,94 @@
+/**
+ * The guard that would have caught the silently-dropped spend cap.
+ *
+ * `bench:ab:live` is cost-bearing, and a roadmap blocker authorises it as
+ * `task bench:ab:live -- --budget <N>` on the stated grounds that the command
+ * "caps per-task spend". It did not: the target invoked
+ * `bench_ab_task_runner` without `{{.CLI_ARGS}}`, so Task had nowhere to put
+ * the trailing flag, the shell accepted it, and the run fell back to the
+ * parser's own default. An operator who named a cap got a different one, on a
+ * paid path, with nothing reporting the difference.
+ *
+ * The test reads the real taskfile rather than a fixture, because the property
+ * that matters is what the shipped target does — a fixture would let the
+ * passthrough disappear from the tree and still pass.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const BENCH_AB = path.join(process.cwd(), 'taskfiles/bench-ab.yml');
+const VALUE = path.join(process.cwd(), 'taskfiles/value.yml');
+
+/** The `cmds:` lines of one task, verbatim, without parsing all of YAML. */
+function cmdsOf(taskName: string, file: string = BENCH_AB): string[] {
+    const lines = fs.readFileSync(file, 'utf8').split('\n');
+    const head = lines.findIndex((l) => l.trimEnd() === `  ${taskName}:`);
+    expect(head, `task ${taskName} not found in ${file}`).toBeGreaterThan(-1);
+
+    let end = lines.length;
+    for (let i = head + 1; i < lines.length; i++) {
+        // The next task at the same indent ends this one.
+        if (/^ {2}\S/.test(lines[i] as string)) {
+            end = i;
+            break;
+        }
+    }
+    const body = lines.slice(head, end);
+    const cmdsAt = body.findIndex((l) => /^ {4}cmds:\s*$/.test(l));
+    if (cmdsAt === -1) return [];
+    const out: string[] = [];
+    for (let i = cmdsAt + 1; i < body.length; i++) {
+        const l = body[i] as string;
+        // Comments and blanks sit between entries in several of these lists —
+        // `bench:ab:value` opens its cmds with a three-line comment, which is
+        // what made the first version of this helper return nothing for it.
+        if (/^ *(#.*)?$/.test(l)) continue;
+        if (!/^ {6}- /.test(l)) break;
+        out.push(l.trim());
+    }
+    return out;
+}
+
+describe('bench-ab taskfile — the spend cap has to reach the runner', () => {
+    it('bench:ab:live forwards trailing args to the task runner', () => {
+        const runner = cmdsOf('bench:ab:live').filter((c) =>
+            c.includes('bench_ab_task_runner'),
+        );
+        expect(runner).toHaveLength(1);
+        expect(runner[0]).toContain('{{.CLI_ARGS}}');
+    });
+
+    it('the clone step deliberately does NOT take them', () => {
+        // `--budget` is not a clone flag; forwarding there would make the
+        // runner's own arguments an error in a different process.
+        const clone = cmdsOf('bench:ab:live').filter((c) => c.includes('bench_ab_clone'));
+        expect(clone).toHaveLength(1);
+        expect(clone[0]).not.toContain('{{.CLI_ARGS}}');
+    });
+
+    it('every cost-bearing sibling that dispatches also forwards them', () => {
+        // The convention this target had broken: `bench:ab:track-b` already
+        // passed CLI_ARGS to its dispatching script while cloning without.
+        const dispatch = cmdsOf('bench:ab:track-b').filter((c) =>
+            c.includes('bench_ab_cache_dispatch'),
+        );
+        expect(dispatch).toHaveLength(1);
+        expect(dispatch[0]).toContain('{{.CLI_ARGS}}');
+    });
+
+    // The sibling search found the same construct on two further paid targets.
+    // Neither claimed a cap, so neither was telling an untruth — but neither
+    // could be bounded by an operator either, and the passthrough is inert
+    // when no trailing args are given. Pinned so the shape cannot come back
+    // on one target while the others stay fixed.
+    it.each([
+        ['bench:ab:value', BENCH_AB],
+        ['value:behaviour', VALUE],
+    ])('%s forwards trailing args to the task runner', (task, file) => {
+        const runner = cmdsOf(task, file).filter((c) => c.includes('bench_ab_task_runner'));
+        expect(runner).toHaveLength(1);
+        expect(runner[0]).toContain('{{.CLI_ARGS}}');
+    });
+});


### PR DESCRIPTION
A documented spend cap that silently did not apply, on a paid path. Found by
step 1.3 of `road-to-gate-autonomy` (PR #1404) while reading the twelve
class-0/1 blockers for a runnable command; shipped separately on purpose, so a
one-line money-safety fix is not skimmed inside a documentation diff.

## The defect

`road-to-surface-consolidation`'s `benchmark-spend` blocker authorises

```
task bench:ab:live -- --budget <N>
```

and states the command "caps per-task spend". It did not. The target invoked

```yaml
- ./scripts-run src/scripts/bench_ab_task_runner --variant both --mode live
```

with **no `{{.CLI_ARGS}}`**, unlike its sibling one target up
(`bench:ab:track-b`, which forwards to its dispatching script while cloning
without). So Task had nowhere to put the trailing flag, the shell accepted
`-- --budget 20` without complaint, and the run fell back to the parser's own
default of `2.0` (`bench_ab_task_runner.ts` `parse_args`). **An operator who
named a cap got a different one, on a cost-bearing path, with nothing reporting
the difference.**

## Sibling search — 3 sites of the construct, 1 of them a false claim

The exact wrong construct: a cost-bearing `bench_ab_task_runner` invocation with
no `{{.CLI_ARGS}}`.

| target | claimed a cap? | before |
|---|---|---|
| `bench:ab:live` (`taskfiles/bench-ab.yml`) | **yes**, via the blocker | flag dropped |
| `bench:ab:value` (`taskfiles/bench-ab.yml`) | no | unboundable by an operator |
| `value:behaviour` (`taskfiles/value.yml`) | no | unboundable by an operator |

Only the first was telling an untruth. The other two claimed nothing — and also
offered no flag an operator could pass, on paths that invoke `claude --print`
per task. All three now forward.

**Why the fix was widened past the one that lied:** the passthrough is *inert*
when no trailing args are given, so adding it changes no existing behaviour, and
fixing one of three sites of the same construct is the "fixed one instance, not
the defect" failure. Both directions are proven per target rather than argued:

```
$ task bench:ab:live --dry -v -- --budget 7
task: [bench:ab:live] ./scripts-run src/scripts/bench_ab_task_runner --variant both --mode live --budget 7

$ task bench:ab:live --dry -v
task: [bench:ab:live] ./scripts-run src/scripts/bench_ab_task_runner --variant both --mode live
```

Same pair verified for `bench:ab:value` and `value:behaviour`. **Nothing paid was
run** — `--dry` prints the expansion without executing it.

The clone step deliberately does **not** take the args: `--budget` is not a clone
flag, and forwarding there would turn the runner's own arguments into an error in
a different process.

## The guard

`tests/scripts/bench_ab_taskfile.test.ts` reads the real taskfiles rather than a
fixture, because the property that matters is what the shipped target does — a
fixture would let the passthrough disappear from the tree and still pass. Same
pattern as the existing `taskfiles/`-reading tests.

**Verified red before the fix**, at exactly the assertion that matters (1 failed,
2 passed with the interpolation removed), so it is not a tautology. Two smaller
things worth recording: it also pins the clone step as deliberately *without* the
passthrough, and its own first version returned nothing for `bench:ab:value`
because that `cmds:` list opens with a three-line comment — the test found that
bug in its own parser.

## Doc impact

None needed, and the reason is the fix's own point: no `docs/` surface documents
this flag, and the only prose that describes it — the `benchmark-spend` blocker —
becomes **true** with this change. The fix removes existing drift rather than
creating any.

## Verification

- `vitest tests/scripts/bench_ab_taskfile.test.ts`: 5 passed; verified red first.
- `task typecheck-ts`: clean. `task preflight`: exit 0.
- `origin/main` moved mid-run (PR #1403 merged) and was merged in: no conflicts,
  the guard re-verified green afterwards.
