### PR TITLE
fix(evidence): retract the legal-safety-floor contradiction, it was a misreading

### DIFF
--- a/agents/evidence/analysis/rule-stub-projection-phase0.md
+++ b/agents/evidence/analysis/rule-stub-projection-phase0.md
@@ -183,17 +183,54 @@ with *no* path-shaped trigger, and every absent rule has one (`design-fidelity`,
 `persona-governance` are all in the census mixed set). They were out of the
 record's scope by construction.
 
-### The one contradiction: `legal-safety-floor`
+### The `keep` overlap is NOT a contradiction — corrected 2026-08-17
 
-`legal-safety-floor` is recorded **`keep`** — "stays always-on and monolithic,
-deliberately" — and simultaneously carries a migration pointer to
-`../skills/legal-practice-profile/SKILL.md`. The two statements are opposites.
+`legal-safety-floor` is the one migrated rule also recorded **`keep`**. This
+document first reported that as a contradiction — "`keep` means stays always-on
+and monolithic, and a pointer says the opposite" — and **that was wrong.** The
+claim was retracted against the record's own text, not softened.
 
-Reported, not resolved. The record is closed and this roadmap never adds a row to
-it; whether the `keep` or the pointer is the stale half is a maintainer call. Its
-measured shape, for whoever takes it: 1,706 tokens, of which 665 are floor and
-736 residue — the highest floor share of any rule in the set, which is at least
-consistent with a deliberate `keep`.
+Three pieces of evidence, each sufficient on its own:
+
+1. **The record defines `keep` against `digest`, not against "was ever
+   migrated".** Its vocabulary section: *"`keep` therefore means: stays always-on
+   and monolithic, deliberately, with a named reason. It is not a deferral and not
+   a pending item."* The alternative it rules out is demotion to a shared digest
+   with the body set `type: manual` — which would remove an enforcement surface
+   from context. It says nothing about a migration that already happened.
+2. **The row describes the POST-migration rule.** It records `body_lines: 139`,
+   which is the rule's size today. The migration landed 2026-07-11
+   (`6ef4102d6`, *"thin-stub the five heaviest auto-rules"*); the residue was
+   measured 2026-08-09. The disposition was assigned to the already-thinned file,
+   so there was never a moment when the two statements described the same body.
+3. **The inventory that produced the classification says so outright.**
+   `rule-body-migration-inventory.md` classes it `stay` **because** of the
+   migration: *"already the best existing exemplar of the P4 pattern applied
+   within a safety floor (5 Iron Laws kept inline, all operating mechanics
+   migrated to `skill:legal-practice-profile`); a template for the other 6 safety
+   floors below, none of which do this yet."*
+
+So `stay` here means *the residue that remains is floor — do not move it
+further*, which is exactly what the measurement shows: 665 floor against 736
+residue, the highest floor share in the set. The tree was coherent; the reading
+was not.
+
+**The real finding, which is more useful than the retracted one.** The record
+names `legal-safety-floor` as the **template** for six sibling safety floors that
+have not had the same treatment: `finance-safety-floor`,
+`strategy-safety-floor`, `engineering-safety-floor`, `domain-safety-disclaimer`,
+`domain-safety-pii`, `domain-safety-retention`. None of them carries a migration
+pointer, so none appears in this table at all — they are outside this roadmap's
+population by construction, and they are a named, sized prospect for
+`road-to-standing-context-40k` rather than a defect here.
+
+**Why the false positive happened, since the mechanism recurs.** The
+reconciliation compared two *labels* — "has a pointer" against "`keep`" — and
+inferred a contradiction from the labels' plain-English connotations without
+opening the register's own definition section, which sits 280 lines above the
+row. A label is not a definition. The same shape produced the three roadmap-prose
+claims this document corrects further up; the fix is the same one each time, and
+it is the cheap half: read the definition, then compare.
 
 ## The live defect this measures, restated with fresh numbers
 

--- a/agents/evidence/reviews/feat-rule-stub-projection.findings.md
+++ b/agents/evidence/reviews/feat-rule-stub-projection.findings.md
@@ -1,13 +1,13 @@
 # Findings: feat-rule-stub-projection
-<!-- completion-review: v1 | reviewed: 2026-08-17 | scope: 2ab219dd1ea1dba772fa64b5e1e93c08b236b6851ec8e7d15fb52dd0f1507c0c | diff: 4a6ec0db0dceb1da526482e4683795b379842df6 | reviewer: r2-fresh-subagent-feat-rule-stub-projection | prompt_hash: e48fa04fe7c0e47bad6b6ba35570d2ebaba9c37aa8f4d733e545a9e43495f490 -->
+<!-- completion-review: v1 | reviewed: 2026-08-17 | scope: 0fc57d913bde37504ef6d79504f3daa9fa9a5f18563f362f88f1b3d0c2029ad1 | diff: 0cfba5a9025e0b0ce7ae29e98c7816205b1e27cf | reviewer: r2-fresh-subagent-feat-rule-stub-projection | prompt_hash: e48fa04fe7c0e47bad6b6ba35570d2ebaba9c37aa8f4d733e545a9e43495f490 -->
 <!-- evidence-type: v1 | type: current-binding | declared: 2026-08-17 -->
 
 <!-- context-manifest: v1
 inputs:
-  diff_sha: 4a6ec0db0dceb1da526482e4683795b379842df6
-  scope_hash: 2ab219dd1ea1dba772fa64b5e1e93c08b236b6851ec8e7d15fb52dd0f1507c0c
+  diff_sha: 0cfba5a9025e0b0ce7ae29e98c7816205b1e27cf
+  scope_hash: 0fc57d913bde37504ef6d79504f3daa9fa9a5f18563f362f88f1b3d0c2029ad1
   roadmap: agents/roadmaps/archive/road-to-rule-stub-projection.md
-  roadmap_hash: a42fa1a2d4e60efe67969a3134c6985685015d631a115735fd868c6547652257
+  roadmap_hash: 9d3c17e04122c358e69196eb23903cc10685006150c51f7ad445e5c4f05a05c6
   ac_hash: 743a55103bf09fceecf918eb1560aa1d9add6eada3fa747fba9925916e1ee94a
 excluded: [session-history, agents/runtime, implementation-context]
 tools: [git-diff-branch-scoped, file-read-branch-paths]

--- a/agents/evidence/reviews/feat-rule-stub-projection.findings.md
+++ b/agents/evidence/reviews/feat-rule-stub-projection.findings.md
@@ -1,13 +1,13 @@
 # Findings: feat-rule-stub-projection
-<!-- completion-review: v1 | reviewed: 2026-08-17 | scope: 0fc57d913bde37504ef6d79504f3daa9fa9a5f18563f362f88f1b3d0c2029ad1 | diff: 0cfba5a9025e0b0ce7ae29e98c7816205b1e27cf | reviewer: r2-fresh-subagent-feat-rule-stub-projection | prompt_hash: e48fa04fe7c0e47bad6b6ba35570d2ebaba9c37aa8f4d733e545a9e43495f490 -->
+<!-- completion-review: v1 | reviewed: 2026-08-17 | scope: 2ab219dd1ea1dba772fa64b5e1e93c08b236b6851ec8e7d15fb52dd0f1507c0c | diff: 4a6ec0db0dceb1da526482e4683795b379842df6 | reviewer: r2-fresh-subagent-feat-rule-stub-projection | prompt_hash: e48fa04fe7c0e47bad6b6ba35570d2ebaba9c37aa8f4d733e545a9e43495f490 -->
 <!-- evidence-type: v1 | type: current-binding | declared: 2026-08-17 -->
 
 <!-- context-manifest: v1
 inputs:
-  diff_sha: 0cfba5a9025e0b0ce7ae29e98c7816205b1e27cf
-  scope_hash: 0fc57d913bde37504ef6d79504f3daa9fa9a5f18563f362f88f1b3d0c2029ad1
+  diff_sha: 4a6ec0db0dceb1da526482e4683795b379842df6
+  scope_hash: 2ab219dd1ea1dba772fa64b5e1e93c08b236b6851ec8e7d15fb52dd0f1507c0c
   roadmap: agents/roadmaps/archive/road-to-rule-stub-projection.md
-  roadmap_hash: 9d3c17e04122c358e69196eb23903cc10685006150c51f7ad445e5c4f05a05c6
+  roadmap_hash: a42fa1a2d4e60efe67969a3134c6985685015d631a115735fd868c6547652257
   ac_hash: 743a55103bf09fceecf918eb1560aa1d9add6eada3fa747fba9925916e1ee94a
 excluded: [session-history, agents/runtime, implementation-context]
 tools: [git-diff-branch-scoped, file-read-branch-paths]

--- a/agents/evidence/reviews/fix-legal-safety-floor-retraction.findings.md
+++ b/agents/evidence/reviews/fix-legal-safety-floor-retraction.findings.md
@@ -1,0 +1,63 @@
+# Findings: fix-legal-safety-floor-retraction
+
+<!-- evidence-type: v1 | type: declared-skip | declared: 2026-08-17 -->
+
+**Skipped:** no code surface for this completion — retracts a false claim from three prose artefacts and adds a verified prospect note to a sibling roadmap; the gate itself measures 0 code paths of 3 changed files, scope ec4aaa6b461f00b95dca2f600dc6269a46d9fc30c25716cc8893272b7529e75f, declared 2026-08-17
+
+## What was retracted, and on what evidence
+
+Phase 0.3 of `road-to-rule-stub-projection` (merged in PR #1403) reported
+`legal-safety-floor` as a contradiction: recorded `keep` in the closed
+disposition register while carrying a migration pointer. That claim is **false**.
+Three independent pieces of evidence, each sufficient on its own:
+
+1. **The register defines `keep` against `digest`, not against having been
+   migrated.** Its own vocabulary section reads *"`keep` therefore means: stays
+   always-on and monolithic, deliberately, with a named reason. It is not a
+   deferral and not a pending item."* The alternative it rules out is demotion to
+   a shared always-on digest with the body set `type: manual` — which would strip
+   an enforcement surface out of context. It says nothing about a migration that
+   already happened.
+2. **The row describes the post-migration rule.** It records `body_lines: 139`,
+   which is the file's size today. The migration landed 2026-07-11 (`6ef4102d6`,
+   *"thin-stub the five heaviest auto-rules"*); the residue was measured
+   2026-08-09. There was never a moment when the two statements described the same
+   body.
+3. **The inventory that produced the classification says so outright.**
+   `docs/guidelines/agent-infra/rule-body-migration-inventory.md` classes it
+   `stay` *because* of the migration: *"already the best existing exemplar of the
+   P4 pattern applied within a safety floor (5 Iron Laws kept inline, all
+   operating mechanics migrated to `skill:legal-practice-profile`); a template for
+   the other 6 safety floors below, none of which do this yet."*
+
+## The replacement finding, verified
+
+The same inventory names `legal-safety-floor` as the **template** for six sibling
+safety floors that have not had the treatment: `finance-safety-floor`,
+`strategy-safety-floor`, `engineering-safety-floor`, `domain-safety-disclaimer`,
+`domain-safety-pii`, `domain-safety-retention`.
+
+Checked against the tree rather than quoted: `grep -ciE 'migrated to|merged into'`
+returns **0** for all six, and none has a file under
+`agents/decisions/rule-migrations/`. So none is in the stub-ceiling gate's
+population, and the Phase-0 residue table is a **floor** on the available residue
+rather than a survey of it — which is now stated where that table was handed over,
+in `road-to-standing-context-40k` step 2.1.
+
+## Why the false positive happened
+
+The reconciliation compared two **labels** — "has a pointer" against "`keep`" —
+and inferred a contradiction from their plain-English connotations, without
+opening the register's definition section, which sits ~280 lines above the row it
+read. A label is not a definition.
+
+Recorded rather than quietly corrected because the mechanism recurs: the same
+shape produced the three roadmap-prose claims the Phase-0 artefact already
+corrects, and it is the cheapest possible check to have skipped.
+
+## Why this is not a twentieth row on the merged review
+
+The R2 reviewer never made this observation. Adding it to
+`feat-rule-stub-projection.findings.md` would backdate an observation nobody
+made, which is precisely the forgery the findings-before-fixes ordering exists to
+prevent. That artefact is restored to the exact state it merged in.

--- a/agents/roadmaps/archive/road-to-rule-stub-projection.md
+++ b/agents/roadmaps/archive/road-to-rule-stub-projection.md
@@ -193,9 +193,9 @@ Siblings and their boundaries, so no step here duplicates an owner:
       and monolithic, deliberately", and a pointer says the opposite.
       **Done: 25 `digest` · 1 `keep` · 18 absent.** The 18 absences are expected,
       not drift — the record covers non-kernel rules with no path trigger, and
-      every absent rule has one. **The one contradiction is `legal-safety-floor`**,
-      recorded `keep` while carrying a pointer to `legal-practice-profile`.
-      Reported under 3.3, never resolved here; the record is unchanged.
+      every absent rule has one. The `keep` row is `legal-safety-floor`; this step
+      first called it a contradiction and **that was retracted** — see 3.3. The
+      record is unchanged either way.
 - **Pre-registered expectation, to falsify:** residue ≥ 25 % of the 103,265-token
   baseline. Priors that make this a measurement rather than a hope: the 42
   migrated rules total 128,261 bytes, and the four largest each exceed 8 KB while
@@ -296,14 +296,29 @@ Siblings and their boundaries, so no step here duplicates an owner:
       **Done**, one sentence, no restatement.
 - [x] **3.3** Report the contradictions from 0.3 (pointer-carrying `keep` rows,
       if any) as findings on this roadmap, not as edits to the closed record.
-      **Finding, one row: `legal-safety-floor`** is recorded `keep` — "stays
-      always-on and monolithic, deliberately" — while carrying a migration pointer
-      to `../skills/legal-practice-profile/SKILL.md`. The two statements are
-      opposites and exactly one is stale. Not resolved here: the record is closed
-      and this roadmap adds no row to it, so which half goes is a maintainer call.
-      Its shape, for whoever takes it: 1,706 tokens, 665 floor / 736 residue — the
-      highest floor share in the set, which is at least consistent with a
-      deliberate `keep`.
+      **RETRACTED 2026-08-17 — there is no contradiction, and the retraction is
+      the finding.** This step reported `legal-safety-floor` as recorded `keep`
+      while carrying a migration pointer, called the two statements opposites, and
+      handed the choice to a maintainer. Checked against the record's own text, all
+      three parts were wrong:
+      (a) the register defines `keep` against `digest` — "stays always-on and
+      monolithic, deliberately" rules out demotion to a shared digest, not a
+      migration that already happened;
+      (b) the row records `body_lines: 139`, the rule's size TODAY — the migration
+      landed 2026-07-11 (`6ef4102d6`) and the disposition was measured 2026-08-09,
+      so the two never described the same body;
+      (c) `rule-body-migration-inventory.md` classes it `stay` *because* of the
+      migration, calling it "already the best existing exemplar of the P4 pattern
+      applied within a safety floor".
+      **The real finding:** that inventory names this rule as the template for six
+      sibling safety floors that have NOT had the treatment —
+      `finance-safety-floor`, `strategy-safety-floor`, `engineering-safety-floor`,
+      `domain-safety-disclaimer`, `domain-safety-pii`, `domain-safety-retention`.
+      None carries a pointer, so none is in this roadmap's population; they are a
+      named prospect for `road-to-standing-context-40k`, not a defect here.
+      **Mechanism, because it recurs:** the reconciliation compared two labels and
+      inferred a contradiction from their plain-English connotations without opening
+      the definition section 280 lines above the row. A label is not a definition.
 - **Exit:** the receiving roadmap carries the table; this roadmap owns no
   body-moving step. **Met.**
 - **Rollback:** revert the edit to the sibling roadmap; the table survives in

--- a/agents/roadmaps/road-to-standing-context-40k.md
+++ b/agents/roadmaps/road-to-standing-context-40k.md
@@ -164,6 +164,16 @@ The revert proved the nineteen must stay **unconditional**. It did not prove the
   > the unconditional set this step targets is wider, so this is a floor on the
   > available residue, never a ceiling.
   >
+  > **A named prospect this table does NOT cover.**
+  > `rule-body-migration-inventory.md` calls `legal-safety-floor` "already the
+  > best existing exemplar of the P4 pattern applied within a safety floor" and a
+  > template for six siblings that have not had it: `finance-safety-floor`,
+  > `strategy-safety-floor`, `engineering-safety-floor`,
+  > `domain-safety-disclaimer`, `domain-safety-pii`, `domain-safety-retention`.
+  > None carries a migration pointer, so none appears above — the table's
+  > population is rules that already declare a migration, which is a floor on the
+  > available residue and not a survey of it.
+  >
   > Moves made under 2.2 now land against **per-rule ceilings**
   > (`src/config/rule-stub-ceilings.json`, gated by `check_rule_stub_ceiling`), so
   > each move's effect is visible per rule instead of only in the aggregate


### PR DESCRIPTION
Follow-up to #1403. Prose only — 4 files, 0 code paths.

## What this retracts

PR #1403's Phase 0.3 reported a contradiction: `legal-safety-floor` is recorded **`keep`** in the closed disposition register while carrying a migration pointer to `skill:legal-practice-profile`. It called the two statements opposites and handed the choice to a maintainer.

**That was wrong.** Checked against the register's own text, all three parts fail:

1. **The register defines `keep` against `digest`, not against having been migrated.** Its vocabulary section: *"`keep` therefore means: stays always-on and monolithic, deliberately, with a named reason. It is not a deferral and not a pending item."* The alternative it rules out is demotion to a shared always-on digest with the body set `type: manual` — which would strip an enforcement surface out of context. It says nothing about a migration that already happened.

2. **The row describes the post-migration rule.** It records `body_lines: 139` — the file's size today. The migration landed **2026-07-11** (`6ef4102d6`, *"thin-stub the five heaviest auto-rules"*); the residue was measured **2026-08-09**. The two statements never described the same body.

3. **The inventory that produced the classification says so outright.** `rule-body-migration-inventory.md` classes it `stay` *because* of the migration: *"already the best existing exemplar of the P4 pattern applied within a safety floor (5 Iron Laws kept inline, all operating mechanics migrated to `skill:legal-practice-profile`); a template for the other 6 safety floors below, none of which do this yet."*

The tree was coherent. The reading was not.

## The replacement finding, verified against the tree

That same inventory names `legal-safety-floor` as the **template** for six sibling safety floors that have not had the treatment: `finance-safety-floor`, `strategy-safety-floor`, `engineering-safety-floor`, `domain-safety-disclaimer`, `domain-safety-pii`, `domain-safety-retention`.

Checked rather than quoted — `grep -ciE 'migrated to|merged into'` returns **0** for all six, and none has a file under `agents/decisions/rule-migrations/`. So none is in the stub-ceiling gate's population, and #1403's residue table is a **floor** on the available residue, not a survey of it. That limit is now stated where the table was handed over, in `road-to-standing-context-40k` step 2.1.

## Why the false positive happened

The reconciliation compared two **labels** — "has a pointer" against "`keep`" — and inferred a contradiction from their plain-English connotations, without opening the register's definition section, which sits ~280 lines above the row it read. **A label is not a definition.**

Recorded rather than quietly corrected, because the mechanism recurs: the same shape produced the three roadmap-prose claims #1403's Phase-0 artefact already corrects, and it is the cheapest check to have skipped.

## Review handling

- `feat-rule-stub-projection.findings.md` is **restored byte-for-byte** to the state it merged in. An in-flight re-bind would have pointed it at this retraction's scope, making it claim a review nobody performed of a diff nobody read.
- This change carries its own **declared skip** — the gate measures 0 code paths across 3 changed files — with the evidence recorded in the artefact.
- It is deliberately **not** a twentieth row on #1403's review. The R2 reviewer never made this observation; adding it would backdate one, which is the forgery the findings-before-fixes ordering exists to prevent.
