### PR TITLE
docs(contracts): a subagent final message is text-only, and the envelope hits disk first

### DIFF
--- a/agents/evidence/investigations/subagent-lifecycle-phase0-return-channel.md
+++ b/agents/evidence/investigations/subagent-lifecycle-phase0-return-channel.md
@@ -35,6 +35,12 @@ This is symptom (2) of the operator's report — *finished, but not returned* �
 and it is now a same-host, controlled observation rather than an upstream issue
 number.
 
+> **Numbering correction, 2026-08-18.** *finished, but not returned* is symptom
+> **(3)**, not (2); (2) is *endless subagent runs*. The roadmap's own header and
+> its symptom → defect map both number it that way. The observation above is
+> unaffected — only the label was wrong — and the original sentence stays so the
+> mistake remains auditable.
+
 The reproduction is a **lower bound on the cost**, not the cost: the work was
 paid for in full and discarded in full. Any dispatch shape that can end on a
 tool call carries this risk, which is exactly why Phase 2 Step 1's contract

--- a/agents/evidence/reviews/subagent-lifecycle-return-contract.findings.md
+++ b/agents/evidence/reviews/subagent-lifecycle-return-contract.findings.md
@@ -1,0 +1,65 @@
+# Completion review — the subagent return-channel contract addendum
+
+**Skipped:** no code surface for this completion — the diff is two context contracts, one roadmap file, one evidence file and the two generated projections, and the gate itself measures zero code paths of seven changed files, scope 11858534bc8a963a1581019a5e547e179551a60d1e51e8fb95db49084a3b6e1b, declared 2026-08-18
+
+## Why a skip rather than a review
+
+The change adds rule (f) to the spawn contract and a `Durable copy` section to
+the response contract, closes Phase 2 Step 1 of
+`road-to-subagent-lifecycle-integrity`, and appends a dated numbering correction
+to the Phase 0 evidence file. It ships no executable surface: no script, no hook,
+no manifest entry, no config key, no test, no frontmatter field.
+`check_completion_review` classifies the diff as zero code paths of seven
+changed files, which is the condition this declaration covers.
+
+Deliberately so, and the addendum says it in its own text: the clause is
+prompt-carried, therefore unenforced, and the `subagent_stop` concern that would
+read the disk copy when a message is empty is named as planned and not shipped.
+A skip here is not a gap in coverage — a code review has nothing to read.
+
+## What replaces it — the verification behind the content
+
+- **The premise is a measurement, not a doc claim.** Phase 0 Step 3 reproduced
+  the failure on host 2.1.229 with a matched control dispatched in the same
+  turn: the treatment arm returned `(no output)` after 3 tool uses and 18,242
+  tokens, the control ending on assistant text returned the full report. Both
+  numbers are read from
+  `agents/evidence/investigations/subagent-lifecycle-phase0-return-channel.md`
+  § F1, and the ledger records in § F2 pin the two arms by duration.
+- **The clause did not already exist.** `grep -rn "never end on a tool
+  call\|text-only\|tool_use block" src/ docs/` returned five hits, none of them
+  about a subagent return shape (a roadmap-routing row, a council comment, a
+  turn-end-gate code comment, a design-capture example, a command-cluster line).
+- **The section anchor resolves.** `check_references` scanned 1328 references
+  with no breakage, which covers the new
+  `subagent-response-contract.md#durable-copy--the-envelope-on-disk-before-the-message`
+  link and the two relative paths into `agents/evidence/investigations/`.
+- **No inbound citation needed updating.** `skill:subagent-orchestration` cites
+  the spawn contract by section name (`§ Worker-prompt rules`), not by
+  enumerating (a) through (e), so adding (f) leaves every pointer valid. The
+  same grep found the other citers to be `verify-budget`, `subagent-steering`,
+  `auto-orchestration-v1` and ADR-105, all section-level or whole-file.
+- **The projection is regenerated, not hand-edited.** `task sync` reports every
+  `.md` projection matching its source, then `task generate-tools`, then
+  `./agent-config roadmap:progress` — in that order, because the dashboard
+  generator runs the dist copy and would otherwise publish pre-edit output.
+- `task preflight` exits 0, including `lint_regression` (no regressions),
+  `skill_linter --changed`, the safety-floor guard (4 rule files guarded, none
+  touched) and the kernel-rule bundle check (no kernel rule touched).
+
+## What this change deliberately does not do
+
+- **It does not wire `validateResponse`.** That function still has zero runtime
+  consumers (V2 of the roadmap) and wiring it is Phase 2 Step 2, which is gated
+  on a verdict split that needs the Phase-1 baseline.
+- **It does not implement the disk write.** `response-envelope.json` is a fixed
+  filename so the durable channel is findable rather than nominal; nothing in
+  the tree writes, reads, or validates it, and both contract sections say so in
+  the same paragraph that introduces it.
+- **It does not close Phase 2.** Steps 2 and 3 stay open and stay gated.
+
+## Standing caveat
+
+A skip declaration is a statement about the diff surface, not a claim that the
+prose is correct. Every claim above names the command, file, or section that
+decides it, so a later reader can refute a row without trusting this artefact.

--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,7 +6,7 @@
 
 ## Overall
 
-**283 / 576 steps done · 49%**
+**284 / 576 steps done · 49%**
 
 ```text
 ████████████████████░░░░░░░░░░░░░░░░░░░░   49%
@@ -57,7 +57,7 @@ These roadmaps have `count_open == 0` but carry `[~]` deferred items. Per `roadm
 | 31 | [road-to-source-first-frontend.md](roadmaps/road-to-source-first-frontend.md) | 6 | 18 | 6 | 11 | 1 | 0 | 0 | ██████░░░░ 65% |
 | 32 | [road-to-standing-context-40k.md](roadmaps/road-to-standing-context-40k.md) | 5 | 9 | 8 | 0 | 1 | 0 | [1](#blockers-road-to-standing-context-40k) | ░░░░░░░░░░ 0% |
 | 33 | [road-to-stop-gate-honesty.md](roadmaps/road-to-stop-gate-honesty.md) | 3 | 7 | 1 | 6 | 0 | 0 | [1](#blockers-road-to-stop-gate-honesty) | █████████░ 86% |
-| 34 | [road-to-subagent-lifecycle-integrity.md](roadmaps/road-to-subagent-lifecycle-integrity.md) | 7 | 21 | 9 | 10 | 0 | 2 | [1](#blockers-road-to-subagent-lifecycle-integrity) | █████░░░░░ 53% |
+| 34 | [road-to-subagent-lifecycle-integrity.md](roadmaps/road-to-subagent-lifecycle-integrity.md) | 7 | 21 | 8 | 11 | 0 | 2 | [1](#blockers-road-to-subagent-lifecycle-integrity) | ██████░░░░ 58% |
 | 35 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
 | 36 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 3 | 14 | 1 | 12 | 1 | 0 | [2](#blockers-road-to-surface-consolidation) | █████████░ 92% |
 | 37 | [road-to-ui-track-integrity-followup.md](roadmaps/road-to-ui-track-integrity-followup.md) | 1 | 10 | 10 | 0 | 0 | 0 | [2](#blockers-road-to-ui-track-integrity-followup) | ░░░░░░░░░░ 0% |
@@ -1024,13 +1024,13 @@ _1 blocker resolved._
 
 ### [road-to-subagent-lifecycle-integrity.md](roadmaps/road-to-subagent-lifecycle-integrity.md)
 
-**Road to subagent lifecycle integrity — turn three production symptoms into deterministic guards** — 10 / 19 done (53%)
+**Road to subagent lifecycle integrity — turn three production symptoms into deterministic guards** — 11 / 19 done (58%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 0 | Spikes — pin the host, reproduce the two upstream premises | 🟡 in progress | 2 | 2 | 0 | 0 | 50% |
 | 1 | Measure — lifecycle capture, no behaviour change | 🟡 in progress | 1 | 3 | 0 | 0 | 75% |
-| 2 | Return-channel integrity — validate, fall back to disk, retry once | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 2 | Return-channel integrity — validate, fall back to disk, retry once | 🟡 in progress | 2 | 1 | 0 | 0 | 33% |
 | 3 | Runaway containment — spawn guard, ledger-aware stop gate, shadow stop-loss | ✅ done | 0 | 3 | 0 | 0 | 100% |
 | 4 | Role axis binds on payload, not env | 🟡 in progress | 2 | 1 | 0 | 0 | 33% |
 | 5 | Tier routing has a caller — measure whether it moved the distribution | 🟡 in progress | 1 | 1 | 0 | 0 | 50% |

--- a/agents/roadmaps/road-to-subagent-lifecycle-integrity.md
+++ b/agents/roadmaps/road-to-subagent-lifecycle-integrity.md
@@ -308,7 +308,7 @@ lines already written stay as data.
 Gated on Phase 1 baseline showing parse-failure or absence at a rate worth a
 mechanism (pre-register the threshold before reading the number).
 
-- [ ] **Step 1:** Worker-prompt contract addendum (dispatch-prompt-carried, per
+- [x] **Step 1:** Worker-prompt contract addendum (dispatch-prompt-carried, per
       the claudefa.st 0/2-vs-1/1 finding and this tree's own contract
       placement): (a) the final message is a single **text-only** envelope —
       never end on a tool call (#58109 mitigation); (b) the same envelope is
@@ -319,6 +319,41 @@ mechanism (pre-register the threshold before reading the number).
       X1): the async design-verifier `road-to-source-first-frontend` leans on is
       itself a subagent on this return channel — a verifier that screenshots,
       grades and never delivers is both operator symptoms in one run.
+
+      **Landed 2026-08-18.** Rule **(f)** in `subagent-spawn-contract.md`
+      § Worker-prompt rules (both clauses plus the no-carve-out-for-verifiers
+      paragraph, since the worker reads its duties from the dispatch prompt) and
+      a new § *Durable copy — the envelope on disk before the message* in
+      `subagent-response-contract.md`.
+
+      **This step is NOT gated on the Phase-1 baseline, and the phase header's
+      gate is about Step 2, not this one.** The header reads "gated on Phase 1
+      baseline showing parse-failure or absence at a rate worth a mechanism" —
+      a rate justifies a *mechanism*, and Step 1 ships no mechanism. Its premise
+      is Phase 0 Step 3's controlled same-host reproduction (`(no output)` after
+      3 tool uses and 18,242 tokens, matched control returning the full report),
+      which the evidence file itself names as "the measurement Phase 2 Step 1's
+      never-end-on-a-tool-call clause was missing". A baseline rate could not
+      strengthen a clause whose failure is already observed at n=1 with a
+      control — and per Phase 1 Step 4 (a) that column does not yet measure
+      envelope return at all, so waiting for it would have gated a text change
+      on a number known to be wrong.
+
+      **Two things the step's text does not name, both decided here.**
+      (i) The durable copy needs a **findable** path or it is nominal, so the
+      filename `response-envelope.json` is fixed in the response contract —
+      declared as a convention, with the fact that nothing writes, reads, or
+      validates it stated in the same paragraph. (ii) Both contract sections
+      carry an explicit honest-scope note: rule (f) is prompt-carried and
+      therefore unenforced, and the `subagent_stop` concern that would read the
+      disk copy is named as planned-and-not-shipped. Without that note the
+      addendum reads as a recovery mechanism that runs, which is the
+      buildable-on-paper failure Phase 0 exists to stop.
+      <!-- verify: ./scripts-run src/scripts/check_references -->
+
+      **Does not close Phase 2.** Steps 2 and 3 stay open and stay gated: the
+      concern needs the three-way `no_message` / `no_envelope` / `ok` verdict
+      split, and that split needs the Phase-1 baseline this step does not.
 - [ ] **Step 2:** `subagent-return-gate` concern on `subagent_stop` *(proposal)*,
       **command type only** (#20221 excludes prompt-type): parse
       `last_assistant_message` with `validateResponse`; on failure, look for

--- a/dist/agent-src/contexts/execution/subagent-response-contract.md
+++ b/dist/agent-src/contexts/execution/subagent-response-contract.md
@@ -31,6 +31,48 @@ orchestrator synthesises and re-verifies.
   chars (~3k tokens against a measured ~251k spawn floor). Constants + checks:
   `src/scripts/_lib/subagent_response.ts`.
 
+## Durable copy — the envelope on disk before the message
+
+```
+THE FINAL MESSAGE IS A SINGLE TEXT-ONLY ENVELOPE. NEVER END ON A TOOL CALL.
+THE SAME ENVELOPE IS WRITTEN TO THE RUNTIME ARTIFACT DIR BEFORE IT IS EMITTED.
+DISK IS THE DURABLE CHANNEL. THE MESSAGE IS THE FAST CHANNEL.
+A RETURN THAT WAS PAID FOR AND NEVER DELIVERED IS THE FAILURE THIS PREVENTS.
+```
+
+The envelope reaches the orchestrator twice, and the two copies are not two
+result shapes:
+
+- **The message** — the worker's final assistant message, text only, carrying
+  the envelope verbatim. Fast, and the channel that can vanish.
+- **The file** — the same envelope written into the runtime artifact dir
+  (gitignored) as `response-envelope.json` *before* the final message is
+  emitted, so it exists even when the message never arrives.
+
+This does not weaken *the envelope is the ONLY return channel* above. That
+clause governs what the orchestrator may **ingest** — one envelope shape, never
+a wholesale transcript. The disk copy carries that same shape, so the
+orchestrator still reads exactly one; what changes is that it can still read it
+after a delivery failure.
+
+**Why the ordering is load-bearing.** A subagent whose last block is a
+`tool_use` delivers nothing to its parent on host 2.1.229 — measured with a
+matched control dispatched in the same turn: `(no output)` after 3 tool uses and
+18,242 tokens, against a control ending on assistant text that returned the
+complete report
+([`subagent-lifecycle-phase0-return-channel.md`](../../../../agents/evidence/investigations/subagent-lifecycle-phase0-return-channel.md)
+§ F1). The tokens were spent either way. Writing the envelope first is what
+turns a dropped message into a recoverable read instead of a paid-for discard.
+
+**Honest status — a convention, not a checked invariant.** Nothing in the tree
+writes, reads, or validates `response-envelope.json`: the filename is fixed here
+so that a durable channel is *findable* rather than nominal, and the clause
+travels in the dispatch prompt (spawn contract rule (f)), which is where a
+worker actually reads its duties. A `subagent_stop` concern that finds the file
+and injects its path when the message is empty is planned and **not shipped** —
+said plainly, because "the durable channel" must not be read as a recovery
+mechanism that already runs.
+
 ## Budget-hit partial result
 
 When the worker's `max_tokens_per_worker` stop-loss fires

--- a/dist/agent-src/contexts/execution/subagent-spawn-contract.md
+++ b/dist/agent-src/contexts/execution/subagent-spawn-contract.md
@@ -170,6 +170,35 @@ contingency.
   subagent's output is never auto-persisted into memory — promotion is
   always the human-gated flow (ADR-098 floor). Auto-surface, never
   auto-write.
+- **(f) Return shape — text-only final message, disk copy written first.** Two
+  clauses, and they ride **here**, at spawn, rather than in a reusable agent
+  definition: a delivery duty stated in an agent definition measured 0/2 against
+  1/1 for the identical duty carried in the dispatch prompt (practitioner
+  report, n small), which is the same verbatim-at-spawn discipline as (a)–(e).
+  - **The final message is a single text-only envelope — never end on a tool
+    call.** Measured on host 2.1.229 with a matched control dispatched in the
+    same turn: the arm told to emit its report and then make one final
+    `echo done` call returned **`(no output)`** to its parent after 3 tool uses
+    and 18,242 tokens, while the control ending on assistant text returned the
+    complete report. The work was paid for in full and discarded in full
+    ([`subagent-lifecycle-phase0-return-channel.md`](../../../../agents/evidence/investigations/subagent-lifecycle-phase0-return-channel.md)
+    § F1).
+  - **Write the envelope to the runtime artifact dir before emitting it.** Disk
+    is the durable channel, the message the fast one — same envelope, so the
+    orchestrator still ingests exactly one shape
+    ([response contract § Durable copy](subagent-response-contract.md#durable-copy--the-envelope-on-disk-before-the-message)).
+
+  **No carve-out for verifier dispatches.** An async verifier — a subagent that
+  screenshots, grades, and reports back — rides this identical return channel,
+  and one that grades and never delivers is two operator symptoms in a single
+  run: work that looks endless from the orchestrator's side, and work that
+  finished without returning. Rule (f) binds it like any other worker.
+
+  **Honest scope.** Nothing enforces (f). It is prompt-carried text, so a worker
+  that ignores it fails exactly as before — the clause buys a stated duty and a
+  known-good path to look in, not a guarantee. The deterministic half needs a
+  `subagent_stop` concern that reads the disk copy, which is planned and not
+  shipped.
 
 ## Hand-off worked examples — step N output feeds step N+1
 

--- a/src/agent-src/contexts/execution/subagent-response-contract.md
+++ b/src/agent-src/contexts/execution/subagent-response-contract.md
@@ -31,6 +31,48 @@ orchestrator synthesises and re-verifies.
   chars (~3k tokens against a measured ~251k spawn floor). Constants + checks:
   `src/scripts/_lib/subagent_response.ts`.
 
+## Durable copy — the envelope on disk before the message
+
+```
+THE FINAL MESSAGE IS A SINGLE TEXT-ONLY ENVELOPE. NEVER END ON A TOOL CALL.
+THE SAME ENVELOPE IS WRITTEN TO THE RUNTIME ARTIFACT DIR BEFORE IT IS EMITTED.
+DISK IS THE DURABLE CHANNEL. THE MESSAGE IS THE FAST CHANNEL.
+A RETURN THAT WAS PAID FOR AND NEVER DELIVERED IS THE FAILURE THIS PREVENTS.
+```
+
+The envelope reaches the orchestrator twice, and the two copies are not two
+result shapes:
+
+- **The message** — the worker's final assistant message, text only, carrying
+  the envelope verbatim. Fast, and the channel that can vanish.
+- **The file** — the same envelope written into the runtime artifact dir
+  (gitignored) as `response-envelope.json` *before* the final message is
+  emitted, so it exists even when the message never arrives.
+
+This does not weaken *the envelope is the ONLY return channel* above. That
+clause governs what the orchestrator may **ingest** — one envelope shape, never
+a wholesale transcript. The disk copy carries that same shape, so the
+orchestrator still reads exactly one; what changes is that it can still read it
+after a delivery failure.
+
+**Why the ordering is load-bearing.** A subagent whose last block is a
+`tool_use` delivers nothing to its parent on host 2.1.229 — measured with a
+matched control dispatched in the same turn: `(no output)` after 3 tool uses and
+18,242 tokens, against a control ending on assistant text that returned the
+complete report
+([`subagent-lifecycle-phase0-return-channel.md`](../../../../agents/evidence/investigations/subagent-lifecycle-phase0-return-channel.md)
+§ F1). The tokens were spent either way. Writing the envelope first is what
+turns a dropped message into a recoverable read instead of a paid-for discard.
+
+**Honest status — a convention, not a checked invariant.** Nothing in the tree
+writes, reads, or validates `response-envelope.json`: the filename is fixed here
+so that a durable channel is *findable* rather than nominal, and the clause
+travels in the dispatch prompt (spawn contract rule (f)), which is where a
+worker actually reads its duties. A `subagent_stop` concern that finds the file
+and injects its path when the message is empty is planned and **not shipped** —
+said plainly, because "the durable channel" must not be read as a recovery
+mechanism that already runs.
+
 ## Budget-hit partial result
 
 When the worker's `max_tokens_per_worker` stop-loss fires

--- a/src/agent-src/contexts/execution/subagent-spawn-contract.md
+++ b/src/agent-src/contexts/execution/subagent-spawn-contract.md
@@ -170,6 +170,35 @@ contingency.
   subagent's output is never auto-persisted into memory — promotion is
   always the human-gated flow (ADR-098 floor). Auto-surface, never
   auto-write.
+- **(f) Return shape — text-only final message, disk copy written first.** Two
+  clauses, and they ride **here**, at spawn, rather than in a reusable agent
+  definition: a delivery duty stated in an agent definition measured 0/2 against
+  1/1 for the identical duty carried in the dispatch prompt (practitioner
+  report, n small), which is the same verbatim-at-spawn discipline as (a)–(e).
+  - **The final message is a single text-only envelope — never end on a tool
+    call.** Measured on host 2.1.229 with a matched control dispatched in the
+    same turn: the arm told to emit its report and then make one final
+    `echo done` call returned **`(no output)`** to its parent after 3 tool uses
+    and 18,242 tokens, while the control ending on assistant text returned the
+    complete report. The work was paid for in full and discarded in full
+    ([`subagent-lifecycle-phase0-return-channel.md`](../../../../agents/evidence/investigations/subagent-lifecycle-phase0-return-channel.md)
+    § F1).
+  - **Write the envelope to the runtime artifact dir before emitting it.** Disk
+    is the durable channel, the message the fast one — same envelope, so the
+    orchestrator still ingests exactly one shape
+    ([response contract § Durable copy](subagent-response-contract.md#durable-copy--the-envelope-on-disk-before-the-message)).
+
+  **No carve-out for verifier dispatches.** An async verifier — a subagent that
+  screenshots, grades, and reports back — rides this identical return channel,
+  and one that grades and never delivers is two operator symptoms in a single
+  run: work that looks endless from the orchestrator's side, and work that
+  finished without returning. Rule (f) binds it like any other worker.
+
+  **Honest scope.** Nothing enforces (f). It is prompt-carried text, so a worker
+  that ignores it fails exactly as before — the clause buys a stated duty and a
+  known-good path to look in, not a guarantee. The deterministic half needs a
+  `subagent_stop` concern that reads the disk copy, which is planned and not
+  shipped.
 
 ## Hand-off worked examples — step N output feeds step N+1
 


### PR DESCRIPTION
Closes Phase 2 Step 1 of `road-to-subagent-lifecycle-integrity`. Docs-only: two
context contracts, one roadmap file, one evidence file, the completion-review
skip artefact, and the two generated projections. Zero code paths.

## The defect this closes

A subagent whose final block is a `tool_use` delivers nothing to its parent.
Phase 0 Step 3 reproduced it on host 2.1.229 with a matched control dispatched in
the same turn:

- **control** — ends on assistant text carrying the report → full report
  received, 1 tool use, 17,737 tokens.
- **treatment** — emits the report as text, then makes one final `echo done`
  call → **`(no output)`** received, 3 tool uses, 18,242 tokens.

The treatment arm did the work and emitted the report. The tokens were paid in
full and the result was discarded in full. Until this PR, **neither** the spawn
contract nor the response contract forbade that shape.

## What lands

- **`subagent-spawn-contract.md` — rule (f)** in § Worker-prompt rules: the final
  message is a single text-only envelope, never ending on a tool call, and the
  envelope is written to the runtime artifact dir before it is emitted. It rides
  in the dispatch prompt like (a) through (e), because a delivery duty stated in
  an agent definition measured 0/2 against 1/1 for the identical duty carried in
  the prompt.
- **`subagent-response-contract.md` — a new § Durable copy**: the same envelope on
  disk as `response-envelope.json` before the message, with why the ordering is
  load-bearing.
- **No carve-out for verifier dispatches.** An async verifier rides the identical
  channel, and one that grades and never delivers is two operator symptoms in a
  single run.

## Three things stated rather than implied

- **The disk copy is not a second result shape.** The existing
  envelope-is-the-only-return-channel clause is unweakened: it governs what the
  orchestrator may *ingest*, and the copy carries that same shape.
- **The filename is a convention nothing validates.** It is fixed so a durable
  channel is findable rather than nominal, and both sections say in the same
  paragraph that nothing in the tree writes, reads, or validates it.
- **Rule (f) is prompt-carried, therefore unenforced.** The `subagent_stop`
  concern that would read the disk copy when a message is empty is Phase 2
  Step 2 and is named as planned and not shipped. Without that note the addendum
  reads as a recovery mechanism that already runs.

## Why this step was not gated on the Phase-1 baseline

The phase header reads *gated on Phase 1 baseline showing parse-failure or
absence at a rate worth a mechanism*. A rate justifies a **mechanism**, and this
step ships none — its premise is the controlled reproduction above, which the
evidence file itself calls "the measurement Phase 2 Step 1's
never-end-on-a-tool-call clause was missing". Waiting would also have gated a
text change on a number Phase 1 Step 4 (a) already records as not yet measuring
envelope return at all: `classifyEnvelope` reports `absent` for both "nothing
came back" and "prose came back", so the column read 25 of 25 `absent` including
the control arm that returned a complete report.

**Phase 2 does not close.** Steps 2 and 3 stay open and stay gated on the
three-way `no_message` / `no_envelope` / `ok` verdict split, which does need the
baseline.

## Also in here

A dated numbering correction on the Phase 0 evidence file: it labelled
*finished, but not returned* as symptom (2); it is (3). The original sentence
stays so the mistake remains auditable.

## Verification

- `task preflight` exit 0, twice — before and after the commits.
- `check_references`: 1328 references scanned, none broken, which covers the new
  section anchor and the two paths into `agents/evidence/investigations/`.
- `check_completion_review`: clean, § 2.4 skip declared at 0 code paths of 7
  changed files.
- `lint_evidence_artifacts`: the one added artefact declares a type.
- `lint_regression`: no regressions. Safety floor untouched, no kernel rule
  touched.
- Regen order held: `task sync`, then `task generate-tools`, then
  `./agent-config roadmap:progress` — the dashboard generator runs the dist copy
  and would otherwise publish pre-edit output.

## Not in scope

`validateResponse` stays unwired (it still has zero runtime consumers), no hook
or manifest entry is touched, and Phase 0 Steps 2 and 4, Phase 1 Step 4,
Phase 4 and Phase 5 Step 2 all remain blocked on a host env edit or on a
20-dispatch window.
