### PR TITLE
fix(hooks): keep an authorization from being clobbered by a parallel session

### DIFF
--- a/src/scripts/git_authorization_hook.ts
+++ b/src/scripts/git_authorization_hook.ts
@@ -43,7 +43,101 @@ import { readHookStdin } from "./hooks/hook_stdin.js";
 
 const EXIT_ALLOW = 0;
 
+/**
+ * Legacy single-file ledger path — one file for the whole project root.
+ *
+ * Kept for direct invocations and for reading a ledger written by an older
+ * build, NOT as the write target when a session id is known. See
+ * `ledgerFileFor` for why one shared file was the defect.
+ */
 export const STATE_FILE = path.join("agents", "state", "git-authorization.json");
+
+/** Per-session ledger directory. */
+export const STATE_DIR = path.join("agents", "state", "git-authorization");
+
+/** Per-session pending-refusal directory. */
+export const PENDING_DIR = path.join("agents", "state", "git-authorization-pending");
+
+/**
+ * A session id reduced to a safe path component.
+ *
+ * The id reaches this from the host's envelope, so it is untrusted input on a
+ * path — `..` or a separator in it would place the ledger outside the state
+ * directory. Anything outside the allowed set collapses to `_`.
+ */
+export function sessionSlug(session_id: string): string {
+    return session_id.replace(/[^A-Za-z0-9._-]/gu, "_").slice(0, 80);
+}
+
+/**
+ * Where THIS session's ledger lives.
+ *
+ * MEASURED DEFECT (2026-08-18, during the 14.0.0 release): the ledger was a
+ * single file per project root, so every prompt from every concurrent session
+ * in the repo overwrote it. A second session typed an 11-character prompt
+ * between the user's `merge den pr` and the guard's read; the guard found a
+ * foreign session id, discarded the ledger as another conversation's consent,
+ * and refused. The refusal then said "no authorization in this turn's prompt",
+ * which was false and unfalsifiable from the message alone — the authorization
+ * had existed and been clobbered. Three consecutive refusals, and the user
+ * re-authorized each time.
+ *
+ * This repo runs dozens of worktrees against one root, so the race is not an
+ * edge case there; it is the normal condition. Scoping the file by session is
+ * what makes "this turn's prompt" mean this conversation's turn.
+ */
+export function ledgerFileFor(session_id: string): string {
+    if (!session_id) {
+        return STATE_FILE;
+    }
+    return path.join(STATE_DIR, `${sessionSlug(session_id)}.json`);
+}
+
+/** Where THIS session's refused-operation record lives. */
+export function pendingFileFor(session_id: string): string {
+    if (!session_id) {
+        return PENDING_FILE;
+    }
+    return path.join(PENDING_DIR, `${sessionSlug(session_id)}.json`);
+}
+
+/**
+ * One refused irreversible operation, waiting for the answer to the question
+ * the guard just told the agent to ask.
+ *
+ * WHY THIS FILE EXISTS — the measured deadlock (2026-08-18, 14.0.0 release):
+ * `user-interaction` requires a decision to be handed to the user as a
+ * NUMBERED-OPTIONS block, and the answer to one is a bare `1`. The classifier
+ * below reads the prompt in isolation, and `1` carries no operation, so the
+ * user's consent was real, visible, and unrecordable. The release deadlocked
+ * for three turns: the guard refused, the agent asked as instructed, the user
+ * answered, and the next attempt refused identically. Two mechanisms this repo
+ * mandates were structurally incompatible on exactly the irreversible subset.
+ *
+ * The fix is deliberately the narrowest thing that resolves it. Widening the
+ * prose list with bare affirmatives was rejected: `ja` would then authorize
+ * `npm publish` on any turn, which is reach, not severity. Instead the guard
+ * records WHICH op it refused, and only that one op can be confirmed, once, by
+ * the immediately following prompt. Everything the user is consenting to has
+ * already been named to them in the refusal they just read.
+ */
+export const PENDING_FILE = path.join("agents", "state", "git-authorization-pending.json");
+
+/** A refused operation carried to exactly one following prompt. */
+export interface PendingRefusal {
+    op: GitOp;
+    session_id: string;
+    refused_at: string;
+}
+
+/**
+ * The window in which a refusal is still the thing the user is answering.
+ *
+ * Short on purpose: this is "the user read the refusal and replied", not "the
+ * user said yes to something at some point today". A stale record expires into
+ * the same not-authorized state the guard starts from.
+ */
+export const PENDING_MAX_AGE_MS = 10 * 60 * 1000;
 
 type JsonValue = string | number | boolean | null | JsonValue[] | { [k: string]: JsonValue };
 type JsonObject = { [k: string]: JsonValue };
@@ -140,6 +234,36 @@ export function isInterrogative(prose: string): boolean {
       t,
     )
   );
+}
+
+/**
+ * Is this prompt an ANSWER to the refusal the user was just shown?
+ *
+ * Accepts the two shapes a numbered-options block actually produces — a bare
+ * selection (`1`, `1.`, `Option 2`) and a bare affirmative (`ja`, `ok`, `mach`,
+ * `go`, `do it`) — and nothing else. The bar is that the prompt says yes and
+ * says NOTHING ELSE: a turn that also carries new instructions is a new turn,
+ * not an answer, and must name its operation like any other.
+ *
+ * That last clause is the whole safety argument, so it is enforced by length
+ * rather than by good intentions. `release und fixe auch den schess bug` reads
+ * as consent to a human and is correctly NOT an affirmative here — it opens new
+ * work, and the op it authorizes is the one it names.
+ */
+export function isAffirmative(prose: string): boolean {
+    const t = prose.trim().replace(/[.!]+$/u, "");
+    if (!t || t.length > 24) {
+        return false;
+    }
+    if (isInterrogative(t)) {
+        return false;
+    }
+    return (
+        /^(?:option\s*)?\d{1,2}[.)]?$/iu.test(t) ||
+        /^(ja|jo|jep|yes|yep|yeah|ok|okay|okey|klar|passt|gut|los|go|go ahead|mach|mach das|mach es|leg los|do it|proceed|bitte)$/iu.test(
+            t,
+        )
+    );
 }
 
 /** Executable commands a user may paste, mapped to the op they authorize. */
@@ -242,6 +366,55 @@ export function classifyAuthorization(prompt: string): {
   return { authorized: [...authorized], evidence };
 }
 
+/**
+ * Read the refused operation, and consume it in the same breath.
+ *
+ * Consuming unconditionally is the single-use guarantee: the record survives
+ * exactly one following prompt whether or not that prompt confirmed it, so a
+ * `ja` three turns later cannot reach back to a refusal the user has long
+ * stopped thinking about.
+ */
+export function takePending(
+    consumer_root: string,
+    session_id: string,
+    now: number,
+): PendingRefusal | null {
+    const file = path.join(consumer_root, pendingFileFor(session_id));
+    let raw: string;
+    try {
+        raw = fs.readFileSync(file, "utf8");
+    } catch {
+        return null;
+    }
+    try {
+        fs.rmSync(file, { force: true });
+    } catch {
+        /* consumed in memory either way — a stale file expires by age below */
+    }
+    try {
+        const decoded = JSON.parse(raw) as unknown;
+        if (!_isObject(decoded)) {
+            return null;
+        }
+        const op = decoded["op"];
+        if (typeof op !== "string" || !(ALL_OPS as readonly string[]).includes(op)) {
+            return null;
+        }
+        const recorded = typeof decoded["session_id"] === "string" ? decoded["session_id"] : "";
+        // A refusal from another conversation is another conversation's question.
+        if (session_id && recorded && recorded !== session_id) {
+            return null;
+        }
+        const at = Date.parse(String(decoded["refused_at"] ?? ""));
+        if (!Number.isFinite(at) || now - at > PENDING_MAX_AGE_MS) {
+            return null;
+        }
+        return { op: op as GitOp, session_id: recorded, refused_at: String(decoded["refused_at"]) };
+    } catch {
+        return null;
+    }
+}
+
 export function run(stdin_text: string, options: { consumer_root: string }): number {
   let envelope: JsonObject = {};
   if (stdin_text.trim()) {
@@ -269,6 +442,18 @@ export function run(stdin_text: string, options: { consumer_root: string }): num
   }
 
   const { authorized, evidence } = classifyAuthorization(prompt);
+
+  // The answer to the guard's own question. Read (and consume) on EVERY prompt,
+  // so the record cannot outlive the turn it was raised in.
+  const session = typeof envelope["session_id"] === "string" ? envelope["session_id"] : "";
+  const pending = takePending(options.consumer_root, session, Date.now());
+  if (pending && !authorized.includes(pending.op) && isAffirmative(prompt)) {
+    authorized.push(pending.op);
+    evidence[pending.op] =
+      `confirmation of the refused \`${pending.op}\` (refused ${pending.refused_at}): ` +
+      `"${prompt.trim().slice(0, 40)}"`;
+  }
+
   const ledger: Ledger = {
     session_id: typeof envelope["session_id"] === "string" ? envelope["session_id"] : "",
     detected_at: new Date().toISOString(),
@@ -278,7 +463,7 @@ export function run(stdin_text: string, options: { consumer_root: string }): num
   };
 
   try {
-    atomic_write_json(path.join(options.consumer_root, STATE_FILE), ledger);
+    atomic_write_json(path.join(options.consumer_root, ledgerFileFor(session)), ledger);
   } catch {
     // Observability only — a failed write degrades the gate to "no ledger",
     // which the pre_tool_use concern treats as "not authorized" for the

--- a/src/scripts/hooks/block_unauthorized_git.ts
+++ b/src/scripts/hooks/block_unauthorized_git.ts
@@ -61,7 +61,13 @@ import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { readHookStdin } from "./hook_stdin.js";
-import { STATE_FILE, type GitOp } from "../git_authorization_hook.js";
+import { atomic_write_json } from "./state_io.js";
+import {
+  ledgerFileFor,
+  pendingFileFor,
+  STATE_FILE,
+  type GitOp,
+} from "../git_authorization_hook.js";
 
 const EXIT_ALLOW = 0;
 // MUST equal dispatch_hook.EXIT_BLOCK. The dispatcher's internal ladder is
@@ -497,18 +503,45 @@ function _loadLedger(
   session_id: string,
   now: number,
 ): { authorized: Set<GitOp>; present: boolean } {
+  // This session's own ledger first; the flat legacy file only as a fallback,
+  // so a ledger written by an older build still counts. Reading the flat file
+  // FIRST was the defect: any concurrent session in the repo overwrites it, and
+  // the session check below then discarded a real authorization as foreign.
+  const candidates = [ledgerFileFor(session_id)];
+  if (!candidates.includes(STATE_FILE)) {
+    candidates.push(STATE_FILE);
+  }
+  for (const rel of candidates) {
+    const found = _readLedgerFile(path.join(consumer_root, rel), session_id, now);
+    if (found !== null) {
+      return found;
+    }
+  }
+  return { authorized: new Set<GitOp>(), present: false };
+}
+
+/**
+ * Read one ledger file. `null` means "this file does not answer the question" —
+ * absent, malformed, foreign session, or expired — so the caller may try the
+ * next candidate. A parsed, in-session, fresh ledger answers definitively.
+ */
+function _readLedgerFile(
+  file: string,
+  session_id: string,
+  now: number,
+): { authorized: Set<GitOp>; present: boolean } | null {
   try {
-    const raw = fs.readFileSync(path.join(consumer_root, STATE_FILE), "utf8");
+    const raw = fs.readFileSync(file, "utf8");
     const decoded = JSON.parse(raw) as unknown;
     if (_isObject(decoded) && Array.isArray(decoded["authorized"])) {
       const ledgerSession = typeof decoded["session_id"] === "string" ? decoded["session_id"] : "";
       // A ledger from a different session is another conversation's consent.
       if (session_id && ledgerSession && ledgerSession !== session_id) {
-        return { authorized: new Set<GitOp>(), present: false };
+        return null;
       }
       const at = Date.parse(String(decoded["detected_at"] ?? ""));
       if (Number.isFinite(at) && now - at > LEDGER_MAX_AGE_MS) {
-        return { authorized: new Set<GitOp>(), present: false };
+        return null;
       }
       return {
         authorized: new Set((decoded["authorized"] as string[]).filter(Boolean) as GitOp[]),
@@ -518,13 +551,21 @@ function _loadLedger(
   } catch {
     /* fall through */
   }
-  return { authorized: new Set<GitOp>(), present: false };
+  return null;
 }
 
 export interface Decision {
   exit: number;
   stdout: string;
   stderr: string;
+  /**
+   * The op this decision refused, when it refused one.
+   *
+   * `decide` stays pure; `run` turns this into the pending record that lets the
+   * user's answer to the refusal count as authorization for that one op. See
+   * `git_authorization_hook.PENDING_FILE` for why that record exists at all.
+   */
+  blockedOp?: GitOp;
 }
 
 export function decide(
@@ -547,7 +588,7 @@ export function decide(
       `This operation is irreversible and non-destructive-by-default already declares it ` +
       `never-autonomous. Command: ${shown}. ` +
       `Ask the user, in one numbered-options block, and run it only after they answer this turn.`;
-    return { exit: EXIT_BLOCK, stdout: "", stderr: `${reason}\n` };
+    return { exit: EXIT_BLOCK, stdout: "", stderr: `${reason}\n`, blockedOp: op };
   }
 
   if (WARN_OPS.has(op)) {
@@ -582,6 +623,21 @@ export function run(stdin_text: string, options: { consumer_root: string }): num
     extractCommand(envelope),
     _loadLedger(options.consumer_root, session_id, Date.now()),
   );
+  if (decision.blockedOp) {
+    // Record WHAT was refused, so the user's answer to the question this
+    // refusal just told the agent to ask can authorize that one operation.
+    // Best-effort: a failed write degrades to the previous behaviour, where a
+    // numbered answer is unrecordable and the refusal simply repeats.
+    try {
+      atomic_write_json(path.join(options.consumer_root, pendingFileFor(session_id)), {
+        op: decision.blockedOp,
+        session_id,
+        refused_at: new Date().toISOString(),
+      });
+    } catch {
+      /* observability only — see above */
+    }
+  }
   if (decision.stdout) {
     process.stdout.write(decision.stdout);
   }

--- a/tests/scripts/git_authorization.test.ts
+++ b/tests/scripts/git_authorization.test.ts
@@ -16,7 +16,10 @@ import { beforeEach, describe, expect, it } from "vitest";
 
 import {
   classifyAuthorization,
+  isAffirmative,
   splitFences,
+  ledgerFileFor,
+  pendingFileFor,
   run as ledgerRun,
   STATE_FILE,
   type GitOp,
@@ -38,20 +41,28 @@ beforeEach(() => {
   tmp = fs.mkdtempSync(path.join(os.tmpdir(), "git-auth-"));
 });
 
-function submit(prompt: string): void {
+function submit(prompt: string, session = "s1"): void {
   ledgerRun(
-    JSON.stringify({ event: "user_prompt_submit", session_id: "s1", payload: { prompt } }),
+    JSON.stringify({ event: "user_prompt_submit", session_id: session, payload: { prompt } }),
     { consumer_root: tmp },
   );
 }
 
-function ledger(): { authorized: GitOp[] } {
-  return JSON.parse(fs.readFileSync(path.join(tmp, STATE_FILE), "utf8")) as { authorized: GitOp[] };
+function ledger(session = "s1"): { authorized: GitOp[] } {
+  return JSON.parse(fs.readFileSync(path.join(tmp, ledgerFileFor(session)), "utf8")) as {
+    authorized: GitOp[];
+  };
 }
 
-function preTool(command: string): number {
+// The guard sees the session id in production, so the fixture does too — the
+// cross-session clobber below is invisible without it.
+function preTool(command: string, session = "s1"): number {
   return gateRun(
-    JSON.stringify({ event: "pre_tool_use", payload: { tool_name: "Bash", tool_input: { command } } }),
+    JSON.stringify({
+      event: "pre_tool_use",
+      session_id: session,
+      payload: { tool_name: "Bash", tool_input: { command } },
+    }),
     { consumer_root: tmp },
   );
 }
@@ -377,5 +388,175 @@ describe("end to end", () => {
   it("no ledger at all is treated as not-authorized for the block subset", () => {
     expect(fs.existsSync(path.join(tmp, STATE_FILE))).toBe(false);
     expect(preTool("npm publish")).toBe(DISPATCHER_BLOCK);
+  });
+});
+
+// The deadlock this pair was measured to produce (2026-08-18, 14.0.0 release).
+//
+// `user-interaction` requires a Hard-Floor decision to reach the user as a
+// numbered-options block; the answer to one is `1`, which carries no operation
+// for the classifier to record. The guard refused, the agent asked exactly as
+// the refusal instructed, the user answered, and the next attempt refused
+// identically — three turns, with real consent on the record every time.
+describe("confirming a refused operation", () => {
+  it("reproduces the deadlock, and closes it: a numbered answer confirms the refused op", () => {
+    submit("mach den Release fertig");
+    expect(preTool("gh pr merge 1412 --merge")).toBe(DISPATCHER_BLOCK);
+    // The agent asks; the user picks option 1.
+    submit("1");
+    expect(ledger().authorized).toContain("pr-merge");
+    expect(preTool("gh pr merge 1412 --merge")).toBe(0);
+  });
+
+  it("confirms ONLY the operation that was refused", () => {
+    submit("mach den Release fertig");
+    expect(preTool("gh pr merge 1412 --merge")).toBe(DISPATCHER_BLOCK);
+    submit("ja");
+    expect(preTool("gh pr merge 1412 --merge")).toBe(0);
+    // The merge refusal never named a publish, so it cannot consent to one.
+    expect(preTool("npm publish")).toBe(DISPATCHER_BLOCK);
+  });
+
+  it("is single-use — a second affirmative does not re-open the same op", () => {
+    submit("mach den Release fertig");
+    expect(preTool("npm publish")).toBe(DISPATCHER_BLOCK);
+    submit("ok");
+    expect(preTool("npm publish")).toBe(0);
+    submit("ok");
+    expect(preTool("npm publish")).toBe(DISPATCHER_BLOCK);
+  });
+
+  it("a prompt that opens new work is not an answer — it must name its own op", () => {
+    submit("mach den Release fertig");
+    expect(preTool("gh pr merge 1412 --merge")).toBe(DISPATCHER_BLOCK);
+    // The real turn that motivated this test. It reads as consent to a human,
+    // and it authorizes exactly the op it names — not the pending one.
+    submit("release und fixe auch den schess bug");
+    expect(ledger().authorized).toContain("release");
+    expect(ledger().authorized).not.toContain("pr-merge");
+    expect(preTool("gh pr merge 1412 --merge")).toBe(DISPATCHER_BLOCK);
+  });
+
+  it("an affirmative with no refusal behind it authorizes nothing", () => {
+    submit("1");
+    expect(ledger().authorized).toEqual([]);
+    expect(preTool("npm publish")).toBe(DISPATCHER_BLOCK);
+  });
+
+  it("a stale refusal has expired — it is not still the question being answered", () => {
+    fs.mkdirSync(path.dirname(path.join(tmp, pendingFileFor("s1"))), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, pendingFileFor("s1")),
+      JSON.stringify({
+        op: "publish",
+        session_id: "s1",
+        refused_at: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      }),
+    );
+    submit("ja");
+    expect(ledger().authorized).toEqual([]);
+    expect(preTool("npm publish")).toBe(DISPATCHER_BLOCK);
+  });
+
+  it("the refusal is recorded so the next prompt can answer it", () => {
+    submit("mach den Release fertig");
+    expect(fs.existsSync(path.join(tmp, pendingFileFor("s1")))).toBe(false);
+    expect(preTool("gh pr merge 1412 --merge")).toBe(DISPATCHER_BLOCK);
+    const pending = JSON.parse(fs.readFileSync(path.join(tmp, pendingFileFor("s1")), "utf8")) as {
+      op: string;
+    };
+    expect(pending.op).toBe("pr-merge");
+  });
+
+  it("a warn-tier refusal records nothing — there is no refusal to answer", () => {
+    submit("lies den code");
+    expect(preTool("git push origin main")).toBe(0);
+    expect(fs.existsSync(path.join(tmp, pendingFileFor("s1")))).toBe(false);
+  });
+});
+
+describe("isAffirmative", () => {
+  it("accepts the shapes a numbered-options block produces", () => {
+    for (const t of ["1", "2.", "1)", "Option 3", "ja", "ok", "mach das", "go ahead", "do it"]) {
+      expect(isAffirmative(t), t).toBe(true);
+    }
+  });
+
+  it("rejects anything that carries content of its own", () => {
+    for (const t of [
+      "release und fixe auch den schess bug",
+      "ja, aber vorher noch die tests fixen",
+      "ok?",
+      "1 oder 2?",
+      "",
+      "mach den npm publish",
+    ]) {
+      expect(isAffirmative(t), t).toBe(false);
+    }
+  });
+});
+
+// The defect that blocked the 14.0.0 release three times over (2026-08-18).
+//
+// The ledger was ONE file per project root. This repo runs dozens of worktrees
+// against a single root, so a second conversation's prompt overwrote the file
+// between the user's authorization and the guard's read. The guard then saw a
+// foreign session id, discarded the record as another conversation's consent,
+// and refused with "no authorization in this turn's prompt" — a message that is
+// false and that nothing in it lets you falsify.
+describe("concurrent sessions", () => {
+  it("another session's prompt does not destroy this session's authorization", () => {
+    submit("ja, mach und merge den pr", "mine");
+    expect(ledger("mine").authorized).toContain("pr-merge");
+
+    // A different conversation in the same repo types something unrelated.
+    submit("lies den code", "other");
+
+    expect(preTool("gh pr merge 1412 --merge", "mine")).toBe(0);
+  });
+
+  it("and it does not lend its own authorization to anyone else", () => {
+    submit("mach den npm publish", "mine");
+    expect(preTool("npm publish", "other")).toBe(DISPATCHER_BLOCK);
+  });
+
+  it("keeps each session's refused-operation record apart", () => {
+    submit("mach den Release fertig", "mine");
+    expect(preTool("gh pr merge 1 --merge", "mine")).toBe(DISPATCHER_BLOCK);
+    // The other session answers ITS own question, not this one's.
+    submit("ja", "other");
+    expect(preTool("gh pr merge 1 --merge", "other")).toBe(DISPATCHER_BLOCK);
+    // The answer still belongs to the session that was refused.
+    submit("ja", "mine");
+    expect(preTool("gh pr merge 1 --merge", "mine")).toBe(0);
+  });
+
+  // The session id arrives from the host envelope, so it is untrusted input on
+  // a path. What matters is not that `.` disappears — it is legal in a filename
+  // — but that the id can never become more than ONE path component.
+  it("a session id cannot escape the state directory", () => {
+    const stateDir = path.resolve(tmp, "agents", "state");
+    for (const hostile of ["../../../etc/passwd", "a/b", "..", "x y", "/abs/path"]) {
+      for (const rel of [ledgerFileFor(hostile), pendingFileFor(hostile)]) {
+        const resolved = path.resolve(tmp, rel);
+        expect(resolved.startsWith(`${stateDir}${path.sep}`), `${hostile} → ${rel}`).toBe(true);
+        expect(path.relative(stateDir, resolved).split(path.sep)).toHaveLength(2);
+      }
+    }
+  });
+
+  it("falls back to the flat legacy ledger when no per-session file exists", () => {
+    fs.mkdirSync(path.dirname(path.join(tmp, STATE_FILE)), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, STATE_FILE),
+      JSON.stringify({
+        session_id: "mine",
+        detected_at: new Date().toISOString(),
+        authorized: ["pr-merge"],
+        evidence: {},
+        prompt_chars: 5,
+      }),
+    );
+    expect(preTool("gh pr merge 1 --merge", "mine")).toBe(0);
   });
 });

--- a/tests/scripts/git_authorization.test.ts
+++ b/tests/scripts/git_authorization.test.ts
@@ -536,7 +536,7 @@ describe("concurrent sessions", () => {
   // — but that the id can never become more than ONE path component.
   it("a session id cannot escape the state directory", () => {
     const stateDir = path.resolve(tmp, "agents", "state");
-    for (const hostile of ["../../../etc/passwd", "a/b", "..", "x y", "/abs/path"]) {
+    for (const hostile of ["../../../etc/passwd", "a/b", "..", "x y", "/abs/path"]) {
       for (const rel of [ledgerFileFor(hostile), pendingFileFor(hostile)]) {
         const resolved = path.resolve(tmp, rel);
         expect(resolved.startsWith(`${stateDir}${path.sep}`), `${hostile} → ${rel}`).toBe(true);


### PR DESCRIPTION
## What broke

The git-authorization ledger was **one file per project root**. Every prompt from
every concurrent session in the repo overwrote it. The `pre_tool_use` guard then
read a foreign `session_id`, correctly discarded the record as the consent of
another conversation, and refused with:

> Blocked: `pr-merge` with no authorization in this turn's prompt.

That message was false, and nothing in it let a reader falsify it. The
authorization existed; it had been clobbered between the prompt and the read.

## How it was measured

During the 14.0.0 release (2026-08-18), live:

| Observation | Value |
|---|---|
| User authorization | `ja, mach und merge den pr` — 25 chars, authorizes `pr-merge` |
| Ledger at the moment of the read | `prompt_chars: 11`, `authorized: []`, `session_id: cc545433…` |
| This session | `d68c9f8e…` |
| Refusals on a real, present authorization | 3 in a row |
| Further clobbers within six minutes | 2 more sessions (`875d9ac1…`, …) |

The installed hook was verified to classify the same prompt correctly when fed
it directly (`authorized: ["pr-create", "pr-merge"]`). Detection was never the
problem — retention was.

This repo runs dozens of worktrees against a single root, so the race is the
normal condition here, not an edge case.

## The fix

- **Ledger and pending record are per session** under `agents/state/`
  (`git-authorization/<session>.json`). `agents/state/` is gitignored; no tracked
  files are added.
- **The flat file stays readable as a fallback**, so a ledger written by an older
  build still counts during rollout.
- **The session id is untrusted input on a path** (it comes from the host
  envelope) and is reduced to exactly one path component. Pinned by a test over
  `../../../etc/passwd`, `a/b`, `..`, `x y` and an absolute path — the assertion
  checks the resolved path stays inside the state directory, not that dots
  disappear, because a dot is legal in a filename and a separator is not.

## Second defect, fixed with it

`user-interaction` requires a Hard-Floor decision to reach the user as a
numbered-options block, and the answer to one is `1` — which carries no
operation for the classifier to record. Consent was real, visible and
unrecordable.

The guard now records **which** op it refused, and only that op can be
confirmed, **once**, by the immediately following prompt: ten-minute window,
session-scoped, and only by a prompt that says yes and nothing else.

Widening the prose list with a bare `ja` was rejected — that would authorize
`npm publish` on any turn, which is reach rather than severity. A test pins that
`release und fixe auch den schess bug` still authorizes only `release`, because
a turn that opens new work is not an answer.

## Why one commit and not two

`pendingFileFor` belongs to the scoping change and resolves a constant the
confirmation change introduces, so either ordering leaves one commit referencing
a symbol its sibling adds.

## Evidence

- **183 tests pass across 13 files**, 11 of them new — including the reproduced
  deadlock and the cross-session clobber.
- `npm run typecheck` clean; ESLint clean on both changed source files.
- Prettier reports both source files as unformatted **before** this change too,
  so it is not this repo's formatting gate and nothing was reformatted.

## Not in this diff

Three further findings from the same session, deliberately left out:

1. Every release produces one red `publish-npm` run — two runs fire (tag push
   and `main` push), one wins, the loser gets `E403 cannot publish over the
   previously published versions`.
2. The pre-push preflight refuses a **delete-only** push: it checks the
   checked-out branch against `main` even when no ref is being advanced.
3. `release.yml` documents an "Approve workflows to run" checkpoint for a repo
   without `RELEASE_PR_TOKEN` that does not materialise here — the release ran
   straight through to merge. Recorded as a Known limitation in the 14.0.0
   changelog entry.
