### PR TITLE
fix(release): three defects the 14.0.0 release exposed in its own tooling

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -28,7 +28,25 @@ on:
         type: string
 
 concurrency:
-  group: publish-npm-${{ github.ref }}
+  # Keyed on the VERSION, never on `github.ref` — the two triggers for one
+  # release do not share a ref, so keying on the ref put them in two different
+  # groups and they raced.
+  #
+  # Measured on 14.0.0 (2026-08-18): release.ts dispatches this workflow with
+  # `--ref main` (so `github.ref` is `refs/heads/main`), while the PAT-pushed
+  # tag fires it natively with `refs/tags/14.0.0`. Both ran at 09:00, both
+  # passed the "Skip if already published" probe below because neither had
+  # published yet, both built, and the loser died on
+  # `E403 cannot publish over the previously published versions: 14.0.0`.
+  # The package shipped exactly once; the artefact was a red run on a green
+  # release, which is the kind of noise that trains people to ignore red.
+  #
+  # `github.ref_name` on a tag push is the bare version, and `inputs.tag` is
+  # the same string, so both triggers now land in one group. With
+  # cancel-in-progress false the second run waits and then finds the version
+  # on the registry — the idempotency probe becomes reachable instead of being
+  # raced past.
+  group: publish-npm-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
   cancel-in-progress: false
 
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,16 +23,23 @@ name: Release
 #
 #   - With RELEASE_PR_TOKEN (contents + pull-requests + actions): fully
 #     unattended end-to-end.
-#   - Without it (default): GitHub's bot-created-PR safeguard (introduced
-#     2026-06-11) queues the release PR's checks — including the required
-#     "Sync + Generate Tools Consistency" check — in an approval-required
-#     state, because the PR was opened via GITHUB_TOKEN. A maintainer must
-#     click "Approve workflows to run" on the release PR once per release
-#     before this job's `gh pr checks --watch` step can see them go green
-#     and proceed to merge. This is a deliberate, acceptable manual
-#     checkpoint for a production-release action (see
-#     docs/contracts/branch-protection-policy.md) — not a bug. Configure
-#     RELEASE_PR_TOKEN to remove it entirely.
+#   - Without it: DO NOT COUNT ON A MANUAL CHECKPOINT. This block used to
+#     promise one — that GitHub's bot-created-PR safeguard queues the release
+#     PR's checks in an approval-required state, so a maintainer must click
+#     "Approve workflows to run" once per release before `gh pr checks --watch`
+#     can proceed to merge. Measured on 14.0.0 (2026-08-18) on this repo with
+#     no RELEASE_PR_TOKEN configured: the checks started IMMEDIATELY, no
+#     approval was requested, and the run would have merged to main, tagged and
+#     published without a human touching it. The dispatched run had to be
+#     cancelled by hand to stop before the merge.
+#
+#     Whether the safeguard applies is a repository/organisation Actions
+#     setting, not a property of this workflow, so the honest contract is:
+#     **treat a dispatched release as unattended end-to-end unless you have
+#     verified the approval gate on THIS repo.** If you want a human gate
+#     before the merge, the reliable ones are a branch-protection required
+#     review (see docs/contracts/branch-protection-policy.md) or cancelling
+#     the run — not this comment.
 #
 # See also:
 #   - src/scripts/release.ts — the shared pipeline (--ci mode).
@@ -191,8 +198,9 @@ jobs:
               echo "❌  Release pipeline failed — see logs. Re-run this workflow (workflow_dispatch) to resume;"
               echo "    src/scripts/release.ts's --ci steps are idempotent."
               echo
-              echo "If the run is stuck waiting on PR checks: the release PR likely needs a maintainer to"
-              echo "click **Approve workflows to run** on it (GitHub's bot-created-PR safeguard) — see the"
-              echo "header comment in this workflow file for the RELEASE_PR_TOKEN alternative."
+              echo "If the run is stuck waiting on PR checks: check whether the release PR is waiting on a"
+              echo "maintainer clicking **Approve workflows to run** (GitHub's bot-created-PR safeguard)."
+              echo "That safeguard is a repo/org Actions setting and does NOT apply everywhere — on 14.0.0"
+              echo "it did not fire at all. If the checks are simply running, the run is not stuck."
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/decisions/ADR-113-ci-native-release-label-trigger.md
+++ b/docs/decisions/ADR-113-ci-native-release-label-trigger.md
@@ -91,6 +91,22 @@ in the PR's merge box. This is a deliberate GitHub security control
 (distinct from, but related to, the fork-first-time-contributor approval
 gate), not a bug in this design.
 
+**Correction (2026-08-18) — the finding above did not hold on this repo, and the
+decision must not lean on it.** During the 14.0.0 release, with no
+`RELEASE_PR_TOKEN` configured, the release PR's checks started immediately: no
+approval was requested, nothing sat in an approval-required state, and the
+dispatched run would have merged to `main`, tagged and published to npm without
+a human touching it. It was cancelled by hand to stop before the merge.
+
+The original finding is left standing as written because it records what GitHub's
+changelog documents and what was believed at decision time. What is corrected is
+the **consequence** drawn from it: the approval click is a repository /
+organisation Actions setting, not a property of this workflow, so it is not a
+checkpoint this design may assume. Treat a dispatched release as unattended
+end-to-end unless the gate has been verified on the repo in question. A
+dependable human gate before a release merge comes from the branch-protection
+ruleset or from cancelling the run.
+
 This repo's branch-protection ruleset (verified live via `gh api
 repos/event4u-app/agent-config/rulesets/17749383`) requires
 **zero** approving reviews (`required_approving_review_count: 0`) and

--- a/docs/succession.md
+++ b/docs/succession.md
@@ -31,7 +31,7 @@ bump + tag + GitHub Release); they gate the **downstream** publish/deploy legs.
 
 | Secret | Gates | Missing → |
 |---|---|---|
-| `RELEASE_PR_TOKEN` (optional PAT / App token, `contents:write` + `pull-requests:write`) | Unattended release PR checks in [`release.yml`](../.github/workflows/release.yml) | One manual **"Approve workflows to run"** click per release (deliberate checkpoint, not a failure). |
+| `RELEASE_PR_TOKEN` (optional PAT / App token, `contents:write` + `pull-requests:write`) | Unattended release PR checks in [`release.yml`](../.github/workflows/release.yml) | Possibly one manual **"Approve workflows to run"** click per release — **but do not rely on it as a gate.** Measured on 14.0.0 (2026-08-18) with the secret absent: checks started immediately, no approval was asked, and the run would have merged, tagged and published unattended. Whether the safeguard applies is a repo/org Actions setting. |
 | — (none: **npm OIDC Trusted Publishing**) | `publish-npm.yml` — uses `id-token: write`, no stored npm token | If OIDC trust is misconfigured on npmjs, npm publish fails; fix the trusted-publisher config on the npm package, not a secret. |
 | `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_WORKER_SUBDOMAIN`, `MCP_SMOKE_TOKEN` | `deploy-mcp-worker.yml` (MCP worker deploy + smoke) | MCP worker deploy skips/fails; core release unaffected. |
 | `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY` | `cross-model-canary.yml` + any AI-council / self-review automation | Canary + council automation skip; core release unaffected. |
@@ -48,7 +48,10 @@ grep -rhoE "secrets\.[A-Z_]+" .github/workflows/ | sort -u
 ## Operator-gated steps (need a human with credentials)
 
 - **Release-PR workflow approval** — the "Approve workflows to run" click when
-  `RELEASE_PR_TOKEN` is absent (see the runbook § 3.A).
+  `RELEASE_PR_TOKEN` is absent (see the runbook § 3.A). **Not a dependable
+  checkpoint:** it did not appear on 14.0.0 (2026-08-18) and the release ran
+  through to publish unattended. A human gate before a release merge has to come
+  from branch protection or from cancelling the run.
 - **Branch-protection ruleset** — applied in GitHub → Settings → Rules UI;
   source of truth mirrored in [`branch-protection-policy.md`](contracts/branch-protection-policy.md).
   Not in code; a successor edits it in the UI.

--- a/src/scripts/install-hooks.sh
+++ b/src/scripts/install-hooks.sh
@@ -35,6 +35,32 @@ cat > "$HOOKS_DIR/pre-push" << 'EOF'
 # so any derived-output drift blocks the push here. Runtime ~15-40s (it
 # regenerates the tool trees) — cheaper than a red CI run and a fixup re-push.
 
+# A delete-only push has no content to gate, so every check below is answering
+# a question nobody asked. Measured 2026-08-18 during the 14.0.0 release:
+# `git push origin --delete release/14.0.0` was refused by the branch-freshness
+# gate because the CHECKED-OUT branch was behind main — a fact with no bearing
+# on removing a remote ref. The deletion had to go through the GitHub API to
+# happen at all, which routes around the whole hook rather than around one gate.
+#
+# Git feeds pre-push one line per ref on stdin:
+#   <local ref> <local sha> <remote ref> <remote sha>
+# and a deletion carries the all-zero local sha. Reading stdin is safe here:
+# nothing below consumes it.
+delete_only=1
+saw_ref=0
+while read -r _local_ref local_sha _remote_ref _remote_sha; do
+    [ -z "${local_sha:-}" ] && continue
+    saw_ref=1
+    # Any non-zero character means a real object is being pushed.
+    case "$local_sha" in
+        *[!0]*) delete_only=0 ;;
+    esac
+done
+if [ "$saw_ref" = "1" ] && [ "$delete_only" = "1" ]; then
+    echo "🗑️  Delete-only push — no ref advances, so the content gates have nothing to check. Skipping."
+    exit 0
+fi
+
 fail=0
 
 if ! command -v task >/dev/null 2>&1; then

--- a/tests/scripts/prepush_delete_only.test.ts
+++ b/tests/scripts/prepush_delete_only.test.ts
@@ -1,0 +1,111 @@
+// The pre-push hook's delete-only short-circuit (src/scripts/install-hooks.sh).
+//
+// Measured 2026-08-18 during the 14.0.0 release: `git push origin --delete
+// release/14.0.0` was refused by the branch-freshness gate because the
+// CHECKED-OUT branch was behind main — a fact with no bearing on removing a
+// remote ref. The deletion then had to go through the GitHub API, which routes
+// around the entire hook rather than around the one gate that misfired.
+//
+// The hook body is generated text inside a heredoc, so the test extracts it the
+// way the installer writes it and runs the real script against synthetic stdin.
+// Asserting on the source string instead would pass while the shipped hook is
+// broken.
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const INSTALLER = path.resolve(__dirname, "../../src/scripts/install-hooks.sh");
+const ZERO = "0".repeat(40);
+const REAL = "9f1b2c3d4e5f60718293a4b5c6d7e8f901234567";
+const MARKER = "Delete-only push";
+
+let hook: string;
+
+/** The pre-push body exactly as install-hooks.sh writes it. */
+function extractPrePush(installer: string): string {
+  const lines = fs.readFileSync(installer, "utf8").split("\n");
+  const start = lines.findIndex((l) => l.includes(`cat > "$HOOKS_DIR/pre-push" <<`));
+  if (start === -1) {
+    throw new Error("pre-push heredoc not found — did install-hooks.sh change shape?");
+  }
+  const end = lines.findIndex((l, i) => i > start && l.trimEnd() === "EOF");
+  if (end === -1) {
+    throw new Error("pre-push heredoc has no terminator");
+  }
+  return `${lines.slice(start + 1, end).join("\n")}\n`;
+}
+
+beforeAll(() => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "prepush-"));
+  hook = path.join(dir, "pre-push");
+  fs.writeFileSync(hook, extractPrePush(INSTALLER), { mode: 0o755 });
+});
+
+/**
+ * Run the hook with `refs` on stdin, from a scratch cwd and a PATH without
+ * `task`, so the negative cases stop at the first content gate instead of
+ * regenerating the tree. Only the marker is asserted, never the exit code of
+ * that later failure.
+ */
+function run(refs: string): string {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "prepush-cwd-"));
+  try {
+    return execFileSync("bash", [hook], {
+      input: refs,
+      cwd,
+      encoding: "utf8",
+      env: {
+        PATH: "/usr/bin:/bin",
+        HOME: cwd,
+        AGENT_CONFIG_SKIP_PREPUSH_PREFLIGHT: "1",
+        AGENT_CONFIG_SKIP_PREPUSH_STATIC: "1",
+      },
+    });
+  } catch (e) {
+    const err = e as { stdout?: string; stderr?: string };
+    return `${err.stdout ?? ""}${err.stderr ?? ""}`;
+  }
+}
+
+describe("pre-push — delete-only push", () => {
+  it("extracts a hook body that actually looks like the hook", () => {
+    const body = extractPrePush(INSTALLER);
+    expect(body).toContain("#!/usr/bin/env bash");
+    expect(body).toContain("Preflight");
+    // Guard against the extractor silently grabbing a one-line slice.
+    expect(body.split("\n").length).toBeGreaterThan(40);
+  });
+
+  it("skips every content gate when the only ref is a deletion", () => {
+    const out = run(`(delete) ${ZERO} refs/heads/release/14.0.0 ${REAL}\n`);
+    expect(out).toContain(MARKER);
+    // Proof it short-circuited rather than merely printing on the way through.
+    expect(out).not.toContain("Preflight");
+  });
+
+  it("skips when several refs are all deletions", () => {
+    const out = run(
+      `(delete) ${ZERO} refs/heads/a ${REAL}\n(delete) ${ZERO} refs/heads/b ${REAL}\n`,
+    );
+    expect(out).toContain(MARKER);
+  });
+
+  it("does NOT skip an ordinary push", () => {
+    const out = run(`refs/heads/topic ${REAL} refs/heads/topic ${ZERO}\n`);
+    expect(out).not.toContain(MARKER);
+  });
+
+  it("does NOT skip when a deletion rides along with a real ref", () => {
+    const out = run(
+      `(delete) ${ZERO} refs/heads/old ${REAL}\nrefs/heads/topic ${REAL} refs/heads/topic ${ZERO}\n`,
+    );
+    expect(out).not.toContain(MARKER);
+  });
+
+  it("does NOT skip when git passes no refs at all", () => {
+    const out = run("");
+    expect(out).not.toContain(MARKER);
+  });
+});


### PR DESCRIPTION
Three defects found while shipping 14.0.0, each measured on that release, each in
its own commit. None of them broke the release — all three make the release
process lie to the next person who runs it.

## 1. Every release produces a red `publish-npm` run

`bbb60a895` · `.github/workflows/publish-npm.yml`

One release fires the workflow **twice**: `release.ts` dispatches it with
`--ref main`, and a PAT-pushed tag fires it natively on `refs/tags/X.Y.Z`. The
concurrency group was keyed on `github.ref`, so the two landed in *different*
groups and ran concurrently.

Both then passed the `Skip if already published` probe — neither had published
yet — both built, and the loser died on:

```
npm error 403 You cannot publish over the previously published versions: 14.0.0.
```

Measured on 14.0.0: two runs at 09:00, one success, one failure. The package
shipped exactly once, so the only artefact was **a red run on a green release** —
the noise that teaches people to stop reading red.

**Fix.** Key the group on the version instead of the ref, so both triggers land
in one group: `github.ref_name` on a tag push is the bare version, and
`inputs.tag` is the same string. With `cancel-in-progress: false` the second run
waits, then finds the version on the registry — the idempotency probe this
workflow *already carries* becomes reachable instead of being raced past. The
ternary is the shape this file already uses for the checkout `ref:`.

## 2. The pre-push hook refuses a delete-only push

`cc197371a` · `src/scripts/install-hooks.sh` + new test

Every gate in `pre-push` reasons about the **content** of a branch. A deletion
has none.

Measured: `git push origin --delete release/14.0.0` was refused by the
branch-freshness gate because the *checked-out* branch was behind `main` — a fact
with no bearing on removing a remote ref. The deletion had to go through the
GitHub API to happen at all, which routes around the **entire hook** rather than
around the one gate that misfired. That is the worst available outcome: a false
positive that trains the operator to bypass the whole gate set.

**Fix.** Git feeds `pre-push` one line per ref, and a deletion carries the
all-zero local sha. When every line is a deletion, the hook exits 0 early.

| Input | Skips? |
|---|---|
| one deletion | yes |
| several deletions | yes |
| ordinary push | no |
| deletion + real ref together | no |
| no refs on stdin | no |

Tested against the **real generated hook body**, not the source string: the test
extracts the heredoc exactly as the installer writes it and runs it with
synthetic stdin, so an assertion cannot pass while the shipped hook is broken.
Six cases, 29 ms.

## 3. `release.yml` promises an approval checkpoint that does not fire

`7327d2ea4` · `release.yml`, `docs/succession.md`, `ADR-113`

The header documented that without `RELEASE_PR_TOKEN`, GitHub queues a
bot-created release PR's checks in an approval-required state, so a maintainer
must click **Approve workflows to run** before the run can merge — and called it
a deliberate manual checkpoint.

Measured on 14.0.0 on this repo, secret absent: the checks started
**immediately**, no approval was requested, and the dispatched run would have
merged to `main`, tagged and published to npm with no human involved. It was
cancelled by hand to stop before the merge.

A documented safety checkpoint that is not there is worse than none, because it
is read as one. Whether the safeguard applies is a repository / organisation
Actions setting, not a property of this workflow.

**Fix.** All four live surfaces that carried the claim now say so: the
`release.yml` header, its stuck-run job summary, the succession secret table, and
the operator-gated list. **ADR-113 keeps its original finding verbatim** — it
records what GitHub's changelog documents and what was believed at decision time
— and gains a dated correction to the *consequence* drawn from it.

Roadmap copies under `agents/roadmaps/` are deliberately untouched: that layer is
transient and is not a surface a reader follows for current behaviour.

## Evidence

- `npm run typecheck` clean; ESLint clean on the new test.
- New pre-push test: 6 pass.
- Both changed workflows parse, and the concurrency expression resolves to the
  intended string.
- Checked byte-wise for NUL and other C0 control characters across all six
  changed files — clean. Stated because I shipped exactly that defect in the
  previous PR and it reddened two checks.

## What is not verified here

The publish-race fix cannot be proven until the next release fires both triggers
again — CI on this PR cannot exercise it. The prediction is falsifiable: the
next release should show one `publish-npm` run reaching `npm publish` and any
second run exiting green through the already-published probe, instead of one
`E403` failure.
