### PR TITLE
fix(r2): read inline acceptance criteria, stop faking an empty extraction

### DIFF
--- a/agents/evidence/reviews/fix-r2-ac-extraction-inline.findings.md
+++ b/agents/evidence/reviews/fix-r2-ac-extraction-inline.findings.md
@@ -1,11 +1,11 @@
 # Findings: fix-r2-ac-extraction-inline
-<!-- completion-review: v1 | reviewed: 2026-08-18 | scope: fccb8e46b6dd566dbf9ff51ab5246695cf663a7a6e5bf34eb67b98f022ef03f7 | diff: 604632b3c991933fb354e3afb50423697489d692 | reviewer: r2-fresh-subagent-fix-r2-ac-extraction-inline | prompt_hash: bbc6263c97285a0bf0ff550fe05d7299a9b187e2b947cbf4ab58f96aae2f9f14 -->
+<!-- completion-review: v1 | reviewed: 2026-08-18 | scope: a1db0037ca6442590e248f48da653fc0384cb95a702724c7df10e77a89b2d53d | diff: 61fdf7d26f1d9eb634c02451621c573784216bbe | reviewer: r2-fresh-subagent-fix-r2-ac-extraction-inline | prompt_hash: bbc6263c97285a0bf0ff550fe05d7299a9b187e2b947cbf4ab58f96aae2f9f14 -->
 <!-- evidence-type: v1 | type: current-binding | declared: 2026-08-18 -->
 
 <!-- context-manifest: v1
 inputs:
-  diff_sha: 604632b3c991933fb354e3afb50423697489d692
-  scope_hash: fccb8e46b6dd566dbf9ff51ab5246695cf663a7a6e5bf34eb67b98f022ef03f7
+  diff_sha: 61fdf7d26f1d9eb634c02451621c573784216bbe
+  scope_hash: a1db0037ca6442590e248f48da653fc0384cb95a702724c7df10e77a89b2d53d
   roadmap: none
   roadmap_hash: none
   ac_hash: none
@@ -16,12 +16,12 @@ dispatched: 2026-08-18T15:35:04Z
 
 | # | Severity | File:Line | Finding | Status | Reason/Ref |
 |---|----------|-----------|---------|--------|------------|
-| 1 | medium | src/scripts/dispatch_r2_reviewer.ts:648-652 | The new third prompt state asserts a fact the extractor cannot establish. `acGiven === false` emits "it declares NO acceptance criteria" for any empty extraction, including a roadmap that does declare criteria in a shape neither matcher recognises — `* **AC-1:**`, an indented `- **AC-1:**`, a bare `**AC-1:**` with no bullet, `### Acceptance Criteria` at h3, or any heading carrying trailing text such as `## Acceptance Criteria (AC)`. The pre-change failure was silent; the post-change failure is an affirmative false statement handed to the one independent check on AC conformance, so the reviewer has no reason to look. | open | |
-| 2 | medium | src/scripts/dispatch_r2_reviewer.ts:510-515 | The continuation walk breaks on the first blank line, so a loose-list AC bullet whose second paragraph is separated by a blank line is silently truncated. The result is a partial extraction that hashes to a real value, writes a non-empty `acceptance-criteria.md`, and reads as complete — the same looks-like-success shape the change exists to remove, relocated. The docblock justification is not true of standard markdown loose lists. No test covers a blank-separated continuation. | open | |
-| 3 | medium | src/scripts/dispatch_r2_reviewer.ts:435 + :1109 | "Are there criteria" is encoded twice, differently: `expectedHashes` uses truthiness while `runDispatch` uses `acText !== null && acText !== ''`. They agree only because `''` is the sole reachable falsy string today. Any later refinement of one makes the manifest and the prompt disagree about the same fact — the two-places-disagree failure this diff repairs, reintroduced one level up. No single predicate, and no test pins the pair. | open | |
-| 4 | low | tests/scripts/dispatch_r2_reviewer.test.ts:761 | The `ac_hash` expectation is computed with the function under test, so it cannot fail on an extraction defect — it only pins "the dispatcher hashes whatever the extractor returned". A literal expected string would make the assertion load-bearing. | open | |
-| 5 | low | src/scripts/dispatch_r2_reviewer.ts:508-515 | An indented nested `- **AC-n:**` bullet is folded into its parent as a continuation rather than emitted as its own criterion, and the `i = j` advance makes the skip permanent. No content is lost, but the extraction shape — and therefore `ac_hash` — becomes a function of indentation depth. Undocumented and untested. | open | |
-| 6 | low | docs/contracts/plan-review-gates.md:712-717 | The "none of them go red" guarantee for the 17 historical empty-string `ac_hash` artefacts rests on `--verify-current`'s scope-based selection. The single-artefact `--verify <path>` entry point has no such selection. Harmless in practice only because `scope_hash` already diverges for a foreign artefact — a different reason than the one the paragraph gives, and the paragraph is what a future reader will trust. | open | |
+| 1 | medium | src/scripts/dispatch_r2_reviewer.ts:648-652 | The new third prompt state asserts a fact the extractor cannot establish. `acGiven === false` emits "it declares NO acceptance criteria" for any empty extraction, including a roadmap that does declare criteria in a shape neither matcher recognises — `* **AC-1:**`, an indented `- **AC-1:**`, a bare `**AC-1:**` with no bullet, `### Acceptance Criteria` at h3, or any heading carrying trailing text such as `## Acceptance Criteria (AC)`. The pre-change failure was silent; the post-change failure is an affirmative false statement handed to the one independent check on AC conformance, so the reviewer has no reason to look. | fixed | 61fdf7d26 — the empty branch now reports the EXTRACTION and names both causes; the trailing-qualifier heading it named was live in 2 roadmaps and is now matched |
+| 2 | medium | src/scripts/dispatch_r2_reviewer.ts:510-515 | The continuation walk breaks on the first blank line, so a loose-list AC bullet whose second paragraph is separated by a blank line is silently truncated. The result is a partial extraction that hashes to a real value, writes a non-empty `acceptance-criteria.md`, and reads as complete — the same looks-like-success shape the change exists to remove, relocated. The docblock justification is not true of standard markdown loose lists. No test covers a blank-separated continuation. | fixed | 61fdf7d26 — a blank ends a criterion only when the next non-blank line is not an indented continuation |
+| 3 | medium | src/scripts/dispatch_r2_reviewer.ts:435 + :1109 | "Are there criteria" is encoded twice, differently: `expectedHashes` uses truthiness while `runDispatch` uses `acText !== null && acText !== ''`. They agree only because `''` is the sole reachable falsy string today. Any later refinement of one makes the manifest and the prompt disagree about the same fact — the two-places-disagree failure this diff repairs, reintroduced one level up. No single predicate, and no test pins the pair. | fixed | 61fdf7d26 — one exported predicate `hasAcceptanceCriteria` behind both sites, with a parity test |
+| 4 | low | tests/scripts/dispatch_r2_reviewer.test.ts:761 | The `ac_hash` expectation is computed with the function under test, so it cannot fail on an extraction defect — it only pins "the dispatcher hashes whatever the extractor returned". A literal expected string would make the assertion load-bearing. | fixed | 61fdf7d26 — literal expectation hoisted to `ROADMAP_INLINE_AC_EXPECTED` |
+| 5 | low | src/scripts/dispatch_r2_reviewer.ts:508-515 | An indented nested `- **AC-n:**` bullet is folded into its parent as a continuation rather than emitted as its own criterion, and the `i = j` advance makes the skip permanent. No content is lost, but the extraction shape — and therefore `ac_hash` — becomes a function of indentation depth. Undocumented and untested. | fixed | 61fdf7d26 — indent-tolerant bullet pattern; a nested criterion is emitted as its own row |
+| 6 | low | docs/contracts/plan-review-gates.md:712-717 | The "none of them go red" guarantee for the 17 historical empty-string `ac_hash` artefacts rests on `--verify-current`'s scope-based selection. The single-artefact `--verify <path>` entry point has no such selection. Harmless in practice only because `scope_hash` already diverges for a foreign artefact — a different reason than the one the paragraph gives, and the paragraph is what a future reader will trust. | fixed | 61fdf7d26 — both reasons stated, with the `--verify <path>` gap named explicitly |
 
 ## Reviewer dispatch — declared prompt delta
 
@@ -34,3 +34,19 @@ the scope hash are the dispatcher's own.
 Declared because `check_review_prompt_binding` hashes the committed `prompt.md`
 rather than the text actually sent, and its own header names that substitution as
 undetectable. A declared delta is checkable; a silent match is not.
+
+## Re-bind — 2026-08-18
+
+Re-bound once, from scope `fccb8e46…` (head `604632b3c`) to `a1db0037…` (head
+`61fdf7d26`), after the single fix pass that closed all six rows. Three fields
+hand-edited and nothing else: `scope:` and `diff:` in the header marker, and
+`scope_hash` / `diff_sha` in the manifest. `roadmap_hash` and `ac_hash` are
+`none` on both sides (this branch carries no roadmap) and `prompt_hash` is
+unchanged, because `prompt.md` was not touched.
+
+`diff.patch` is deliberately left at the reviewed revision. It is the record of
+what the reviewer actually read, and regenerating it would replace that record
+with content nobody reviewed.
+
+No `--force` at any point: it overwrites, and the only thing it would have
+destroyed is the record of the review that happened.

--- a/agents/evidence/reviews/fix-r2-ac-extraction-inline.findings.md
+++ b/agents/evidence/reviews/fix-r2-ac-extraction-inline.findings.md
@@ -1,0 +1,36 @@
+# Findings: fix-r2-ac-extraction-inline
+<!-- completion-review: v1 | reviewed: 2026-08-18 | scope: fccb8e46b6dd566dbf9ff51ab5246695cf663a7a6e5bf34eb67b98f022ef03f7 | diff: 604632b3c991933fb354e3afb50423697489d692 | reviewer: r2-fresh-subagent-fix-r2-ac-extraction-inline | prompt_hash: bbc6263c97285a0bf0ff550fe05d7299a9b187e2b947cbf4ab58f96aae2f9f14 -->
+<!-- evidence-type: v1 | type: current-binding | declared: 2026-08-18 -->
+
+<!-- context-manifest: v1
+inputs:
+  diff_sha: 604632b3c991933fb354e3afb50423697489d692
+  scope_hash: fccb8e46b6dd566dbf9ff51ab5246695cf663a7a6e5bf34eb67b98f022ef03f7
+  roadmap: none
+  roadmap_hash: none
+  ac_hash: none
+excluded: [session-history, agents/runtime, implementation-context]
+tools: [git-diff-branch-scoped, file-read-branch-paths]
+dispatched: 2026-08-18T15:35:04Z
+-->
+
+| # | Severity | File:Line | Finding | Status | Reason/Ref |
+|---|----------|-----------|---------|--------|------------|
+| 1 | medium | src/scripts/dispatch_r2_reviewer.ts:648-652 | The new third prompt state asserts a fact the extractor cannot establish. `acGiven === false` emits "it declares NO acceptance criteria" for any empty extraction, including a roadmap that does declare criteria in a shape neither matcher recognises — `* **AC-1:**`, an indented `- **AC-1:**`, a bare `**AC-1:**` with no bullet, `### Acceptance Criteria` at h3, or any heading carrying trailing text such as `## Acceptance Criteria (AC)`. The pre-change failure was silent; the post-change failure is an affirmative false statement handed to the one independent check on AC conformance, so the reviewer has no reason to look. | open | |
+| 2 | medium | src/scripts/dispatch_r2_reviewer.ts:510-515 | The continuation walk breaks on the first blank line, so a loose-list AC bullet whose second paragraph is separated by a blank line is silently truncated. The result is a partial extraction that hashes to a real value, writes a non-empty `acceptance-criteria.md`, and reads as complete — the same looks-like-success shape the change exists to remove, relocated. The docblock justification is not true of standard markdown loose lists. No test covers a blank-separated continuation. | open | |
+| 3 | medium | src/scripts/dispatch_r2_reviewer.ts:435 + :1109 | "Are there criteria" is encoded twice, differently: `expectedHashes` uses truthiness while `runDispatch` uses `acText !== null && acText !== ''`. They agree only because `''` is the sole reachable falsy string today. Any later refinement of one makes the manifest and the prompt disagree about the same fact — the two-places-disagree failure this diff repairs, reintroduced one level up. No single predicate, and no test pins the pair. | open | |
+| 4 | low | tests/scripts/dispatch_r2_reviewer.test.ts:761 | The `ac_hash` expectation is computed with the function under test, so it cannot fail on an extraction defect — it only pins "the dispatcher hashes whatever the extractor returned". A literal expected string would make the assertion load-bearing. | open | |
+| 5 | low | src/scripts/dispatch_r2_reviewer.ts:508-515 | An indented nested `- **AC-n:**` bullet is folded into its parent as a continuation rather than emitted as its own criterion, and the `i = j` advance makes the skip permanent. No content is lost, but the extraction shape — and therefore `ac_hash` — becomes a function of indentation depth. Undocumented and untested. | open | |
+| 6 | low | docs/contracts/plan-review-gates.md:712-717 | The "none of them go red" guarantee for the 17 historical empty-string `ac_hash` artefacts rests on `--verify-current`'s scope-based selection. The single-artefact `--verify <path>` entry point has no such selection. Harmless in practice only because `scope_hash` already diverges for a foreign artefact — a different reason than the one the paragraph gives, and the paragraph is what a future reader will trust. | open | |
+
+## Reviewer dispatch — declared prompt delta
+
+The prompt sent to the reviewer differs from the hashed `prompt.md` in three
+mechanical respects: the working directory, the path to `diff.patch`, and a
+return-the-table-as-text instruction in place of write-the-file. It carried no
+verdict expectation and no scope narrowing — the changed-file list, the diff and
+the scope hash are the dispatcher's own.
+
+Declared because `check_review_prompt_binding` hashes the committed `prompt.md`
+rather than the text actually sent, and its own header names that substitution as
+undetectable. A declared delta is checkable; a silent match is not.

--- a/agents/evidence/reviews/fix-r2-ac-extraction-inline.review-input/diff.patch
+++ b/agents/evidence/reviews/fix-r2-ac-extraction-inline.review-input/diff.patch
@@ -1,0 +1,340 @@
+diff --git a/docs/contracts/plan-review-gates.md b/docs/contracts/plan-review-gates.md
+index 5e0318a56468f9239b60611db93ab51ef895fd36..167f26daa0940fa5fa976840d66ab7ec4b2d301d 100644
+--- a/docs/contracts/plan-review-gates.md
++++ b/docs/contracts/plan-review-gates.md
+@@ -674,7 +674,7 @@ inputs:
+   scope_hash: <64-hex § 2.0 review-scope hash — compared>
+   roadmap: <path>
+   roadmap_hash: <sha256>
+-  ac_hash: <sha256 of the extracted Acceptance Criteria block>
++  ac_hash: <sha256 of the extracted acceptance criteria, or `none` when there are none>
+ excluded: [session-history, agents/runtime, implementation-context]
+ tools: [git-diff-branch-scoped, file-read-branch-paths]
+ dispatched: YYYY-MM-DDTHH:MM:SSZ
+@@ -691,6 +691,30 @@ dispatched: YYYY-MM-DDTHH:MM:SSZ
+   Exit `2` in `--verify` is reserved for genuine internal failures (the file
+   is missing or unreadable, git fails). A bare § 2.4 skip declaration
+   carries no reviewer dispatch and needs no manifest.
++- **Acceptance criteria are read in BOTH authored forms, and their absence is
++  said out loud.** The dispatcher extracts either a `## Acceptance Criteria`
++  section (heading form, 21 of the 44 active roadmaps as of 2026-08-18) or inline
++  `- **AC-n:**` bullets declared per phase (7 of 44); the heading form wins if a
++  file ever carries both. When neither is present, `ac_hash` is **`none`** and the
++  reviewer's prompt states that the roadmap declares no criteria — it does not
++  claim an extraction.
++
++  This is a repair, not a refinement. The extractor previously matched the heading
++  only, so an inline-only roadmap produced an empty extraction that was then
++  hashed: `ac_hash` recorded `e3b0c442…b855`, the SHA-256 of the empty string,
++  which looks like a real hash in the manifest and re-derives identically on
++  `--verify-current` — so this gate **confirmed a criteria set that was never
++  there**, while the reviewer was handed a 0-byte `acceptance-criteria.md` under a
++  prompt saying the criteria had been extracted. The R2 reviewer is the
++  independent check on AC conformance, so the effect was to blind that check while
++  the artefact read as though it had run.
++
++  **Historical artefacts are deliberately left alone.** 17 committed findings
++  files carry the empty-string `ac_hash`; only the handful whose roadmap is
++  inline-only were the defect, and `--verify-current` re-derives the *current*
++  PR's artefact only, so none of them go red. An artefact dispatched before this
++  change whose roadmap is inline-only will mismatch on its next re-derivation and
++  needs a re-bind (a hand-edit of `ac_hash`), exactly like any other moved input.
+ - **Compared set:** `scope_hash`, `roadmap_hash`, `ac_hash`. `diff_sha` is
+   provenance and is never compared, for the § 2.0 reasons. The manifest's
+   `scope_hash` must also agree with the header's `scope:`; a disagreement is
+diff --git a/src/scripts/dispatch_r2_reviewer.ts b/src/scripts/dispatch_r2_reviewer.ts
+index c72f599425048a3120bcd16a46abde6e373c076c..21896d0c62950058259df89bb5448cfee8053d29 100644
+--- a/src/scripts/dispatch_r2_reviewer.ts
++++ b/src/scripts/dispatch_r2_reviewer.ts
+@@ -426,13 +426,46 @@ export function expectedHashes(args: {
+     return {
+         scope_hash: sha256(args.scopeDiffText),
+         roadmap_hash: args.roadmapText == null ? 'none' : sha256(args.roadmapText),
+-        ac_hash: args.acText == null ? 'none' : sha256(args.acText),
++        // Falsy, not `== null`. An empty extraction used to hash to
++        // e3b0c44298fc…b855 — the SHA-256 of the empty string, which looks like
++        // a real hash in the manifest and re-derives identically on
++        // `--verify-current`, so the gate confirmed a criteria set that was
++        // never there. `'none'` is the value that already means "no input" for
++        // `roadmap_hash`; an absent AC block gets the same word.
++        ac_hash: args.acText ? sha256(args.acText) : 'none',
+     };
+ }
+ 
+ /**
+- * Extract the `## Acceptance Criteria` section — from that heading (inclusive)
+- * to the next `## ` heading or EOF. No section → empty string.
++ * Extract a roadmap's acceptance criteria in either form the tree uses.
++ *
++ * Two forms, because roadmap authors write both and the reviewer needs whichever
++ * one is present:
++ *
++ * 1. A `## Acceptance Criteria` section — from that heading (inclusive) to the
++ *    next `## ` heading or EOF.
++ * 2. Inline `- **AC-n:**` bullets, declared per phase with no section heading —
++ *    collected with their indented continuation lines.
++ *
++ * Neither form → empty string, and every caller must treat that as "no criteria"
++ * rather than as an extracted-and-empty block: see {@link expectedHashes} and the
++ * prompt's roadmap line.
++ *
++ * The heading form is tried first and wins outright when found. Measured
++ * 2026-08-18 over the 44 active roadmaps: 21 heading-only, 7 inline-only, 0
++ * carrying both, 16 carrying neither — so the two forms do not currently
++ * co-occur and a precedence rule is a guard against a future file rather than a
++ * choice between live populations.
++ *
++ * WHY THE INLINE FORM WAS MISSING, stated because this is the second instance of
++ * the same defect class in this one function. The first was case sensitivity
++ * (`## Acceptance criteria` extracted nothing, found by the zcs-close R2 review
++ * 2026-08-09). The second is this: an inline-only roadmap yielded `''`, nothing
++ * downstream noticed, and the reviewer was handed a 0-byte
++ * `acceptance-criteria.md` under a prompt that said the criteria had been
++ * extracted. The R2 reviewer is the independent check on AC conformance, so
++ * blinding it while the artefact reads as though it checked is the
++ * gate-that-scans-nothing-exits-green shape one layer up.
+  */
+ export function extractAcceptanceCriteria(roadmapText: string): string {
+     const lines = roadmapText.split('\n');
+@@ -446,15 +479,42 @@ export function extractAcceptanceCriteria(roadmapText: string): string {
+             break;
+         }
+     }
+-    if (start === -1) return '';
+-    let end = lines.length;
+-    for (let i = start + 1; i < lines.length; i++) {
+-        if (/^## /.test(lines[i] as string)) {
+-            end = i;
+-            break;
++    if (start !== -1) {
++        let end = lines.length;
++        for (let i = start + 1; i < lines.length; i++) {
++            if (/^## /.test(lines[i] as string)) {
++                end = i;
++                break;
++            }
++        }
++        return lines.slice(start, end).join('\n');
++    }
++    return extractInlineAcceptanceCriteria(lines);
++}
++
++/**
++ * Collect inline `- **AC-n:**` bullets and their continuation lines.
++ *
++ * A continuation line is indented and non-blank. The walk stops at the first
++ * blank or non-indented line, which is what separates one criterion from the
++ * prose or heading that follows it. Bullets are emitted in file order and
++ * separated by nothing but their own newline: each one is self-labelling
++ * (`AC-0`, `AC-1`, …), so a synthetic section heading would be text this
++ * function invented rather than text the roadmap declared.
++ */
++function extractInlineAcceptanceCriteria(lines: readonly string[]): string {
++    const out: string[] = [];
++    for (let i = 0; i < lines.length; i++) {
++        if (!/^- \*\*AC-/.test(lines[i] as string)) continue;
++        out.push(lines[i] as string);
++        for (let j = i + 1; j < lines.length; j++) {
++            const line = lines[j] as string;
++            if (!/^\s+\S/.test(line)) break;
++            out.push(line);
++            i = j;
+         }
+     }
+-    return lines.slice(start, end).join('\n');
++    return out.join('\n');
+ }
+ 
+ /**
+@@ -576,11 +636,20 @@ function reviewerPrompt(args: {
+     headSha: string;
+     scopeHash: string;
+     roadmapGiven: boolean;
++    acGiven: boolean;
+     changedFiles: readonly string[];
+ }): string {
+-    const roadmapLine = args.roadmapGiven
+-        ? '- roadmap under review: `roadmap.md` (Acceptance Criteria extracted to `acceptance-criteria.md`)'
+-        : '- roadmap under review: none (`acceptance-criteria.md` is empty)';
++    // Three states, not two. Branching on `roadmapGiven` alone told the reviewer
++    // "Acceptance Criteria extracted" whenever a roadmap was supplied — including
++    // when the extraction returned nothing and the file beside it was 0 bytes. A
++    // reviewer told the criteria are in a file it finds empty has no way to tell
++    // an extraction failure from a roadmap that genuinely declares none, so it
++    // cannot report the gap. Say which of the two it is.
++    const roadmapLine = !args.roadmapGiven
++        ? '- roadmap under review: none (`acceptance-criteria.md` is empty)'
++        : args.acGiven
++          ? '- roadmap under review: `roadmap.md` (Acceptance Criteria extracted to `acceptance-criteria.md`)'
++          : '- roadmap under review: `roadmap.md` — it declares NO acceptance criteria, so `acceptance-criteria.md` is empty. Review the diff on its own terms and say so if the roadmap should have carried criteria.';
+     return [
+         `# R2 completion review — ${args.slug}`,
+         '',
+@@ -1037,6 +1106,7 @@ function runDispatch(args: Args): number {
+         headSha,
+         scopeHash: hashes.scope_hash,
+         roadmapGiven: roadmapText !== null,
++        acGiven: acText !== null && acText !== '',
+         changedFiles,
+     });
+     const manifest = deriveManifest({
+diff --git a/tests/scripts/dispatch_r2_reviewer.test.ts b/tests/scripts/dispatch_r2_reviewer.test.ts
+index f447231d8f4a66ad74976acb5cf7a107862a7d33..4025fe59b0b78cb8d31f38e9148d25bdf7a90387 100644
+--- a/tests/scripts/dispatch_r2_reviewer.test.ts
++++ b/tests/scripts/dispatch_r2_reviewer.test.ts
+@@ -95,8 +95,35 @@ function scopeDiff(repo: string, base = 'main'): string {
+     return git(repo, ...reviewScopeDiffArgs(base));
+ }
+ 
++/**
++ * A roadmap declaring its criteria as inline `- **AC-n:**` bullets per phase,
++ * with no `## Acceptance Criteria` heading anywhere — the form 7 of the 44 active
++ * roadmaps use. Continuation lines are indented two spaces, and the trailing
++ * prose exists so a test can prove the collector stops rather than swallowing it.
++ */
++const ROADMAP_INLINE_AC = [
++    '# Road Y',
++    '',
++    '## Phase 1',
++    '- [ ] step',
++    '- **AC-0:** the first criterion holds, and this line wraps',
++    '  onto a continuation the collector must keep.',
++    '',
++    '## Phase 2',
++    '- [ ] other step',
++    '- **AC-1:** the second criterion holds.',
++    '',
++    'Trailing prose that is NOT a criterion and must not be collected.',
++    '',
++].join('\n');
++
++/** A roadmap that declares no acceptance criteria in either form. */
++const ROADMAP_NO_AC = ['# Road Z', '', '## Phase 1', '- [ ] step', '', '## Notes', '', 'tail', ''].join(
++    '\n',
++);
++
+ /** Fresh git repo: main with roadmap + a.txt, then a feature branch with one commit. */
+-function initRepo(opts: { branch?: boolean } = {}): string {
++function initRepo(opts: { branch?: boolean; roadmap?: string } = {}): string {
+     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'r2-dispatch-'));
+     tmpDirs.push(dir);
+     git(dir, 'init', '-q', '-b', 'main');
+@@ -104,7 +131,7 @@ function initRepo(opts: { branch?: boolean } = {}): string {
+     git(dir, 'config', 'user.name', 'r2');
+     git(dir, 'config', 'commit.gpgsign', 'false');
+     write(dir, 'a.txt', 'base\n');
+-    write(dir, 'agents/roadmaps/road-x.md', ROADMAP);
++    write(dir, 'agents/roadmaps/road-x.md', opts.roadmap ?? ROADMAP);
+     git(dir, 'add', '-A');
+     git(dir, 'commit', '-qm', 'init');
+     if (opts.branch !== false) {
+@@ -657,6 +684,109 @@ describe('dispatch_r2_reviewer — pure helpers', () => {
+         expect(extractAcceptanceCriteria(lower)).toContain('- crit A');
+     });
+ 
++    it('extractAcceptanceCriteria collects inline AC bullets with their continuation lines', () => {
++        // The second instance of the same defect class as the case-sensitivity
++        // bug above: an inline-only roadmap yielded '', the reviewer got a
++        // 0-byte acceptance-criteria.md, and the prompt said the criteria had
++        // been extracted. Measured 2026-08-18: 7 of 44 active roadmaps are
++        // inline-only, including the one the backlog named as the next pick.
++        const ac = extractAcceptanceCriteria(ROADMAP_INLINE_AC);
++        expect(ac).toBe(
++            [
++                '- **AC-0:** the first criterion holds, and this line wraps',
++                '  onto a continuation the collector must keep.',
++                '- **AC-1:** the second criterion holds.',
++            ].join('\n'),
++        );
++    });
++
++    it('extractAcceptanceCriteria stops at the first blank or non-indented line', () => {
++        // Over-collection is the failure that would look like success: a
++        // collector running to EOF would ship the whole roadmap tail as
++        // "criteria" and the positive test above would still pass.
++        //
++        // The first two assertions are this test's OWN vacuity guard, and they
++        // are not decoration — a mutation run proved the exclusions below pass
++        // over an empty string, i.e. the test would have gone green against the
++        // exact defect it exists to catch. Assert there is something to exclude
++        // FROM before excluding anything.
++        const ac = extractAcceptanceCriteria(ROADMAP_INLINE_AC);
++        expect(ac).not.toBe('');
++        expect(ac).toContain('- **AC-1:**');
++        expect(ac).not.toContain('Trailing prose');
++        expect(ac).not.toContain('## Phase 2');
++        expect(ac).not.toContain('- [ ] other step');
++    });
++
++    it('extractAcceptanceCriteria prefers the heading form when a roadmap carries both', () => {
++        // No roadmap in the tree carries both today (21 heading-only, 7
++        // inline-only, 0 both), so this pins a precedence rule against a future
++        // file rather than resolving a live ambiguity.
++        const both = [ROADMAP, '- **AC-9:** an inline bullet added later.', ''].join('\n');
++        const ac = extractAcceptanceCriteria(both);
++        expect(ac).toContain('- AC one');
++        expect(ac).not.toContain('AC-9');
++    });
++
++    it('extractAcceptanceCriteria returns empty string when neither form is present', () => {
++        expect(extractAcceptanceCriteria(ROADMAP_NO_AC)).toBe('');
++    });
++
++    it('expectedHashes maps an EMPTY extraction to none, not to the empty-string hash', () => {
++        // e3b0c442…b855 is sha256(''). It was recorded whenever extraction came
++        // back empty, looks like a real hash in the manifest, and re-derives
++        // identically on --verify-current — so the gate confirmed a criteria set
++        // that was never there. Named explicitly so a revert cannot pass.
++        const EMPTY_SHA = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
++        expect(sha256('')).toBe(EMPTY_SHA);
++        const h = expectedHashes({ scopeDiffText: 'd', roadmapText: 'r', acText: '' });
++        expect(h.ac_hash).toBe('none');
++        expect(h.ac_hash).not.toBe(EMPTY_SHA);
++        // A non-empty extraction still hashes.
++        expect(expectedHashes({ scopeDiffText: 'd', roadmapText: 'r', acText: 'x' }).ac_hash).toBe(
++            sha256('x'),
++        );
++    });
++
++    it('dispatch on an inline-AC roadmap writes real criteria and a prompt that claims extraction', () => {
++        const repo = initRepo({ roadmap: ROADMAP_INLINE_AC });
++        const res = run(dispatchArgs(repo, ['--format', 'json']));
++        expect(res.status, res.stderr).toBe(0);
++        const out = JSON.parse(res.stdout) as { hashes: { ac_hash: string } };
++
++        const inputDir = path.join(repo, OUT, `${SLUG}.review-input`);
++        const acFile = fs.readFileSync(path.join(inputDir, 'acceptance-criteria.md'), 'utf-8');
++        expect(acFile).toContain('- **AC-0:**');
++        expect(acFile).toContain('- **AC-1:**');
++        expect(out.hashes.ac_hash).toBe(sha256(extractAcceptanceCriteria(ROADMAP_INLINE_AC)));
++        expect(out.hashes.ac_hash).not.toBe('none');
++
++        // The vacuity guard for the next test: prove the "extracted" wording is
++        // what a criteria-carrying roadmap actually produces, so asserting its
++        // ABSENCE below is a real assertion rather than a tautology over prose
++        // that never appears.
++        const prompt = fs.readFileSync(path.join(inputDir, 'prompt.md'), 'utf-8');
++        expect(prompt).toContain('Acceptance Criteria extracted to `acceptance-criteria.md`');
++    });
++
++    it('dispatch on a roadmap with no criteria records none and tells the reviewer so', () => {
++        const repo = initRepo({ roadmap: ROADMAP_NO_AC });
++        const res = run(dispatchArgs(repo, ['--format', 'json']));
++        expect(res.status, res.stderr).toBe(0);
++        const out = JSON.parse(res.stdout) as { hashes: { roadmap_hash: string; ac_hash: string } };
++
++        // A roadmap WAS supplied — so this is the third state, distinct from
++        // "no roadmap", and the reviewer must be able to tell them apart.
++        expect(out.hashes.roadmap_hash).toBe(sha256(ROADMAP_NO_AC));
++        expect(out.hashes.ac_hash).toBe('none');
++
++        const inputDir = path.join(repo, OUT, `${SLUG}.review-input`);
++        expect(fs.readFileSync(path.join(inputDir, 'acceptance-criteria.md'), 'utf-8')).toBe('');
++        const prompt = fs.readFileSync(path.join(inputDir, 'prompt.md'), 'utf-8');
++        expect(prompt).toContain('it declares NO acceptance criteria');
++        expect(prompt).not.toContain('Acceptance Criteria extracted');
++    });
++
+     it('reviewScopeDiffArgs excludes every gate-owned evidence path from the reviewed scope', () => {
+         const argv = reviewScopeDiffArgs('origin/main');
+         // Asserted as structure, not as a frozen array: the byte-stability flag

--- a/agents/evidence/reviews/fix-r2-ac-extraction-inline.review-input/prompt.md
+++ b/agents/evidence/reviews/fix-r2-ac-extraction-inline.review-input/prompt.md
@@ -1,0 +1,55 @@
+# R2 completion review — fix-r2-ac-extraction-inline
+
+You are a FRESH reviewer subagent. You have no implementation context and
+you must not acquire any (blind-review pattern, plan-review-gates.md §5).
+
+## Review mode
+
+Senior-engineer review of the branch diff. Search grid — hunt for:
+
+- errors
+- inconsistent logic
+- inefficiencies
+- bug-producing patterns
+
+## Rules
+
+- Review only — write no code, fix nothing.
+- Tool allowlist (contract §5): branch-scoped `git diff` + reads of
+  branch-touched files only; no `git log` beyond the branch, no repo-wide
+  grep, no reads of `agents/runtime/` or session artifacts.
+
+## Inputs
+
+- diff: `diff.patch` — the review scope (branch head 604632b3c991933fb354e3afb50423697489d692, review
+  artefacts excluded), scope hash `fccb8e46b6dd566dbf9ff51ab5246695cf663a7a6e5bf34eb67b98f022ef03f7`
+- roadmap under review: none (`acceptance-criteria.md` is empty)
+
+Changed files:
+
+- docs/contracts/plan-review-gates.md
+- src/scripts/dispatch_r2_reviewer.ts
+- tests/scripts/dispatch_r2_reviewer.test.ts
+
+## Output format (contract §2.2)
+
+Fill the findings table in `fix-r2-ac-extraction-inline.findings.md`:
+
+```markdown
+| # | Severity | File:Line | Finding | Status | Reason/Ref |
+|---|----------|-----------|---------|--------|------------|
+| 1 | critical | src/x.ts:42 | ... | open | |
+```
+
+- Severity ∈ {`critical`, `high`, `medium`, `low`}, rows sorted descending
+  by severity (ties keep authoring order).
+- Initial status of every finding: `open`.
+- A row is LIVE wherever it appears — a code fence around it changes
+  nothing. If you quote the template as an illustration, its Status cell
+  must be exactly `example`, or the gate reads it as a real finding.
+- 0 findings → replace the table with exactly this honest-null line
+  (contract §2.3):
+
+```markdown
+**Honest-null:** 0 findings, scope fccb8e46b6dd566dbf9ff51ab5246695cf663a7a6e5bf34eb67b98f022ef03f7, reviewed <YYYY-MM-DD>
+```

--- a/docs/contracts/plan-review-gates.md
+++ b/docs/contracts/plan-review-gates.md
@@ -691,13 +691,26 @@ dispatched: YYYY-MM-DDTHH:MM:SSZ
   Exit `2` in `--verify` is reserved for genuine internal failures (the file
   is missing or unreadable, git fails). A bare § 2.4 skip declaration
   carries no reviewer dispatch and needs no manifest.
-- **Acceptance criteria are read in BOTH authored forms, and their absence is
-  said out loud.** The dispatcher extracts either a `## Acceptance Criteria`
-  section (heading form, 21 of the 44 active roadmaps as of 2026-08-18) or inline
-  `- **AC-n:**` bullets declared per phase (7 of 44); the heading form wins if a
-  file ever carries both. When neither is present, `ac_hash` is **`none`** and the
-  reviewer's prompt states that the roadmap declares no criteria — it does not
-  claim an extraction.
+- **Acceptance criteria are read in BOTH authored forms, and a failed extraction
+  is said out loud.** The dispatcher extracts either a `## Acceptance criteria`
+  section — heading form, case-insensitive and tolerant of trailing qualifier text
+  such as `(per phase)`, 23 of the 44 active roadmaps as of 2026-08-18 — or inline
+  `- **AC-n:**` bullets declared per phase (7 of 44), at any indent and with
+  either bullet marker, including their loose-list continuation paragraphs. The
+  heading form wins if a file ever carries both. The remaining 14 roadmaps declare
+  no criteria in either form.
+
+  When the extraction comes back empty, `ac_hash` is **`none`** and the reviewer's
+  prompt says that no criteria could be **extracted** — naming both possible
+  causes, a roadmap that declares none and a roadmap that declares them in an
+  unrecognised shape, because the dispatcher cannot distinguish them. It must not
+  assert the first: an affirmative "this roadmap declares no criteria" is strictly
+  worse than silence, since silence invites the reviewer to look and a false
+  assertion forecloses it.
+
+  One predicate decides "are there criteria" for both the manifest and the prompt
+  (`hasAcceptanceCriteria`, whitespace-only counts as absent). Encoding it twice
+  is how the manifest and the prompt come to disagree about the same fact.
 
   This is a repair, not a refinement. The extractor previously matched the heading
   only, so an inline-only roadmap produced an empty extraction that was then
@@ -709,12 +722,22 @@ dispatched: YYYY-MM-DDTHH:MM:SSZ
   independent check on AC conformance, so the effect was to blind that check while
   the artefact read as though it had run.
 
-  **Historical artefacts are deliberately left alone.** 17 committed findings
-  files carry the empty-string `ac_hash`; only the handful whose roadmap is
-  inline-only were the defect, and `--verify-current` re-derives the *current*
-  PR's artefact only, so none of them go red. An artefact dispatched before this
-  change whose roadmap is inline-only will mismatch on its next re-derivation and
-  needs a re-bind (a hand-edit of `ac_hash`), exactly like any other moved input.
+  **Historical artefacts are deliberately left alone, for two independent
+  reasons — and only the second covers every entry point.** 17 committed findings
+  files carry the empty-string `ac_hash`; only the few whose roadmap declares
+  criteria in a now-recognised form were ever the defect. First, `--verify-current`
+  selects by review scope and re-derives the *current* PR's artefact alone, so a
+  corpus of foreign artefacts is never re-derived at all. Second — and this is the
+  reason that also holds for the single-artefact `--verify <path>`, which has no
+  such selection — a foreign artefact already diverges on `scope_hash`, so it
+  never reaches the `ac_hash` comparison on a semantics change. Do not read the
+  first reason as the whole guarantee: a caller that walks the committed corpus
+  with `--verify` inherits the semantics change and is protected only by the
+  second.
+
+  An artefact dispatched before this change whose roadmap does carry criteria in a
+  newly recognised form will mismatch on its next re-derivation and needs a
+  re-bind (a hand-edit of `ac_hash`), exactly like any other moved input.
 - **Compared set:** `scope_hash`, `roadmap_hash`, `ac_hash`. `diff_sha` is
   provenance and is never compared, for the § 2.0 reasons. The manifest's
   `scope_hash` must also agree with the header's `scope:`; a disagreement is

--- a/docs/contracts/plan-review-gates.md
+++ b/docs/contracts/plan-review-gates.md
@@ -674,7 +674,7 @@ inputs:
   scope_hash: <64-hex § 2.0 review-scope hash — compared>
   roadmap: <path>
   roadmap_hash: <sha256>
-  ac_hash: <sha256 of the extracted Acceptance Criteria block>
+  ac_hash: <sha256 of the extracted acceptance criteria, or `none` when there are none>
 excluded: [session-history, agents/runtime, implementation-context]
 tools: [git-diff-branch-scoped, file-read-branch-paths]
 dispatched: YYYY-MM-DDTHH:MM:SSZ
@@ -691,6 +691,30 @@ dispatched: YYYY-MM-DDTHH:MM:SSZ
   Exit `2` in `--verify` is reserved for genuine internal failures (the file
   is missing or unreadable, git fails). A bare § 2.4 skip declaration
   carries no reviewer dispatch and needs no manifest.
+- **Acceptance criteria are read in BOTH authored forms, and their absence is
+  said out loud.** The dispatcher extracts either a `## Acceptance Criteria`
+  section (heading form, 21 of the 44 active roadmaps as of 2026-08-18) or inline
+  `- **AC-n:**` bullets declared per phase (7 of 44); the heading form wins if a
+  file ever carries both. When neither is present, `ac_hash` is **`none`** and the
+  reviewer's prompt states that the roadmap declares no criteria — it does not
+  claim an extraction.
+
+  This is a repair, not a refinement. The extractor previously matched the heading
+  only, so an inline-only roadmap produced an empty extraction that was then
+  hashed: `ac_hash` recorded `e3b0c442…b855`, the SHA-256 of the empty string,
+  which looks like a real hash in the manifest and re-derives identically on
+  `--verify-current` — so this gate **confirmed a criteria set that was never
+  there**, while the reviewer was handed a 0-byte `acceptance-criteria.md` under a
+  prompt saying the criteria had been extracted. The R2 reviewer is the
+  independent check on AC conformance, so the effect was to blind that check while
+  the artefact read as though it had run.
+
+  **Historical artefacts are deliberately left alone.** 17 committed findings
+  files carry the empty-string `ac_hash`; only the handful whose roadmap is
+  inline-only were the defect, and `--verify-current` re-derives the *current*
+  PR's artefact only, so none of them go red. An artefact dispatched before this
+  change whose roadmap is inline-only will mismatch on its next re-derivation and
+  needs a re-bind (a hand-edit of `ac_hash`), exactly like any other moved input.
 - **Compared set:** `scope_hash`, `roadmap_hash`, `ac_hash`. `diff_sha` is
   provenance and is never compared, for the § 2.0 reasons. The manifest's
   `scope_hash` must also agree with the header's `scope:`; a disagreement is

--- a/src/scripts/dispatch_r2_reviewer.ts
+++ b/src/scripts/dispatch_r2_reviewer.ts
@@ -426,13 +426,46 @@ export function expectedHashes(args: {
     return {
         scope_hash: sha256(args.scopeDiffText),
         roadmap_hash: args.roadmapText == null ? 'none' : sha256(args.roadmapText),
-        ac_hash: args.acText == null ? 'none' : sha256(args.acText),
+        // Falsy, not `== null`. An empty extraction used to hash to
+        // e3b0c44298fc…b855 — the SHA-256 of the empty string, which looks like
+        // a real hash in the manifest and re-derives identically on
+        // `--verify-current`, so the gate confirmed a criteria set that was
+        // never there. `'none'` is the value that already means "no input" for
+        // `roadmap_hash`; an absent AC block gets the same word.
+        ac_hash: args.acText ? sha256(args.acText) : 'none',
     };
 }
 
 /**
- * Extract the `## Acceptance Criteria` section — from that heading (inclusive)
- * to the next `## ` heading or EOF. No section → empty string.
+ * Extract a roadmap's acceptance criteria in either form the tree uses.
+ *
+ * Two forms, because roadmap authors write both and the reviewer needs whichever
+ * one is present:
+ *
+ * 1. A `## Acceptance Criteria` section — from that heading (inclusive) to the
+ *    next `## ` heading or EOF.
+ * 2. Inline `- **AC-n:**` bullets, declared per phase with no section heading —
+ *    collected with their indented continuation lines.
+ *
+ * Neither form → empty string, and every caller must treat that as "no criteria"
+ * rather than as an extracted-and-empty block: see {@link expectedHashes} and the
+ * prompt's roadmap line.
+ *
+ * The heading form is tried first and wins outright when found. Measured
+ * 2026-08-18 over the 44 active roadmaps: 21 heading-only, 7 inline-only, 0
+ * carrying both, 16 carrying neither — so the two forms do not currently
+ * co-occur and a precedence rule is a guard against a future file rather than a
+ * choice between live populations.
+ *
+ * WHY THE INLINE FORM WAS MISSING, stated because this is the second instance of
+ * the same defect class in this one function. The first was case sensitivity
+ * (`## Acceptance criteria` extracted nothing, found by the zcs-close R2 review
+ * 2026-08-09). The second is this: an inline-only roadmap yielded `''`, nothing
+ * downstream noticed, and the reviewer was handed a 0-byte
+ * `acceptance-criteria.md` under a prompt that said the criteria had been
+ * extracted. The R2 reviewer is the independent check on AC conformance, so
+ * blinding it while the artefact reads as though it checked is the
+ * gate-that-scans-nothing-exits-green shape one layer up.
  */
 export function extractAcceptanceCriteria(roadmapText: string): string {
     const lines = roadmapText.split('\n');
@@ -446,15 +479,42 @@ export function extractAcceptanceCriteria(roadmapText: string): string {
             break;
         }
     }
-    if (start === -1) return '';
-    let end = lines.length;
-    for (let i = start + 1; i < lines.length; i++) {
-        if (/^## /.test(lines[i] as string)) {
-            end = i;
-            break;
+    if (start !== -1) {
+        let end = lines.length;
+        for (let i = start + 1; i < lines.length; i++) {
+            if (/^## /.test(lines[i] as string)) {
+                end = i;
+                break;
+            }
+        }
+        return lines.slice(start, end).join('\n');
+    }
+    return extractInlineAcceptanceCriteria(lines);
+}
+
+/**
+ * Collect inline `- **AC-n:**` bullets and their continuation lines.
+ *
+ * A continuation line is indented and non-blank. The walk stops at the first
+ * blank or non-indented line, which is what separates one criterion from the
+ * prose or heading that follows it. Bullets are emitted in file order and
+ * separated by nothing but their own newline: each one is self-labelling
+ * (`AC-0`, `AC-1`, …), so a synthetic section heading would be text this
+ * function invented rather than text the roadmap declared.
+ */
+function extractInlineAcceptanceCriteria(lines: readonly string[]): string {
+    const out: string[] = [];
+    for (let i = 0; i < lines.length; i++) {
+        if (!/^- \*\*AC-/.test(lines[i] as string)) continue;
+        out.push(lines[i] as string);
+        for (let j = i + 1; j < lines.length; j++) {
+            const line = lines[j] as string;
+            if (!/^\s+\S/.test(line)) break;
+            out.push(line);
+            i = j;
         }
     }
-    return lines.slice(start, end).join('\n');
+    return out.join('\n');
 }
 
 /**
@@ -576,11 +636,20 @@ function reviewerPrompt(args: {
     headSha: string;
     scopeHash: string;
     roadmapGiven: boolean;
+    acGiven: boolean;
     changedFiles: readonly string[];
 }): string {
-    const roadmapLine = args.roadmapGiven
-        ? '- roadmap under review: `roadmap.md` (Acceptance Criteria extracted to `acceptance-criteria.md`)'
-        : '- roadmap under review: none (`acceptance-criteria.md` is empty)';
+    // Three states, not two. Branching on `roadmapGiven` alone told the reviewer
+    // "Acceptance Criteria extracted" whenever a roadmap was supplied — including
+    // when the extraction returned nothing and the file beside it was 0 bytes. A
+    // reviewer told the criteria are in a file it finds empty has no way to tell
+    // an extraction failure from a roadmap that genuinely declares none, so it
+    // cannot report the gap. Say which of the two it is.
+    const roadmapLine = !args.roadmapGiven
+        ? '- roadmap under review: none (`acceptance-criteria.md` is empty)'
+        : args.acGiven
+          ? '- roadmap under review: `roadmap.md` (Acceptance Criteria extracted to `acceptance-criteria.md`)'
+          : '- roadmap under review: `roadmap.md` — it declares NO acceptance criteria, so `acceptance-criteria.md` is empty. Review the diff on its own terms and say so if the roadmap should have carried criteria.';
     return [
         `# R2 completion review — ${args.slug}`,
         '',
@@ -1037,6 +1106,7 @@ function runDispatch(args: Args): number {
         headSha,
         scopeHash: hashes.scope_hash,
         roadmapGiven: roadmapText !== null,
+        acGiven: acText !== null && acText !== '',
         changedFiles,
     });
     const manifest = deriveManifest({

--- a/src/scripts/dispatch_r2_reviewer.ts
+++ b/src/scripts/dispatch_r2_reviewer.ts
@@ -426,14 +426,35 @@ export function expectedHashes(args: {
     return {
         scope_hash: sha256(args.scopeDiffText),
         roadmap_hash: args.roadmapText == null ? 'none' : sha256(args.roadmapText),
-        // Falsy, not `== null`. An empty extraction used to hash to
-        // e3b0c44298fc…b855 — the SHA-256 of the empty string, which looks like
-        // a real hash in the manifest and re-derives identically on
-        // `--verify-current`, so the gate confirmed a criteria set that was
-        // never there. `'none'` is the value that already means "no input" for
-        // `roadmap_hash`; an absent AC block gets the same word.
-        ac_hash: args.acText ? sha256(args.acText) : 'none',
+        // ONE predicate, shared with the prompt builder. An empty extraction
+        // used to hash to e3b0c44298fc…b855 — the SHA-256 of the empty string,
+        // which looks like a real hash in the manifest and re-derives
+        // identically on `--verify-current`, so the gate confirmed a criteria
+        // set that was never there. `'none'` is the value that already means
+        // "no input" for `roadmap_hash`; an absent AC block gets the same word.
+        ac_hash: hasAcceptanceCriteria(args.acText) ? sha256(args.acText as string) : 'none',
     };
+}
+
+/**
+ * Does an extraction carry acceptance criteria?
+ *
+ * The single predicate behind BOTH the manifest's `ac_hash` and the reviewer
+ * prompt's roadmap line. It exists because the first version of this fix encoded
+ * the same question twice — truthiness in {@link expectedHashes}, an explicit
+ * `!== null && !== ''` at the call site — and the two agreed only for as long as
+ * `''` stayed the sole reachable falsy value. Refining one alone (this `.trim()`,
+ * for instance) would then have made the manifest record a hash while the prompt
+ * told the reviewer there were no criteria: the same two-places-disagree failure
+ * this module was being repaired for, one level up. Caught by the R2 review of
+ * that very fix.
+ *
+ * Whitespace-only counts as absent. The inline collector can emit blank lines
+ * between a criterion and its loose-list continuation, so a result that is
+ * structurally non-empty and semantically empty is reachable.
+ */
+export function hasAcceptanceCriteria(acText: string | null | undefined): boolean {
+    return typeof acText === 'string' && acText.trim() !== '';
 }
 
 /**
@@ -471,10 +492,20 @@ export function extractAcceptanceCriteria(roadmapText: string): string {
     const lines = roadmapText.split('\n');
     let start = -1;
     for (let i = 0; i < lines.length; i++) {
-        // Case-insensitive: the tree carries both `## Acceptance Criteria` and
+        // Case-insensitive, and NOT anchored at the end of the line.
+        //
+        // Case first: the tree carries both `## Acceptance Criteria` and
         // `## Acceptance criteria`; a case-sensitive match silently extracted
         // nothing for the latter (found by the zcs-close R2 review, 2026-08-09).
-        if (/^## acceptance criteria\s*$/i.test(lines[i] as string)) {
+        //
+        // The end-anchor was the same defect wearing a different mask, and it was
+        // LIVE: `\s*$` rejected a heading carrying a qualifier, so
+        // `## Acceptance criteria (per phase, on promotion to ready)` and
+        // `## Acceptance criteria (anti-dump — the review-s own rule)` extracted
+        // nothing. Two roadmaps, measured 2026-08-18 — and they had been counted
+        // as "declares no criteria" by the very census that motivated this fix,
+        // which is how a matcher tuned to its own measurement hides its misses.
+        if (/^##\s+acceptance criteria\b/i.test(lines[i] as string)) {
             start = i;
             break;
         }
@@ -493,26 +524,70 @@ export function extractAcceptanceCriteria(roadmapText: string): string {
 }
 
 /**
+ * An inline criterion bullet, at any indent and with either bullet marker.
+ *
+ * Indent-tolerant so a nested criterion is emitted as its own row rather than
+ * folded into its parent as a continuation line — folding made the extraction
+ * shape, and therefore `ac_hash`, a function of indentation depth. Neither the
+ * `*` marker nor a nested criterion occurs in the tree today (measured
+ * 2026-08-18 across all 44 active roadmaps: zero of each), so this is a guard
+ * against a future file, not a fix for a live population.
+ */
+const AC_BULLET_RE = /^\s*[-*]\s+\*\*AC-/;
+
+/**
  * Collect inline `- **AC-n:**` bullets and their continuation lines.
  *
- * A continuation line is indented and non-blank. The walk stops at the first
- * blank or non-indented line, which is what separates one criterion from the
- * prose or heading that follows it. Bullets are emitted in file order and
- * separated by nothing but their own newline: each one is self-labelling
- * (`AC-0`, `AC-1`, …), so a synthetic section heading would be text this
- * function invented rather than text the roadmap declared.
+ * A continuation line is indented and non-blank. Bullets are emitted in file
+ * order and separated by nothing but their own newline: each one is
+ * self-labelling (`AC-0`, `AC-1`, …), so a synthetic section heading would be
+ * text this function invented rather than text the roadmap declared.
+ *
+ * Two stopping rules, and the second is the subtle one:
+ *
+ * - another criterion bullet ends the current one, at any indent — see
+ *   {@link AC_BULLET_RE};
+ * - a blank line ends it ONLY when the next non-blank line is not an indented
+ *   continuation. Markdown loose lists separate a bullet from its second
+ *   paragraph with exactly that blank line, so breaking on the blank
+ *   unconditionally truncated the criterion and emitted a PARTIAL extraction —
+ *   which then hashed to a real value and read as complete. That is the
+ *   looks-like-success shape this whole function exists to remove, relocated
+ *   from "empty but claimed" to "half but claimed"; caught by the R2 review of
+ *   the first version. No roadmap uses a loose continuation today (measured
+ *   2026-08-18: zero across all 44), so this is latent-defect removal.
  */
 function extractInlineAcceptanceCriteria(lines: readonly string[]): string {
     const out: string[] = [];
     for (let i = 0; i < lines.length; i++) {
-        if (!/^- \*\*AC-/.test(lines[i] as string)) continue;
+        if (!AC_BULLET_RE.test(lines[i] as string)) continue;
         out.push(lines[i] as string);
-        for (let j = i + 1; j < lines.length; j++) {
+        let j = i + 1;
+        while (j < lines.length) {
             const line = lines[j] as string;
-            if (!/^\s+\S/.test(line)) break;
-            out.push(line);
-            i = j;
+            // A sibling or nested criterion owns itself; hand it back to the
+            // outer loop rather than absorbing it.
+            if (AC_BULLET_RE.test(line)) break;
+            if (/^\s+\S/.test(line)) {
+                out.push(line);
+                j++;
+                continue;
+            }
+            if (line.trim() !== '') break;
+            // Blank: look past the run of blanks for an indented continuation.
+            let k = j;
+            while (k < lines.length && (lines[k] as string).trim() === '') k++;
+            const resumes =
+                k < lines.length &&
+                /^\s+\S/.test(lines[k] as string) &&
+                !AC_BULLET_RE.test(lines[k] as string);
+            if (!resumes) break;
+            for (let b = j; b < k; b++) out.push(lines[b] as string);
+            j = k;
         }
+        // Resume the outer scan AT the line that stopped the walk, so a
+        // criterion bullet that ended this one is still matched.
+        i = j - 1;
     }
     return out.join('\n');
 }
@@ -644,12 +719,21 @@ function reviewerPrompt(args: {
     // when the extraction returned nothing and the file beside it was 0 bytes. A
     // reviewer told the criteria are in a file it finds empty has no way to tell
     // an extraction failure from a roadmap that genuinely declares none, so it
-    // cannot report the gap. Say which of the two it is.
+    // cannot report the gap.
+    //
+    // The empty branch reports the EXTRACTION, never the roadmap. Its first
+    // version said "it declares NO acceptance criteria" — a claim the extractor
+    // cannot establish, since an unrecognised shape produces the identical empty
+    // result. That turned a silent failure into an affirmative false statement
+    // handed to the one independent check on AC conformance, which is strictly
+    // worse: silence invites a look, a false assertion forecloses it. Caught by
+    // the R2 review of the first version, and it was not hypothetical — the
+    // trailing-text heading it names was live in two roadmaps.
     const roadmapLine = !args.roadmapGiven
         ? '- roadmap under review: none (`acceptance-criteria.md` is empty)'
         : args.acGiven
           ? '- roadmap under review: `roadmap.md` (Acceptance Criteria extracted to `acceptance-criteria.md`)'
-          : '- roadmap under review: `roadmap.md` — it declares NO acceptance criteria, so `acceptance-criteria.md` is empty. Review the diff on its own terms and say so if the roadmap should have carried criteria.';
+          : '- roadmap under review: `roadmap.md` — NO acceptance criteria could be EXTRACTED from it, in either recognised form (an `## Acceptance criteria` heading, or inline `- **AC-n:**` bullets), so `acceptance-criteria.md` is empty. Two different things produce that result and the dispatcher cannot tell them apart: the roadmap declares none, or it declares them in a shape the extractor does not recognise. Open `roadmap.md`, decide which, and report a finding if the criteria are there.';
     return [
         `# R2 completion review — ${args.slug}`,
         '',
@@ -1106,7 +1190,7 @@ function runDispatch(args: Args): number {
         headSha,
         scopeHash: hashes.scope_hash,
         roadmapGiven: roadmapText !== null,
-        acGiven: acText !== null && acText !== '',
+        acGiven: hasAcceptanceCriteria(acText),
         changedFiles,
     });
     const manifest = deriveManifest({

--- a/tests/scripts/dispatch_r2_reviewer.test.ts
+++ b/tests/scripts/dispatch_r2_reviewer.test.ts
@@ -28,6 +28,7 @@ import {
     deriveSlug,
     expectedHashes,
     extractAcceptanceCriteria,
+    hasAcceptanceCriteria,
     isEmptyScope,
     parseManifest,
     reviewScopeDiffArgs,
@@ -115,6 +116,20 @@ const ROADMAP_INLINE_AC = [
     '',
     'Trailing prose that is NOT a criterion and must not be collected.',
     '',
+].join('\n');
+
+/**
+ * What `ROADMAP_INLINE_AC` must extract to, written out as a literal.
+ *
+ * Deliberately NOT computed by calling the extractor: an expectation derived from
+ * the function under test cannot fail on an extraction defect, it only pins "the
+ * dispatcher hashed whatever came back". The R2 review of the first version of
+ * this fix caught exactly that in the end-to-end hash assertion below.
+ */
+const ROADMAP_INLINE_AC_EXPECTED = [
+    '- **AC-0:** the first criterion holds, and this line wraps',
+    '  onto a continuation the collector must keep.',
+    '- **AC-1:** the second criterion holds.',
 ].join('\n');
 
 /** A roadmap that declares no acceptance criteria in either form. */
@@ -690,14 +705,7 @@ describe('dispatch_r2_reviewer — pure helpers', () => {
         // 0-byte acceptance-criteria.md, and the prompt said the criteria had
         // been extracted. Measured 2026-08-18: 7 of 44 active roadmaps are
         // inline-only, including the one the backlog named as the next pick.
-        const ac = extractAcceptanceCriteria(ROADMAP_INLINE_AC);
-        expect(ac).toBe(
-            [
-                '- **AC-0:** the first criterion holds, and this line wraps',
-                '  onto a continuation the collector must keep.',
-                '- **AC-1:** the second criterion holds.',
-            ].join('\n'),
-        );
+        expect(extractAcceptanceCriteria(ROADMAP_INLINE_AC)).toBe(ROADMAP_INLINE_AC_EXPECTED);
     });
 
     it('extractAcceptanceCriteria stops at the first blank or non-indented line', () => {
@@ -732,6 +740,75 @@ describe('dispatch_r2_reviewer — pure helpers', () => {
         expect(extractAcceptanceCriteria(ROADMAP_NO_AC)).toBe('');
     });
 
+    it('extractAcceptanceCriteria accepts a heading that carries trailing qualifier text', () => {
+        // LIVE defect, not a hypothetical: the end-anchored `\s*$` rejected
+        // `## Acceptance criteria (per phase, on promotion to ready)` and
+        // `## Acceptance criteria (anti-dump — …)`, two real roadmaps that the
+        // census behind this fix had therefore counted as declaring none. Found
+        // by the R2 review of the first version.
+        const qualified = [
+            '# X',
+            '',
+            '## Acceptance criteria (per phase, on promotion to ready)',
+            '',
+            '- crit A',
+            '',
+            '## Next',
+            '',
+        ].join('\n');
+        const ac = extractAcceptanceCriteria(qualified);
+        expect(ac).toContain('- crit A');
+        expect(ac).not.toContain('## Next');
+    });
+
+    it('extractAcceptanceCriteria keeps a loose-list continuation separated by a blank line', () => {
+        // Markdown loose lists put a blank line between a bullet and its second
+        // paragraph. Breaking on the blank truncated the criterion and produced a
+        // PARTIAL extraction that hashed to a real value and read as complete —
+        // the same looks-like-success shape, relocated from "empty but claimed"
+        // to "half but claimed".
+        const loose = [
+            '## Phase 1',
+            '- **AC-0:** first paragraph of the criterion.',
+            '',
+            '  second paragraph, still part of AC-0.',
+            '',
+            'Unindented prose that ends it.',
+            '',
+        ].join('\n');
+        const ac = extractAcceptanceCriteria(loose);
+        expect(ac).toContain('first paragraph');
+        expect(ac).toContain('second paragraph, still part of AC-0.');
+        expect(ac).not.toContain('Unindented prose');
+    });
+
+    it('extractAcceptanceCriteria emits a nested AC bullet as its own criterion', () => {
+        // Indent-folding made the extraction shape — and therefore ac_hash — a
+        // function of indentation depth, and the skip was permanent because the
+        // outer scan resumed past the folded line.
+        const nested = ['## Phase 1', '- **AC-0:** parent.', '  - **AC-1:** nested child.', ''].join(
+            '\n',
+        );
+        const ac = extractAcceptanceCriteria(nested);
+        expect(ac.split('\n')).toEqual(['- **AC-0:** parent.', '  - **AC-1:** nested child.']);
+    });
+
+    it('hasAcceptanceCriteria is the single predicate behind ac_hash and the prompt', () => {
+        // The pair used to be encoded twice with two different tests, agreeing
+        // only while '' stayed the sole reachable falsy value. Pinned as parity so
+        // refining the predicate cannot desynchronise the manifest from the prompt.
+        expect(hasAcceptanceCriteria(null)).toBe(false);
+        expect(hasAcceptanceCriteria(undefined)).toBe(false);
+        expect(hasAcceptanceCriteria('')).toBe(false);
+        expect(hasAcceptanceCriteria('   \n\n  ')).toBe(false);
+        expect(hasAcceptanceCriteria('- **AC-0:** x')).toBe(true);
+        // Parity: whatever the predicate says, ac_hash agrees.
+        for (const ac of [null, '', '   \n ', '- **AC-0:** x']) {
+            const h = expectedHashes({ scopeDiffText: 'd', roadmapText: 'r', acText: ac }).ac_hash;
+            expect(h === 'none').toBe(!hasAcceptanceCriteria(ac));
+        }
+    });
+
     it('expectedHashes maps an EMPTY extraction to none, not to the empty-string hash', () => {
         // e3b0c442…b855 is sha256(''). It was recorded whenever extraction came
         // back empty, looks like a real hash in the manifest, and re-derives
@@ -758,7 +835,10 @@ describe('dispatch_r2_reviewer — pure helpers', () => {
         const acFile = fs.readFileSync(path.join(inputDir, 'acceptance-criteria.md'), 'utf-8');
         expect(acFile).toContain('- **AC-0:**');
         expect(acFile).toContain('- **AC-1:**');
-        expect(out.hashes.ac_hash).toBe(sha256(extractAcceptanceCriteria(ROADMAP_INLINE_AC)));
+        // Literal expectation, not `sha256(extractAcceptanceCriteria(...))` —
+        // see ROADMAP_INLINE_AC_EXPECTED for why that form proves nothing.
+        expect(acFile).toBe(ROADMAP_INLINE_AC_EXPECTED);
+        expect(out.hashes.ac_hash).toBe(sha256(ROADMAP_INLINE_AC_EXPECTED));
         expect(out.hashes.ac_hash).not.toBe('none');
 
         // The vacuity guard for the next test: prove the "extracted" wording is
@@ -783,8 +863,12 @@ describe('dispatch_r2_reviewer — pure helpers', () => {
         const inputDir = path.join(repo, OUT, `${SLUG}.review-input`);
         expect(fs.readFileSync(path.join(inputDir, 'acceptance-criteria.md'), 'utf-8')).toBe('');
         const prompt = fs.readFileSync(path.join(inputDir, 'prompt.md'), 'utf-8');
-        expect(prompt).toContain('it declares NO acceptance criteria');
-        expect(prompt).not.toContain('Acceptance Criteria extracted');
+        // The line reports the EXTRACTION, never the roadmap: an unrecognised
+        // shape yields the identical empty result, so asserting the roadmap
+        // "declares none" would be a claim the dispatcher cannot establish.
+        expect(prompt).toContain('NO acceptance criteria could be EXTRACTED from it');
+        expect(prompt).toContain('the extractor does not recognise');
+        expect(prompt).not.toContain('Acceptance Criteria extracted to');
     });
 
     it('reviewScopeDiffArgs excludes every gate-owned evidence path from the reviewed scope', () => {

--- a/tests/scripts/dispatch_r2_reviewer.test.ts
+++ b/tests/scripts/dispatch_r2_reviewer.test.ts
@@ -95,8 +95,35 @@ function scopeDiff(repo: string, base = 'main'): string {
     return git(repo, ...reviewScopeDiffArgs(base));
 }
 
+/**
+ * A roadmap declaring its criteria as inline `- **AC-n:**` bullets per phase,
+ * with no `## Acceptance Criteria` heading anywhere — the form 7 of the 44 active
+ * roadmaps use. Continuation lines are indented two spaces, and the trailing
+ * prose exists so a test can prove the collector stops rather than swallowing it.
+ */
+const ROADMAP_INLINE_AC = [
+    '# Road Y',
+    '',
+    '## Phase 1',
+    '- [ ] step',
+    '- **AC-0:** the first criterion holds, and this line wraps',
+    '  onto a continuation the collector must keep.',
+    '',
+    '## Phase 2',
+    '- [ ] other step',
+    '- **AC-1:** the second criterion holds.',
+    '',
+    'Trailing prose that is NOT a criterion and must not be collected.',
+    '',
+].join('\n');
+
+/** A roadmap that declares no acceptance criteria in either form. */
+const ROADMAP_NO_AC = ['# Road Z', '', '## Phase 1', '- [ ] step', '', '## Notes', '', 'tail', ''].join(
+    '\n',
+);
+
 /** Fresh git repo: main with roadmap + a.txt, then a feature branch with one commit. */
-function initRepo(opts: { branch?: boolean } = {}): string {
+function initRepo(opts: { branch?: boolean; roadmap?: string } = {}): string {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'r2-dispatch-'));
     tmpDirs.push(dir);
     git(dir, 'init', '-q', '-b', 'main');
@@ -104,7 +131,7 @@ function initRepo(opts: { branch?: boolean } = {}): string {
     git(dir, 'config', 'user.name', 'r2');
     git(dir, 'config', 'commit.gpgsign', 'false');
     write(dir, 'a.txt', 'base\n');
-    write(dir, 'agents/roadmaps/road-x.md', ROADMAP);
+    write(dir, 'agents/roadmaps/road-x.md', opts.roadmap ?? ROADMAP);
     git(dir, 'add', '-A');
     git(dir, 'commit', '-qm', 'init');
     if (opts.branch !== false) {
@@ -655,6 +682,109 @@ describe('dispatch_r2_reviewer — pure helpers', () => {
         // found by the zcs-close R2 review (2026-08-09), pinned here.
         const lower = '# X\n\n## Acceptance criteria\n\n- crit A\n\n## Next\n';
         expect(extractAcceptanceCriteria(lower)).toContain('- crit A');
+    });
+
+    it('extractAcceptanceCriteria collects inline AC bullets with their continuation lines', () => {
+        // The second instance of the same defect class as the case-sensitivity
+        // bug above: an inline-only roadmap yielded '', the reviewer got a
+        // 0-byte acceptance-criteria.md, and the prompt said the criteria had
+        // been extracted. Measured 2026-08-18: 7 of 44 active roadmaps are
+        // inline-only, including the one the backlog named as the next pick.
+        const ac = extractAcceptanceCriteria(ROADMAP_INLINE_AC);
+        expect(ac).toBe(
+            [
+                '- **AC-0:** the first criterion holds, and this line wraps',
+                '  onto a continuation the collector must keep.',
+                '- **AC-1:** the second criterion holds.',
+            ].join('\n'),
+        );
+    });
+
+    it('extractAcceptanceCriteria stops at the first blank or non-indented line', () => {
+        // Over-collection is the failure that would look like success: a
+        // collector running to EOF would ship the whole roadmap tail as
+        // "criteria" and the positive test above would still pass.
+        //
+        // The first two assertions are this test's OWN vacuity guard, and they
+        // are not decoration — a mutation run proved the exclusions below pass
+        // over an empty string, i.e. the test would have gone green against the
+        // exact defect it exists to catch. Assert there is something to exclude
+        // FROM before excluding anything.
+        const ac = extractAcceptanceCriteria(ROADMAP_INLINE_AC);
+        expect(ac).not.toBe('');
+        expect(ac).toContain('- **AC-1:**');
+        expect(ac).not.toContain('Trailing prose');
+        expect(ac).not.toContain('## Phase 2');
+        expect(ac).not.toContain('- [ ] other step');
+    });
+
+    it('extractAcceptanceCriteria prefers the heading form when a roadmap carries both', () => {
+        // No roadmap in the tree carries both today (21 heading-only, 7
+        // inline-only, 0 both), so this pins a precedence rule against a future
+        // file rather than resolving a live ambiguity.
+        const both = [ROADMAP, '- **AC-9:** an inline bullet added later.', ''].join('\n');
+        const ac = extractAcceptanceCriteria(both);
+        expect(ac).toContain('- AC one');
+        expect(ac).not.toContain('AC-9');
+    });
+
+    it('extractAcceptanceCriteria returns empty string when neither form is present', () => {
+        expect(extractAcceptanceCriteria(ROADMAP_NO_AC)).toBe('');
+    });
+
+    it('expectedHashes maps an EMPTY extraction to none, not to the empty-string hash', () => {
+        // e3b0c442…b855 is sha256(''). It was recorded whenever extraction came
+        // back empty, looks like a real hash in the manifest, and re-derives
+        // identically on --verify-current — so the gate confirmed a criteria set
+        // that was never there. Named explicitly so a revert cannot pass.
+        const EMPTY_SHA = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';
+        expect(sha256('')).toBe(EMPTY_SHA);
+        const h = expectedHashes({ scopeDiffText: 'd', roadmapText: 'r', acText: '' });
+        expect(h.ac_hash).toBe('none');
+        expect(h.ac_hash).not.toBe(EMPTY_SHA);
+        // A non-empty extraction still hashes.
+        expect(expectedHashes({ scopeDiffText: 'd', roadmapText: 'r', acText: 'x' }).ac_hash).toBe(
+            sha256('x'),
+        );
+    });
+
+    it('dispatch on an inline-AC roadmap writes real criteria and a prompt that claims extraction', () => {
+        const repo = initRepo({ roadmap: ROADMAP_INLINE_AC });
+        const res = run(dispatchArgs(repo, ['--format', 'json']));
+        expect(res.status, res.stderr).toBe(0);
+        const out = JSON.parse(res.stdout) as { hashes: { ac_hash: string } };
+
+        const inputDir = path.join(repo, OUT, `${SLUG}.review-input`);
+        const acFile = fs.readFileSync(path.join(inputDir, 'acceptance-criteria.md'), 'utf-8');
+        expect(acFile).toContain('- **AC-0:**');
+        expect(acFile).toContain('- **AC-1:**');
+        expect(out.hashes.ac_hash).toBe(sha256(extractAcceptanceCriteria(ROADMAP_INLINE_AC)));
+        expect(out.hashes.ac_hash).not.toBe('none');
+
+        // The vacuity guard for the next test: prove the "extracted" wording is
+        // what a criteria-carrying roadmap actually produces, so asserting its
+        // ABSENCE below is a real assertion rather than a tautology over prose
+        // that never appears.
+        const prompt = fs.readFileSync(path.join(inputDir, 'prompt.md'), 'utf-8');
+        expect(prompt).toContain('Acceptance Criteria extracted to `acceptance-criteria.md`');
+    });
+
+    it('dispatch on a roadmap with no criteria records none and tells the reviewer so', () => {
+        const repo = initRepo({ roadmap: ROADMAP_NO_AC });
+        const res = run(dispatchArgs(repo, ['--format', 'json']));
+        expect(res.status, res.stderr).toBe(0);
+        const out = JSON.parse(res.stdout) as { hashes: { roadmap_hash: string; ac_hash: string } };
+
+        // A roadmap WAS supplied — so this is the third state, distinct from
+        // "no roadmap", and the reviewer must be able to tell them apart.
+        expect(out.hashes.roadmap_hash).toBe(sha256(ROADMAP_NO_AC));
+        expect(out.hashes.ac_hash).toBe('none');
+
+        const inputDir = path.join(repo, OUT, `${SLUG}.review-input`);
+        expect(fs.readFileSync(path.join(inputDir, 'acceptance-criteria.md'), 'utf-8')).toBe('');
+        const prompt = fs.readFileSync(path.join(inputDir, 'prompt.md'), 'utf-8');
+        expect(prompt).toContain('it declares NO acceptance criteria');
+        expect(prompt).not.toContain('Acceptance Criteria extracted');
     });
 
     it('reviewScopeDiffArgs excludes every gate-owned evidence path from the reviewed scope', () => {


### PR DESCRIPTION
## What was wrong

`extractAcceptanceCriteria` in `dispatch_r2_reviewer.ts` matched
`/^## acceptance criteria\s*$/i` and nothing else. Two authored forms in the tree
missed it, and both misses were silent:

- **inline `- **AC-n:**` bullets** declared per phase, with no section heading — 7
  of the 44 active roadmaps;
- **a heading carrying trailing qualifier text**, such as
  `## Acceptance criteria (per phase, on promotion to ready)` — 2 more, rejected
  purely by the end anchor.

Nothing downstream noticed, in two compounding ways:

- `acText` became `''` rather than `null`, so `ac_hash` recorded
  `e3b0c44298fc…b855` — the SHA-256 of the empty string. That looks like a real
  hash in the context manifest and re-derives identically under
  `--verify-current`, so **the gate confirmed a criteria set that was never
  there**.
- the prompt branched on `roadmapGiven`, not on the extracted text, so the
  reviewer was told *"Acceptance Criteria extracted to `acceptance-criteria.md`"*
  over a 0-byte file.

The R2 reviewer is the independent check on AC conformance. Handed an empty file
under a prompt claiming extraction, it cannot check the criteria — and the
artefact then reads as though it did. That is the gate-that-scans-nothing shape
one layer up. PR #1418, opened the same day this was found, ships a 0-byte
`acceptance-criteria.md` (empty blob `e69de29bb`) beside a 756-line roadmap.

This is the **second instance of the class in this one function**; the first was
case sensitivity, caught by the zcs-close review on 2026-08-09. The docblock now
says so, because a recurring defect class is worth naming where it recurs.

## What changed

Three behaviours, each pinned by a mutation-verified test:

1. **Both authored forms are read.** The heading match is case-insensitive and no
   longer end-anchored; inline `- **AC-n:**` bullets are collected with their
   continuation lines, at any indent, with either bullet marker, including
   loose-list paragraphs separated by a blank line. Heading form wins if a file
   ever carries both.
2. **`ac_hash` is `none` for an empty extraction** — the word that already means
   "no input" for `roadmap_hash`.
3. **The prompt distinguishes three states, not two** — no roadmap, criteria
   extracted, and *nothing could be extracted*. The third names both causes it
   cannot distinguish (declares none / unrecognised shape) and tells the reviewer
   to open `roadmap.md` and decide.

One exported predicate, `hasAcceptanceCriteria`, answers "are there criteria" for
both the manifest and the prompt.

## Verification

- 52 tests green; `npm run typecheck` and eslint clean; `task preflight` exit 0.
- **Mutation-checked in three passes, one per half.** Disabling the inline
  fallback fails 2 tests; reverting the `ac_hash` branch fails 2; reverting the
  prompt branch fails 1.
- **The mutation run found a real defect in my own test:** the
  stops-at-boundary assertion passed over an empty string, i.e. it would have gone
  green against the exact defect it exists to catch. It now carries its own
  vacuity guard.
- Live re-run across all 44 roadmaps after the fix: **23 heading · 7 inline · 14
  none**, every no-criteria file recording `none`, the 7 inline files yielding
  8–27 lines of real criteria.

The distribution correction matters: the first pass measured 21/7/16, and the two
qualifier-heading roadmaps were counted as declaring no criteria **by the census
that motivated the fix**. A matcher tuned to its own measurement hides its own
misses.

## Blast radius — bounded, and checked rather than assumed

- 17 committed findings files carry the empty-string `ac_hash`. `--verify-current`
  selects by review scope and re-derives the current PR's artefact only; and for
  the single-artefact `--verify <path>`, which has no such selection, a foreign
  artefact already diverges on `scope_hash` and never reaches the `ac_hash`
  comparison. Both reasons are now in the contract, with a warning not to read the
  first as the whole guarantee.
- `check_review_prompt_binding` hashes the committed `prompt.md` rather than
  regenerating it, so the prompt change breaks no binding.
- `probe_review_binding_drift` calls the extractor but is an on-demand probe with
  no exit codes, registered in no workflow. Its `ac` verdict will read `moved`
  rather than `same` for the few genuinely-defective artefacts, which is the
  honest verdict.

**One consequence outside this branch:** PR #1418 is in flight over an inline-AC
roadmap and records the empty-string `ac_hash`. Once this lands, its next
re-derivation mismatches and it needs a re-bind — a hand-edit of `ac_hash`, the
same step any moved input requires.

## R2 completion review

Six findings, three medium, all closed in `61fdf7d26` and recorded in
`agents/evidence/reviews/fix-r2-ac-extraction-inline.findings.md`. The findings
were committed with every row `open` **before** any fix, then re-bound once.

The three medium findings each named the same looks-like-success shape the fix
existed to remove, relocated rather than eliminated — the sharpest being that the
new empty-state prompt *asserted* "this roadmap declares no acceptance criteria",
a claim the extractor cannot establish. A silent failure had been turned into an
affirmative false statement, which is worse: silence invites a look, a false
assertion forecloses it. That finding is also what surfaced the live
trailing-qualifier heading.

The artefact declares the delta between the prompt actually sent and the hashed
`prompt.md` (working directory, input path, return channel — no verdict
expectation, no scope narrowing). Declared because the binding gate hashes the
committed file rather than the sent text and its own header names that
substitution undetectable.

## One thing raised, not fixed

The sibling search for the defect construct — an end-anchored heading matcher
whose miss yields a silently-empty extraction — found **one further live
instance**, in a different module and therefore outside this diff:

`src/scripts/lint_plan_risk_register.ts:118` uses
`/^##\s+Acceptance Criteria\s*$/` — case-sensitive **and** end-anchored — and on a
miss hashes the empty string as its AC staleness signal. Measured: it sees **13 of
the 30** roadmaps that carry criteria, so 17 have an AC staleness hash that cannot
change when their criteria do.

Same construct, same silent-empty consequence, different gate. Raised for a
decision rather than repaired here.
