### PR TITLE
docs(review): mark the six committed reviews that were dispatched AC-blind

### DIFF
--- a/agents/evidence/reviews/catalogue-host-fit-phase1.findings.md
+++ b/agents/evidence/reviews/catalogue-host-fit-phase1.findings.md
@@ -30,3 +30,27 @@ dispatched: 2026-08-18T00:41:29Z
 | 12 | low | src/scripts/capture_skill_catalogue.ts:287 | The join's disk side carries no scope or freshness discipline while the host side is built entirely around it. `resolveSkillsRoot` picks `.claude/skills` first, which in this checkout holds 338 entries against the roadmap's stated scoped 219 / legacy-all 290 — i.e. the joined catalogue matches neither projection mode, the same `indeterminate` condition `projectionModeFlagFor` refuses to label three functions earlier. The output prints the root and raw entry count, so it is traceable, but `pointableBare` grows with a stale-large root and the row carries no record of which projection it was joined against. Record the resolved root's mode classification in the `--json` payload. | fixed | 87ec63a15 |
 | 13 | low | agents/roadmaps-progress.md:37,46,79-98,125 | The regeneration folds in blocker-section churn for two roadmaps this branch does not touch — `road-to-gate-autonomy` (blocker count 2→3, new `b-estate-prose-pass-from-1-3`) and `road-to-mixed-trigger-activation-cost` (1→2, new `b-matrix-semantics-amendment`) — and drops both sections' `_1 blocker resolved._` footers. Neither source roadmap appears in the diff, so either the base dashboard was stale (benign, but unstated) or the regeneration read a tree state this commit does not contain. Per `minimal-safe-diff` this is unrelated drift riding in a Phase-1 change; state which of the two it is in the commit message, so a later bisect does not attribute those blockers here. | accepted-risk | It is the FIRST of the two, verified rather than assumed: at `origin/main` those roadmap files already carry 3 and 2 `### blocker:` sections while the committed dashboard says 2 and 1, so the base dashboard was stale and this regeneration corrected it. Nothing in the branch produced those blockers. Stated here and in the PR body so a bisect does not attribute them to this change; the correction itself is kept, since reverting it would re-ship a dashboard known to disagree with the tree. |
 | 14 | low | agents/evidence/reviews/catalogue-host-fit-phase1.review-input/acceptance-criteria.md:1 | The AC input handed to this review is 0 bytes, and the manifest's `ac_hash` is `e3b0c442…b7852b855` — the SHA-256 of the empty string — while `roadmap.md` plainly carries `**AC-0:**` through `**AC-3:**`. The extractor produced an empty file and the pipeline hashed it without complaint, so this review could not check the diff against its acceptance criteria and the artefact records that silently. Out of the diff's scope, reported because it degraded this review: the extractor should fail loudly on a roadmap that contains `AC-` lines but yields none. | deferred | `agents/roadmaps/road-to-plan-gates-measurement.md` § Defect to fix BEFORE the enforced flip — filed there because the defect is in `dispatch_r2_reviewer`, not in this diff, and that roadmap owns the R2 advisory window this corrupts. An enforced gate whose AC input can be empty is worse than an advisory one. |
+
+
+## Acceptance-criteria binding — this review was AC-BLIND
+
+Recorded 2026-08-18, after the fact.
+
+The manifest above carries `ac_hash: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`,
+which is the SHA-256 of the **empty string** rather than of any criteria. This
+review was dispatched against `agents/roadmaps/road-to-catalogue-host-fit.md`,
+which declares its criteria as inline `- **AC-n:**` bullets per phase and
+carries no `## Acceptance Criteria` heading at all, while the extractor of the
+day matched the heading form and nothing else. The reviewer therefore received a **0-byte** `acceptance-criteria.md`
+under a prompt stating that the acceptance criteria had been extracted for it.
+
+**So the findings above review the DIFF, and nothing in them was checked against
+the acceptance criteria** — the criteria were not in the reviewer context at all.
+The same roadmap yields 19 lines of criteria under the extractor as it stands
+today. The extractor learned the inline form in PR #1419 (2026-08-18).
+
+The manifest is deliberately left unchanged. `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`
+is the honest record of the input this review actually received, and rewriting it
+to today's value would assert a binding that never existed — the precise failure
+this note exists to prevent. The artefact binds a scope that no longer exists, so
+no gate re-derives it and nothing here is stale.

--- a/agents/evidence/reviews/catalogue-host-fit-phase3.findings.md
+++ b/agents/evidence/reviews/catalogue-host-fit-phase3.findings.md
@@ -35,3 +35,27 @@ declared rather than closed, and the reason cell says why closing it would be wo
 | 10 | low | src/scripts/hooks/skill_route_hook.ts:184 | The cost paragraph was re-argued only on the free path. Every firing prompt now additionally reads and JSON-parses the whole observation log, uncached, per prompt (`knownBareForHost` → `readObservationLog`), yet the header still presents the pre-branch "12.3 ms warm … about 5 % of the 250 ms p95 budget" as the cost of a prompt that reaches the ranker. The new paragraph only establishes that the SUB-floor path stays at 0 ms. The added cost is likely small, which is an argument for measuring it once and saying so, not for leaving a measured claim describing a path that changed. | fixed | c41b89a1c — measured: 0.015 ms median / 0.022 ms p95 (n=2000, warm) against an 8.3 ms ranked pass. Header also states that `bench_hook_latency` cannot see it (its payload carries neither `prompt` nor `platform`) |
 | 11 | low | src/config/hook-token-budget.json:60 | The falsifier baseline is a bare ratio with an ambiguous denominator: `16/338` "of the observed catalogue", while the ranker catalogue is cited as 337 entries in the consuming hook (`skill_route_hook.ts:236`). A future reader cannot tell whether 338 is the host-observed entry count or the ranker catalogue size, and the two are the populations the join deliberately keeps apart. Name the denominator (`entries_total` of the 2026-08-12 claude observation, or the ranker catalogue) so the comparison is reproducible. | fixed | 03fe4732d — all three populations named: `entries_total` 336, 35 enumerated (16 bare + 19 described), ranker catalogue 338. The comparable share is 16 of 35 |
 <!-- reviewer fills the table; 0 findings => replace the table with the exact honest-null line per docs/contracts/plan-review-gates.md §2.3 AND change the evidence-type to `honest-null` per docs/contracts/evidence-artifact-types.md §4 -->
+
+
+## Acceptance-criteria binding — this review was AC-BLIND
+
+Recorded 2026-08-18, after the fact.
+
+The manifest above carries `ac_hash: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`,
+which is the SHA-256 of the **empty string** rather than of any criteria. This
+review was dispatched against `agents/roadmaps/road-to-catalogue-host-fit.md`,
+which declares its criteria as inline `- **AC-n:**` bullets per phase and
+carries no `## Acceptance Criteria` heading at all, while the extractor of the
+day matched the heading form and nothing else. The reviewer therefore received a **0-byte** `acceptance-criteria.md`
+under a prompt stating that the acceptance criteria had been extracted for it.
+
+**So the findings above review the DIFF, and nothing in them was checked against
+the acceptance criteria** — the criteria were not in the reviewer context at all.
+The same roadmap yields 19 lines of criteria under the extractor as it stands
+today. The extractor learned the inline form in PR #1419 (2026-08-18).
+
+The manifest is deliberately left unchanged. `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`
+is the honest record of the input this review actually received, and rewriting it
+to today's value would assert a binding that never existed — the precise failure
+this note exists to prevent. The artefact binds a scope that no longer exists, so
+no gate re-derives it and nothing here is stale.

--- a/agents/evidence/reviews/feat-gate-autonomy.findings.md
+++ b/agents/evidence/reviews/feat-gate-autonomy.findings.md
@@ -62,3 +62,27 @@ pre-registration commit verified to exist with sections 3 and 4 empty; the
 "HARD, not ratcheted" claim verified against the code path; `blocker_is_resolved`
 verified to match the lint's existing prefix semantics; src/dist parity verified
 blob-identical; the gate-execute fixtures counted.
+
+
+## Acceptance-criteria binding — this review was AC-BLIND
+
+Recorded 2026-08-18, after the fact.
+
+The manifest above carries `ac_hash: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`,
+which is the SHA-256 of the **empty string** rather than of any criteria. This
+review was dispatched against `agents/roadmaps/road-to-gate-autonomy.md`,
+which declares its criteria as inline `- **AC-n:**` bullets per phase and
+carries no `## Acceptance Criteria` heading at all, while the extractor of the
+day matched the heading form and nothing else. The reviewer therefore received a **0-byte** `acceptance-criteria.md`
+under a prompt stating that the acceptance criteria had been extracted for it.
+
+**So the findings above review the DIFF, and nothing in them was checked against
+the acceptance criteria** — the criteria were not in the reviewer context at all.
+The same roadmap yields 27 lines of criteria under the extractor as it stands
+today. The extractor learned the inline form in PR #1419 (2026-08-18).
+
+The manifest is deliberately left unchanged. `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`
+is the honest record of the input this review actually received, and rewriting it
+to today's value would assert a binding that never existed — the precise failure
+this note exists to prevent. The artefact binds a scope that no longer exists, so
+no gate re-derives it and nothing here is stale.

--- a/agents/evidence/reviews/feat-road-to-zero-ceremony-settings.findings.md
+++ b/agents/evidence/reviews/feat-road-to-zero-ceremony-settings.findings.md
@@ -56,3 +56,28 @@ Checked and deliberately NOT filed, with what was traced:
 - **`--source`** cannot influence the class lookup or the write target.
 - **`gate-coverage.yml` header numbers**: 27 claimed, 27 present.
 
+
+
+## Acceptance-criteria binding — this review was AC-BLIND
+
+Recorded 2026-08-18, after the fact.
+
+The manifest above carries `ac_hash: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`,
+which is the SHA-256 of the **empty string** rather than of any criteria. This
+review was dispatched against `agents/roadmaps/archive/road-to-zero-ceremony-settings.md`,
+which declares its criteria under a `## Acceptance criteria` heading spelled
+with a lowercase `c`, while the extractor of the day matched
+`## Acceptance Criteria` case-SENSITIVELY. The reviewer therefore received a **0-byte** `acceptance-criteria.md`
+under a prompt stating that the acceptance criteria had been extracted for it.
+
+**So the findings above review the DIFF, and nothing in them was checked against
+the acceptance criteria** — the criteria were not in the reviewer context at all.
+The same roadmap yields 25 lines of criteria under the extractor as it stands
+today. The extractor was made case-insensitive on 2026-08-09 — found by the zcs-close
+review itself. This artefact predates that repair.
+
+The manifest is deliberately left unchanged. `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`
+is the honest record of the input this review actually received, and rewriting it
+to today's value would assert a binding that never existed — the precise failure
+this note exists to prevent. The artefact binds a scope that no longer exists, so
+no gate re-derives it and nothing here is stale.

--- a/agents/evidence/reviews/zcs-closure-round2.findings.md
+++ b/agents/evidence/reviews/zcs-closure-round2.findings.md
@@ -24,3 +24,28 @@ dispatched: 2026-08-06T22:42:44Z
 | 7 | low | tests/scripts/jit_ask_budget.test.ts:486 | `seeAlsoBoundary` returns `lines.length` when no line matches `/^#{1,6}\s+see also\s*$/iu` exactly (a heading with trailing text, or no See-also section at all). The `inBody` check at :509 then degenerates to the plain `toContain('settings-ask-protocol')` that the block's own comment rejects as insufficient against the stated mutation. Nothing asserts a boundary was actually found, so the discriminator can be silently absent for some of the four MIGRATED files. | fixed | e1-fix — seeAlsoBoundary returns null for "no section" and the two cases assert differently; a near-miss heading now fails loudly instead of degrading to plain presence |
 | 8 | low | src/scripts/memory_learn_hook.ts:73 | The tri-state paragraph says "`undefined` means the key is absent", contradicting the same docstring's opening line and the code at :87: an unreadable settings file (permissions, a directory at the path, I/O error) also yields `undefined`, and `learnConsent` then reports `withheld-default`. An unreadable-but-permissive file is therefore indistinguishable from an absent one — the same silent-no-op class the docstring flags for malformed scalars, but not listed among them. | fixed | e1-fix — docstring names BOTH collapses (absent/unreadable, deliberate-false/malformed); a test pins the unreadable-file case |
 | 9 | low | tests/scripts/memory_learn_hook.test.ts:121 | "does NOT distinguish a deliberate false from a malformed value" asserts only equality between the two reads, so it would still pass if the parser regressed to returning `undefined` for both — i.e. it cannot fail for the reason it names. The preceding case pins the concrete `false`, so the behaviour is covered; this case adds no independent signal. | fixed | e1-fix — asserts the concrete false on both reads, so a regression to undefined fails the case it is named after |
+
+
+## Acceptance-criteria binding — this review was AC-BLIND
+
+Recorded 2026-08-18, after the fact.
+
+The manifest above carries `ac_hash: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`,
+which is the SHA-256 of the **empty string** rather than of any criteria. This
+review was dispatched against `agents/roadmaps/archive/road-to-zero-ceremony-settings.md`,
+which declares its criteria under a `## Acceptance criteria` heading spelled
+with a lowercase `c`, while the extractor of the day matched
+`## Acceptance Criteria` case-SENSITIVELY. The reviewer therefore received a **0-byte** `acceptance-criteria.md`
+under a prompt stating that the acceptance criteria had been extracted for it.
+
+**So the findings above review the DIFF, and nothing in them was checked against
+the acceptance criteria** — the criteria were not in the reviewer context at all.
+The same roadmap yields 25 lines of criteria under the extractor as it stands
+today. The extractor was made case-insensitive on 2026-08-09 — found by the zcs-close
+review itself. This artefact predates that repair.
+
+The manifest is deliberately left unchanged. `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`
+is the honest record of the input this review actually received, and rewriting it
+to today's value would assert a binding that never existed — the precise failure
+this note exists to prevent. The artefact binds a scope that no longer exists, so
+no gate re-derives it and nothing here is stale.

--- a/agents/evidence/reviews/zcs-closure.findings.md
+++ b/agents/evidence/reviews/zcs-closure.findings.md
@@ -24,3 +24,28 @@ dispatched: 2026-08-06T22:27:00Z
 | 7 | medium | agents/roadmaps/archive/road-to-zero-ceremony-settings.md:175 | The decision to keep the Phase-2 item at `[~]` rests on "with the three Phase-3 steps re-encoded to `[ ]` this roadmap keeps `open_ ≥ 3`, so it does not archive". That premise expires the moment the recorded blocker `absent-is-not-default-for-projection-mode` clears and Phase 3 closes: `count_open` returns to 0 with one `[~]` still present, re-firing the same `roadmap-progress-sync` Iron Law 3 condition the § Glyph re-encoding section documents as a repo-wide **commit refusal** with no agent-side bypass. The section declines the council's fix on a temporary property without recording the recurrence as a blocker, a follow-up, or an exit condition — so the next contributor to close Phase 3 hits an unannounced commit block. | fixed | e0-fix — recorded as an exit condition on the step AND in the blocker resolution |
 | 8 | low | src/scripts/memory_learn_hook.ts:73 | The docstring states `readLearnValue` returns "The raw scalar … or `undefined` when the file or the key is absent", and a sibling test (`memory_learn_hook.test.ts:113`) pins "distinguishes an absent key from a key set to false". Neither is accurate: a present-but-non-`true` scalar (`yes`, `1`, `on`, `maybe`) also returns `false` via `m[1] === 'true'` at :94, so a malformed value is indistinguishable from a deliberate opt-out. The fail-safe direction is right, but the exported tri-state does not mean what it documents, and a user who wrote `learn_on_session_end: yes` gets a silent permanent no-op with no diagnostic on either the value or the shape. | fixed | e0-fix — docstring states the false/malformed ambiguity; a test pins it |
 | 9 | low | tests/shared/nicknamePrefill.test.ts:73 | The rule file is read via `path.resolve('src/rules/settings-ask-protocol.md')` — CWD-relative, and evaluated in the describe body (i.e. at collection time), so a runner rooted anywhere but the repo root turns a targeted assertion into a whole-file collection error. Same pattern at `tests/scripts/memory_learn_hook.test.ts:84`. The sibling suite for the same feature already establishes the robust convention: `const REPO = path.resolve(__dirname, '..', '..')` (`jit_ask_budget.test.ts:40`), anchored on the test's own location rather than on the process CWD. | fixed | e0-fix — both suites anchor on __dirname, not the process CWD |
+
+
+## Acceptance-criteria binding — this review was AC-BLIND
+
+Recorded 2026-08-18, after the fact.
+
+The manifest above carries `ac_hash: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`,
+which is the SHA-256 of the **empty string** rather than of any criteria. This
+review was dispatched against `agents/roadmaps/archive/road-to-zero-ceremony-settings.md`,
+which declares its criteria under a `## Acceptance criteria` heading spelled
+with a lowercase `c`, while the extractor of the day matched
+`## Acceptance Criteria` case-SENSITIVELY. The reviewer therefore received a **0-byte** `acceptance-criteria.md`
+under a prompt stating that the acceptance criteria had been extracted for it.
+
+**So the findings above review the DIFF, and nothing in them was checked against
+the acceptance criteria** — the criteria were not in the reviewer context at all.
+The same roadmap yields 25 lines of criteria under the extractor as it stands
+today. The extractor was made case-insensitive on 2026-08-09 — found by the zcs-close
+review itself. This artefact predates that repair.
+
+The manifest is deliberately left unchanged. `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`
+is the honest record of the input this review actually received, and rewriting it
+to today's value would assert a binding that never existed — the precise failure
+this note exists to prevent. The artefact binds a scope that no longer exists, so
+no gate re-derives it and nothing here is stale.


### PR DESCRIPTION
## What this fixes

Six committed findings artefacts carry `ac_hash: e3b0c442…b855` — the SHA-256 of
the **empty string** — beside a roadmap that does declare acceptance criteria.
Each was dispatched with a 0-byte `acceptance-criteria.md` under a prompt saying
the criteria had been extracted. Their findings review the **diff**; nothing in
them was ever checked against the criteria.

Left alone, a reader sees a manifest hash and reads it as a criteria binding that
never existed — which is the same wrongness PR #1419 repaired in the extractor,
sitting in the evidence record rather than in the code.

## Two causes, and they are not the same bug

Naming the right one per file is the point of the sweep:

| cause | repaired | artefacts |
|---|---|---|
| inline `- **AC-n:**` bullets, no heading at all | PR #1419, 2026-08-18 | `catalogue-host-fit-phase1`, `catalogue-host-fit-phase3`, `feat-gate-autonomy` |
| heading spelled `## Acceptance criteria` (lowercase `c`), matched case-sensitively | 2026-08-09, found by the zcs-close review itself | `feat-road-to-zero-ceremony-settings`, `zcs-closure`, `zcs-closure-round2` |

The second group predates its own repair — worth stating, because a single
"extractor was broken" note would have been wrong for half the set.

## Selection was measured, not guessed

Every `*.findings.md` whose manifest names a roadmap **and** records the
empty-string `ac_hash` **and** whose roadmap yields non-empty criteria under
today's extractor.

That last clause is what separates these six from the **eleven** artefacts
recording the same hash entirely legitimately, because their roadmap genuinely
declares no criteria. Three further artefacts name a roadmap no longer present in
the tree and were left alone rather than guessed at.

## What this deliberately does NOT do

- **No manifest is re-bound.** The empty-string hash is the honest record of the
  input each review actually received. Rewriting it to today's value would assert
  exactly the binding these notes exist to deny.
- **No renames, no table rows, no code.** Additive prose only — the validator
  parses any table in an artefact as findings rows.
- Every one of the six binds a scope that no longer exists, so no gate re-derives
  them and none of them is stale.

## Verification

- `check_completion_review` clean; `task preflight` exit 0.
- `lint_evidence_artifacts` is scoped to **added** files (`--diff-filter=A`),
  checked in its source — so modifying artefacts that predate the `evidence-type`
  marker cannot red it. Three of the six carry no such marker.
- `check_no_roadmap_refs` scans `src/rules`, `src/skills`, `src/agent-src/*`,
  `docs/guidelines`, `docs/contracts` — not `agents/evidence/reviews/` — so the
  roadmap paths quoted in the notes are in scope for no gate.
- Contract §2.7 was read before touching anything: it governs the naming of
  superseded rounds and says the rename is "an archival step at the end of a
  round, **never an edit ban on the live artefact**".
