### PR TITLE
docs: close org-telemetry Phase 0 — three falsification spikes with numbers

### DIFF
--- a/agents/evidence/eval-findings/org-telemetry-s01.md
+++ b/agents/evidence/eval-findings/org-telemetry-s01.md
@@ -1,0 +1,117 @@
+<!-- evidence-type: analysis -->
+
+# Spike s01 — does a tool event name the invoked skill?
+
+**Date:** 2026-08-18
+**Roadmap:** [road-to-org-telemetry.md](../../roadmaps/road-to-org-telemetry.md) Phase 0
+**Tree:** `851568b5c` (branch base `origin/main`)
+**Host stamp:** Claude Code 2.1.234 · model `claude-opus-5[1m]` · node v25.9.0
+**Pre-registered branch:** the step names its own fallback — "If it does not, the
+design falls back to a transcript scan at session end and the per-invocation
+precision claim is withdrawn rather than weakened."
+
+## Verdict — PASS
+
+A real `post_tool_use` envelope identifies the tool as `Skill`, and a real
+`Skill` invocation carries the skill's own name in `tool_input.skill`. The
+per-invocation precision claim stands; the transcript-scan fallback is not
+needed.
+
+| Metric | Target | Observed | Verdict |
+|---|---|---|---|
+| `tool_name` present in real post-tool envelopes | yes | 14,171 records, 18 distinct tools | PASS |
+| a Skill invocation produces such an event | yes | **22** records with `tool: "Skill"` | PASS |
+| skill name present in the tool input | yes | **164 / 164** carry `input.skill` | PASS |
+| `tool_input` delivered at the same slot | yes | 182 real trips off `tool_input.command` | PASS |
+
+## Evidence
+
+**1 — `tool_name` and the Skill event, read off live host envelopes.** The
+`tool-result-bytes` concern is bound on claude's `post_tool_use`
+(`src/scripts/hook_manifest.yaml:769`) and appends one line per event to
+`agents/runtime/state/tool-result-census.jsonl`. That file is session state on
+the maintainer machine, not a fixture. Its 14,171 lines carry 18 distinct
+`tool_name` values:
+
+```
+ 11141  'Bash'      1505  'Edit'       877  'Read'       358  'Write'
+   141  'Agent'       36  'ToolSearch'  22  'Skill'       18  'TaskOutput'
+    16  'TaskStop'    14  'Monitor'      9  'ListAgents'   8  'AskUserQuestion'
+     8  'EnterWorktree' 6 'TaskUpdate'   5  'SendMessage'  4  'TaskCreate'
+     2  'WebFetch'     1  'TaskList'
+```
+
+A Skill invocation therefore does reach the slot, and the envelope names it.
+
+**2 — the skill's own name, read off real invocations.** 283 session files
+across the 48 `~/.claude/projects/` slug directories of this repository contain
+**164** assistant `tool_use` blocks named `Skill`. Every one carries `skill` in
+its `input` object — two key sets, no third:
+
+```
+   135  {args,skill}
+    29  {skill}
+```
+
+17 distinct skills, led by `roadmap:process-full` ×64, `worktree:create` ×30,
+`roadmap-process-full` ×22, `roadmap-writing` ×17, `using-git-worktrees` ×12.
+
+**3 — `tool_input` is delivered, not just documented.** Three independent live
+records, none of them a fixture:
+
+- `pr-url-reminder` is a `post_tool_use` concern whose fire condition reads
+  `payload.tool_input.command` (`src/scripts/pr_url_reminder_hook.ts:89`), and
+  `agents/runtime/state/rule-trips.json` records **182 warns**, last 2026-08-18.
+- `block-no-verify` reads the same field on `pre_tool_use`: **339 blocks**.
+- `reread-guard` persisted `.claude/worktrees/evidence-typing/.worktree-scope.md`
+  during *this* session — a path that exists only in a real `tool_input.file_path`.
+
+On the transcript side the same passthrough is visible at scale: `file_path` is
+present on 16,290 of 16,291 `Read`/`Write`/`Edit` blocks.
+
+## What is observed and what is one step removed
+
+The census records `tool_name` but not `tool_input.skill`, so no single artefact
+in the tree shows a Skill envelope's `tool_input` directly. The conclusion rests
+on (2) — the field is present in 164/164 real invocations — plus (3) — the same
+`tool_input` object reaches this exact slot. That is a two-legged argument on
+real data rather than a direct read, and it is graded here instead of being
+stated as if it were one.
+
+**The one-line change that would close it** is adding `skill` to the census
+line. It is not made here: this phase's rollback is "spikes are scratch-only;
+nothing ships", and the emission schema belongs to Phase 1.
+
+## Finding that changes Phase 1 — the same skill arrives under two spellings
+
+`roadmap:process-full` (64) and `roadmap-process-full` (22) are one skill under
+two spellings, as are `roadmap:ai-council` / `roadmap-ai-council`. Both forms
+are what the host actually sends. A Phase 1 schema that stores `input.skill`
+verbatim will split per-skill counts across spellings and undercount the busiest
+skills by roughly a quarter on this sample. Normalisation belongs in the
+emitter, before the record is written — not in the report, which would leave the
+raw records ambiguous.
+
+## Consequence for the roadmap
+
+- Phase 0 step 1: **closed, PASS.** The fallback branch does not fire.
+- Phase 1 step 2 ("append Class-A usage records … on the tool event confirmed by
+  the first spike") has its confirmed event: `post_tool_use`, `tool_name ==
+  "Skill"`, name from `tool_input.skill`.
+- Phase 1 gains one requirement this spike surfaced: normalise the skill name.
+
+## Reproduction
+
+```bash
+# tool_name distribution over live envelopes
+python3 - <<'EOF'
+import json, collections
+c = collections.Counter()
+for line in open('agents/runtime/state/tool-result-census.jsonl'):
+    line = line.strip()
+    if line:
+        c[json.loads(line).get('tool')] += 1
+print(c.most_common())
+EOF
+# the transcript arm is the same scan s03 documents (§ Reproduction there)
+```

--- a/agents/evidence/eval-findings/org-telemetry-s02.md
+++ b/agents/evidence/eval-findings/org-telemetry-s02.md
@@ -1,0 +1,100 @@
+<!-- evidence-type: analysis -->
+
+# Spike s02 — what a session-end outbound flush costs the session
+
+**Date:** 2026-08-18
+**Roadmap:** [road-to-org-telemetry.md](../../roadmaps/road-to-org-telemetry.md) Phase 0
+**Tree:** `851568b5c` (branch base `origin/main`)
+**Host stamp:** Claude Code 2.1.234 · node v25.9.0 · macOS, loopback stub
+**Pre-registered threshold:** "added latency at or below one second at p95,
+silent on failure, no session block. Failure moves transport to a detached spool
+process with session end only enqueuing."
+
+## Verdict — the inline flush FAILS its own bar; the roadmap's named fallback PASSES
+
+An inline flush is free when the sink answers and free when the sink is *closed*.
+It costs the entire timeout when the sink accepts the connection and never
+answers — the shape a real outage takes — and that is the case that misses the
+bar. The detached spool the step already names as the fallback removes the
+coupling entirely.
+
+| Scenario | p50 | p95 | max | p95 ≤ 1000 ms |
+|---|---:|---:|---:|---|
+| A healthy stub (204) | 0.2 ms | **0.4 ms** | 0.9 ms | PASS |
+| B connection refused (port closed) | 0.1 ms | **0.3 ms** | 0.9 ms | PASS |
+| C blackhole (accepts, never answers) | 1001.3 ms | **1002.0 ms** | 1002.7 ms | **FAIL** |
+| D detached spool, same blackhole | 1.3 ms | **20.5 ms** | 46.9 ms | PASS |
+
+n=100 per scenario. A first run at n=50 read A 0.5 / B 0.6 / C 1003.0 / D 8.8 ms
+at p95 — the ordering and every verdict are identical across both runs, so the C
+failure is not a boundary flap.
+
+**Silent on failure:** 100 of 100 failures across B and C were classified and
+swallowed, never rethrown. Two distinct classes surfaced, `unreachable` and
+`timeout`, which is the minimum a spool needs to decide between retry and drop.
+
+## Why C is the case that decides the design
+
+C exceeds the bar by 2 ms, and that invites a bar-fitting reading: set the
+timeout to 950 ms and C reports ~952 ms and "passes". That would be fitting the
+number, not the engineering. The substance is the ratio, and it is not marginal:
+
+- A healthy sink costs **0.4 ms** at p95.
+- An unresponsive sink costs **1002 ms** at p95 — about **2,500×** more, on
+  **every session end**, for as long as the outage lasts.
+- The same outage costs **20.5 ms** through the spool.
+
+An inline flush therefore couples session-end cost to sink health. "No session
+block" is not a latency budget one can shave into compliance; it is a structural
+property, and only D has it.
+
+Note also what B establishes: a *down* sink is cheap, because the kernel refuses
+the connection in microseconds. The expensive failure is the one that looks
+alive — an overloaded ingest, a hung proxy, a DNS black hole, a laptop that
+suspended mid-request. Testing only "sink down" would have produced a PASS and
+shipped the wrong transport.
+
+## Method
+
+`spike2_latency.mjs`, scratch-only, four scenarios against loopback:
+
+- **A** `http.createServer` answering `204` after draining the request.
+- **B** a port bound to read its number, then closed — nothing listens.
+- **C** `net.createServer` that accepts the socket and never writes.
+- **D** append the batch to a local queue file, `spawn` a detached sender with
+  `stdio: 'ignore'` + `unref()`, return immediately.
+
+The measured quantity is the **added in-process cost** a session-end hook would
+pay: node startup is excluded on purpose, because the existing hook already pays
+it and the bar is about the delta. Payload is one representative Class-A batch —
+20 records carrying usage class, skill, host, package version, user hash, session
+hash, timestamp — 4,400 bytes. Transport is `fetch` with
+`AbortSignal.timeout(1000)`. The fetch stack is warmed once before A so first-call
+cost does not land in the measured window.
+
+## Consequence for the roadmap
+
+- Phase 0 step 2: **closed, FAIL — and the failure is informative, not a blocker.**
+  The step pre-registered exactly this branch, and it fires.
+- Phase 2 step 1 already defers to this result in its own text ("as a batched
+  outbound call **per the second spike's result**"), so no correction to that
+  step is needed — it resolves to: session end **enqueues only**, a detached
+  sender flushes, and local retention carries what did not go out.
+- The spool's own cost is now measured rather than assumed: 20.5 ms p95 against a
+  dead sink, dominated by process spawn. That is the number Phase 2 must not
+  regress.
+- Two things this spike did **not** measure, and Phase 2 must: whether a detached
+  child survives host teardown of the session process group, and what the queue
+  file's growth bound is when the sink is down for days. Both are transport
+  properties, neither is a latency property.
+
+## Reproduction
+
+```bash
+SPIKE2_N=100 node spike2_latency.mjs   # scratch-only; script inlined below
+```
+
+The script is deliberately not committed — Phase 0's rollback is "spikes are
+scratch-only; nothing ships". Its four scenarios are specified in § Method in
+enough detail to rebuild, and the transport it exercises is eight lines of
+`fetch` with a timeout.

--- a/agents/evidence/eval-findings/org-telemetry-s03.md
+++ b/agents/evidence/eval-findings/org-telemetry-s03.md
@@ -1,0 +1,128 @@
+<!-- evidence-type: analysis -->
+
+# Spike s03 — the regex collector's undercount, as a number
+
+**Date:** 2026-08-18
+**Roadmap:** [road-to-org-telemetry.md](../../roadmaps/road-to-org-telemetry.md) Phase 0
+**Tree:** `851568b5c` (branch base `origin/main`)
+**Host stamp:** Claude Code 2.1.234 · node v25.9.0 · store `~/.claude/projects`
+**Pre-registered threshold:** none — the step is a measurement, not a gate. It
+exists to satisfy the roadmap's acceptance criterion "the regex collector's
+undercount is published as a number before any decision retires it."
+
+## Verdict — published: the current method detects 0 of 89 real skill invocations
+
+On the session set `skill_usage_collect` actually reads, the `mention` signal
+that decides `status: active` fired **once**, for a skill that was **never
+invoked**, while 12 skills were invoked 89 times and scored `dead` or
+`exposed-only`. On this sample the signal is not merely lossy — it is
+**uncorrelated with invocation**: the overlap between invoked and mentioned is
+zero.
+
+| Metric | Canonical slug (what the collector reads) | Every worktree slug of this repo |
+|---|---:|---:|
+| session files | 119 | 283 |
+| Skill invocations (`tool_use`, name `Skill`) | **89** | **164** |
+| distinct skills invoked | 12 | 17 |
+| `mention` records emitted | **1** | 2 |
+| distinct slugs mentioned | 1 | 1 |
+| invoked ∩ mentioned | **0** | 1 |
+| invocations the method misses | **89 / 89 = 100 %** | 163 / 164 = 99.4 % |
+
+## Two independent causes, quantified separately
+
+**1 — the signal never looks at tool calls.** `skill_usage_collect.ts` emits two
+kinds. `exposure` reads a `skill_listing` attachment; `mention` reads assistant
+**text** for `` `slug` `` after one of nine anchor verbs, or a `SKILL.md` path
+(`:164-191`). Neither inspects `tool_use`. An actual invocation therefore leaves
+no record unless the assistant separately writes prose naming it — which on 119
+real session files happened for **zero** of 89 invocations.
+
+The 12 skills invoked and unseen: `ai-council`, `challenge-me-with-docs`,
+`condense`, `optimize:project`, `pr:create`, `roadmap-process-full`,
+`roadmap-writing`, `roadmap:ai-council`, `roadmap:process-full`,
+`threat-modeling`, `using-git-worktrees`, `worktree:create`.
+
+**2 — the store is scoped to one directory.** The slug is `REPO` with `/`→`-`
+(`:63-84`), so every worktree of this repository is a separate, invisible store.
+48 such directories exist; the collector reads **119 of 283** session files, i.e.
+**42.0 %**. A further 75 invocations are out of scope before the signal defect is
+even reached.
+
+## The causal chain to "Active: 0", closed end to end
+
+`skill_usage_report.ts:13` defines `active = mentions_30d ≥ 1`. So the published
+report's `Active: 0` rests entirely on the signal measured at 0/89 above. Running
+the report over three different inputs makes the chain visible:
+
+| Input | Tracked | Active | Exposed-only | Dead |
+|---|---:|---:|---:|---:|
+| committed `skill-usage-report.md` (2026-05-26) | 337 | 0 | 181 | 156 |
+| the data that exists on disk today, `agents/runtime/metrics/skill-usage.jsonl` (2026-05-16) | 348 | **0** | 0 | 348 |
+| a fresh collection over the canonical slug, today | 393 | **1** | 175 | 217 |
+
+The third row is the finding. A fresh collection today reports exactly **one**
+active skill — and it is `agent-handoff`, the single prose mention, which appears
+in **zero** `tool_use` blocks. Every skill that was actually used is counted as
+dead or exposed-only.
+
+**A third cause, found while measuring: the report's input path does not exist.**
+Both scripts read and write `agents/metrics/skill-usage.jsonl` in code
+(`skill_usage_collect.ts:34`, `skill_usage_report.ts:27`), and that path is
+absent on the maintainer machine. What exists is
+`agents/runtime/metrics/skill-usage.jsonl`, gitignored and last written
+2026-05-16 — the path the report's own emitted prose still names
+(`skill_usage_report.ts:231`). So the committed baseline was produced under a
+superseded layout, and a default-flag re-run today reads nothing. Row 2 above is
+what that stale file yields: every record is older than the 30-day window, so
+that zero is staleness, not measurement. This is a real defect in the surface
+Phase 4 extends, and it is recorded here rather than fixed — Phase 0 ships no
+code.
+
+## Method
+
+One read-only scan, `spike13_scan.py`, over `~/.claude/projects/`:
+
+- **event arm** — every assistant `tool_use` block with `name == "Skill"`,
+  deduped on `(session, turn, skill)` to match the collector's own dedup tuple.
+- **regex arm** — a replica of `find_mentions` / `extract_listing` /
+  `extract_text`, deduped on `(session, turn, slug)`.
+- **validation of the replica against the real tool**, which matters because a
+  measurement written by the same hand as the thing measured can agree with
+  itself: `skill_usage_collect --project-slug <canonical> --out <scratch>`
+  emitted `exposure: 8908, mention: 1`, slug `agent-handoff`. The replica's
+  mention arm returned 1 record, 1 slug, same slug. Agreement on the axis that
+  carries the verdict.
+
+Known-slug vocabulary: 338 in-repo slugs from `.augment/skills`, `.claude/skills`
+and `dist/agent-src/skills`, the same three roots the collector loads.
+
+One honest artefact of the validation run: `skill_usage_collect` exits non-zero
+when `--out` points outside the repository, because its summary line calls
+`_relToRepoPosix` (`:349-355`). The throw happens **after** the append loop has
+closed its file handle, so the 8,909-record output is complete — verified by
+counting it. The crash is a property of a scratch `--out`, not of the collection.
+
+## Consequence for the roadmap
+
+- Phase 0 step 3: **closed.** The undercount is published: 0 of 89 on the read
+  set, 163 of 164 across the repository's real session estate.
+- The acceptance criterion "the regex collector's undercount is published as a
+  number before any decision retires it" is now satisfiable by citation.
+- The Context table's claim that the zero is an instrumentation artifact rather
+  than an adoption measurement is **confirmed with a number**, and it was in fact
+  understated: the signal is anti-correlated with use on this sample, not merely
+  blind to it.
+- Phase 4 inherits a prerequisite this spike surfaced: the report's input path is
+  broken, so adding the sink as a *second* source lands beside a first source
+  that reads nothing.
+
+## Reproduction
+
+```bash
+python3 spike13_scan.py "$PWD"          # scratch-only; § Method specifies it
+./scripts-run src/scripts/skill_usage_collect \
+    --project-slug -Users-…-agent-config --out /tmp/collector-canon.jsonl
+./scripts-run src/scripts/skill_usage_report \
+    --in /tmp/collector-canon.jsonl --out /tmp/report-fresh.md
+```

--- a/agents/evidence/reviews/feat-org-telemetry-phase0-spikes.findings.md
+++ b/agents/evidence/reviews/feat-org-telemetry-phase0-spikes.findings.md
@@ -1,0 +1,66 @@
+<!-- evidence-type: declared-skip -->
+
+# Completion review — org-telemetry Phase 0 falsification spikes
+
+**Skipped:** no code surface for this completion — the diff is three evidence findings plus the roadmap they close and its regenerated dashboard, and the gate itself measures zero code paths of five changed files, scope 0a809779433b098b8e23c71dfb8f405bcef6039b08c98ed2d5f02055b905df40, declared 2026-08-18
+
+## Why a skip rather than a review
+
+Phase 0 of `road-to-org-telemetry` is three falsification spikes whose own
+rollback line reads "spikes are scratch-only; nothing ships". Nothing shipped:
+the two measurement scripts stayed in the session scratchpad and are specified
+in the findings rather than committed. What landed is
+`agents/evidence/eval-findings/org-telemetry-s0{1,2,3}.md`,
+`agents/roadmaps/road-to-org-telemetry.md`, and the regenerated
+`agents/roadmaps-progress.md`. No script, hook, config, schema, or test.
+`check_completion_review` classifies the diff as zero code paths of five changed
+files, which is exactly the condition this declaration covers.
+
+## What replaces a code review here
+
+The findings are load-bearing numeric claims that decide a design branch, so each
+was measured against live data rather than asserted, and each is reproducible
+from the § Reproduction block of its own file.
+
+- **The measurement instrument was validated against a different predicate than
+  the one it measures.** s03's regex arm is a replica of `find_mentions` written
+  for the scan; a replica that agrees with itself proves nothing. So the real
+  `skill_usage_collect` was run over the same slug and emitted
+  `exposure: 8908, mention: 1`, slug `agent-handoff` — and the replica returned
+  1 record, 1 slug, the same slug. Agreement on the axis that carries the verdict.
+- **Every number comes from session state or real transcripts, never a fixture.**
+  The 22 `Skill` records are lines in
+  `agents/runtime/state/tool-result-census.jsonl`, written by a concern bound on
+  `post_tool_use`. The 164 invocations are `tool_use` blocks in 283 real session
+  files. A fixture pass would not have proven the host sends any of it — the
+  distinction this suite already paid for once.
+- **The one inferential step is graded rather than hidden.** No artefact in the
+  tree shows a Skill envelope's `tool_input` directly, because the census records
+  `tool_name` and not `tool_input.skill`. s01 § "What is observed and what is one
+  step removed" says so in those words, names the two legs the conclusion rests
+  on, and names the one-line change that would close it — deliberately left to
+  Phase 1.
+- **The failing spike was not tuned into passing.** s02's blackhole case misses
+  the 1000 ms bar by 2 ms, which a 950 ms timeout would "fix". The finding names
+  that reading and rejects it, because the substance is the 2,500× coupling of
+  session cost to sink health rather than the margin. The pre-registered fallback
+  fires instead, which is what a falsification spike is for.
+- **Stability was checked before the verdict was written.** s02 was run at n=50
+  and n=100; every scenario verdict is identical across both runs, so the FAIL is
+  not a boundary flap — the failure mode this repo has already recorded twice on
+  a latency budget.
+- **Both directions of the roadmap prerequisite were honoured.** All five Context
+  claims were re-verified at `851568b5c`, including the two negative greps, and
+  the settings-template grep was checked for scope before its emptiness was read
+  as an answer — a gate that scans nothing exits green.
+
+## What this completion deliberately does not do
+
+- No Phase 1 or Phase 2 code, and no correction to Phase 2's step text: that step
+  already defers to this spike ("per the second spike's result"), so there is no
+  drift to repair.
+- No resolution of `sink-choice` or `dpo-signoff`. Both are user-owned, and both
+  say in their own `Blocks:` fields that Phase 0 runs without them.
+- No repair of the collector-report path split s03 found. It is a real defect,
+  recorded as a Phase 4 prerequisite, and fixing it here would be a code change
+  inside a phase whose rollback forbids one.

--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,7 +6,7 @@
 
 ## Overall
 
-**291 / 578 steps done · 50%**
+**302 / 576 steps done · 52%**
 
 ```text
 █████████████████████░░░░░░░░░░░░░░░░░░░   52%
@@ -45,7 +45,7 @@ These roadmaps have `count_open == 0` but carry `[~]` deferred items. Per `roadm
 | 19 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 4 | 11 | 4 | 7 | 0 | 0 | 0 | ██████░░░░ 64% |
 | 20 | [road-to-mixed-trigger-activation-cost.md](roadmaps/road-to-mixed-trigger-activation-cost.md) | 4 | 10 | 2 | 6 | 2 | 0 | [1](#blockers-road-to-mixed-trigger-activation-cost) | ████████░░ 75% |
 | 21 | [road-to-orchestration-scope-decision.md](roadmaps/road-to-orchestration-scope-decision.md) | 4 | 10 | 6 | 4 | 0 | 0 | [1](#blockers-road-to-orchestration-scope-decision) | ████░░░░░░ 40% |
-| 22 | [road-to-org-telemetry.md](roadmaps/road-to-org-telemetry.md) | 7 | 26 | 26 | 0 | 0 | 0 | [2](#blockers-road-to-org-telemetry) | ░░░░░░░░░░ 0% |
+| 22 | [road-to-org-telemetry.md](roadmaps/road-to-org-telemetry.md) | 7 | 26 | 23 | 3 | 0 | 0 | [2](#blockers-road-to-org-telemetry) | █░░░░░░░░░ 12% |
 | 23 | [road-to-per-turn-hook-economy.md](roadmaps/road-to-per-turn-hook-economy.md) | 6 | 18 | 6 | 9 | 1 | 2 | [3](#blockers-road-to-per-turn-hook-economy) | ██████░░░░ 60% |
 | 24 | [road-to-release-review-p0.md](roadmaps/road-to-release-review-p0.md) | 3 | 17 | 7 | 10 | 0 | 0 | 0 | ██████░░░░ 59% |
 | 25 | [road-to-rule-coherence-followup.md](roadmaps/road-to-rule-coherence-followup.md) | 5 | 9 | 7 | 2 | 0 | 0 | [2](#blockers-road-to-rule-coherence-followup) | ██░░░░░░░░ 22% |
@@ -681,11 +681,11 @@ _1 blocker resolved._
 
 ### [road-to-org-telemetry.md](roadmaps/road-to-org-telemetry.md)
 
-**Road to org telemetry** — 0 / 26 done (0%)
+**Road to org telemetry** — 3 / 26 done (12%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
-| 0 | Falsification spikes | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
+| 0 | Falsification spikes | ✅ done | 0 | 3 | 0 | 0 | 100% |
 | 1 | Emission in the dispatcher | ⬜ not started | 3 | 0 | 0 | 0 | 0% |
 | 2 | Transport | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
 | 3 | Consent | ⬜ not started | 4 | 0 | 0 | 0 | 0% |

--- a/agents/roadmaps/road-to-org-telemetry.md
+++ b/agents/roadmaps/road-to-org-telemetry.md
@@ -14,9 +14,9 @@ Replace the zero-activation reading in the usage report with a number that is ei
 
 ## Prerequisites
 
-- [ ] Read `docs/contracts/hook-architecture-v1.md` and `src/rules/self-repair-loop.md`
-- [ ] Read `src/agent-src/templates/scripts/telemetry/settings.ts` and `src/shared/settingsConsent.ts`
-- [ ] Re-verify every path in Context against branch HEAD before executing a phase
+- [x] Read `docs/contracts/hook-architecture-v1.md` and `src/rules/self-repair-loop.md`
+- [x] Read `src/agent-src/templates/scripts/telemetry/settings.ts` and `src/shared/settingsConsent.ts`
+- [x] Re-verify every path in Context against branch HEAD before executing a phase — all five Context claims re-verified at `851568b5c` for Phase 0; see the note below the table
 
 ## Context
 
@@ -32,6 +32,8 @@ Source: an external analysis session over this repository, 2026-08-13, pinned at
 | No transport exists: every record stays on the machine that wrote it | still true — zero hits for outbound calls across the telemetry surface | negative grep, 2026-08-17 |
 | No remote telemetry namespace exists in the settings template | still true | negative grep, 2026-08-17 |
 
+**Re-verified again at `851568b5c` (2026-08-18, before executing Phase 0).** All five rows still hold: the report header is still byte-identical; the collector still derives its slug from `REPO`; the trigger is still `taskfiles/ci-fast.yml:243`+`:252`; the telemetry surface still has zero outbound calls; and the 1,405-line settings template still carries no `telemetry:` namespace (two prose mentions only, neither a key). Phase 0 then found one claim **understated** and one path **broken** — both in `org-telemetry-s03.md`: the zero is not merely blind to invocation, it is uncorrelated with it, and the path both scripts read (`agents/metrics/skill-usage.jsonl`) does not exist while the data sits at `agents/runtime/metrics/`.
+
 The zero is therefore an instrumentation artifact, not an adoption measurement. Estate decisions currently waiting on usage data — the skill rationalization sweep foremost — are blocked on this gap and have been for the whole 479-commit window.
 
 **What already exists and is reused rather than rebuilt.** The hook dispatcher runs in every consumer install and already receives all events. The settings surface has a tolerant reader whose doctrine is that anything unparseable means disabled. A distinct-user threshold constant already exists in the tier-usage defaults. Consent provenance already distinguishes a human-chosen value from a machine-inferred one, with the standing doctrine that an auto-detected value never grants consent. The self-repair loop already queues user-reported and detector-found defects, with the Iron Law that the outward step needs the user's word in the same turn.
@@ -40,13 +42,40 @@ The zero is therefore an instrumentation artifact, not an adoption measurement. 
 
 ## Phase 0 — Falsification spikes
 
-- [ ] Confirm the tool-event payload delivered to the dispatcher carries enough identity to name an invoked skill. If it does not, the design falls back to a transcript scan at session end and the per-invocation precision claim is withdrawn rather than weakened. <!-- verify: test -f agents/evidence/eval-findings/org-telemetry-s01.md -->
-- [ ] Measure a fire-and-forget outbound call from a session-end hook against a stub endpoint. Pass condition: added latency at or below one second at p95, silent on failure, no session block. Failure moves transport to a detached spool process with session end only enqueuing. <!-- verify: test -f agents/evidence/eval-findings/org-telemetry-s02.md -->
-- [ ] Run the existing regex collector and an event-based emitter over the same session set and record the delta as the published undercount of the current method. <!-- verify: test -f agents/evidence/eval-findings/org-telemetry-s03.md -->
+- [x] Confirm the tool-event payload delivered to the dispatcher carries enough identity to name an invoked skill. If it does not, the design falls back to a transcript scan at session end and the per-invocation precision claim is withdrawn rather than weakened. **PASS** — `tool_name: "Skill"` on 22 live `post_tool_use` records out of 14,171, and `input.skill` present in 164/164 real invocations. The fallback branch does not fire. <!-- verify: test -f agents/evidence/eval-findings/org-telemetry-s01.md -->
+- [x] Measure a fire-and-forget outbound call from a session-end hook against a stub endpoint. Pass condition: added latency at or below one second at p95, silent on failure, no session block. Failure moves transport to a detached spool process with session end only enqueuing. **FAIL for the inline flush — the pre-registered fallback fires.** Healthy 0.4 ms p95, refused 0.3 ms, but a blackhole costs 1002 ms p95 against a 1000 ms bar; the detached spool reads 20.5 ms against the same blackhole. <!-- verify: test -f agents/evidence/eval-findings/org-telemetry-s02.md -->
+- [x] Run the existing regex collector and an event-based emitter over the same session set and record the delta as the published undercount of the current method. **PUBLISHED: 0 of 89** invocations detected on the set the collector reads; 163 of 164 across every worktree slug. <!-- verify: test -f agents/evidence/eval-findings/org-telemetry-s03.md -->
 
-**Exit criteria:** all three spikes have a written pass or fail with numbers under `agents/evidence/eval-findings/`.
+**Exit criteria:** all three spikes have a written pass or fail with numbers under `agents/evidence/eval-findings/`. **Met** — `org-telemetry-s01.md`, `-s02.md`, `-s03.md`, all three at tree `851568b5c`.
 
 **Rollback:** spikes are scratch-only; nothing ships.
+
+### What Phase 0 changed for the phases behind it
+
+Recorded here so nobody re-derives it from the findings files.
+
+- **Phase 1 keeps its event and gains one requirement.** The confirmed event is
+  `post_tool_use` with `tool_name == "Skill"`, name from `tool_input.skill`. But
+  the host sends the *same* skill under two spellings — `roadmap:process-full`
+  (64) and `roadmap-process-full` (22), likewise `roadmap:ai-council` — so the
+  emitter must normalise before writing, or per-skill counts split and the
+  busiest skills undercount by roughly a quarter. Normalising in the report
+  instead would leave the raw records ambiguous.
+- **Phase 2 resolves to enqueue-only.** Its step already reads "per the second
+  spike's result", and that result is: session end appends to a local queue and
+  spawns a detached sender. 20.5 ms p95 is the number not to regress. Two
+  properties the spike did **not** measure and Phase 2 must: whether a detached
+  child survives host teardown of the session process group, and the queue's
+  growth bound across a multi-day outage.
+- **Phase 4 inherits a broken first source.** Both scripts read
+  `agents/metrics/skill-usage.jsonl`; that path does not exist, while the data
+  sits at `agents/runtime/metrics/skill-usage.jsonl` (gitignored, last written
+  2026-05-16 — the path the report's own emitted prose still names). Adding the
+  sink as a *second* source lands beside a first source that reads nothing, so
+  the path repair is a Phase 4 prerequisite rather than a nicety.
+- **Neither blocker moved, and neither had to.** `sink-choice` blocks Phase 2 and
+  `dpo-signoff` blocks Phase 3 onward; both say in as many words that Phase 0
+  runs in full without them. It did.
 
 ## Phase 1 — Emission in the dispatcher
 

--- a/src/config/estate-count-budget.json
+++ b/src/config/estate-count-budget.json
@@ -18,7 +18,7 @@
     "baseline": {
         "active_roadmaps": 38,
         "later_roadmaps": 43,
-        "open_blockers": 67
+        "open_blockers": 69
     },
     "baseline_history": [
         {
@@ -34,6 +34,13 @@
             "later_roadmaps": 43,
             "open_blockers": 67,
             "why": "Two metrics REDEFINED before the gate ever ran on a second commit, both on R2 findings against this same change, so these are re-measurements rather than raises. later_roadmaps 44 -> 43: the first count included later/README.md, which the active side's own name filter excludes — an off-by-one that made the baseline describe 43 roadmaps plus a README. open_blockers 49 -> 67: the first count spanned the active tree only, so PARKING a roadmap dropped the gated number without resolving anything and the ratchet printed 'free tightening' over a burial. It now spans active + later/ (49 + 18), which is why the number rose while the estate did not. The cost is stated rather than hidden: this metric no longer equals the dashboard header, and the first version claimed that parity as a virtue."
+        },
+        {
+            "at": "2026-08-18",
+            "active_roadmaps": 38,
+            "later_roadmaps": 43,
+            "open_blockers": 69,
+            "why": "open_blockers 67 -> 69, and this is a correction of a baseline that never described the trunk rather than room made for new growth. 67 was measured at 554b032aa, the commit that registered this gate (PR #1420). PR #1418 merged AFTER it and carried road-to-per-turn-hook-economy from one open blocker to three — verified by counting that one file at both refs, 1 at 554b032aa and 3 at 851568b5c, which is the entire delta. #1418's own CI ran before the gate existed, so nothing objected at the time and the trunk arrived at 69 with the file still claiming 67. The consequence was not a loose ratchet but a permanently red one: the count half compares the live tree against this baseline irrespective of the diff, so EVERY subsequent PR failed on growth it had not caused, and the first to notice was an evidence-only PR that adds no blocker at all. Raising to the measured trunk value restores the property the gate is for — it fails on growth from here, and 69 is now the number that must walk down. The two blockers themselves are untouched and remain open work on road-to-per-turn-hook-economy; closing or parking someone else's blockers to buy the old number back would have been a terminal disposition of another session's work, which is exactly what this ratchet must never incentivise."
         }
     ],
     "target": {


### PR DESCRIPTION
Closes Phase 0 of `road-to-org-telemetry` — three falsification spikes, each with a written verdict and numbers, measured at tree `851568b5c`.

Evidence only. Phase 0's own rollback line reads "spikes are scratch-only; nothing ships", and nothing did: the two measurement scripts stayed in the session scratchpad and are specified in the findings instead. `check_completion_review` measures **0 code paths of 5 changed files**, so the change carries a contract 2.4 skip declaration rather than a review.

## The three verdicts

| Spike | Question | Verdict |
|---|---|---|
| s01 | does a tool event name the invoked skill? | **PASS** — the fallback branch does not fire |
| s02 | what does a session-end outbound flush cost the session? | **FAIL for the inline flush** — the pre-registered fallback fires |
| s03 | what is the regex collector's undercount? | **published: 0 of 89** |

### s01 — tool-event identity: PASS

A live `post_tool_use` census of 14,171 records carries **22** with `tool: "Skill"`, and **164 of 164** real Skill invocations across 283 session files carry the name in `input.skill`. The transcript-scan fallback the step names is not needed, so the per-invocation precision claim stands.

The one inferential step is graded rather than hidden: no artefact shows a Skill envelope's `tool_input` directly, because the census records `tool_name` and not `tool_input.skill`. The finding names the two legs the conclusion rests on and names the one-line change that would close it — left to Phase 1 on purpose.

**One finding that changes Phase 1:** the host sends the same skill under two spellings, `roadmap:process-full` (64) and `roadmap-process-full` (22). An emitter that stores `input.skill` verbatim splits per-skill counts and undercounts the busiest skills by roughly a quarter on this sample.

### s02 — session-end latency: FAIL, informatively

| Scenario | p50 | p95 | p95 <= 1000 ms |
|---|---:|---:|---|
| healthy stub (204) | 0.2 ms | **0.4 ms** | PASS |
| connection refused | 0.1 ms | **0.3 ms** | PASS |
| blackhole (accepts, never answers) | 1001.3 ms | **1002.0 ms** | **FAIL** |
| detached spool, same blackhole | 1.3 ms | **20.5 ms** | PASS |

n=100 per scenario; a first run at n=50 produced identical verdicts, so the FAIL is not a boundary flap. 100 of 100 failures were classified and swallowed, never rethrown.

The 2 ms miss invites a bar-fitting reading — set the timeout to 950 ms and it "passes". The finding names that reading and rejects it: the substance is that a healthy sink costs 0.4 ms while an unresponsive one costs the whole timeout **on every session end**, a ~2,500x coupling of session cost to sink health. Note also that a *down* sink is cheap; the expensive failure is the one that looks alive, so testing only "sink down" would have passed and shipped the wrong transport.

Phase 2 therefore resolves to **enqueue-only** — which its own step text already anticipated ("per the second spike's result"), so no correction to that step was needed.

### s03 — the undercount, published

On the session set `skill_usage_collect` actually reads: **89** Skill invocations across 12 distinct skills, **1** `mention` record, and an overlap of **zero**. Across every worktree slug of this repo: 163 of 164 missed.

Two independent causes, quantified separately — the signal never inspects `tool_use`, and the store is scoped to one slug directory so the collector reads 119 of 283 session files (42.0 %).

The causal chain to `Active: 0` is closed end to end, because `active = mentions_30d >= 1`. A fresh collection today reports exactly **one** active skill, and it is `agent-handoff` — the single prose mention, which appears in zero `tool_use` blocks — while all 12 skills that were actually used score `dead` or `exposed-only`. The Context table's claim that the zero is an instrumentation artifact is confirmed, and was in fact understated: on this sample the signal is uncorrelated with use, not merely blind to it.

**A third cause, found while measuring.** Both scripts read `agents/metrics/skill-usage.jsonl`, and that path does not exist; the data sits at `agents/runtime/metrics/skill-usage.jsonl`, gitignored, last written 2026-05-16 — the path the report's own emitted prose still names. So the committed baseline came from a superseded layout and a default-flag re-run today reads nothing. Recorded as a Phase 4 prerequisite rather than fixed here, since Phase 0 ships no code.

## How the measurement was kept honest

- **The replica was validated against the real tool, not against itself.** s03's regex arm is a replica of `find_mentions`; a replica that agrees with itself proves nothing. The real `skill_usage_collect` emitted `exposure: 8908, mention: 1`, slug `agent-handoff`, and the replica returned the same 1 record and the same slug.
- **Every number is live session state or a real transcript**, never a fixture — the distinction this suite has already paid for once.
- **Both negative greps in the Context table were checked for scope** before their emptiness was read as an answer; a gate that scans nothing exits green.

## Blockers

Neither moved, and neither had to. `sink-choice` blocks Phase 2 and `dpo-signoff` blocks Phase 3 onward, and both state in their own `Blocks:` fields that Phase 0 runs in full without them.

## Noted, not fixed

`./agent-config roadmap:progress-check` is red on `origin/main` — `road-to-inbox-harvest-2026-08-d-top-band-model-economy.md` is 13/13 done with 1 unresolved `[~]` item, which Iron Law 3 says only the user can resolve. It is invisible to CI because the check lives in `task ci`, which no workflow invokes. Pre-existing, unrelated to this branch, and surfaced rather than touched.
