### PR TITLE
ci(economy): settle the shard fold-back on a 50-run post-fix measurement

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -231,9 +231,18 @@ jobs:
         # quarter of the file set. The subprocess-heavy clusters (golden +
         # workspace) hash-clump into one over-budget shard regardless of shard
         # count, so they are excluded here and run in the dedicated
-        # `golden-tests` / `workspace-tests` jobs below → each node-tests shard
-        # stays light and balanced. (There has never been a `heavy-tests` job;
-        # the name this comment used to carry named nothing.)
+        # `golden-tests` / `workspace-tests` jobs below. (There has never been a
+        # `heavy-tests` job; the name this comment used to carry named nothing.)
+        #
+        # The exclusion does NOT make the shards balanced, and this comment used
+        # to claim it did. Measured over 50 successful `main` runs on 2026-08-18:
+        # shard 3/4 averages 357 s ubuntu / 516 s macOS against 147–164 s for its
+        # three siblings, so it is 2.3× the others and over the 5-min per-job
+        # ceiling. The driver is `tests/scripts/build_proof.test.ts`, which is
+        # NOT excluded here and spawns nothing — its cost is `render()` at ~54 s
+        # a call. Folding the two dedicated jobs back in was evaluated against
+        # these figures and rejected; the arithmetic and the revisit-if live in
+        # docs/contracts/ci-cost-budget.md § Fold-back decision, 2026-08-18.
         run: >-
           npm run test:ts --silent --
           --shard=${{ matrix.shard }}/4

--- a/agents/evidence/reviews/feat-ci-economy-shard-fold-back.findings.md
+++ b/agents/evidence/reviews/feat-ci-economy-shard-fold-back.findings.md
@@ -1,0 +1,78 @@
+# Completion review — ci-economy shard fold-back decision
+
+**Skipped:** no code surface for this completion — the diff is one contract document, one comment-only hunk in a workflow, one roadmap file and its generated dashboard, and the gate itself measures zero code paths of four changed files, scope b8b76958a29d655782102e606c96bc70e256025622abb383dbb8373298b474d7, declared 2026-08-18
+
+## Why a skip rather than a review
+
+Four files, no executable surface between them:
+
+- `docs/contracts/ci-cost-budget.md` — measured figures and a decision.
+- `.github/workflows/tests.yml` — a comment. No step, trigger, matrix
+  dimension, exclusion or job key changed; `git diff` on this file touches
+  only `#`-prefixed lines.
+- `agents/roadmaps/road-to-inbox-harvest-2026-08-b-ci-economy.md` — one
+  checkbox closed, two glyphs restored, reasoning recorded.
+- `agents/roadmaps-progress.md` — regenerated from the file above.
+
+No script, hook, schema, config, test or generator. `check_completion_review`
+classifies the diff as zero code paths of four changed files, which is the
+condition this declaration covers.
+
+## What replaces a code review here
+
+The change is a measurement and a decision taken from it, so the reviewable
+surface is whether the numbers are real and whether the decision follows. Each
+was checked rather than asserted:
+
+- **The figures come from CI, per-job, over the sample the contract itself
+  specifies.** 50 most-recent successful `main` runs of `tests.yml`, aggregated
+  from `/actions/runs/<id>/jobs`, 1150 job rows. Not run-level — the contract's
+  own Method note records that mixing the two manufactured two regressions the
+  last time it happened, so the mistake is named and avoided rather than
+  re-derived.
+- **All 50 runs are post-fix.** The oldest is 2026-08-12 and the shard-3 fix
+  merged 2026-08-11 (PR 1271), so no pre-fix run contaminates the average. That
+  boundary was checked, not assumed from the run count.
+- **Sample size is reported as a result, not a footnote.** Shard 3/4 on ubuntu
+  ranges 217–406 s across the 50. The 2026-08-11 baseline used three runs, so it
+  could have read anywhere from under the ceiling to 1.4× it — which is why the
+  re-measurement widened the sample to the one the ceiling clause already asked
+  for instead of repeating the old method.
+- **The decision does not rest on the threshold alone.** The step's stated rule
+  was a single comparison against 300 s. Keeping two dedicated runners on one
+  inequality is thin, so the fold-back was also costed: ≈ 172 s of test-time to
+  redistribute, giving ≈ 400 s even-split and ≈ 529 s clumped on ubuntu. Both
+  bounds are worse, so the verdict holds however vitest happens to distribute —
+  and clumping is the documented behaviour, which is the whole reason the
+  dedicated jobs exist.
+- **The overhead figure is borrowed from this contract, not invented.** The
+  ≈ 25 s per-job fixed cost is the number the file already derives in its
+  build-artefact rejection; the arithmetic reuses it and says so.
+- **One claim was falsified during the work and removed rather than shipped.**
+  The first justification for restoring the two `[~]` glyphs was that leaving
+  them would red the PR. Checked: `roadmap-progress-check` is registered only in
+  `task ci` (`Taskfile.yml:358`), no workflow invokes it, and the pre-push hook
+  runs `task consistency` + `task preflight`, neither of which reaches it. The
+  breach was local-only, so the mechanism claim is stated as refuted inside the
+  roadmap and the correction rests on accuracy alone.
+- **The workflow comment's remaining claims were re-checked before the edit, so
+  the correction is narrow.** The exclusion rationale (golden + workspace
+  hash-clump) is about files that are still excluded and is untouched. Only the
+  "stays light and balanced" clause is falsified by the measurement, because the
+  shard-3 driver is not one of the excluded files.
+
+Gates green on this branch: `task preflight` (exit 0), `lint_workflow_paths`,
+`lint_workflow_security`, `check_references`, `check_no_roadmap_refs`,
+`lint_roadmap_family_cap`, YAML parse of the edited workflow, and the three
+`verify:` annotations 3.4 ships with.
+
+## Standing caveat
+
+A skip declaration is a statement about the diff's surface, not a claim that the
+reasoning is right. The strongest objection is that a 50-run average still mixes
+two OS legs, PR-triggered and push-triggered runs, and whatever runner variance
+GitHub had that week, so 357 s is a figure with an unstated confidence interval
+rather than a constant. The counter is that the decision needs only the sign of
+the comparison and it is the same at every bound computed here — the best single
+ubuntu run (217 s) is the only observation that falls the other side of the
+ceiling, and one run is what the widened sample exists to stop being decisive.

--- a/agents/evidence/reviews/feat-ci-economy-shard-fold-back.findings.md
+++ b/agents/evidence/reviews/feat-ci-economy-shard-fold-back.findings.md
@@ -48,13 +48,23 @@ was checked rather than asserted:
 - **The overhead figure is borrowed from this contract, not invented.** The
   ≈ 25 s per-job fixed cost is the number the file already derives in its
   build-artefact rejection; the arithmetic reuses it and says so.
-- **One claim was falsified during the work and removed rather than shipped.**
-  The first justification for restoring the two `[~]` glyphs was that leaving
-  them would red the PR. Checked: `roadmap-progress-check` is registered only in
-  `task ci` (`Taskfile.yml:358`), no workflow invokes it, and the pre-push hook
-  runs `task consistency` + `task preflight`, neither of which reaches it. The
-  breach was local-only, so the mechanism claim is stated as refuted inside the
-  roadmap and the correction rests on accuracy alone.
+- **Two mechanism claims were falsified during the work and are recorded as
+  refuted rather than quietly dropped.** Both concerned the glyph restore on 4.2
+  and 4.3, and each would have justified the opposite edit:
+  - *"Leaving them `[~]` reds the PR."* False. `roadmap-progress-check` is
+    registered only in `task ci` (`Taskfile.yml:358`), no workflow invokes it,
+    and the pre-push hook runs `task consistency` + `task preflight`, neither of
+    which reaches it. Local-only red. This also refutes a line carried in the
+    project's own notes since 2026-08-11.
+  - *"Restoring them grows `open_blockers` and reds the estate ratchet."* Also
+    false, and believed for several steps because the ratchet **did** go red on
+    this PR at `open_blockers 67 → 69`. Measured both ways in one worktree:
+    `check_estate_count` reports **69 with `[~]` and 69 with `[ ]`**. The +2 is
+    pre-existing on `main` — run 32173675188 at `851568b5c` fails with the
+    identical number before this branch existed. The lesson generalises: a red
+    that appears on your PR is not evidence your PR caused it.
+
+  The restore therefore rests on accuracy alone, which is where it started.
 - **The workflow comment's remaining claims were re-checked before the edit, so
   the correction is narrow.** The exclusion rationale (golden + workspace
   hash-clump) is about files that are still excluded and is untouched. Only the
@@ -65,6 +75,16 @@ Gates green on this branch: `task preflight` (exit 0), `lint_workflow_paths`,
 `lint_workflow_security`, `check_references`, `check_no_roadmap_refs`,
 `lint_roadmap_family_cap`, YAML parse of the edited workflow, and the three
 `verify:` annotations 3.4 ships with.
+
+**One check is red and it is inherited, not caused here.**
+`Sync + Generate Tools Consistency` — the single required check — fails on
+`check_estate_count` with `open_blockers 67 → 69`. The same step fails on `main`
+at `851568b5c` (run 32173675188, 2026-08-18 18:55), before this branch existed,
+and the number is identical with either glyph choice on 4.2/4.3. Clearing it is
+an estate-budget decision — one-in-one-out, or a reasoned baseline raise in
+`src/config/estate-count-budget.json` — so it is surfaced to the maintainer
+rather than absorbed here. Raising the baseline to make one PR green is exactly
+the move that ratchet exists to refuse.
 
 ## Standing caveat
 

--- a/agents/evidence/reviews/feat-ci-economy-shard-fold-back.findings.md
+++ b/agents/evidence/reviews/feat-ci-economy-shard-fold-back.findings.md
@@ -1,6 +1,6 @@
 # Completion review — ci-economy shard fold-back decision
 
-**Skipped:** no code surface for this completion — the diff is one contract document, one comment-only hunk in a workflow, one roadmap file and its generated dashboard, and the gate itself measures zero code paths of four changed files, scope e1fc0e64afe880efc4c4c60aa57b83f877614bc412c80c008458f96341798e1b, declared 2026-08-18
+**Skipped:** no code surface for this completion — the diff is one contract document, one comment-only hunk in a workflow, one roadmap file and its generated dashboard, and the gate itself measures zero code paths of four changed files, scope 6ccc0caa10ee765e76bff68cedb22508e93393f8603f0cb5a3615d803ce52ae2, declared 2026-08-18
 
 ## Why a skip rather than a review
 
@@ -76,15 +76,29 @@ Gates green on this branch: `task preflight` (exit 0), `lint_workflow_paths`,
 `lint_roadmap_family_cap`, YAML parse of the edited workflow, and the three
 `verify:` annotations 3.4 ships with.
 
-**One check is red and it is inherited, not caused here.**
-`Sync + Generate Tools Consistency` — the single required check — fails on
-`check_estate_count` with `open_blockers 67 → 69`. The same step fails on `main`
-at `851568b5c` (run 32173675188, 2026-08-18 18:55), before this branch existed,
-and the number is identical with either glyph choice on 4.2/4.3. Clearing it is
-an estate-budget decision — one-in-one-out, or a reasoned baseline raise in
-`src/config/estate-count-budget.json` — so it is surfaced to the maintainer
-rather than absorbed here. Raising the baseline to make one PR green is exactly
-the move that ratchet exists to refuse.
+**Three checks were red on the first push and none was caused here. One has since
+been fixed on the base; two remain inherited.**
+
+- **`Sync + Generate Tools Consistency` — RESOLVED on the base, not by this
+  branch.** It failed on `check_estate_count` at `open_blockers 67 → 69`, and the
+  same step failed on `main` at `851568b5c` (run 32173675188) before this branch
+  existed. PR #1423 then merged and raised the baseline to 69 with its own
+  recorded reason; after merging that base in, `check_estate_count` exits 0 at
+  `open_blockers 69 (baseline 69, +0)`. Stated as a base fix rather than quietly
+  dropped, because the earlier version of this section named it a live breach and
+  a reader comparing the two would otherwise not know which is true.
+- **`Node Tests` shard 1/4, ubuntu and macOS — inherited.** Same failing step
+  (`Vitest (shard 1/4, heavy suites excluded)`, step 7) on `main` run 32173675197
+  at `851568b5c`. No test file, config or exclusion changed here; the shard-1 file
+  set is untouched by this diff.
+- **`Static Checks` — a known runner-variance flake, and not on a path this diff
+  touches.** The failing step is 12, `hook-latency bench gate (pre-registered
+  budget, real path)`. No hook, manifest or concern changed here. `prepack` and
+  `typecheck` both exit 0 locally on this tree.
+
+Nothing here absorbs an inherited red into this change, and no baseline was
+raised to make this PR green — that is the move the ratchet exists to refuse, and
+the raise that did happen was another PR's, with its own reason.
 
 ## Standing caveat
 

--- a/agents/evidence/reviews/feat-ci-economy-shard-fold-back.findings.md
+++ b/agents/evidence/reviews/feat-ci-economy-shard-fold-back.findings.md
@@ -1,6 +1,6 @@
 # Completion review — ci-economy shard fold-back decision
 
-**Skipped:** no code surface for this completion — the diff is one contract document, one comment-only hunk in a workflow, one roadmap file and its generated dashboard, and the gate itself measures zero code paths of four changed files, scope b8b76958a29d655782102e606c96bc70e256025622abb383dbb8373298b474d7, declared 2026-08-18
+**Skipped:** no code surface for this completion — the diff is one contract document, one comment-only hunk in a workflow, one roadmap file and its generated dashboard, and the gate itself measures zero code paths of four changed files, scope e1fc0e64afe880efc4c4c60aa57b83f877614bc412c80c008458f96341798e1b, declared 2026-08-18
 
 ## Why a skip rather than a review
 

--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,7 +6,7 @@
 
 ## Overall
 
-**291 / 578 steps done · 50%**
+**300 / 578 steps done · 52%**
 
 ```text
 █████████████████████░░░░░░░░░░░░░░░░░░░   52%
@@ -36,7 +36,7 @@ These roadmaps have `count_open == 0` but carry `[~]` deferred items. Per `roadm
 | 10 | [road-to-frontend-skill-application.md](roadmaps/road-to-frontend-skill-application.md) | 5 | 31 | 9 | 22 | 0 | 0 | [3](#blockers-road-to-frontend-skill-application) | ███████░░░ 71% |
 | 11 | [road-to-gate-autonomy.md](roadmaps/road-to-gate-autonomy.md) | 4 | 9 | 1 | 6 | 2 | 0 | [2](#blockers-road-to-gate-autonomy) | █████████░ 86% |
 | 12 | [road-to-gated-reach-followup.md](roadmaps/road-to-gated-reach-followup.md) | 1 | 12 | 12 | 0 | 0 | 0 | [1](#blockers-road-to-gated-reach-followup) | ░░░░░░░░░░ 0% |
-| 13 | [road-to-inbox-harvest-2026-08-b-ci-economy.md](roadmaps/road-to-inbox-harvest-2026-08-b-ci-economy.md) | 5 | 24 | 1 | 17 | 2 | 4 | [2](#blockers-road-to-inbox-harvest-2026-08-b-ci-economy) | █████████░ 94% |
+| 13 | [road-to-inbox-harvest-2026-08-b-ci-economy.md](roadmaps/road-to-inbox-harvest-2026-08-b-ci-economy.md) | 5 | 24 | 2 | 18 | 0 | 4 | [2](#blockers-road-to-inbox-harvest-2026-08-b-ci-economy) | █████████░ 90% |
 | 14 | [road-to-inbox-harvest-2026-08-b-dispatch-safety.md](roadmaps/road-to-inbox-harvest-2026-08-b-dispatch-safety.md) | 4 | 21 | 1 | 14 | 0 | 6 | 0 | █████████░ 93% |
 | 15 | [road-to-inbox-harvest-2026-08-c-evidence-lifecycle.md](roadmaps/road-to-inbox-harvest-2026-08-c-evidence-lifecycle.md) | 3 | 13 | 1 | 9 | 0 | 3 | [1](#blockers-road-to-inbox-harvest-2026-08-c-evidence-lifecycle) | █████████░ 90% |
 | 16 | [road-to-inbox-harvest-2026-08-d-top-band-model-economy.md](roadmaps/road-to-inbox-harvest-2026-08-d-top-band-model-economy.md) | 4 | 14 | 0 | 13 | 1 | 0 | 0 | ██████████ 100% |
@@ -447,15 +447,15 @@ _1 blocker resolved._
 
 ### [road-to-inbox-harvest-2026-08-b-ci-economy.md](roadmaps/road-to-inbox-harvest-2026-08-b-ci-economy.md)
 
-**Road to CI Economy — cut the redundant full builds and re-anchor the cost artefacts to CI-recorded data** — 17 / 18 done (94%)
+**Road to CI Economy — cut the redundant full builds and re-anchor the cost artefacts to CI-recorded data** — 18 / 20 done (90%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 0 | Re-anchor the two existing cost artefacts to CI-recorded data | ✅ done | 0 | 4 | 0 | 1 | 100% |
 | 1 | Free hygiene: dead filters, missing concurrency, stale comments, caches | ✅ done | 0 | 7 | 0 | 0 | 100% |
 | 2 | The build fan-out: stop rebuilding the same 6 targets 13 times | ✅ done | 0 | 2 | 0 | 3 | 100% |
-| 3 | The subprocess lever: extend in-process running, do not add a skill | 🟡 in progress | 1 | 3 | 0 | 0 | 75% |
-| 4 | Required-check-set changes (authored here, applied by the maintainer) | ✅ done | 0 | 1 | 2 | 0 | 100% |
+| 3 | The subprocess lever: extend in-process running, do not add a skill | ✅ done | 0 | 4 | 0 | 0 | 100% |
+| 4 | Required-check-set changes (authored here, applied by the maintainer) | 🟡 in progress | 2 | 1 | 0 | 0 | 33% |
 
 <a id="blockers-road-to-inbox-harvest-2026-08-b-ci-economy"></a>
 **Blockers**

--- a/agents/roadmaps/road-to-inbox-harvest-2026-08-b-ci-economy.md
+++ b/agents/roadmaps/road-to-inbox-harvest-2026-08-b-ci-economy.md
@@ -383,9 +383,51 @@ Re-derived in this worktree at `c073d5732` (v9.32.0):
       the node-vitest subprocess-vs-in-process axis gives it a second stack peer,
       which also moves it toward the multi-stack shape
       `framework-neutrality-in-generic-skills` asks of a generically named artefact.
-- [ ] **3.4 Retire the `heavy-tests` framing if the clumping cause is gone.**
-      **Stays OPEN, not deferred — its decision input does not exist yet, and
-      cannot until this PR lands.** `[ ]` rather than `[~]` on purpose: this is
+- [x] **3.4 Retire the `heavy-tests` framing if the clumping cause is gone.**
+      **Closed 2026-08-18 on the post-merge measurement the step was waiting
+      for. The framing STAYS — the clumping cause is not gone — and the step's
+      real deliverable turned out to be a falsified sentence in the workflow
+      comment rather than the retirement it is named after.**
+
+      The firing condition below (*"shard 3/4 has a post-merge duration on
+      `main`"`*) had been satisfiable since 2026-08-11, when PR #1271 merged;
+      two backlog screens excluded this roadmap on the stale reason *"a
+      post-merge measurement that cannot exist in its own PR"* after it could.
+      Recorded because the exclusion outlived its cause by a week: a resume-when
+      condition needs re-probing, not re-reading.
+
+      **Measured**, per this file's own method (`ci-cost-budget.md` quarterly
+      checklist item 1 — per-job via `/actions/runs/<id>/jobs`, never run-level),
+      over the **50** most recent successful `main` runs, all post-fix:
+      shard 3/4 = **357 s ubuntu / 516 s macOS** against 147–164 s for its three
+      siblings. Pre-fix was 645 s / 852 s, so 3.2 bought **−45 % / −39 %** — and
+      the job is **still over** the 300 s ceiling at 1.2× / 1.7×. Sample size is
+      part of the result: ubuntu ranges 217–406 s across the 50, so the
+      three-run sample the 2026-08-11 baseline used could have reported anything
+      from under the ceiling to 1.4× it.
+
+      **Decision: no fold-back**, and it does not rest on the threshold alone.
+      Returning the excluded file-time (≈ 99 s golden + ≈ 73 s workspace, net of
+      the ≈ 25 s fixed per-job overhead this file derives elsewhere) puts shard
+      3/4 at ≈ 400 s / 559 s on an even split and ≈ 529 s / 688 s if it clumps —
+      and clumping is the documented behaviour, since vitest shards by file
+      **count** and these files are why the dedicated jobs exist. Both bounds are
+      worse; the arithmetic and a falsifiable revisit-if are in
+      `ci-cost-budget.md` § Fold-back decision, 2026-08-18.
+
+      **One sentence in `tests.yml` was false and is now corrected** — the
+      exclusion comment claimed the shards therefore "stay light and balanced".
+      They do not: shard 3/4 is 2.3× its siblings and over the ceiling, because
+      the driver (`build_proof.test.ts`) is **not** one of the excluded files. The
+      exclusion rationale itself is untouched and still true. **Next lever named:**
+      `render()` at ~54 s a call, not the job layout.
+      <!-- verify: grep -n 'hash-clump' .github/workflows/tests.yml  # exclusion rationale still present -->
+      <!-- verify: grep -n 'Fold-back decision' docs/contracts/ci-cost-budget.md -->
+      <!-- verify: grep -c 'light and balanced' .github/workflows/tests.yml  # expect 0 -->
+
+      Original framing, kept for the trail:
+      **Stayed OPEN, not deferred — its decision input did not exist yet, and
+      could not until that PR landed.** `[ ]` rather than `[~]` on purpose: this is
       real work with a firing condition, so it belongs in the open count and on
       the dashboard. Marking it `[~]` would drive `count_open` to 0 beside the
       two maintainer-gated deferrals and fire Iron Law 3 — a repo-wide archive
@@ -458,13 +500,61 @@ Re-derived in this worktree at `c073d5732` (v9.32.0):
            sed -n '/^## Blockers/,$p' agents/roadmaps/road-to-inbox-harvest-2026-08-b-ci-economy.md | grep -c 'ADR-222'  # expect 0.
            Step 4.1 itself mentions ADR-222 several times on purpose: it is the
            document that took the number, and naming it is the whole explanation. -->
-- [~] **4.2 Demote the macOS leg and/or the `npm audit` PR gate.** Deferred behind
+- [ ] **4.2 Demote the macOS leg and/or the `npm audit` PR gate.** Open behind
       `blocker: required-check-set-change`. Touches ruleset `17749383` plus
       `docs/contracts/branch-protection-policy.md`, `ci-green-floor.md` and
       `release-pr-gating.md` in the same change.
-- [~] **4.3 Enable a GitHub merge queue.** Deferred behind
+- [ ] **4.3 Enable a GitHub merge queue.** Open behind
       `blocker: merge-queue-enablement`. `merge_group` appears zero times in
       `.github/`, so nothing in-tree is wired for it either way.
+
+<!-- Glyph correction 2026-08-18, `[~]` → `[ ]` on both, applied as the Iron-Law-3
+     resolution outcome 4 (`roadmap-management § 4b` — "restore selected items to
+     [ ]"). Surfaced to the maintainer in the same reply and reversible in one edit.
+
+     The two glyphs are not synonyms: `[~]` is DEFERRED — work consciously moved
+     OUT of this plan — and `[ ]` is OPEN. Neither step was moved out. Phase 4's
+     own heading says what they are: "authored here, applied by the maintainer".
+     The authoring shipped (4.1 = ADR-223, plus both step-by-step procedures inside
+     the blockers). What remains is a repo-admin write that is a
+     `non-destructive-by-default` Hard-Floor action, so it waits on a human —
+     which is exactly what a `[ ]` plus a recorded blocker already expresses, and
+     what every other blocker-gated step in this estate carries.
+
+     The correction is right independent of the gate, which is the test that keeps
+     it from being gate-driven: a step is marked by what is true of it. Closing 3.4
+     is merely what made the glyph load-bearing — it drove `count_open` to 0 and
+     `roadmap:progress-check` to exit 1 (verified: 18/18 done · 2 deferred), a
+     repo-wide archive refusal for two steps that are plainly waiting rather than
+     abandoned. Identical correction, identical reasoning, taken once before on
+     `road-to-stop-gate-honesty` step 2.1.
+
+     **What this correction does NOT buy, checked rather than assumed, because the
+     tempting justification is false.** It does not keep a PR green.
+     `roadmap-progress-check` is registered in exactly one place — `task ci`
+     (`Taskfile.yml:358`, defined at `taskfiles/content.yml:246`) — no workflow
+     under `.github/workflows/` invokes `task ci` or the script, and the pre-push
+     hook runs `task consistency` + `task preflight`, neither of which reaches it
+     (`src/scripts/install-hooks.sh:24-140`). So the Iron-Law-3 breach was a
+     LOCAL-ONLY red the whole time. Recorded because "it would red the PR" is the
+     reason a reader would reconstruct for this edit, and it would be wrong — the
+     reason is accuracy, and the gate merely surfaced the inaccuracy.
+
+     **Pre-existing, untouched:** `road-to-inbox-harvest-2026-08-d-top-band-model-economy`
+     is still listed by that gate (13/13 done · 1 deferred) and is a different
+     roadmap's Iron-Law-3 decision, so it is noted rather than fixed here. -->
+<!-- (continued)
+
+     What this does NOT do: it does not touch either blocker, does not perform or
+     authorise a ruleset write or a merge-queue enablement, and does not archive
+     this roadmap. The roadmap stays active with two open, human-blocked steps.
+
+     verify: `agent-config roadmap:progress-check` no longer lists THIS file under
+     Iron Law 3. Its exit code stays 1 for the pre-existing `-d-top-band-model-economy`
+     entry, so read the listing, not the code — measure `$?` directly if you do
+     (piping to `tail` reports `tail`'s status and reads as a false green).
+     verify: the dashboard reports 2 open and 0 deferred for this roadmap. -->
+
 
 ## Risk Register
 <!-- risk-review: v1 | reviewed: 2026-08-11 | reviewer: claude/host -->

--- a/agents/roadmaps/road-to-inbox-harvest-2026-08-b-ci-economy.md
+++ b/agents/roadmaps/road-to-inbox-harvest-2026-08-b-ci-economy.md
@@ -553,9 +553,12 @@ Re-derived in this worktree at `c073d5732` (v9.32.0):
      ruleset write or a merge-queue enablement, and does not archive this roadmap.
      The roadmap stays active with two open, human-blocked steps.
 
-     Pre-existing and untouched, both noted rather than fixed here:
-     the `open_blockers 67 → 69` ratchet breach on `main` (an estate-budget
-     decision — one-in-one-out or a reasoned baseline raise), and
+     Pre-existing, noted rather than fixed here — and one of the two has since
+     been closed on the base, which is recorded so this note does not read as a
+     live breach it no longer is:
+     the `open_blockers 67 → 69` ratchet breach on `main` was **resolved by
+     PR #1423**, which raised the baseline to 69 with its own recorded reason; on
+     the merged base `check_estate_count` exits 0 at `+0`. Still open:
      `road-to-inbox-harvest-2026-08-d-top-band-model-economy` under the same
      Iron Law 3 (13/13 done · 1 deferred), a different roadmap's decision.
 

--- a/agents/roadmaps/road-to-inbox-harvest-2026-08-b-ci-economy.md
+++ b/agents/roadmaps/road-to-inbox-harvest-2026-08-b-ci-economy.md
@@ -519,41 +519,53 @@ Re-derived in this worktree at `c073d5732` (v9.32.0):
      the blockers). What remains is a repo-admin write that is a
      `non-destructive-by-default` Hard-Floor action, so it waits on a human —
      which is exactly what a `[ ]` plus a recorded blocker already expresses, and
-     what every other blocker-gated step in this estate carries.
+     what every other blocker-gated step in this estate carries. Same correction
+     and reasoning as `road-to-stop-gate-honesty` step 2.1.
 
-     The correction is right independent of the gate, which is the test that keeps
+     The correction is right independent of any gate, which is the test that keeps
      it from being gate-driven: a step is marked by what is true of it. Closing 3.4
      is merely what made the glyph load-bearing — it drove `count_open` to 0 and
-     `roadmap:progress-check` to exit 1 (verified: 18/18 done · 2 deferred), a
-     repo-wide archive refusal for two steps that are plainly waiting rather than
-     abandoned. Identical correction, identical reasoning, taken once before on
-     `road-to-stop-gate-honesty` step 2.1.
+     put this file under Iron Law 3 at 18/18 done · 2 deferred.
 
-     **What this correction does NOT buy, checked rather than assumed, because the
-     tempting justification is false.** It does not keep a PR green.
-     `roadmap-progress-check` is registered in exactly one place — `task ci`
-     (`Taskfile.yml:358`, defined at `taskfiles/content.yml:246`) — no workflow
-     under `.github/workflows/` invokes `task ci` or the script, and the pre-push
-     hook runs `task consistency` + `task preflight`, neither of which reaches it
-     (`src/scripts/install-hooks.sh:24-140`). So the Iron-Law-3 breach was a
-     LOCAL-ONLY red the whole time. Recorded because "it would red the PR" is the
-     reason a reader would reconstruct for this edit, and it would be wrong — the
-     reason is accuracy, and the gate merely surfaced the inaccuracy.
+     **TWO mechanism claims were tempting here and BOTH are false. Measured, not
+     reasoned, and recorded because each would have justified the opposite edit.**
 
-     **Pre-existing, untouched:** `road-to-inbox-harvest-2026-08-d-top-band-model-economy`
-     is still listed by that gate (13/13 done · 1 deferred) and is a different
-     roadmap's Iron-Law-3 decision, so it is noted rather than fixed here. -->
-<!-- (continued)
+     1. *"Leaving them `[~]` reds the PR."* No. `roadmap-progress-check` is
+        registered in exactly one place — `task ci` (`Taskfile.yml:358`, defined at
+        `taskfiles/content.yml:246`). No workflow under `.github/workflows/`
+        invokes `task ci` or the script, and the pre-push hook runs
+        `task consistency` + `task preflight`, neither of which reaches it
+        (`src/scripts/install-hooks.sh:24-140`). An Iron-Law-3 breach is a
+        LOCAL-only red. This also refutes the "the real teeth are the CI backstop,
+        which reds the PR" reading that had been carried since 2026-08-11.
 
-     What this does NOT do: it does not touch either blocker, does not perform or
-     authorise a ruleset write or a merge-queue enablement, and does not archive
-     this roadmap. The roadmap stays active with two open, human-blocked steps.
+     2. *"Restoring them grows `open_blockers` and reds the estate ratchet."* Also
+        no, and this one was believed for a while because the ratchet DID go red on
+        PR #1425 at `open_blockers 67 → 69`. Measured both ways in the same
+        worktree: `check_estate_count` reports **69 with `[~]` and 69 with `[ ]`**.
+        The glyph does not move the metric. The +2 is **pre-existing on `main`** —
+        run 32173675188 at `851568b5c` fails with the identical number, before this
+        branch existed. A red that appears on your PR is not evidence your PR caused
+        it; diff the number against the base before attributing it.
+
+     So the restore costs nothing measurable and rests on accuracy alone. What it
+     does NOT do: it does not touch either blocker, does not perform or authorise a
+     ruleset write or a merge-queue enablement, and does not archive this roadmap.
+     The roadmap stays active with two open, human-blocked steps.
+
+     Pre-existing and untouched, both noted rather than fixed here:
+     the `open_blockers 67 → 69` ratchet breach on `main` (an estate-budget
+     decision — one-in-one-out or a reasoned baseline raise), and
+     `road-to-inbox-harvest-2026-08-d-top-band-model-economy` under the same
+     Iron Law 3 (13/13 done · 1 deferred), a different roadmap's decision.
 
      verify: `agent-config roadmap:progress-check` no longer lists THIS file under
-     Iron Law 3. Its exit code stays 1 for the pre-existing `-d-top-band-model-economy`
-     entry, so read the listing, not the code — measure `$?` directly if you do
-     (piping to `tail` reports `tail`'s status and reads as a false green).
-     verify: the dashboard reports 2 open and 0 deferred for this roadmap. -->
+     Iron Law 3. Its exit code stays 1 for the pre-existing `-d-top-band` entry, so
+     read the listing, not the code — and measure `$?` directly if you do (piping
+     to `tail` reports `tail`'s status and reads as a false green).
+     verify: the dashboard reports 2 open and 0 deferred for this roadmap.
+     verify: `./scripts-run src/scripts/check_estate_count` reports open_blockers
+     69 with these glyphs AND with `[~]` — the number is independent of the choice. -->
 
 
 ## Risk Register

--- a/docs/contracts/ci-cost-budget.md
+++ b/docs/contracts/ci-cost-budget.md
@@ -15,14 +15,23 @@ keep-beta-until: 2026-09-04
 > [`release-pr-gating.md`](release-pr-gating.md) and
 > [`branch-protection-policy.md`](branch-protection-policy.md).
 
-## Baseline (re-measured 2026-08-11)
+## Baseline (re-measured 2026-08-11 · `tests.yml` rows re-measured 2026-08-18, post-fix)
 
 **Method.** Every row is a **per-job** duration from the GitHub Actions jobs
-API (`/actions/runs/<id>/jobs`) — `tests.yml` averaged over the three most
-recent **successful** main-branch runs, the other workflows from the most
+API (`/actions/runs/<id>/jobs`) — the non-`tests.yml` workflows from the most
 recent successful run. Recorded from CI, never from a developer machine — a
 locally captured baseline measures the environment offset instead of the
 regression (`docs/hook-latency.json:2`).
+
+The `tests.yml` rows are a **50-run average** as of 2026-08-18: the
+most-recent 50 **successful** `main` runs, all of them after the shard-3 fix
+merged (2026-08-11), aggregated per job name. Three runs was the 2026-08-11
+sample and it is not the sample this file's own ceiling clause asks for — the
+ceiling is defined "across the most-recent 50 main-branch runs", and the
+quarterly checklist prescribes the same jobs-API pass. Three runs also cannot
+separate a shard figure from runner variance, which the spread here makes
+concrete: shard 3/4 on ubuntu ranges 217–406 s across the 50, so a
+three-run sample could have reported anything from 1.0× to 1.4× the ceiling.
 
 A run-level figure (`gh run list … startedAt,updatedAt`) is **not**
 interchangeable with a job figure and is not used here. For a matrix workflow
@@ -36,13 +45,13 @@ lists each shard family once, with the per-shard average.
 
 | Workflow | Job | OS × variant | Avg duration | Trigger surface |
 |---|---|---|--:|---|
-| `tests.yml` | `install-tests` | 4 shards × 2 OS | 51 s ubuntu / 85 s macOS | `scripts/**`, `tests/**`, `src/**`, manifest pins |
-| `tests.yml` | `install-aux-tests` | 2 OS | 64 s ubuntu / 118 s macOS | same as above |
-| `tests.yml` | `node-tests` shards 1, 2, 4 | 2 OS × 3 shards | 125–152 s | same as above |
-| `tests.yml` | `node-tests` **shard 3/4** | 2 OS | **645 s ubuntu / 852 s macOS** | same as above — over ceiling, see below |
-| `tests.yml` | `static-checks` | ubuntu, no matrix | 131 s | same as above |
-| `tests.yml` | `golden-tests` | 2 OS | 132 s ubuntu / 138 s macOS | same as above |
-| `tests.yml` | `workspace-tests` | 2 OS | 98 s ubuntu / 85 s macOS | same as above |
+| `tests.yml` | `install-tests` | 4 shards × 2 OS | 49–59 s ubuntu / 83–98 s macOS | `scripts/**`, `tests/**`, `src/**`, manifest pins |
+| `tests.yml` | `install-aux-tests` | 2 OS | 62 s ubuntu / 108 s macOS | same as above |
+| `tests.yml` | `node-tests` shards 1, 2, 4 | 2 OS × 3 shards | 147–159 s ubuntu / 161–164 s macOS | same as above |
+| `tests.yml` | `node-tests` **shard 3/4** | 2 OS | **357 s ubuntu / 516 s macOS** | same as above — still over ceiling, see below |
+| `tests.yml` | `static-checks` | ubuntu, no matrix | 140 s | same as above |
+| `tests.yml` | `golden-tests` | 2 OS | 124 s ubuntu / 122 s macOS | same as above |
+| `tests.yml` | `workspace-tests` | 2 OS | 98 s ubuntu / 100 s macOS | same as above |
 | `smoke-public-install.yml` | per-OS × Node leg | 3 OS × 2 Node = 6 jobs | 24–30 s ubuntu / 39–47 s macOS / **159–169 s windows** | install paths + setup.sh + templates |
 | `consistency.yml` | `Sync + Generate Tools Consistency` | ubuntu, single job | 75 s | always-on (PR / push) |
 | `smoke.yml` | `smoke-kernel` · `smoke-router` · `smoke-schema` · `smoke-skills` | ubuntu, 4 jobs | 20–23 s each | `scripts/schemas/**` |
@@ -148,10 +157,17 @@ main-branch runs requires one of:
 3. An ADR superseding the ceiling for this specific job (e.g. integration
    smoke that proves a real consumer-visible promise).
 
-Current jobs above the ceiling (2026-08-11): **`tests.yml` `node-tests`
-shard 3/4**, at 645 s on ubuntu and 852 s on macOS — 2.2× and 2.8× the
-ceiling. Its sibling shards run 125–152 s, so this is not a whole-suite
-cost: `Vitest (shard 3/4)` alone accounts for 594 s of a 673 s job.
+Current jobs above the ceiling (**re-measured 2026-08-18**, 50 successful
+`main` runs): **`tests.yml` `node-tests` shard 3/4**, at **357 s on ubuntu and
+516 s on macOS** — 1.2× and 1.7× the ceiling. Its sibling shards run
+147–164 s, so this is not a whole-suite cost.
+
+The 2026-08-11 figures were 645 s / 852 s, measured **before** the
+`build_proof.test.ts` fix below landed. Post-fix the job is **−45 % on ubuntu
+and −39 % on macOS** and remains the only ceiling breach in the tree. Stated
+as a delta rather than a replacement because the pre-fix pair is what the
+fold-back decision below had to be taken against, and a reader who sees only
+the new numbers cannot tell whether 357 s is an improvement or a regression.
 
 **The cause is one test file, and it is not subprocess overhead.** A
 per-file duration pass over 977 files (local, `--reporter=json`; relative
@@ -169,6 +185,48 @@ attributes the clump to "subprocess-heavy clusters"; for the largest
 contributor that was not true, so re-check the attribution before acting on
 it. And the remaining ~103 s is dominated by `render()` itself at 54 s a
 call — the next lever on this file is that function, not the test.
+
+### Fold-back decision, 2026-08-18: `golden-tests` and `workspace-tests` stay dedicated
+
+The dedicated-runner layout was opened with a stated exit: if the shard-3 fix
+removed enough of the clump, both jobs fold back into the `node-tests` matrix
+and two runners per OS disappear. The decision input was a **post-merge**
+shard-3 duration on `main`, which could not exist inside the PR that shipped
+the fix. It exists now, and the answer is **no fold-back**.
+
+**Threshold read.** The condition was shard 3/4 landing under the 300 s
+ceiling. It does not: **357 s ubuntu / 516 s macOS** over 50 successful runs,
+1.2× and 1.7×. On ubuntu the *best* of the 50 runs (217 s) is under the
+ceiling and the average is not, which is the reading a smaller sample would
+have gotten wrong in whichever direction it happened to land.
+
+**Arithmetic read, because a threshold alone is a thin basis for keeping two
+jobs.** Folding back returns the excluded file-time to the matrix. Each
+dedicated job carries ≈ 25 s of fixed overhead (checkout · setup-node ·
+`npm ci` · build — the figure this file derives in the build-artefact
+rejection above), so the test-time to redistribute is ≈ 99 s from
+`golden-tests` and ≈ 73 s from `workspace-tests`, ≈ 172 s in total. Two
+bounds, and the decision does not depend on which one holds:
+
+- **Even split** (the optimistic bound, which vitest does not promise): +43 s
+  per shard → shard 3/4 ≈ **400 s** ubuntu, ≈ **559 s** macOS. Worse, and
+  still over.
+- **Clumped** (the documented behaviour — vitest shards by file **count**, not
+  duration, and these files are why the dedicated jobs exist): the whole
+  ≈ 172 s lands in one shard → ≈ **529 s** ubuntu, ≈ **688 s** macOS, i.e.
+  back to roughly the pre-fix breach the fix just removed.
+
+So the fold-back trades two runners for a worse ceiling breach on the critical
+path in both bounds. It is not reopened.
+
+**Next lever, named rather than left implicit:** `render()` at ~54 s a call,
+inside `tests/scripts/build_proof.test.ts` — not the job layout. Two calls
+remain and both are load-bearing for the determinism assertion, so the saving
+has to come from the function, not from further call elimination.
+
+**Revisit if** shard 3/4 averages under 300 s on ubuntu **and** macOS across
+50 successful `main` runs — at which point re-run the arithmetic above with
+fresh overhead figures rather than reusing these.
 
 `smoke-public-install.yml` was the previous entry here at 413 s and is no
 longer one. Both figures need their unit stated or the comparison is the


### PR DESCRIPTION
## What this closes

`road-to-inbox-harvest-2026-08-b-ci-economy` **step 3.4** — the last open step
on that roadmap. It had a firing condition rather than a blocker: *"shard 3/4
has a post-merge duration on `main`"*, which could not exist inside the PR that
shipped the fix.

**That condition became satisfiable on 2026-08-11** when PR #1271 merged, and
two later backlog screens still excluded the roadmap on the stale reason *"a
post-merge measurement that cannot exist in its own PR"*. The exclusion outlived
its cause by a week. Worth naming on its own: a resume-when condition needs
re-probing, not re-reading.

## The measurement

Per the contract's own quarterly-checklist method — **per-job** via
`/actions/runs/<id>/jobs`, never run-level — over the **50** most recent
successful `main` runs of `tests.yml` (1150 job rows). All 50 postdate the fix
(oldest 2026-08-12), so no pre-fix run contaminates the average.

| job | pre-fix (2026-08-11) | post-fix (2026-08-18, n=50) | delta |
|---|---|---|---|
| `node-tests` shard 3/4 ubuntu | 645 s | **357 s** | −45 % |
| `node-tests` shard 3/4 macOS | 852 s | **516 s** | −39 % |
| `node-tests` shards 1/2/4 | 125–152 s | 147–159 s ubuntu / 161–164 s macOS | — |
| `golden-tests` | 132 / 138 s | 124 / 122 s | — |
| `workspace-tests` | 98 / 85 s | 98 / 100 s | — |
| `static-checks` | 131 s | 140 s | — |

Shard 3/4 is **still over** the 300 s ceiling at 1.2× / 1.7×, and remains the
only breach in the tree.

**Sample size is part of the result.** Ubuntu ranges 217–406 s across the 50, so
the three-run sample the old baseline used could have reported anywhere from
under the ceiling to 1.4× it. The widened sample is what the ceiling clause
already asked for.

## The decision: no fold-back

The dedicated-runner layout was opened with a stated exit — if the fix removed
enough of the clump, `golden-tests` and `workspace-tests` fold back and two
runners per OS disappear.

It does not, and the verdict does not rest on the threshold alone, because
keeping two runners deserves arithmetic. Returning the excluded file-time
(≈ 99 s + ≈ 73 s, net of the ≈ 25 s fixed per-job overhead this contract already
derives) gives:

- **even split** — shard 3/4 ≈ 400 s ubuntu / 559 s macOS. Worse, still over.
- **clumped** — ≈ 529 s / 688 s, back to roughly the pre-fix breach. This is the
  documented behaviour: vitest shards by file **count**, and these files are why
  the dedicated jobs exist.

Both bounds are worse. Next lever named explicitly: `render()` at ~54 s a call
inside `build_proof.test.ts`, not the job layout. A falsifiable revisit-if ships
with it.

## One false sentence removed from `tests.yml`

The exclusion comment claimed the shards therefore *"stay light and balanced"*.
They do not — shard 3/4 is 2.3× its siblings and over the ceiling, because the
driver is **not** one of the excluded files. Comment-only; the exclusion
rationale itself is untouched and still true.

## Iron Law 3, and two claims that were falsified during the work

Closing 3.4 drove `count_open` to 0 beside two `[~]` items and tripped Iron
Law 3. Resolved as **outcome 4 — restore to `[ ]`** (`roadmap-management § 4b`),
because that is what is true of them: Phase 4's own heading reads *"authored here,
applied by the maintainer"*, the authoring shipped (ADR-223 plus both
step-by-step procedures inside the blockers), and what remains is a repo-admin
write that waits on a human. That is `[ ]` plus a recorded blocker, not
deferred-out-of-plan. Same correction and reasoning as
`road-to-stop-gate-honesty` 2.1.

Two mechanism claims were tempting here and **both are false**. Each is recorded
as refuted inside the roadmap rather than quietly dropped, because each would
have justified the *opposite* edit:

1. *"Leaving them `[~]` reds the PR."* No. `roadmap-progress-check` is registered
   only in `task ci` (`Taskfile.yml:358`); no workflow invokes `task ci` or the
   script, and the pre-push hook runs `task consistency` + `task preflight`,
   neither of which reaches it. It is a **local-only** red.
2. *"Restoring them grows `open_blockers` and reds the estate ratchet."* Also no —
   and this one was believed for a while, because the ratchet **did** go red here.
   Measured both ways in one worktree: `check_estate_count` reports **69 with
   `[~]` and 69 with `[ ]`**. The glyph does not move the metric.

Neither blocker is touched, no ruleset write or merge-queue enablement is
performed or authorised, and nothing archives. The roadmap stays active at
**2 open · 0 deferred · 90 %**.

**Maintainer, one line if you disagree:** the glyph restore is reversible in one
edit. The alternative outcomes were 3 (keep deferred, confirm the drop) and 5
(cancel to `[-]`).

## CI status — read this before the red X's

Three checks were red on the first push. **None was caused by this diff**, and
one has since been fixed on the base:

| check | verdict | evidence |
|---|---|---|
| `Sync + Generate Tools Consistency` | **resolved on the base** | Failed at `check_estate_count` `open_blockers 67 → 69`. The same step failed on `main` @ `851568b5c` (run 32173675188) before this branch existed. PR #1423 then raised the baseline to 69 with its own reason; after merging that base in, `check_estate_count` exits **0** at `+0`. |
| `Node Tests` shard 1/4 (ubuntu + macOS) | **inherited** | Identical failing step (`Vitest (shard 1/4, heavy suites excluded)`, step 7) on `main` run 32173675197 @ `851568b5c`. This diff changes no test file, config or exclusion. |
| `Static Checks` | **known flake** | Failing step is 12, `hook-latency bench gate (pre-registered budget, real path)` — runner variance. This diff touches no hook, manifest or concern; `prepack` and `typecheck` both exit 0 locally. |

No baseline was raised and no inherited red was absorbed into this change to make
it green — the raise that did happen was another PR's, with its own recorded
reason.

## Verification

`task preflight` exit 0 (twice — before each push) · `lint_workflow_paths` ·
`lint_workflow_security` · `check_references` · `check_no_roadmap_refs` ·
`lint_roadmap_family_cap` · `check_estate_count` exit 0 on the merged base ·
`check_completion_review` · `lint_evidence_artifacts` · `prepack` · `typecheck` ·
YAML parse of the edited workflow · and 3.4's three own `verify:` annotations.

Completion review declared **skipped** — zero code paths of four changed files
by the gate's own classification; the artefact records what replaces a code
review on a measurement-and-decision change, including both refutations above.
