### PR TITLE
docs(roadmaps): resume request-scoped-rule-load out of later/ on a condition satisfied eleven days ago

### DIFF
--- a/agents/evidence/reviews/resume-scoped-rule-load.findings.md
+++ b/agents/evidence/reviews/resume-scoped-rule-load.findings.md
@@ -17,12 +17,15 @@ The substance of this change is a **claim about the past**, so it was verified b
 probing the tree rather than by reasoning about a diff. Each of the four facts
 the step requires was established with a command:
 
-| Claim | How it was established | Result |
-|---|---|---|
-| The resume condition | read verbatim from the park block | *"Resume when P2.1 of `road-to-rule-delivery-integrity` closes"*, restated 2026-08-08, owner maintainer |
-| The date it was satisfied | P2.1's own completion marker in the archived parent | `done 2026-08-08` |
-| The artefact that satisfied it | the marker names it | `agents/evidence/analysis/skill-catalogue-description-delivery.md` |
-| No resumption event followed | `git log --since=2026-08-08` over the parked file | **zero commits**, i.e. eleven days |
+- **The resume condition** — read verbatim from the park block:
+  *"Resume when P2.1 of `road-to-rule-delivery-integrity` closes"*, restated
+  2026-08-08, owner maintainer.
+- **The date it was satisfied** — P2.1's own completion marker in the archived
+  parent reads `done 2026-08-08`.
+- **The artefact that satisfied it** — named by that same marker:
+  `agents/evidence/analysis/skill-catalogue-description-delivery.md`.
+- **No resumption event followed** — `git log --since=2026-08-08` over the parked
+  file returns **zero commits**, i.e. eleven days.
 
 Two adjacent facts were probed because the note asserts them: the parent roadmap
 archived 2026-08-09 at `259039157` (`git log --diff-filter=A`), and the

--- a/agents/evidence/reviews/resume-scoped-rule-load.findings.md
+++ b/agents/evidence/reviews/resume-scoped-rule-load.findings.md
@@ -1,0 +1,76 @@
+# Completion review — resume request-scoped-rule-load out of `later/`
+
+**Skipped:** no code surface for this completion — one parked roadmap moved into the active tree with a resumption-evidence note, a Risk Register and a status flip, one step closed on the roadmap that owns the note, the regenerated dashboard, and a two-number estate-ratchet entry in `src/config/estate-count-budget.json`; the validator reports 0 code path(s) of 5 changed file(s), scope 8aebc48111a8f52ffdd2edf6cc816a0099bc4d1e38b33cb97be66a9a9541131e, declared 2026-08-19
+
+## Why a skip rather than a review
+
+Every changed path is a roadmap, a generated roadmap view, or a gate baseline in
+`src/config/`. No script, hook, test, schema, rule body or skill body changes, so
+there is no executable surface for R2 to bind to. `src/config/*.json` is
+deliberately outside `CODE_EXTENSIONS`, which is why the gate measures zero code
+paths rather than one — verified by the gate's own count line rather than by
+reading the extension list.
+
+## What a reviewer would otherwise check, and what was verified instead
+
+The substance of this change is a **claim about the past**, so it was verified by
+probing the tree rather than by reasoning about a diff. Each of the four facts
+the step requires was established with a command:
+
+| Claim | How it was established | Result |
+|---|---|---|
+| The resume condition | read verbatim from the park block | *"Resume when P2.1 of `road-to-rule-delivery-integrity` closes"*, restated 2026-08-08, owner maintainer |
+| The date it was satisfied | P2.1's own completion marker in the archived parent | `done 2026-08-08` |
+| The artefact that satisfied it | the marker names it | `agents/evidence/analysis/skill-catalogue-description-delivery.md` |
+| No resumption event followed | `git log --since=2026-08-08` over the parked file | **zero commits**, i.e. eleven days |
+
+Two adjacent facts were probed because the note asserts them: the parent roadmap
+archived 2026-08-09 at `259039157` (`git log --diff-filter=A`), and the
+machine-decidable probe reports FIRED on that archival rather than on P2.1
+itself — so the written condition and the probe agree while measuring different
+events, and the note says which is which rather than blurring them.
+
+## The three gate consequences, none of them incidental
+
+1. **Gate R1 lifted its grandfather exemption.** `lint_plan_risk_register`
+   exempts a pre-2026-08-04 plan only until it changes substantially; the
+   resumption note is that change. A Risk Register was added covering Phase 4 and
+   the resumption itself, not the 35 landed steps. Two of its four rows initially
+   carried `Anchored under` values that resolve to no heading (`resumption note
+   (park block)`, `Goal · Acceptance criteria`) and the gate rejected both — a
+   register can be substantively right and still dangle, and only the gate says so.
+2. **The estate ratchet needed a raise, and the exempt field did not cover it.**
+   `estate_offset_exempt` satisfies the diff-scoped one-in-one-out half only; the
+   raw COUNT half is diff-blind and reported `active_roadmaps 33 → 34` regardless.
+   The legal discharge is a baseline raise landing exactly on the measurement with
+   a `baseline_history` entry naming the metric — plus the `later_roadmaps 50 → 49`
+   walk-down, which the gate demands separately and which is what makes the net
+   estate zero. `open_blockers` unchanged at 71 is the invariant that proves the
+   move was a disposition change and not growth.
+3. **`lint_roadmap_family_cap` was checked rather than assumed.** The done-note on
+   step 1.1 claims the file is a `road-to-request-*` singleton; measured 1 of 1,
+   gate green at 1/2 slots.
+
+## Residual risk this change knowingly leaves
+
+- **The raise is not underwritten by future work.** Every prior raise in that
+  history is redeemed by a measurement or a closure; this one walks down only when
+  Phase 4 terminates, and Phase 4 is council-parked with a maintainer owner. The
+  entry says so rather than implying a return path it does not have.
+- **Resumption can be misread as promotion.** Rank 1 of the new Risk Register, and
+  the reason both Phase 4 steps stay `[ ]` and the heading still reads PARKED. The
+  mitigation is prose, so it is model-carried: nothing mechanically stops the next
+  session from executing a parked phase.
+- **The dashboard on the trunk was stale before this change** (277/523 committed
+  against 280/523 live, pre-existing drift), so the header delta in this PR is
+  larger than the resumption alone accounts for. Named here so a reader does not
+  attribute the whole jump to the un-park.
+
+## What this change did NOT do, deliberately
+
+It does not touch the five other open steps of `road-to-standing-context-40k`.
+Each carries a dated non-executable verdict, and two were re-probed today rather
+than taken from the file: no `norm`-pinning script exists under `src/scripts/`
+(2.1 and 2.2 sequencing genuinely unmet), and `InstructionsLoaded` appears zero
+times in `dispatch_hook.ts` (3.0's premise refuted). Step 0.1 names colleague
+hardware and a per-machine settings write, which is a Hard-Floor halt.

--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -2,14 +2,14 @@
 
 > Auto-generated — do not edit. Regenerate with `task roadmap-progress` or by running the `update_roadmap_progress` script for your install; rewritten on every roadmap create / execute / completion change (timestamp lives in git history).
 >
-> 33 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **49** open blockers, **23** need you → `agent-config gates`
+> 34 open roadmaps · [roadmaps/](roadmaps/) · [archive/](roadmaps/archive/) · [skipped/](roadmaps/skipped/) · [later/](roadmaps/later/) · **49** open blockers, **23** need you → `agent-config gates`
 
 ## Overall
 
-**277 / 523 steps done · 53%**
+**315 / 559 steps done · 56%**
 
 ```text
-██████████████████████░░░░░░░░░░░░░░░░░░   54%
+██████████████████████░░░░░░░░░░░░░░░░░░   56%
 ```
 
 ## Open roadmaps
@@ -36,19 +36,20 @@
 | 18 | [road-to-org-telemetry.md](roadmaps/road-to-org-telemetry.md) | 7 | 27 | 17 | 10 | 0 | 0 | [2](#blockers-road-to-org-telemetry) | ████░░░░░░ 37% |
 | 19 | [road-to-per-turn-hook-economy.md](roadmaps/road-to-per-turn-hook-economy.md) | 6 | 18 | 3 | 11 | 2 | 2 | [6](#blockers-road-to-per-turn-hook-economy) | ████████░░ 79% |
 | 20 | [road-to-release-review-p0.md](roadmaps/road-to-release-review-p0.md) | 3 | 17 | 7 | 10 | 0 | 0 | 0 | ██████░░░░ 59% |
-| 21 | [road-to-rule-coherence-followup.md](roadmaps/road-to-rule-coherence-followup.md) | 5 | 9 | 7 | 2 | 0 | 0 | [2](#blockers-road-to-rule-coherence-followup) | ██░░░░░░░░ 22% |
-| 22 | [road-to-run-continuation-observation.md](roadmaps/road-to-run-continuation-observation.md) | 1 | 4 | 1 | 3 | 0 | 0 | [1](#blockers-road-to-run-continuation-observation) | ████████░░ 75% |
-| 23 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | [1](#blockers-road-to-scale-history-bench-run) | ░░░░░░░░░░ 0% |
-| 24 | [road-to-skill-description-measurement.md](roadmaps/road-to-skill-description-measurement.md) | 1 | 4 | 4 | 0 | 0 | 0 | [1](#blockers-road-to-skill-description-measurement) | ░░░░░░░░░░ 0% |
-| 25 | [road-to-skill-ecosystem-gate-integrity.md](roadmaps/road-to-skill-ecosystem-gate-integrity.md) | 5 | 43 | 3 | 40 | 0 | 0 | [1](#blockers-road-to-skill-ecosystem-gate-integrity) | █████████░ 93% |
-| 26 | [road-to-solution-minimalism.md](roadmaps/road-to-solution-minimalism.md) | 4 | 36 | 6 | 29 | 0 | 1 | [1](#blockers-road-to-solution-minimalism) | ████████░░ 83% |
-| 27 | [road-to-source-first-frontend.md](roadmaps/road-to-source-first-frontend.md) | 6 | 18 | 6 | 11 | 1 | 0 | 0 | ██████░░░░ 65% |
-| 28 | [road-to-standing-context-40k.md](roadmaps/road-to-standing-context-40k.md) | 5 | 9 | 6 | 2 | 1 | 0 | [1](#blockers-road-to-standing-context-40k) | ██░░░░░░░░ 25% |
-| 29 | [road-to-subagent-lifecycle-integrity.md](roadmaps/road-to-subagent-lifecycle-integrity.md) | 7 | 21 | 8 | 11 | 0 | 2 | [1](#blockers-road-to-subagent-lifecycle-integrity) | ██████░░░░ 58% |
-| 30 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
-| 31 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 3 | 14 | 1 | 12 | 1 | 0 | [2](#blockers-road-to-surface-consolidation) | █████████░ 92% |
-| 32 | [road-to-ui-track-integrity-followup.md](roadmaps/road-to-ui-track-integrity-followup.md) | 1 | 10 | 10 | 0 | 0 | 0 | [2](#blockers-road-to-ui-track-integrity-followup) | ░░░░░░░░░░ 0% |
-| 33 | [road-to-user-out-of-the-loop.md](roadmaps/road-to-user-out-of-the-loop.md) | 9 | 40 | 31 | 9 | 0 | 0 | [2](#blockers-road-to-user-out-of-the-loop) | ██░░░░░░░░ 22% |
+| 21 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 7 | 37 | 2 | 34 | 0 | 1 | 0 | █████████░ 94% |
+| 22 | [road-to-rule-coherence-followup.md](roadmaps/road-to-rule-coherence-followup.md) | 5 | 9 | 7 | 2 | 0 | 0 | [2](#blockers-road-to-rule-coherence-followup) | ██░░░░░░░░ 22% |
+| 23 | [road-to-run-continuation-observation.md](roadmaps/road-to-run-continuation-observation.md) | 1 | 4 | 1 | 3 | 0 | 0 | [1](#blockers-road-to-run-continuation-observation) | ████████░░ 75% |
+| 24 | [road-to-scale-history-bench-run.md](roadmaps/road-to-scale-history-bench-run.md) | 1 | 2 | 2 | 0 | 0 | 0 | [1](#blockers-road-to-scale-history-bench-run) | ░░░░░░░░░░ 0% |
+| 25 | [road-to-skill-description-measurement.md](roadmaps/road-to-skill-description-measurement.md) | 1 | 4 | 4 | 0 | 0 | 0 | [1](#blockers-road-to-skill-description-measurement) | ░░░░░░░░░░ 0% |
+| 26 | [road-to-skill-ecosystem-gate-integrity.md](roadmaps/road-to-skill-ecosystem-gate-integrity.md) | 5 | 43 | 3 | 40 | 0 | 0 | [1](#blockers-road-to-skill-ecosystem-gate-integrity) | █████████░ 93% |
+| 27 | [road-to-solution-minimalism.md](roadmaps/road-to-solution-minimalism.md) | 4 | 36 | 6 | 29 | 0 | 1 | [1](#blockers-road-to-solution-minimalism) | ████████░░ 83% |
+| 28 | [road-to-source-first-frontend.md](roadmaps/road-to-source-first-frontend.md) | 6 | 18 | 6 | 11 | 1 | 0 | 0 | ██████░░░░ 65% |
+| 29 | [road-to-standing-context-40k.md](roadmaps/road-to-standing-context-40k.md) | 5 | 9 | 5 | 3 | 1 | 0 | [1](#blockers-road-to-standing-context-40k) | ████░░░░░░ 38% |
+| 30 | [road-to-subagent-lifecycle-integrity.md](roadmaps/road-to-subagent-lifecycle-integrity.md) | 7 | 21 | 8 | 11 | 0 | 2 | [1](#blockers-road-to-subagent-lifecycle-integrity) | ██████░░░░ 58% |
+| 31 | [road-to-subagent-value-realization-followup.md](roadmaps/road-to-subagent-value-realization-followup.md) | 2 | 9 | 6 | 3 | 0 | 0 | [1](#blockers-road-to-subagent-value-realization-followup) | ███░░░░░░░ 33% |
+| 32 | [road-to-surface-consolidation.md](roadmaps/road-to-surface-consolidation.md) | 3 | 14 | 1 | 12 | 1 | 0 | [2](#blockers-road-to-surface-consolidation) | █████████░ 92% |
+| 33 | [road-to-ui-track-integrity-followup.md](roadmaps/road-to-ui-track-integrity-followup.md) | 1 | 10 | 10 | 0 | 0 | 0 | [2](#blockers-road-to-ui-track-integrity-followup) | ░░░░░░░░░░ 0% |
+| 34 | [road-to-user-out-of-the-loop.md](roadmaps/road-to-user-out-of-the-loop.md) | 9 | 40 | 31 | 9 | 0 | 0 | [2](#blockers-road-to-user-out-of-the-loop) | ██░░░░░░░░ 22% |
 
 ---
 
@@ -729,6 +730,20 @@ _1 blocker resolved._
 | 2 | Evidence artifact typing | ✅ done | 0 | 4 | 0 | 0 | 100% |
 | 3 | Provider qualification | 🟡 in progress | 3 | 6 | 0 | 0 | 67% |
 
+### [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md)
+
+**Road to request-scoped rule load — ship only what the request needs** — 34 / 36 done (94%)
+
+| # | Phase | State | Open | Done | Deferred | Cancelled | % |
+|---|---|---|---:|---:|---:|---:|---:|
+| 0 | Workspace/pack fields into the router (schema, additive) | ✅ done | 0 | 5 | 0 | 0 | 100% |
+| 1 | Consumer-scoped rule projection (the ~50k lever) | ✅ done | 0 | 5 | 0 | 0 | 100% |
+| 1b | Pipeline B: make scoping reach actual consumer installs | ✅ done | 0 | 5 | 0 | 0 | 100% |
+| 2 | Host-native activation: populate globs (deterministic) | ✅ done | 0 | 4 | 0 | 0 | 100% |
+| 3 | Pack hygiene (two confirmed misfits + one sweep) | ✅ done | 0 | 3 | 0 | 0 | 100% |
+| 4 | PARKED: rules-as-skills falsification probe (Claude Code) | ⬜ not started | 1 | 0 | 0 | 0 | 0% |
+| 5 | P4 rule-body migration batches (feedback-8.11 routing, 2026-07-12) | 🟡 in progress | 1 | 12 | 0 | 1 | 92% |
+
 ### [road-to-rule-coherence-followup.md](roadmaps/road-to-rule-coherence-followup.md)
 
 **Follow-up to road-to-rule-coherence** — 2 / 9 done (22%)
@@ -954,12 +969,12 @@ _1 blocker resolved._
 
 ### [road-to-standing-context-40k.md](roadmaps/road-to-standing-context-40k.md)
 
-**Road to standing context 40k — the registered destination, given a route** — 2 / 8 done (25%)
+**Road to standing context 40k — the registered destination, given a route** — 3 / 8 done (38%)
 
 | # | Phase | State | Open | Done | Deferred | Cancelled | % |
 |---|---|---|---:|---:|---:|---:|---:|
 | 0 | Rule out the double-delivery layer first | ⬜ not started | 1 | 0 | 0 | 0 | 0% |
-| 1 | Pull the lever that already exists | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
+| 1 | Pull the lever that already exists | 🟡 in progress | 1 | 1 | 0 | 0 | 50% |
 | 2 | Shrink the structural payload without touching reach | ⬜ not started | 2 | 0 | 0 | 0 | 0% |
 | 3 | Give rules a runtime carrier, or retire the dead triggers | ⬜ not started | 1 | 0 | 1 | 0 | 0% |
 | 4 | Per-turn injection aggregate | ✅ done | 0 | 2 | 0 | 0 | 100% |

--- a/agents/roadmaps/road-to-request-scoped-rule-load.md
+++ b/agents/roadmaps/road-to-request-scoped-rule-load.md
@@ -1,7 +1,8 @@
 ---
 complexity: structural
-status: later
+status: ready
 parent_roadmap: road-to-token-saving
+estate_offset_exempt: "resumed out of later/ on a satisfied resume condition (2026-08-08), so active_roadmaps rises by one while later_roadmaps falls by one — a disposition change, not estate growth. The ratchet gates the two metrics separately and has no cross-metric offset; without this field an un-park can never be recorded, which would make later/ a one-way door and exactly the burial the estate-drawdown quality anchor exists to prevent."
 ---
 
 # Road to request-scoped rule load — ship only what the request needs
@@ -63,6 +64,46 @@ parent_roadmap: road-to-token-saving
 > or its gates. Phase 1b addition council-confirmed 2026-07-08
 > (claude-sonnet-4-5 + gpt-4o, 2 rounds: extend this roadmap, do not
 > spawn a sibling).
+
+> **PARK DISCHARGED — resumed 2026-08-19 into the active tree.** Written as the
+> deliverable of step 1.1 of [`road-to-standing-context-40k`](road-to-standing-context-40k.md),
+> which owns the resumption-evidence note but deliberately does **not** own this
+> roadmap's remaining work. The park block above is kept verbatim as the
+> historical record; this note discharges it rather than replacing it.
+>
+> - **The resume condition, verbatim:** *"Resume when P2.1 of
+>   `road-to-rule-delivery-integrity` closes"* — restated 2026-08-08 by P0.4 of
+>   that roadmap, owner maintainer.
+> - **Date it was satisfied: 2026-08-08.** P2.1's own completion marker in
+>   [`archive/road-to-rule-delivery-integrity.md`](archive/road-to-rule-delivery-integrity.md)
+>   carries `done 2026-08-08`. The parent roadmap itself archived one day later,
+>   2026-08-09 (`259039157`), which is the event `agent-config gates` reports the
+>   machine-decidable probe as having FIRED on. Both point at the same discharge;
+>   the written condition is the earlier and narrower of the two.
+> - **The artefact that satisfied it:**
+>   [`skill-catalogue-description-delivery.md`](../evidence/analysis/skill-catalogue-description-delivery.md).
+>   Its finding is *not* the one P2.1 hypothesised: 414/414 installed skills carry
+>   a description on disk (measured), while 5 of 8 sampled catalogue entries
+>   reached the model without one (first-party observation). So the projection is
+>   complete and **the loss is host-side** — "our projection is missing
+>   descriptions" is refuted. It claims no total bare-vs-described rate, because
+>   the catalogue is not persisted and hand-counting a context window would not be
+>   verifiable. That is what the two Phase-4 steps below now have to be read
+>   against: the surface a rules-as-skills probe would move rules *onto* is
+>   measured, and measured lossy for a reason this suite does not control.
+> - **No resumption event followed, for eleven days.** `git log` over this file
+>   since 2026-08-08 returns **zero** commits, so nothing acted on the satisfied
+>   condition and nothing recorded a decision not to. Three consecutive
+>   `/roadmap:next` screens (2026-08-18 h, 2026-08-19 i, and this one) logged the
+>   FIRED probe in their by-product findings and each correctly declined it as a
+>   maintainer-owned Phase-4 probe — which is why the file needed the note and the
+>   move, not execution.
+>
+> **What resuming does and does not authorise.** It puts the file where the
+> dashboard counts it and where a screen can see it, and it records why. It does
+> **not** promote Phase 4: both remaining steps stay `[ ]` and stay
+> council-parked by the 2026-07-07 verdict with their design locked. Owner
+> unchanged: maintainer.
 
 ## Goal
 
@@ -499,6 +540,22 @@ checks green per batch; trigger-eval coverage not regressed; backlink report
 current.
 **Rollback:** per-batch — restore the monolithic rule bodies from git; the
 target files' added sections are additive.
+
+## Risk Register
+
+<!-- risk-review: v1 | reviewed: 2026-08-19 | reviewer: claude/host -->
+
+Written at resumption, not at authoring: the grandfather exemption lifts on the
+first substantial edit after 2026-08-04, and the resumption note above is that
+edit. So this register covers what is left — Phase 4 and the resumption itself —
+rather than the 35 steps that already landed.
+
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | Resumption reads as promotion and Phase 4 gets executed | implementation | The file leaving `later/` is the visible change, so the next reader can take "active" to mean "start the probe" — while the 2026-07-07 council verdict that parked Phase 4 with its design locked is unchanged and its owner is still the maintainer | The resumption note says in as many words what resuming does and does not authorise; both Phase 4 steps stay `[ ]`; the phase heading still reads PARKED | Phase 4 — PARKED: rules-as-skills falsification probe |
+| 2 | The probe is run against a surface already measured lossy, and its null is misread as a verdict on rules-as-skills | product | The artefact that discharged the resume condition found 5 of 8 sampled catalogue entries reaching the model with no description while 414/414 carry one on disk — so a probe that moves rules onto the skill surface can fail for a host-side reason that has nothing to do with the hypothesis | The resumption note records that finding at the point of resumption, including its explicit refusal to claim a bare-vs-described rate; the probe's design is locked and any run has to state which of the two it is measuring | Phase 4 — PARKED: rules-as-skills falsification probe |
+| 3 | An un-park becomes a routine way to move estate numbers | implementation | If resuming a parked file is cheap, `later/` turns into a staging area both directions and the ratchet stops describing the estate | The estate raise is recorded with its reason in `estate-count-budget.json` and states that it is NOT underwritten by future work; `later_roadmaps` falls by one in the same commit, which is the invariant that distinguishes a disposition change from growth | Acceptance criteria |
+| 4 | The remaining consumer-scoping levers are believed shipped and are not | product | Phases 0-3 and 5 are marked done against 2026-07/08 measurements; a consumer install that still ships unfiltered rules would make this roadmap's Goal false while every checkbox reads closed | The Goal's claim is measurable rather than asserted — `check_standing_rule_delivery` and `report_carrier_divergence` both read the live install, and the sibling `road-to-standing-context-40k` owns the standing-delivery number | Goal |
 
 ## Acceptance criteria
 

--- a/agents/roadmaps/road-to-standing-context-40k.md
+++ b/agents/roadmaps/road-to-standing-context-40k.md
@@ -113,20 +113,29 @@ colleague's report on its own.
 > resumption evidence note. Steps 1.1 and 1.2 stay below as a description of what
 > the resumption delivers, not as work to duplicate.
 
-- [ ] **1.1** Write the resumption evidence note into that roadmap's park block:
+- [x] **1.1** Write the resumption evidence note into that roadmap's park block:
       the resume condition, the date it was satisfied, the artefact that satisfied
       it, and the fact that no resumption event followed. Move the file out of
       `later/` under its own disposition rules.
       `verify:` the file is in the active tree and the dashboard counts it.
-      **NOT executed 2026-08-19 — a scope call, not a blocker, and the cheapest
-      open item left in this file.** It is genuinely repo work and nothing gates
-      it. It is also a *disposition change to a different roadmap*: it moves a
-      file between dispositions, changes what the dashboard counts, and can
-      interact with `lint_roadmap_family_cap`. Landing that inside a PR whose
-      subject is a dispatcher mechanism mixes two reviewable concerns in one diff,
-      which `minimal-safe-diff` refuses. It wants its own small PR, together with
-      the park-note read — `agent-config gates` reports that resume condition
-      FIRED. **Next executor: start here.**
+      **DONE 2026-08-19 — in its own PR, as the prior screen's note asked for.**
+      [`road-to-request-scoped-rule-load.md`](road-to-request-scoped-rule-load.md)
+      is in the active tree with `status: ready`; the park block is kept verbatim
+      and discharged by an appended note carrying all four required facts. The
+      condition — *"Resume when P2.1 of `road-to-rule-delivery-integrity` closes"* —
+      was satisfied **2026-08-08** by
+      [`skill-catalogue-description-delivery.md`](../evidence/analysis/skill-catalogue-description-delivery.md)
+      (parent roadmap archived 2026-08-09, `259039157`, which is what the
+      machine-decidable probe reports FIRED on). **No resumption event followed for
+      eleven days:** `git log` over the parked file since 2026-08-08 returns zero
+      commits. Three consecutive screens logged the FIRED probe and each declined
+      it — correctly, since Phase 4 is maintainer-owned; both its steps stay `[ ]`
+      and stay council-parked. Two gate consequences, both handled here rather than
+      left for the reader: the resumed file carries `estate_offset_exempt` (the
+      ratchet gates `active_roadmaps` and `later_roadmaps` separately with no
+      cross-metric offset, so without it an un-park is unrecordable and `later/`
+      becomes a one-way door), and `lint_roadmap_family_cap` is unaffected — the
+      file is a `road-to-request-*` singleton.
 - [ ] **1.2** (Owned by that roadmap, tracked here for the interlock only.) The
       machinery is built and tested; only the human gate is unpulled. Consumer
       installs default to workspace-derived scope, `legacy-all` becomes the

--- a/src/config/estate-count-budget.json
+++ b/src/config/estate-count-budget.json
@@ -16,8 +16,8 @@
     ]
   },
   "baseline": {
-    "active_roadmaps": 33,
-    "later_roadmaps": 50,
+    "active_roadmaps": 34,
+    "later_roadmaps": 49,
     "open_blockers": 71
   },
   "baseline_history": [
@@ -111,6 +111,13 @@
       "later_roadmaps": 50,
       "open_blockers": 71,
       "why": "RAISED by 1 blocker, and the raise is the alternative to a silent drop rather than room made for new growth. road-to-run-continuation-observation step 0.1 carries the parent criterion \"a process-full contract run finishes a 3-phase roadmap with zero synchronous contacts, re-engaging across turns, and opens the PR\". Its sibling step 0.0 closed on a real engagement observed 2026-08-19, and 0.1 did NOT: this roadmap has one phase, so the three-phase half cannot be read off that run however the rest of it went, and closing it there would be the attribution error the step's own text warns against. The choice was therefore between recording the gap as three-phase-contract-run, where the dashboard and this ratchet both see it, and leaving it as prose in a step nobody counts \u2014 which is the invisible-gate failure road-to-solution-minimalism recorded when its own halt lived in prose and the generated dashboard published zero blockers for a roadmap stopped for four days. Active and later are unchanged, which is the check that this is not a park wearing a tightening's clothes. The entry is class 3 rather than 0 on purpose and that bounds what the raise buys: an agent does the work, but choosing which roadmap gets worked next is the operator's, so no command produces a qualifying run and this number walks back down on the first three-phase autonomous roadmap anyone finishes from a worktree \u2014 as a side effect, with no dedicated effort."
+    },
+    {
+      "at": "2026-08-19",
+      "active_roadmaps": 34,
+      "later_roadmaps": 49,
+      "open_blockers": 71,
+      "why": "An UN-PARK, which is the one estate move this gate had no shape for. active_roadmaps 33 -> 34 is RAISED and later_roadmaps 50 -> 49 is WALKED DOWN, by the same single file moving in the same commit: later/road-to-request-scoped-rule-load.md returns to the active tree. Net estate is zero, and the two numbers move in opposite directions for that reason rather than by coincidence. Read the raise together with the walk-down or it reads as growth, which it is not: no roadmap was created, no work was added, and open_blockers is UNCHANGED at 71 because open_blockers already spans active plus later/ and therefore cannot notice a move between them. That invariance is the check that this is a disposition change and not a park wearing a tightening's clothes, in the exact mirror of the test the 2026-08-19 batch-1 entry above applies in the parking direction. WHY THE FILE MOVES: its resume condition, restated 2026-08-08 and owned by the maintainer, was 'Resume when P2.1 of road-to-rule-delivery-integrity closes'. P2.1's own completion marker in the archived parent reads done 2026-08-08, the parent archived 2026-08-09 at 259039157, and git log over the parked file since 2026-08-08 returns ZERO commits. So the condition has been satisfied for eleven days with nothing acting on it and nothing recording a decision not to, while three consecutive /roadmap:next screens logged the FIRED probe as a by-product finding and each correctly declined the work behind it as maintainer-owned. Declining the work and leaving the file parked are different acts, and only the first was ever decided. THE RAISE IS NOT UNDERWRITTEN BY FUTURE WORK, which distinguishes it from every prior raise in this history: nothing is promised, and it does not walk back down on a measurement. It walks down when Phase 4 terminates in either direction, and Phase 4 stays council-parked by the 2026-07-07 verdict with its design locked and both steps still open. The file carries estate_offset_exempt so the one-in-one-out half passes on its own terms; what fires is the raw COUNT half, which is diff-blind by design and cannot see that the offset it wants is the later/ decrement recorded on the very same line. The alternative was archiving an unrelated roadmap to buy the number back, which moves the count without moving the estate and is what this ratchet's own history repeatedly refuses. Left unrecorded, the shape has a worse cost than one raise: an un-park would be permanently unrepresentable, later/ would be a one-way door, and burial would be the cheapest disposition available - which is precisely the failure the later_roadmaps metric was added to prevent."
     }
   ],
   "target": {


### PR DESCRIPTION
Closes step **1.1** of `road-to-standing-context-40k`, the one open step in that
roadmap the prior screen marked **"Next executor: start here"** and explicitly
asked for in its own PR.

## What this is

`later/road-to-request-scoped-rule-load.md` has been parked since 2026-07-28
behind a resume condition that was **satisfied on 2026-08-08 and never acted
on**. This PR writes the resumption-evidence note and moves the file back into
the active tree. It does **not** start the work behind it.

Each of the four facts step 1.1 requires was established by command, not read off
prose:

| Fact | Established by | Result |
|---|---|---|
| the resume condition | park block, verbatim | *"Resume when P2.1 of `road-to-rule-delivery-integrity` closes"* — restated 2026-08-08, owner maintainer |
| date satisfied | P2.1's completion marker in the archived parent | `done 2026-08-08` |
| the artefact | named by that marker | `agents/evidence/analysis/skill-catalogue-description-delivery.md` |
| no resumption followed | `git log --since=2026-08-08` over the parked file | **zero commits** — eleven days |

Two adjacent facts, probed because the note asserts them: the parent archived
2026-08-09 (`259039157`), and the machine-decidable probe reports FIRED on *that
archival* rather than on P2.1 — so condition and probe agree while measuring
different events, and the note says which is which instead of blurring them.

## Why it sat there

Three consecutive `/roadmap:next` screens (2026-08-18 h, 2026-08-19 i, and this
one) logged the FIRED probe in their by-product findings, and each **correctly**
declined the work behind it as maintainer-owned Phase 4. Declining the work and
leaving the file parked are different acts, and only the first was ever decided.
That is the whole gap this PR closes.

## What resuming does not authorise

Phase 4 stays parked by the 2026-07-07 council verdict with its design locked.
Both its steps stay `[ ]`, the heading still reads **PARKED**, the owner is
unchanged. Rank 1 of the new Risk Register is exactly this misreading, and the
mitigation is prose — so it is model-carried, and nothing mechanically stops a
later session from executing a parked phase.

The resumption note also records what the discharging artefact actually found,
which is *not* P2.1's hypothesis: 414/414 installed skills carry a description on
disk while 5 of 8 sampled catalogue entries reached the model without one, so the
projection is complete and **the loss is host-side**. Any future rules-as-skills
probe has to say which of the two it is measuring.

## Three gate consequences, all discharged here

1. **Gate R1** lifts its grandfather exemption on the first substantial post-2026-08-04
   edit, and the note is that edit — so a Risk Register was added covering Phase 4
   and the resumption, not the 35 landed steps. Two rows first dangled on
   `Anchored under` values resolving to no heading; only the gate said so.
2. **The estate ratchet** needed a raise. `estate_offset_exempt` covers the
   diff-scoped one-in-one-out half only; the raw COUNT half is diff-blind and
   reported `active_roadmaps 33 → 34` anyway. Discharged by a baseline landing
   exactly on the measurement, **plus** the `later_roadmaps 50 → 49` walk-down the
   gate demands separately. `open_blockers` unchanged at **71** is the invariant
   that proves this was a disposition change and not growth — that metric already
   spans active plus `later/`, so it cannot notice a move between them.
3. **`lint_roadmap_family_cap`** was measured rather than assumed: singleton, 1/2
   slots, green.

## Honest notes

- **The raise is not underwritten by future work.** Every prior raise in that
  history is redeemed by a measurement or a closure. This one walks down only when
  Phase 4 terminates, and Phase 4 has a maintainer owner. The entry says so rather
  than implying a return path it does not have. The alternative — archiving an
  unrelated roadmap to buy the number back — moves the count without moving the
  estate, which is what that history repeatedly refuses.
- **The trunk dashboard was already stale** (committed 277/523 against 280/523
  live) before this branch, so the header delta here is larger than the un-park
  alone accounts for.
- **The other five open steps of `road-to-standing-context-40k` are untouched**,
  and two were re-probed today rather than trusted: no `norm`-pinning script exists
  under `src/scripts/` (2.1 and 2.2 sequencing genuinely unmet), and
  `InstructionsLoaded` appears **zero** times in `dispatch_hook.ts` (3.0's premise
  refuted). Step 0.1 names colleague hardware plus a per-machine settings write —
  a Hard-Floor halt, which is where this run stops.

## Verification

`task preflight` exit 0 · `check_estate_count` green (34/49/71, raise recorded) ·
`lint_plan_risk_register` green · `lint_roadmap_family_cap` 1/2 ·
`check_references` no broken references · `roadmap:progress-check` up to date ·
`check_completion_review` clean (0 code paths of 5 changed files, section-2.4 skip
declared) · `lint_evidence_artifacts` 1/1 typed.
