### PR TITLE
docs(stubs): repair the drain-run transfers section into one table

### DIFF
--- a/agents/roadmaps-progress.md
+++ b/agents/roadmaps-progress.md
@@ -6,7 +6,7 @@
 
 ## Overall
 
-**309 / 576 steps done · 54%**
+**309 / 574 steps done · 54%**
 
 ```text
 ██████████████████████░░░░░░░░░░░░░░░░░░   54%
@@ -19,6 +19,7 @@ These roadmaps are **complete** (`count_open == 0`, `count_deferred == 0`) but s
 | Roadmap | Done | Total |
 |---|---:|---:|
 | [road-to-hook-state-followups.md](roadmaps/road-to-hook-state-followups.md) | 10 | 10 |
+| [road-to-inbox-harvest-2026-08-b-ci-economy.md](roadmaps/road-to-inbox-harvest-2026-08-b-ci-economy.md) | 18 | 18 |
 | [road-to-maintainer-bus-factor.md](roadmaps/road-to-maintainer-bus-factor.md) | 7 | 7 |
 | [road-to-release-review-p0.md](roadmaps/road-to-release-review-p0.md) | 12 | 12 |
 | [road-to-request-scoped-rule-load.md](roadmaps/road-to-request-scoped-rule-load.md) | 36 | 36 |

--- a/agents/roadmaps/stubs/README.md
+++ b/agents/roadmaps/stubs/README.md
@@ -47,77 +47,64 @@ automation can supply: a live host session, a repo secret, a repo-admin write, a
 legal signature, another human, or a capability nobody is building. The parent
 roadmap closes against an explicit outcome state (`transferred`), so a completed
 roadmap can never be read as an achieved goal.
+
+The distinction that decides which gates apply: the stubs in **§ Current stubs**
+are **demand-gated** — the work is buildable today and the open question is
+whether it *should* be built. A drain-run transfer is **capability-gated** — the
+scope decision is already made, the work is wanted, and the only thing missing is
+an environment the run did not have.
+
 Each entry carries the framework's three-point stub-integrity check — the
 original criterion **verbatim**, the complete list of dependent steps moved, and
 a **named producer with a detection probe** (never "when some subsystem exists",
 which names nobody) — plus the probe's measured baseline on the transfer date, so
-a later reader can tell real movement from noise.
-| Stub | Transferred from | Outcome state | Re-entry gates (baseline at transfer) |
+a later reader can tell real movement from noise, and any reasoning that would
+otherwise die with the parent.
+
+| Stub | Transferred from | Outcome state | Re-entry gate (its own probe, baseline at transfer) |
 |---|---|---|---|
 | [`road-to-host-aware-skill-projection.md`](road-to-host-aware-skill-projection.md) | `road-to-release-review-p0.md` Phase 1 + AC1, 2026-08-20 | `transferred` | P1-P3 in the stub: a same-`projection_mode` observation pair, a non-throwing scoped path in `condense.ts`, and a published projected-away-skill finding — each with a probe, all three measured failing |
 | [`road-to-bus-factor-external-actions.md`](road-to-bus-factor-external-actions.md) | [`road-to-maintainer-bus-factor.md`](../road-to-maintainer-bus-factor.md) Phase 1-4, 2026-08-20 | `transferred` | 4 items: `ANTHROPIC_API_KEY` present **and** a non-skipped `live-advisory` run (absent; 0 live runs) · ruleset 17749383 requires code-owner review, ≥ 1 approval, > 1 check (`false` / `0` / `1`) · a dated cold-dry-run record (none) · distinct trailing-90-day reviewers > 1 (1) |
 | [`road-to-main-protection-ruleset-changes.md`](road-to-main-protection-ruleset-changes.md) | `road-to-inbox-harvest-2026-08-b-ci-economy.md` Phase 4, blockers `required-check-set-change` + `merge-queue-enablement`, 2026-08-20 | `transferred` | One gate, in the stub: a repo-admin write on ruleset `17749383` by the named producer. Two probes, both measured at transfer time: required checks **1**, `merge_queue` entries **0**, `merge_group` files **0** |
+| [`road-to-multi-host-screenshot-census.md`](road-to-multi-host-screenshot-census.md) | [`road-to-source-first-frontend`](../road-to-source-first-frontend.md) — Phase 1 Step 2, the screenshot dimension of Phase 6 Step 1, and the W5 URL / live-page handover class | `transferred` | A **page-reaching** capture primitive on a second supported host. Measured 2026-08-20: this host has `screencapture` only, which photographs the display. Display-only capture on a second host changes nothing. |
 
-**The shared promotion criteria below do NOT govern a drain-run transfer.** They
-were written for the org-mode stubs and require a recruited customer, a funded
-security audit, and an ADR lifting a Hard-Floor item. A drain-run transfer
-introduces no new product surface — it is existing, already-agreed work waiting
-on one external act — so demanding a funded audit before adding a repo secret or
-asking a second person to review would be a category error that parks the work
-permanently. **A drain-run transfer is gated only by its own per-item probe.**
-Promote per item, not per file, and delete the stub when its last item is gone.
-One qualification, because the shorter version of that sentence is false: a
-transfer crossing no *new* surface is not the same as a transfer crossing no Hard
-Floor. Some of these pending acts — a repo-admin ruleset write, a branch
-protection change — **are** Hard-Floor actions in their own right. Being exempt
-from the org-mode promotion gates does not exempt the act itself: when a human
-performs it, it needs its own this-turn approval under
-`non-destructive-by-default`, exactly as it would have inside the parent roadmap.
-
-**One qualification the paragraph above deliberately scopes out.** It says a
-drain-run transfer *of internal work* crosses no Hard Floor, which is true of
-that class and not of the second row: a repository-administration setting is a
-`non-destructive-by-default` Hard-Floor trigger, and that is precisely why the
-council could only transfer it. Its gate is therefore neither an org-mode
-criterion nor a measurement — it is the authority itself, exercised by a named
-human with a this-turn approval naming the exact object. Requiring a recruited
-customer and a funded security audit before a maintainer may edit their own
-repository settings would gate on nothing and make the stub unclosable.
-
-## Promotion criteria (shared)
-Applies to the **org-mode stubs** in § Current stubs only — not to
-drain-run transfers, which name their own per-item probes. Such a stub
-may move from `stubs/` to `agents/roadmaps/` only when **all three** of
-these are true:
-A **drain-run transfer** is a different kind of stub, and it is registered
-separately because the shared criteria below would misgovern it.
-The stubs in the table above are **demand-gated**: the work is buildable today
-and the open question is whether it *should* be built. A drain-run transfer is
-**capability-gated**: the scope decision is already made, the work is wanted, and
-the only thing missing is an environment the run did not have. Applying a
-recruited customer or a funded security audit to that is a category error — there
-is no customer to recruit for a tool surface that simply is not connected, and no
-audit clears a missing capability.
 ```
-THE SHARED PROMOTION CRITERIA BELOW — RECRUITED CUSTOMER, FUNDED SECURITY
-AUDIT, ADR SIGN-OFF — DO **NOT** GOVERN A DRAIN-RUN TRANSFER.
+THE SHARED PROMOTION CRITERIA IN THE NEXT SECTION — RECRUITED CUSTOMER, FUNDED
+SECURITY AUDIT, ADR SIGN-OFF — DO **NOT** GOVERN A DRAIN-RUN TRANSFER.
 A TRANSFER IS PROMOTED BY ITS OWN NAMED PROBE RETURNING TRUE. NOTHING ELSE.
 ```
-Each transfer carries, per the drain-run stub-integrity check: the parent
-criterion **verbatim**, the complete list of what moved, a **named** producer and
-probe with the reading measured on the day of transfer, and any reasoning that
-would otherwise die with the parent. The parent records `transferred` as its
-outcome state so that "archived" can never read as "achieved".
-| Stub | Transferred from | Gate (its own probe) |
-|---|---|---|
-| [`road-to-multi-host-screenshot-census.md`](road-to-multi-host-screenshot-census.md) | [`road-to-source-first-frontend`](../road-to-source-first-frontend.md) — Phase 1 Step 2, the screenshot dimension of Phase 6 Step 1, and the W5 URL / live-page handover class | A **page-reaching** capture primitive on a second supported host. Measured 2026-08-20: this host has `screencapture` only, which photographs the display. Display-only capture on a second host changes nothing. |
+
+Applying a recruited customer or a funded security audit to a capability-gated
+transfer is a category error: there is no customer to recruit for a tool surface
+that simply is not connected, and no audit clears a missing capability. Promote
+**per item**, not per file, and delete a stub when its last item is gone.
+
+Two qualifications, because the short version of that paragraph is false in two
+different directions.
+
+**A transfer crossing no *new* surface is not a transfer crossing no Hard Floor.**
+Some pending acts here — a repo-admin ruleset write, a branch-protection change —
+**are** Hard-Floor actions in their own right, and the third row is exactly that
+case: a repository-administration setting is a `non-destructive-by-default`
+trigger, which is precisely why the council could only transfer it. Being exempt
+from the org-mode promotion gates does not exempt the act. When a human performs
+it, it needs its own this-turn approval naming the exact object, exactly as it
+would have inside the parent roadmap.
+
+**A gate is not always a measurement.** For that same row the gate is the
+*authority* itself, exercised by a named human — not a number anyone can read.
+Requiring a recruited customer and a funded audit before a maintainer may edit
+their own repository settings would gate on nothing and make the stub unclosable.
+
 Framework of record for drain-run dispositions:
-`agents/evidence/council/drain-blocker-dispositions-a.md` <!-- ref-ignore -->
-(on `origin/drain/council-records`, PR #1463; not yet on `main`, hence the
-ignore marker).
-Governs the **demand-gated** stubs in `## Current stubs` only — never a
-drain-run transfer (above). Any such stub may move from `stubs/` to
-`agents/roadmaps/` only when **all three** of these are true:
+[`drain-blocker-dispositions-a.md`](../../evidence/council/drain-blocker-dispositions-a.md)
+and its batch-B sibling.
+
+## Promotion criteria (shared)
+
+Governs the **demand-gated** stubs in § Current stubs only — never a drain-run
+transfer, which names its own probe above. Any such stub may move from `stubs/`
+to `agents/roadmaps/` only when **all three** of these are true:
 
 1. A real first customer has been recruited and is named in
    `agents/recruit-sessions/<role>/`. No speculative promotion.


### PR DESCRIPTION
Six parallel drain branches each added a row or a prose block to `agents/roadmaps/stubs/README.md`, and every merge resolved as a faithful union — including the ones resolved by hand with an explicit "keep both sides" rule. The result was **correct line by line and wrong as a document**.

What was actually on `main`:

- **Two** `## Promotion criteria (shared)` intros, interleaved with a **second** transfer table in a different column shape (3 against 4).
- The demand-gated versus capability-gated distinction stated twice, in different words, in two places.
- Three overlapping paragraphs about Hard Floors, each qualifying the previous one.
- Blank lines lost between paragraph and table, so **the tables did not render**.
- A framework citation still carrying `<!-- ref-ignore -->` and the note "not yet on `main`" — the council record landed in #1463, so the suppression was hiding a check that now passes.

## What this does

One table, four rows, one column shape. The `road-to-multi-host-screenshot-census` row is normalised into the 4-column form rather than left as the odd one out.

The two qualifications that were each true and each half-stated survive as **two named paragraphs**, because collapsing them loses one:

1. **A transfer crossing no *new* surface is not a transfer crossing no Hard Floor.** Some pending acts here — a repo-admin ruleset write, a branch-protection change — are Hard-Floor actions in their own right. Being exempt from the org-mode promotion gates does not exempt the act; when a human performs it, it needs its own this-turn approval naming the exact object.
2. **A gate is not always a measurement.** For the repo-admin row the gate is the *authority* itself, exercised by a named human — not a number anyone can read. Requiring a recruited customer and a funded audit before a maintainer may edit their own repository settings would gate on nothing and make the stub unclosable.

The fenced block stating that the shared criteria do **not** govern a drain-run transfer is kept verbatim — it is the load-bearing line, and it now sits once instead of competing with two prose restatements.

## Verified

`check_references` green over 1,443 files with the marker **removed**, which is the direction that matters: the citation resolves on its own now. `check_md_language` clean on the file, `lint_empty_roadmaps` and `check_no_roadmap_refs` green, and the transfer table parses as 6 lines of exactly 4 columns. Derived outputs regenerated after the trunk merge, so the consistency gate is green rather than skipped.

Reported by an agent working an unrelated roadmap, which is the useful part: a document nobody reads end-to-end during a fan-out is exactly where this failure mode hides.