### PR TITLE
fix: repair the broken ADR-238 links and the review findings from #1507

### DIFF
--- a/dist/agent-src/skills/security-audit/SKILL.md
+++ b/dist/agent-src/skills/security-audit/SKILL.md
@@ -129,7 +129,7 @@ true. Report the finding, route the fix to
 <https://cheatsheetseries.owasp.org/> — Cryptographic Storage, Transport Layer
 Security, Password Storage, XML External Entity Prevention — and never name a
 value from memory. Rationale and reopening condition:
-[ADR-238](../../docs/decisions/ADR-238-security-content-routes-to-external-authority.md).
+[ADR-238](../../../docs/decisions/ADR-238-security-content-routes-to-external-authority.md).
 
 ### 4. Framework-specific checks
 
@@ -189,4 +189,4 @@ reaches it"). An audit that rejects nothing has usually skipped the gate.
 
 ## See also
 
-- [`docs/threat-model.md`](../../docs/threat-model.md) — package attack surface and trust boundary documentation.
+- [`docs/threat-model.md`](../../../docs/threat-model.md) — package attack surface and trust boundary documentation.

--- a/dist/agent-src/skills/security/SKILL.md
+++ b/dist/agent-src/skills/security/SKILL.md
@@ -64,11 +64,11 @@ Focus on: attack surface, trusting user input, authorization gaps.
 
 ### Crypto, password storage, certificates — route, do not guess
 
-This skill carries no algorithm choice, key size, work factor, cipher suite, or
-TLS version floor: such a value is authoritative-looking long after it stops
+This skill carries no cryptographic parameter, key size, work factor, cipher
+suite, or TLS version floor: such a value is authoritative-looking long after it stops
 being true. Take it from <https://cheatsheetseries.owasp.org/> at the moment you
 need it — never from memory, never from this file. Rationale and reopening
-condition: [ADR-238](../../docs/decisions/ADR-238-security-content-routes-to-external-authority.md).
+condition: [ADR-238](../../../docs/decisions/ADR-238-security-content-routes-to-external-authority.md).
 
 ### Validate
 

--- a/docs/decisions/ADR-238-security-content-routes-to-external-authority.md
+++ b/docs/decisions/ADR-238-security-content-routes-to-external-authority.md
@@ -9,17 +9,20 @@ phase: —
 type: structural
 reopen_policy: directional
 review_trigger: >-
-  Reopen on any of three observations together, never on one alone, because the
-  three are what the rejection rested on. First — a named maintainer accepts
-  ownership of security-domain content with a stated review cadence, since
-  "no owner exists" was the decisive ground and an owner removes it. Second —
-  a fixture set shows the package's security skills missing a real defect that
-  local content would have caught, since coverage was asserted and never
-  measured. Third — the external authority this record routes to stops being
-  maintained or stops being freely reachable, since routing to a dead authority
-  is worse than the copy it replaced. A reopening that cannot show all three has
-  not met the condition; a reopening that shows all three should proceed without
-  re-deriving the eleven gaps, which are recorded in the roadmap named below.
+  TWO INDEPENDENT triggers, either one sufficient — they reopen different
+  questions and conjoining them would make the record unreachable rather than
+  strict. Trigger A reopens WHETHER TO CARRY LOCAL CONTENT and needs both of
+  its parts, because each answers one of the two grounds the rejection rested
+  on: a named maintainer accepting ownership with a stated review cadence, AND
+  a fixture set showing the package's security skills missing a real defect
+  that local content would have caught. The fixture half is not satisfiable by
+  assertion: the fixtures are authored against the CURRENT skills before any
+  replacement content exists, the miss is observed rather than argued, and a
+  fixture set written alongside the content it justifies does not count.
+  Trigger B reopens WHETHER ROUTING STILL WORKS and stands alone: the external
+  authority stops being maintained, or stops being freely reachable. A
+  reopening under either trigger should proceed without re-deriving the eleven
+  gaps, which are recorded in the roadmap named below.
 ---
 
 # ADR-238 — Security-domain parameters are routed to the maintained authority, not carried
@@ -44,7 +47,17 @@ hardening is already carried by `skill:terraform`, dependency security by
 rather than a gap. The surviving eight are real. Cryptography is the largest:
 a grep for `AES-GCM`, `argon2`, `TLS 1.2`, `ChaCha20`, `ML-KEM` and
 `post-quantum` across every skill, rule and guideline returns exactly one
-incidental table row. XXE returns nothing at all.
+match. XXE returns nothing at all.
+
+That one match is `skill:ai-code-blindspots:55` — a checklist row reading
+"password columns use bcrypt/argon2, never MD5/SHA". It is named here rather
+than left as "incidental", because a boundary with an unexplained match is not
+a boundary. It **stays**, and it does not violate the decision below: it names
+algorithm *families* in a prohibition-plus-default, which is a stable
+class-level statement, and it carries no parameter, key size, work factor,
+cipher suite, or version floor — the enumerated set this record actually
+bounds. An algorithm family whose deprecation is measured in decades is not
+the thing that rots; a work factor revised every few years is.
 
 So the question was never whether gaps exist. It was whether *this* package is
 the right place to close them.
@@ -58,8 +71,17 @@ which topics it does not cover.**
 Concretely, and as a bright line rather than a preference: no cryptographic
 algorithm tier, key size, work factor, iteration count, cipher suite, TLS
 version floor, or certificate-lifetime value is authored into this corpus.
-Where a consumer needs one, the skill they are reading names the topic as
-out of scope and points at the authority that maintains it.
+
+The boundary is stated in **two** artefacts, and the count is deliberate rather
+than partial. `skill:security-audit` and `skill:security` are the two a
+consumer reaches with "is this safe" and "how do I write this safely", so they
+carry the notice. `skill:secrets-management` already does the same thing in its
+own words at `:31` — "the decision is which cipher to use for at-rest
+encryption — read the provider's KMS docs directly" — so a third notice would
+be duplication, not coverage. `skill:authz-review` and
+`docs/guidelines/php/security.md` are named in the Context above as part of the
+security corpus, not as places this boundary applies: neither carries or
+invites a cryptographic parameter.
 
 What this package *does* carry, and keeps carrying, is the enforcement layer:
 `rule:secret-vcs-guard` with its detector and CI net, `skill:authz-review`'s
@@ -104,8 +126,16 @@ member's conditional position, and it is the strongest alternative. It was
 gated on three conditions of that member's own naming: fixtures showing a real
 detection gain, a named owner, and a resolved provenance classification. None
 was available, and the member's stated kill criterion — *no maintainer accepts
-ownership before merge* — therefore fired. The path is not closed; it is the
-reopening condition in this record's frontmatter.
+ownership before merge* — therefore fired.
+
+The path is not closed, and Trigger A in the frontmatter is what reopens it —
+but the two lists are **not** the same list, and conflating them would be an
+error. That member named three conditions *for adopting content in that
+session*, provenance among them. Provenance is not a reopening condition here:
+this record adapts nothing, so there is nothing to classify, and a future
+proposal that adapts something acquires that obligation from
+`rule:code-provenance` rather than from this ADR. Trigger A therefore carries
+the two conditions that survive the decision — owner and observed miss.
 
 **Do nothing at all.** Rejected as dishonest. The gaps are real and now
 measured; leaving the corpus silent about its own boundary means the next

--- a/src/config/gate-coverage.yml
+++ b/src/config/gate-coverage.yml
@@ -555,7 +555,7 @@ gates:
 
   - id: lint_plan_risk_register
     argv: []
-    min_scanned: 10
+    min_scanned: 5
     corpus: "ready roadmap files under agents/roadmaps/ top level (19 at baseline: 14 grandfathered + 4 draft-exempt + 1 carrying a live register)"
     status: enforced
     note: >
@@ -563,21 +563,35 @@ gates:
       FILES INSPECTED incl. grandfathered/draft-exempt ones — exemptions are
       reported, never silently skipped.
 
-      Lowered 12 → 10 on 2026-08-21, and the reason matters more than the
-      number: the previous note asserted that "a collapse below the floor
-      means the roadmaps root moved, not that the corpus went clean." That
-      premise is now falsified by evidence. Archiving two roadmaps that were
-      each at zero open and zero deferred steps on main dropped the top-level
-      count from 12 to 10 with the root untouched — the corpus really did go
-      cleaner. A floor calibrated to the exact size of a corpus that
-      road-to-estate-drawdown is deliberately shrinking fails on the drawdown
-      succeeding, which is the wrong thing to detect.
+      Lowered 12 → 5 on 2026-08-21, and the SHAPE of the change matters more
+      than the number. The previous note asserted that "a collapse below the
+      floor means the roadmaps root moved, not that the corpus went clean."
+      That premise is falsified: archiving roadmaps at zero open and zero
+      deferred steps dropped the top-level count from 12 to 10 with the root
+      untouched — the corpus really did go cleaner, which is what
+      road-to-estate-drawdown exists to achieve. A floor pinned to the exact
+      corpus size fails on the drawdown succeeding, which is the wrong thing
+      to detect.
 
-      The floor still does its job: it catches the root moving or the scanner
-      silently reading nothing. It is NOT a proxy for how many roadmaps ought
-      to exist. Revisit-if the active roadmap set is deliberately grown back
-      above 12, or if a future drop is traced to a scanner defect rather than
-      to archival — either falsifies the number, not the obligation.
+      So the replacement is deliberately NOT today's count. Re-pinning at 10
+      would repeat the defect one archival later and force this note to be
+      rewritten every time a roadmap closes. 5 sits structurally below any
+      plausible active set while still catching the two failures this floor is
+      for: the roadmaps root moving, and the scanner silently reading nothing.
+      It is not a target for how many roadmaps ought to exist.
+
+      Count reconciliation, since two numbers move in this change and they
+      count different populations: this gate counts READY files at the top
+      level of agents/roadmaps/ (12 → 10 here), while
+      estate-count-budget.json::active_roadmaps counts NON-DRAFT candidates as
+      collect() sees them (11 → 10). The gap is the draft-status file each
+      population treats differently; neither number is derivable from the
+      other.
+
+      Revisit-if the active set is deliberately grown past ~15, at which point
+      5 is uninformatively low, or if a drop is ever traced to a scanner
+      defect rather than to archival — either falsifies the number, not the
+      obligation.
 
   - id: check_estate_count
     argv: []

--- a/src/skills/security-audit/SKILL.md
+++ b/src/skills/security-audit/SKILL.md
@@ -129,7 +129,7 @@ true. Report the finding, route the fix to
 <https://cheatsheetseries.owasp.org/> — Cryptographic Storage, Transport Layer
 Security, Password Storage, XML External Entity Prevention — and never name a
 value from memory. Rationale and reopening condition:
-[ADR-238](../../docs/decisions/ADR-238-security-content-routes-to-external-authority.md).
+[ADR-238](../../../docs/decisions/ADR-238-security-content-routes-to-external-authority.md).
 
 ### 4. Framework-specific checks
 
@@ -189,4 +189,4 @@ reaches it"). An audit that rejects nothing has usually skipped the gate.
 
 ## See also
 
-- [`docs/threat-model.md`](../../docs/threat-model.md) — package attack surface and trust boundary documentation.
+- [`docs/threat-model.md`](../../../docs/threat-model.md) — package attack surface and trust boundary documentation.

--- a/src/skills/security/SKILL.md
+++ b/src/skills/security/SKILL.md
@@ -64,11 +64,11 @@ Focus on: attack surface, trusting user input, authorization gaps.
 
 ### Crypto, password storage, certificates — route, do not guess
 
-This skill carries no algorithm choice, key size, work factor, cipher suite, or
-TLS version floor: such a value is authoritative-looking long after it stops
+This skill carries no cryptographic parameter, key size, work factor, cipher
+suite, or TLS version floor: such a value is authoritative-looking long after it stops
 being true. Take it from <https://cheatsheetseries.owasp.org/> at the moment you
 need it — never from memory, never from this file. Rationale and reopening
-condition: [ADR-238](../../docs/decisions/ADR-238-security-content-routes-to-external-authority.md).
+condition: [ADR-238](../../../docs/decisions/ADR-238-security-content-routes-to-external-authority.md).
 
 ### Validate
 

--- a/tests/scripts/check_no_external_sources.test.ts
+++ b/tests/scripts/check_no_external_sources.test.ts
@@ -133,3 +133,66 @@ describe('check_no_external_sources — synthetic hits', () => {
         expect(parsed.hits[0]!.token).toBe('\\b' + TOK1 + '\\b');
     });
 });
+
+// --- Layer 3: the SHIPPED denylist patterns added 2026-08-21 ---------------
+//
+// The three tokens added for the evaluated security ruleset are broad enough
+// to deserve pinning in both directions. Positive: each one fires. Negative:
+// a word-boundary token must not match inside a longer word, and the OWASP
+// routing URL that the same change adds to two skills must stay clean —
+// otherwise the gate would flag the very pointer the decision routes to.
+//
+// Tokens are assembled from fragments at runtime for the same reason as
+// Layer 2: the literals must not appear in this file's own source.
+describe('check_no_external_sources — 2026-08-21 denylist additions', () => {
+    let work: string;
+
+    const SLUG = 'project' + '-' + 'code' + 'guard';
+    const WORD = 'code' + 'guard';
+    const ORG = 'co' + 'sai';
+    const NEAR = ORG + 'co'; // longer word — the \b anchor must NOT match it
+    const ROUTE = 'https://cheatsheetseries.owasp.org/';
+
+    beforeEach(() => {
+        work = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'cnes3-')));
+        fs.mkdirSync(path.join(work, 'src', 'scripts'), { recursive: true });
+        fs.copyFileSync(
+            path.join(REPO_ROOT, 'src', 'scripts', 'external_sources_denylist.json'),
+            path.join(work, 'src', 'scripts', 'external_sources_denylist.json'),
+        );
+        fs.copyFileSync(TS_SCRIPT, path.join(work, 'src', 'scripts', 'check_no_external_sources.ts'));
+        fs.mkdirSync(path.join(work, 'src', 'scripts', '_lib'), { recursive: true });
+        fs.copyFileSync(SCAN_SCOPE_SRC, path.join(work, 'src', 'scripts', '_lib', 'scan_scope.ts'));
+        spawnSync('git', ['init', '-q'], big(work));
+    });
+
+    afterEach(() => {
+        fs.rmSync(work, { recursive: true, force: true });
+    });
+
+    const scan = (body: string): ReturnType<typeof spawnSync> => {
+        fs.writeFileSync(path.join(work, 'probe.md'), body, 'utf-8');
+        spawnSync('git', ['add', '-A'], big(work));
+        return spawnSync(
+            TSX_BIN,
+            [path.join(work, 'src', 'scripts', 'check_no_external_sources.ts')],
+            big(work),
+        );
+    };
+
+    it.each([
+        ['slug form', SLUG],
+        ['bare word form', WORD],
+        ['org form', ORG],
+    ])('fires on the %s', (_label, token) => {
+        expect(scan(`harvested from ${token} at a pin\n`).status).toBe(1);
+    });
+
+    it('does not fire on a longer word containing the org token', () => {
+        expect(scan(`the ${NEAR} pattern is unrelated\n`).status).toBe(0);
+    });
+
+    it('does not fire on the OWASP routing URL the same change adds', () => {
+        expect(scan(`route the fix to <${ROUTE}>\n`).status).toBe(0);
+    });
+});


### PR DESCRIPTION
## Why this exists

A neutral cross-model review of #1507 returned **REJECT / REQUEST_CHANGES**
while that PR was being merged. Four of its five findings were confirmed
against the tree; one was refuted. #1507 is already on `main`, so the
repairs land here.

**Two of those findings are live on `main` right now**: both ADR-238
references added by #1507 are broken links a consumer would click.


A cross-model council review over the branch delta (neutral prompt, whole
delta, prompt recorded) came back **REJECT / REQUEST_CHANGES** with five
findings. Four were confirmed against the tree and fixed in `0e3ec91`; one was
refuted with evidence.

| Finding | Verdict | Resolution |
|---|---|---|
| Both new ADR-238 links are broken (`../../` from `src/skills/<name>/` lands in `src/docs/`) | **confirmed — mine** | fixed to `../../../`; the same file's pre-existing `threat-model.md` link had the identical defect and was fixed in the same pass |
| Reopening condition unreachable and self-contradictory (frontmatter required three conjuncts; body named a different third) | **confirmed** | now two *independent* triggers — owner + observed miss reopens carrying content, authority failure reopens routing — and the fixture half is spelled out so it cannot be met by authoring fixtures alongside the content they justify |
| "One incidental table row" left unexplained while the boundary claims absoluteness | **confirmed** | the match is named (`ai-code-blindspots:55`), classified as an algorithm-family prohibition rather than a parameter, and kept |
| Boundary lands in 2 of the 5 artefacts the ADR names | **confirmed** | ADR now states why two: `secrets-management` already routes cipher choice to provider docs at `:31`, the other two carry no parameter |
| `min_scanned: 10` repeats the defect its own note diagnoses | **confirmed** | decoupled from the corpus entirely (5, structurally below any plausible active set) instead of re-pinned to today's count; the note reconciles the two populations that move here |
| Denylist names the source in the tracked tree, violating its own rule | **refuted** | that file is in its own `skip_paths` with the shipped reason "the linter + its denylist + the source-confidentiality rule necessarily contain the deny tokens as data" — outside the reviewed diff, so not visible to the reviewer |

The three denylist patterns now carry positive and negative tests
(`tests/scripts/check_no_external_sources.test.ts`), including that the OWASP
routing URL this change adds must not itself be flagged. **Proven sensitive:**
removing the three tokens turns exactly the three positive cases red.
