### PR TITLE
fix(gates): stop three corpus guards tracking the estate size

### DIFF
--- a/agents/roadmaps/archive/INDEX.md
+++ b/agents/roadmaps/archive/INDEX.md
@@ -5,7 +5,7 @@
 > history, not in this file (a clock here would make every drift check a
 > false red).
 
-**546 archived roadmaps** · archived-with-open-steps 33 · closed-with-cancellations 199 · completed 254 · completed-with-deferrals 26 · not-extractable 34
+**547 archived roadmaps** · archived-with-open-steps 33 · closed-with-cancellations 199 · completed 255 · completed-with-deferrals 26 · not-extractable 34
 
 Every column is extracted deterministically from the file itself. No
 summary here is model-written: a verdict the frontmatter does not carry

--- a/agents/roadmaps/archive/index.json
+++ b/agents/roadmaps/archive/index.json
@@ -1,7 +1,7 @@
 {
   "generated_by": "src/scripts/build_archive_index.ts",
   "source": "agents/roadmaps/archive",
-  "count": 546,
+  "count": 547,
   "entries": [
     {
       "slug": "00-overview-and-ordering",

--- a/src/config/gate-coverage.yml
+++ b/src/config/gate-coverage.yml
@@ -592,8 +592,8 @@ gates:
 
   - id: lint_plan_risk_register
     argv: []
-    min_scanned: 5
-    corpus: "ready roadmap files under agents/roadmaps/ top level (19 at baseline: 14 grandfathered + 4 draft-exempt + 1 carrying a live register)"
+    min_scanned: 1
+    corpus: "ready roadmap files under agents/roadmaps/ top level (6 as of 2026-08-21; 19 at the original baseline: 14 grandfathered + 4 draft-exempt + 1 carrying a live register)"
     status: enforced
     note: >
       Gate R1 (docs/contracts/plan-review-gates.md § 1). The count is READY
@@ -636,6 +636,18 @@ gates:
       have reddened CI for the exact reason this entry says is the wrong thing to
       detect. 5 keeps the root-moved / scanner-blind signal (both scan 0) and
       stops the number from needing a commit per archived roadmap.
+
+      Lowered again 5 → 1, and this time the SHAPE changed rather than the
+      number. 5 was picked to have headroom and did not: the drain took the
+      corpus to 6, so a review provoked the red by archiving one roadmap. The
+      lesson is that no absolute floor survives here — this gate's sibling
+      `check_estate_count` forbids growth, so the corpus can only shrink and any
+      floor above 0 is met eventually. 1 is the smallest value that still
+      distinguishes "the scanner read something" from "the root moved or the
+      scope is dead", which is the only thing this field was ever asked to
+      detect. Revisit-if the gate gains a way to express "non-empty" directly,
+      or if a drop to 0 is ever traced to a scanner defect rather than to an
+      empty corpus.
 
   - id: check_estate_count
     argv: []

--- a/tests/scripts/dispatch_r2_reviewer.test.ts
+++ b/tests/scripts/dispatch_r2_reviewer.test.ts
@@ -1195,13 +1195,14 @@ describe('extractAcceptanceCriteria — over the REAL active tree, not a fixture
             if (!hasAcceptanceCriteria(extractAcceptanceCriteria(text))) blind.push(name);
         }
         // Vacuity guard: a moved roadmaps root would make the loop assert nothing.
-        // Tied to the corpus rather than a pinned count. The floor used to be
-        // `declaring > 10`, chosen when the active estate was large; archival
-        // shrinks that estate (26 -> 14 active over the 2026-08-21 PR drain) and
-        // the constant reached exactly 10, failing for a reason unrelated to a
-        // moved root. `scanned` proves the root is real; `declaring` proves the
-        // loop had something to assert over.
-        expect(scanned).toBeGreaterThan(5);
+        // Tied to the corpus rather than a pinned count. The floor was
+        // `declaring > 10`, chosen when the active estate was large, then 5.
+        // Both rot for one reason: `check_estate_count` forbids growth, so this
+        // corpus only shrinks and any absolute floor above 0 is met eventually —
+        // a review provoked exactly that at 6 files against a floor of 5.
+        // `scanned > 0` proves the root is real (a moved root scans 0);
+        // `declaring > 0` proves the loop had something to assert over.
+        expect(scanned).toBeGreaterThan(0);
         expect(declaring).toBeGreaterThan(0);
         expect(blind).toEqual([]);
     });

--- a/tests/scripts/run_checkpoint.test.ts
+++ b/tests/scripts/run_checkpoint.test.ts
@@ -638,12 +638,18 @@ describe('countRoadmap — a phase span survives its own sub-headings', () => {
         const files = fs
             .readdirSync(dir)
             .filter((n) => n.endsWith('.md') && n.startsWith('road-to-'));
-        // Corpus guard, not an estate-size assertion: it must fail when the root
-        // moves or the filter matches nothing (either gives 0), and must NOT fail
-        // when archival legitimately shrinks the active tree. The floor was 10,
-        // pinned to a corpus the drain deliberately reduces; a tree-wide grep for
-        // this construct found two instances and this is the second.
-        expect(files.length).toBeGreaterThan(5);
+        // Corpus guard, not an estate-size assertion. It must fail when the root
+        // moves or the filter matches nothing — both give 0 — and must NOT fail
+        // because archival shrank the active tree.
+        //
+        // Was 10, then 5. Both were wrong in the same way: `check_estate_count`
+        // forbids growth, so this corpus can only shrink, and any absolute floor
+        // above 0 is met eventually. A review provoked it — with 6 files at the
+        // top level and a floor of 5, archiving one roadmap redded this test.
+        // `> 0` detects exactly the named failure and cannot rot. A genuinely
+        // empty corpus still reds, which is correct: the assertion below would
+        // then pass vacuously, and that is what this guard exists to prevent.
+        expect(files.length).toBeGreaterThan(0);
         const falseCompletions: string[] = [];
         for (const name of files) {
             const body = fs.readFileSync(path.join(dir, name), 'utf-8');


### PR DESCRIPTION
Follow-up to the PR-drain run, and a correction of that run's own work.

A neutral review provoked the failure my earlier fix claimed to prevent: with
6 roadmaps at the top level and floors of 5, archiving one roadmap reds
`run_checkpoint.test.ts` and `dispatch_r2_reviewer.test.ts`. The commit message on
`ff4d54faa` asserted floor 5 "will not re-break on the next archival" — that was
wrong, and wrong twice over, because 10 had already failed the same way.

**The number was never the defect.** `check_estate_count` forbids growth, so this
corpus can only shrink, and any absolute floor above 0 is met eventually. What
each guard exists to detect, per its own comment, is a moved root or a filter
matching nothing — and both yield exactly 0.

- `tests/scripts/run_checkpoint.test.ts` — `files.length > 0`
- `tests/scripts/dispatch_r2_reviewer.test.ts` — `scanned > 0`
- `src/config/gate-coverage.yml` — `min_scanned: 1` for `lint_plan_risk_register`

A genuinely empty corpus still reds, which is correct: the assertions these
guards protect would otherwise pass vacuously, which is why they exist.

**Proved in both directions rather than argued:**

| probe | expected | observed |
|---|---|---|
| archive one roadmap | must NOT red | 97 tests pass |
| empty the top level | MUST red | 3 tests red · `check_gate_coverage`: `scanned 0, floor 1` |

Also fixes the stale `corpus:` string, which still claimed "19 at baseline"
against a real count of 6. That correction was written during the drain and lost
in a merge — the competing trunk version carried a longer note plus the old
corpus line. The field is printed into the gate's own failure message, so a
future red would have described a corpus three times the real one.

Not addressed here, and needing a maintainer decision: `decision-revisit-gate`
left `check_rule_stub_ceiling`'s scope at `cafb8a255` while growing 2186 → 8020
chars against a 545-token ceiling, and its migration ledger is now an orphan that
no gate objects to. Re-adding a ceiling either reds CI immediately or bakes in the
growth.