### PR TITLE
fix(gate): unblock preflight during a release — two gates that could not be green mid-release

### DIFF
--- a/src/scripts/check_rule_layer_partition.ts
+++ b/src/scripts/check_rule_layer_partition.ts
@@ -51,7 +51,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { isExclusivelyPackageOnly } from '../install/partitionEligibility.js';
+import { isExclusivelyPackageOnly, resolvePartitionVerdict } from '../install/partitionEligibility.js';
 import { PROJECT_RULE_DIRS, globalRuleLayerNames, globalRuleLayerPath } from '../install/globalRuleLayers.js';
 import { GateLedger, UnaccountedTargetsError } from './_lib/gate_ledger.js';
 import { reportScanned } from './_lib/scan_scope.js';
@@ -380,6 +380,20 @@ function prune(audit: PartitionAudit, root: string): number {
     return removed;
 }
 
+/**
+ * Does a duplication in this projection mode mean an emitter FAILED, or that the
+ * partition deliberately did not run?
+ *
+ * Split out of `main` so both directions are testable without a lockfile on disk:
+ * the un-injected path can only assert whatever the machine happens to be, and this
+ * one bit differs between a maintainer checkout mid-release and a partitioned one —
+ * the same environment-dependence `ruleLayerPartition.ts` records for its own
+ * `active` override.
+ */
+export function partitionEnforces(mode: string): boolean {
+    return mode === 'dual-layer/partitioned';
+}
+
 export function main(argv: readonly string[] = process.argv.slice(2)): number {
     if (argv.includes('--self-test')) {
         return selfTest();
@@ -458,6 +472,43 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
             return 1;
         }
         process.stdout.write('✅  re-audit after prune: 0 duplicated\n');
+        return 0;
+    }
+
+    // A duplication the PARTITION ITSELF declined to remove is not a defect — it is
+    // the documented fail-safe, and hard-failing on it makes this gate contradict
+    // its own sibling. `check_single_delivery` reads the same fact and reports it:
+    // "a machine whose install predates the fingerprint keeps the full projection
+    // BY DESIGN". This gate refused instead, and the two verdicts on one condition
+    // are how a release push got blocked on 2026-08-22 with no reachable repair —
+    // `task generate-tools` re-emits exactly the files it demanded be gone, so the
+    // partition gate and `check_bridge_derivation` deadlock, each red in the state
+    // the other requires.
+    //
+    // The block is structural rather than incidental: during ANY release the
+    // building version is ahead of the installed one, so `resolvePartitionVerdict`
+    // returns `standalone/full` on every maintainer machine for the whole release
+    // window. A gate that cannot be green while a release is in progress is not
+    // measuring the release.
+    //
+    // Teeth are unchanged where the partition IS active: there a duplicate means an
+    // emitter failed to withhold what the partition selected, which is the defect
+    // this gate exists to catch. In CI both layers are absent, `offenders` is empty,
+    // and this branch is never reached — so nothing here relaxes the CI reading.
+    const verdict = resolvePartitionVerdict(root);
+    if (!partitionEnforces(verdict.mode)) {
+        for (const d of offenders) {
+            process.stdout.write(
+                `⚠️  ${d.dir}: ${String(d.duplicated.length)} rule(s) also present in ` +
+                    `${d.globalLayer ?? '(unknown)'}\n`,
+            );
+        }
+        process.stdout.write(
+            `⚠️  check_rule_layer_partition: partition INACTIVE (${verdict.reason}), so the ` +
+                `generators emit the full projection by design and this overlap is the fail-safe ` +
+                `working. Reported, not enforced — run \`agent-config install\` to activate the ` +
+                `partition here, then this gate has teeth again.\n`,
+        );
         return 0;
     }
 

--- a/src/scripts/check_single_delivery.ts
+++ b/src/scripts/check_single_delivery.ts
@@ -115,6 +115,25 @@ const TYPES = ['rules', 'skills', 'commands', 'personas', 'user-types', 'agents'
 type ArtefactType = (typeof TYPES)[number];
 
 /**
+ * Directory names under `<repo>/.claude/` that the HOST writes, not a generator.
+ *
+ * `unknownProjectFamilies` used to rest on the premise that `<repo>/.claude/` is
+ * "written by `condense.ts` generators and nothing else". That premise is false
+ * and the gate proved it on 2026-08-22, refusing a release push over
+ * `.claude/worktrees/` — the maintainer's git-worktree root, gitignored at
+ * `.gitignore:246`, named as a conventional worktree location by
+ * `worktree_cleanup_check.STANDARD_WORKTREE_DIRS`, and excluded from
+ * `inventory_abstraction_budget`. Nothing about it is an artefact family, so
+ * "add it to TYPES" was advice that could not be taken.
+ *
+ * The set is hand-written and stays independent of any producer registry, for
+ * the same reason `TYPES` is: a verifier that derives its scope from a producer
+ * inherits that producer's omissions. It grows only on tree evidence that a name
+ * is host state — never to silence a family a generator actually emits.
+ */
+const HOST_OWNED = new Set(['worktrees']);
+
+/**
  * What a layer's entries physically ARE — symlinks, directories, or regular files.
  *
  * R2 finding 2: without this, name-equality was reported as "delivered twice" for
@@ -304,9 +323,10 @@ export interface Verdict {
      * reported — a gate cannot report a family it was never told exists.
      *
      * Only the PROJECT layer is scanned, and that is the whole reason this can be
-     * a hard refusal rather than a warning. `<repo>/.claude/` is written by
-     * `condense.ts` generators and nothing else, so every entry in it is a family
-     * this repository chose to emit. `~/.claude/` is the host's own directory —
+     * a hard refusal rather than a warning. Every entry in `<repo>/.claude/` is a
+     * family this repository chose to emit, EXCEPT the host-written names in
+     * `HOST_OWNED` — see that constant for why the unqualified version of this
+     * sentence was wrong. `~/.claude/` is the host's own directory —
      * `plugins`, `projects`, `sessions`, `shell-snapshots`, `telemetry` and a
      * dozen more live there — and treating an unrecognised name in it as a defect
      * would be a false-positive generator, not a check.
@@ -333,7 +353,13 @@ function unknownProjectFamilies(projectRoot: string): string[] {
         return []; // no project layer at all — nothing emitted, nothing to miss
     }
     return entries
-        .filter((e) => e.isDirectory() && !e.name.startsWith('.') && !known.has(e.name))
+        .filter(
+            (e) =>
+                e.isDirectory() &&
+                !e.name.startsWith('.') &&
+                !known.has(e.name) &&
+                !HOST_OWNED.has(e.name),
+        )
         .map((e) => e.name)
         .sort();
 }

--- a/tests/scripts/check_rule_layer_partition.test.ts
+++ b/tests/scripts/check_rule_layer_partition.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { auditRuleLayers, renderTable } from '../../src/scripts/check_rule_layer_partition.js';
+import { auditRuleLayers, partitionEnforces, renderTable } from '../../src/scripts/check_rule_layer_partition.js';
 import { GLOBAL_RULE_DIRS, PROJECT_RULE_DIRS } from '../../src/install/globalRuleLayers.js';
 
 /**
@@ -129,5 +129,26 @@ describe('check_rule_layer_partition', () => {
         const a = auditRuleLayers(root, seedHome(['global-scope.md']));
         expect(a.dirs.map((d) => d.dir)).toEqual(['.cursor/rules']);
         expect(Object.keys(a.skipped)).toHaveLength(4);
+    });
+});
+
+describe('partitionEnforces', () => {
+    it('enforces only where the partition actually ran', () => {
+        expect(partitionEnforces('dual-layer/partitioned')).toBe(true);
+    });
+
+    it('does NOT enforce while the projection is standalone/full', () => {
+        // 2026-08-22: a release push was blocked here with no reachable repair.
+        // Building 14.8.0 against an installed 14.7.0 makes `resolvePartitionVerdict`
+        // return `standalone/full`, so the generators emit every rule by design —
+        // and `task generate-tools` re-writes exactly the files this gate demanded be
+        // gone, deadlocking it against `check_bridge_derivation`. Every release hits
+        // this by construction: the building version is always ahead of the installed
+        // one for the whole release window.
+        expect(partitionEnforces('standalone/full')).toBe(false);
+    });
+
+    it('treats an unrecognised mode as non-enforcing (fail-safe, not fail-loud)', () => {
+        expect(partitionEnforces('some-future-mode')).toBe(false);
     });
 });

--- a/tests/scripts/check_single_delivery.test.ts
+++ b/tests/scripts/check_single_delivery.test.ts
@@ -222,4 +222,25 @@ describe('unknown family in the project layer', () => {
         mkdirSync(join(root, 'p', 'alpha'), { recursive: true });
         expect(evaluate(join(root, 'g'), join(root, 'p')).unknownFamilies).toEqual(['alpha', 'zeta']);
     });
+
+    it('does NOT report `worktrees` — host state, not a generator-emitted family', () => {
+        // 2026-08-22: this gate refused a release push over `.claude/worktrees/`,
+        // the maintainer's gitignored git-worktree root, telling the agent to add
+        // it to TYPES — advice that could not be taken, because it is not an
+        // artefact family. See HOST_OWNED in the gate.
+        rule(layer('g', 'rules'), 'a.md');
+        rule(layer('p', 'rules'), 'b.md');
+        mkdirSync(join(root, 'p', 'worktrees', 'some-branch'), { recursive: true });
+        expect(evaluate(join(root, 'g'), join(root, 'p')).unknownFamilies).toEqual([]);
+        expect(main(args())).toBe(0);
+    });
+
+    it('still reports a NEIGHBOURING unknown family beside `worktrees` (sensitivity)', () => {
+        // Without this, the exclusion above could be passing because detection is
+        // off on this tree rather than because one name is excluded.
+        rule(layer('g', 'rules'), 'a.md');
+        mkdirSync(join(root, 'p', 'worktrees'), { recursive: true });
+        mkdirSync(join(root, 'p', 'widgets'), { recursive: true });
+        expect(evaluate(join(root, 'g'), join(root, 'p')).unknownFamilies).toEqual(['widgets']);
+    });
 });


### PR DESCRIPTION
`task release` for 14.8.0 could not push: preflight refused, and neither refusal had a reachable repair.

## 1 — `check_single_delivery` reported `.claude/worktrees` as an unknown artefact family

Its scan rested on the premise that `<repo>/.claude/` is "written by `condense.ts` generators and nothing else". It is not — `.claude/worktrees/` is the maintainer's git-worktree root, gitignored at `.gitignore:246`, named by `worktree_cleanup_check.STANDARD_WORKTREE_DIRS`, excluded from `inventory_abstraction_budget`. The gate's advice was "add it to TYPES", which cannot be taken for something that is not an artefact family.

`HOST_OWNED` names it. It is hand-written and independent of any producer registry, for the same reason `TYPES` is, and grows only on tree evidence that a name is host state.

## 2 — `check_rule_layer_partition` refused while the partition was inactive

Building 14.8.0 against an installed 14.7.0 makes `resolvePartitionVerdict` return `standalone/full`, so the generators emit the full projection by design and 103 rules land in both layers. Its sibling `check_single_delivery` reads that same fact and reports it; this gate refused.

There was no way out. `task generate-tools` re-emits exactly the files the gate demanded be gone, so it deadlocks against `check_bridge_derivation` — each red in the state the other requires. And the block is structural rather than incidental: during any release the building version is ahead of the installed one for the whole release window, so this gate could not be green on any maintainer machine while a release was in progress.

`partitionEnforces` is split out so both directions are testable without a lockfile on disk. Teeth are unchanged where the partition is active; in CI both layers are absent, `offenders` is empty, and the new branch is never reached.

## Verification

- `task preflight` — green (was red at both gates).
- `npx vitest run` over the 8 partition / single-delivery test files — 87 passed, plus 5 new tests.
- Sensitivity, both fixes: neutralising the mechanism reds it, restoring greens it. Fix 1 — both new tests fail with the `HOST_OWNED` filter removed. Fix 2 — forcing `partitionEnforces` to `true` gives rc=1 on the live tree, restoring gives rc=0.
- Pre-existing local red, untouched by this diff: `rule_partition_per_host > projected_rule_trees` expects >0 keys and this checkout's `agents/.agent-tools.yml` is skip-worktree-masked to `tools: []`. CI activates all eight.
