### PR TITLE
feat(gates): refuse a reintroduced stub-inventory table in CI

### DIFF
--- a/.github/workflows/rule-backstops.yml
+++ b/.github/workflows/rule-backstops.yml
@@ -361,3 +361,18 @@ jobs:
 
       - name: Governed writes (protected surfaces)
         run: ./scripts-run src/scripts/lint_governed_writes
+
+      # --- a gate standing in for a paragraph that lost ----------------------
+      # agents/roadmaps/stubs/README.md carried a hand-maintained index of its
+      # own directory: the largest AUTHORED merge-conflict path in the tree,
+      # every row duplicating its stub. Deleted 2026-08-21 (3793855b3, AI
+      # council both seats) with a note written in the same change telling
+      # future runs not to restore a row. A merge restored one anyway on
+      # 2026-08-22 (28ba2f592, PR #1505) — both parents lacked the table, so it
+      # was a deliberate restore against that note, not a mis-resolved
+      # modify/delete. Prose cannot refuse; this can. Wired here rather than
+      # left local-only on purpose: a gate `task ci` runs and no workflow does
+      # is its own violation under ci-parity:local-only (165, shrink-only).
+
+      - name: Stub inventory table stays deleted
+        run: ./scripts-run src/scripts/check_no_stub_inventory_table

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -256,6 +256,7 @@ tasks:
       - task: lint-load-context
       - task: check-context-paths
       - task: check-no-roadmap-refs
+      - task: check-no-stub-inventory-table
       - task: lint-documented-commands
       - task: lint-store-boundary
       - task: check-knowledge-cards

--- a/agents/evidence/notes/drain-run-handoff.md
+++ b/agents/evidence/notes/drain-run-handoff.md
@@ -66,6 +66,11 @@ applies — a stub would be a copy of it under another name.
   needed — six parallel union merges once produced two competing tables and
   non-rendering markdown, and the index had drifted stale within a day of its
   last repair. Add the stub file; that is the whole procedure now.
+  **This note is no longer the only thing holding it.** It was, and it lost:
+  a merge restored the table on 2026-08-22 against this exact paragraph.
+  `check_no_stub_inventory_table` now refuses the reintroduction in CI
+  (`rule-backstops.yml`), so a conflict resolution that keeps a table fails
+  the build instead of relying on someone reading this.
 - A **scope-bound** completion-review or `original-review` artefact citing a
   moved roadmap path gets a per-line `ref-ignore` marker, never a rewrite —
   rewriting falsifies what was reviewed at that scope.

--- a/agents/roadmaps/stubs/README.md
+++ b/agents/roadmaps/stubs/README.md
@@ -127,7 +127,9 @@ including the three rows appended *after* the restore
 never seen and which the restore's own note miscounted as part of its twelve.
 
 **If you are resolving a conflict on this file, the resolution without a table
-is the correct one.**
+is the correct one.** `check_no_stub_inventory_table` enforces that in CI — a
+restored table fails the build rather than relying on this paragraph, which is
+the one that lost last time.
 
 To see what is here, list the directory:
 

--- a/src/config/gate-coverage.yml
+++ b/src/config/gate-coverage.yml
@@ -42,13 +42,24 @@
 #
 # COVERAGE — THE HONEST DENOMINATOR (re-measured 2026-08-18)
 # ----------------------------------------------------------
-# 269 `lint_*` / `check_*` / `audit_*` scripts live under `src/scripts/`
+# 272 `lint_*` / `check_*` / `audit_*` scripts live under `src/scripts/`
 # (the count is computed, not asserted — `check_gate_coverage.count_gate_scripts`,
-# re-run 2026-08-21 and it returns 269).
-# **45 of them emit the machine-readable `scanned: <N>` line under their
-# CI-identical argv, and 42 of those 45 are listed below.** The manifest is
+# re-run 2026-08-22 and it returns 272).
+# **47 of them emit the machine-readable `scanned: <N>` line under their
+# CI-identical argv, and 44 of those 47 are listed below.** The manifest is
 # therefore complete with respect to its own contract for every gate that can
-# carry a floor, and covers ~16 % of the population.
+# carry a floor, and covers ~17 % of the population.
+#
+# RECOUNTED on 2026-08-22, and it was wrong on every figure before the recount —
+# which is the fourth time, and the reason this paragraph keeps asking to be
+# computed. `check_no_stub_inventory_table` added ONE row and ONE script, but the
+# readings moved by more than one in three of the four places: population
+# 269 -> 272 (two scripts had landed since 2026-08-21 without touching this
+# prose), listed rows 42 -> 44 (the file already held 43 before this change; the
+# prose had again been adjusted instead of recounted, and the paragraph below
+# says so about its own previous revision), emitters 45 -> 47. Every number here
+# is reproducible: `grep -c '^  - id:' src/config/gate-coverage.yml` for the rows
+# and `count_gate_scripts()` for the population.
 #
 # Both halves were RE-DERIVED on 2026-08-21, not incremented, and the previous
 # reading was off by one in a way worth recording: it said "42 … and 41 of those
@@ -59,14 +70,14 @@
 # the prose was adjusted by one instead of recounted.
 #
 # The derivation now, so the next reader can check it rather than trust it:
-# `grep -c '^  - id:'` returns 42 (computable, and computed); every listed row
+# `grep -c '^  - id:'` returns 44 (computable, and computed); every listed row
 # is an emitter, because a row that did not emit could carry no floor and the
 # guard would report it `failing`; THREE emitters are deliberately unlisted —
 # `lint_evidence_artifacts` (below), `adr_cite_check` and
 # `check_new_adr_evidence` (each in the block where its row would have sat);
-# 42 + 3 = 45. The population figure comes from the function, and it stays 269
-# because `check_new_adr_evidence` matches the population prefix whether or not
-# it carries a row here.
+# 44 + 3 = 47. The population figure comes from the function, and
+# `check_new_adr_evidence` matches the population prefix whether or not it
+# carries a row here.
 #
 # `adr/evidence_census` emits a `scanned:` line too and is NOT in either number:
 # it carries no `lint|check|audit` prefix, so `count_gate_scripts()` never sees
@@ -1074,6 +1085,30 @@ gates:
     # an already-listed file that GREW while the file COUNT stayed at one. That
     # last case is what pins the metric as excess lines rather than a file count;
     # a count-based ratchet passes it, and this gate must not.
+
+  - id: check_no_stub_inventory_table
+    argv: ["--quiet"]
+    min_scanned: 1
+    corpus: "the guarded watch list — agents/roadmaps/stubs/README.md (1 file; the whole scope, not a sample)"
+    status: enforced
+    # No `canary:` recipe: the guarded path already EXISTS, and the canary
+    # contract is create-only. A recipe would have to mutate a tracked file
+    # rather than plant one, which the contract does not express. The gate
+    # reports UNPROVEN there rather than green, which is the honest state.
+    #
+    # Discrimination is proven by the gate's own `--self-test` instead, and the
+    # five cases are the sabotage probes it was verified with before landing:
+    # a restored transfer table, the inventory header alone, a DEAD watch list
+    # (the `check_safety_floor_untouched` shape — it must red, never report
+    # clean), plus two accepting cases that pin the narrowness review asked for
+    # — a glossary table and a table citing parent roadmaps one directory up
+    # must both pass. A blanket ban on markdown tables in the file would trade
+    # one regression for a permanent block on legitimate documentation.
+    #
+    # `min_scanned: 1` is the true corpus, not a weak floor: the scope is one
+    # known file. The collapse this file's rule 3 guards against is covered by
+    # `assertWatchlistResolves`, which refuses to report clean when the path
+    # does not resolve — so a rename reds the gate instead of retiring it.
 
   # check_new_adr_evidence is DELIBERATELY NOT REGISTERED here, following this
   # file's own two precedents rather than breaking them.

--- a/src/scripts/check_no_stub_inventory_table.ts
+++ b/src/scripts/check_no_stub_inventory_table.ts
@@ -1,0 +1,292 @@
+#!/usr/bin/env tsx
+/**
+ * Stub-inventory-table guard.
+ *
+ * `agents/roadmaps/stubs/README.md` carried a hand-maintained index of the stub
+ * files sitting beside it: two tables, 6 demand-gated rows and 27 transfer rows,
+ * appended by hand by every roadmap-transfer session. It was the largest
+ * *authored* merge-conflict path in the repository — everything above it in the
+ * ranking is generated — and every row duplicated facts already in the stub it
+ * pointed at. `3793855b3` deleted it on 2026-08-21, after the AI council chose
+ * deletion over building a generator (both seats) and after all 33 rows were
+ * checked cell by cell against their stub file.
+ *
+ * It came back on 2026-08-22. A merge (`28ba2f592`, PR #1505) reintroduced a
+ * 12-row version; both parents of that merge lacked the table, so it was not a
+ * mis-resolved `modify/delete` but a deliberate restore — taken against a note
+ * in `agents/evidence/notes/drain-run-handoff.md` written in the same change as
+ * the deletion for the express purpose of preventing one. Three further rows
+ * were then appended by later sessions.
+ *
+ * That is the whole reason this gate exists rather than another paragraph: the
+ * paragraph was tried, and it lost to a merge. Prose cannot refuse.
+ *
+ * WHAT IT REJECTS — the structure, never "tables"
+ * ----------------------------------------------
+ * Two signatures, both keyed to an inventory of the guarded file's own
+ * directory:
+ *
+ *   1. a table header row whose first cell is `Stub` — the header both
+ *      historical tables used (`| Stub | Transferred from | … |` and
+ *      `| Stub | Triggers org-mode surface | Gates |`);
+ *   2. a table body row whose FIRST cell links to a `.md` file in the SAME
+ *      directory — an inventory row by construction.
+ *
+ * A `../`-prefixed or otherwise pathed link does not match: a prose table that
+ * cites parent roadmaps is not an index of this directory. A future two-column
+ * glossary, a decision matrix, or any table that does not enumerate the
+ * neighbouring stubs is unaffected. This narrowness is deliberate and was asked
+ * for by review: a blanket ban on markdown tables in the file would block
+ * legitimate documentation to stop one specific regression.
+ *
+ * WHY A WATCH LIST AND NOT A TREE WALK
+ * ------------------------------------
+ * The guarded set is one known file, so there is no corpus to count, and a
+ * one-path guard is exactly the shape that rots into a permanent pass when the
+ * path moves — `check_safety_floor_untouched` announced "4 rules guarded" while
+ * guarding none for months. `assertWatchlistResolves` refuses to report clean when its
+ * targets do not resolve, so a rename reds this gate instead of retiring it
+ * silently.
+ *
+ * Exit codes: 0 clean · 1 findings or a dead watch list.
+ */
+// ledger-exempt: the scope is ONE watch-list file, not a collected population — there is
+// no per-target accounting to publish, and the empty path is already refused by
+// assertWatchlistResolves rather than skipped. Same shape as check_branch_freshness.
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { runGateCli, runSelfTest, type SelfTestCase } from './_lib/gate_self_test.js';
+import { assertWatchlistResolves, DeadScopeError, reportScanned } from './_lib/scan_scope.js';
+
+const _HERE = fileURLToPath(import.meta.url);
+export const ROOT = path.resolve(path.dirname(_HERE), '..', '..');
+
+/**
+ * Self-test floors. Below these, `--self-test` fails instead of printing success —
+ * deleting cases would otherwise be the cheapest route to a green self-test.
+ */
+const SELF_TEST_MIN_CASES = 5;
+const SELF_TEST_MIN_REJECT = 3;
+
+/** This script's repo-relative path, for the self-test's CLI invocations. */
+const SELF = 'src/scripts/check_no_stub_inventory_table.ts';
+
+/** Files whose inventory tables are banned. Repo-relative. */
+export const GUARDED: readonly string[] = ['agents/roadmaps/stubs/README.md'];
+
+/**
+ * A header row that opens with the literal `Stub` column.
+ *
+ * Both deleted tables used it, and it is not a phrase a prose table reaches for
+ * by accident: a first cell of exactly `Stub` announces a per-stub listing.
+ */
+const INVENTORY_HEADER = /^\|\s*Stub\s*\|/;
+
+/**
+ * A body row whose first cell links to a `.md` file in the same directory.
+ *
+ * `[^)/]*` is the load-bearing part: it excludes `../road-to-x.md` and any other
+ * pathed target, so only a link to a sibling of the guarded file matches. That
+ * is what makes this an inventory signature rather than a link count.
+ */
+const INVENTORY_ROW = /^\|\s*\[`?[^\]]*`?\]\([^)/]*\.md\)/;
+
+export interface Finding {
+    readonly file: string;
+    readonly line: number;
+    readonly kind: 'inventory-header' | 'inventory-row';
+    readonly text: string;
+}
+
+export function scan_file(rel: string, text: string): Finding[] {
+    const findings: Finding[] = [];
+    const lines = text.split('\n');
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i]!;
+        if (INVENTORY_HEADER.test(line)) {
+            findings.push({ file: rel, line: i + 1, kind: 'inventory-header', text: line.trim() });
+        } else if (INVENTORY_ROW.test(line)) {
+            findings.push({ file: rel, line: i + 1, kind: 'inventory-row', text: line.trim() });
+        }
+    }
+    return findings;
+}
+
+/**
+ * Read `--root <path>` / `--root=<path>` out of argv.
+ *
+ * Parsed by NAME, never by position. `lint_handoffs` took `args[0]` as its scan
+ * root, and the Taskfile injects `--quiet` first — so the flag became the root,
+ * the scan found nothing, and the gate was red under the argv CI runs while
+ * green under a bare probe. A named flag cannot make that mistake.
+ */
+export function parseRoot(argv: readonly string[], fallback: string): string {
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i]!;
+        if (a.startsWith('--root=')) return path.resolve(a.slice('--root='.length));
+        if (a === '--root' && argv[i + 1] !== undefined) return path.resolve(argv[i + 1]!);
+    }
+    return fallback;
+}
+
+export function main(argv: readonly string[] = process.argv.slice(2), root?: string): number {
+    const QUIET = argv.includes('--quiet');
+    root = root ?? parseRoot(argv, ROOT);
+    let present: readonly string[];
+    try {
+        present = assertWatchlistResolves({
+            gate: 'check_no_stub_inventory_table',
+            candidates: GUARDED,
+            repoRoot: root,
+        });
+    } catch (exc) {
+        if (exc instanceof DeadScopeError) {
+            process.stdout.write(`❌  ${exc.message}\n`);
+            return 1;
+        }
+        throw exc;
+    }
+
+    const findings: Finding[] = [];
+    for (const rel of present) {
+        findings.push(...scan_file(rel, fs.readFileSync(path.join(root, rel), 'utf-8')));
+    }
+
+    // Outside the --quiet guard on purpose: CI passes --quiet, and a gate whose
+    // count disappears under the real argv reads as `silent` to the coverage guard.
+    reportScanned({
+        gate: 'check_no_stub_inventory_table',
+        scanned: present.length,
+        units: 'guarded file(s)',
+        roots: GUARDED,
+    });
+
+    if (findings.length === 0) {
+        if (!QUIET) process.stdout.write('✅  No stub-inventory table in the guarded file(s).\n');
+        return 0;
+    }
+
+    process.stdout.write(
+        `❌  Stub-inventory table reintroduced — ${String(findings.length)} row(s):\n`,
+    );
+    for (const f of findings) {
+        process.stdout.write(`    ${f.file}:${String(f.line)}: ${f.kind} — ${f.text.slice(0, 100)}\n`);
+    }
+    process.stdout.write(
+        '\nThe stub files ARE the inventory; `ls agents/roadmaps/stubs/*.md` lists them.\n' +
+            'If you reached this while resolving a merge conflict, the resolution\n' +
+            'WITHOUT a table is the correct one — the table was deleted deliberately\n' +
+            '(3793855b3, AI council 2026-08-21) and restored once by a merge already.\n' +
+            'If you need a per-stub fact, it is in that stub; all 33 rows were verified\n' +
+            'against their stub file before deletion and all 15 again before the second.\n',
+    );
+    return 1;
+}
+
+/**
+ * Build a fixture repository holding one guarded file with `body`, or none at all
+ * when `body` is null (the dead-watch-list case).
+ */
+function _fixture(body: string | null): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'stub-inv-self-'));
+    if (body !== null) {
+        const target = path.join(dir, GUARDED[0]!);
+        fs.mkdirSync(path.dirname(target), { recursive: true });
+        fs.writeFileSync(target, body);
+    }
+    return dir;
+}
+
+/**
+ * Prove the gate's rejections still fire, through the CLI a contributor runs.
+ *
+ * The three rejecting cases are the sabotage probes this gate was verified with
+ * by hand before it landed; keeping them here is what stops the verification
+ * from being a one-time claim in a commit message.
+ */
+export function selfTest(): number {
+    const cases: SelfTestCase[] = [
+        {
+            name: 'rejects a restored transfer table (header + rows)',
+            expect: 'reject',
+            run: () =>
+                runGateCli(
+                    ROOT,
+                    SELF,
+                    ['--quiet', '--root', _fixture(
+                        '| Stub | Transferred from |\n|---|---|\n' +
+                            '| [`road-to-a.md`](road-to-a.md) | p |\n',
+                    )],
+                    ROOT,
+                ),
+        },
+        {
+            name: 'rejects the inventory header on its own',
+            expect: 'reject',
+            run: () => runGateCli(ROOT, SELF, ['--quiet', '--root', _fixture('| Stub | Gates |\n')], ROOT),
+        },
+        {
+            name: 'rejects a dead watch list rather than reporting clean',
+            expect: 'reject',
+            run: () => runGateCli(ROOT, SELF, ['--quiet', '--root', _fixture(null)], ROOT),
+        },
+        {
+            name: 'accepts a guarded file with no inventory table',
+            expect: 'accept',
+            run: () =>
+                runGateCli(
+                    ROOT,
+                    SELF,
+                    ['--quiet', '--root', _fixture('# Stubs\n\nThe directory is the index.\n')],
+                    ROOT,
+                ),
+        },
+        {
+            name: 'accepts a glossary table and a table citing parent roadmaps',
+            expect: 'accept',
+            run: () =>
+                runGateCli(
+                    ROOT,
+                    SELF,
+                    ['--quiet', '--root', _fixture(
+                        '| Term | Meaning |\n|---|---|\n| capability-gated | env missing |\n\n' +
+                            '| Parent | Phase |\n|---|---|\n' +
+                            '| [`road-to-x.md`](../archive/road-to-x.md) | 2.1 |\n',
+                    )],
+                    ROOT,
+                ),
+        },
+    ];
+    return runSelfTest({
+        gate: 'check_no_stub_inventory_table',
+        cases,
+        minCases: SELF_TEST_MIN_CASES,
+        minRejectCases: SELF_TEST_MIN_REJECT,
+    });
+}
+
+function _isCliEntry(): boolean {
+    if (process.argv[1] === undefined) return false;
+    const argvUrl = pathToFileURL(path.resolve(process.argv[1])).href;
+    if (import.meta.url === argvUrl) return true;
+    try {
+        return (
+            fs.realpathSync(fileURLToPath(import.meta.url)) ===
+            fs.realpathSync(path.resolve(process.argv[1]))
+        );
+    } catch {
+        return false;
+    }
+}
+
+if (_isCliEntry() || process.argv[1] === _HERE) {
+    const argv = process.argv.slice(2);
+    if (argv.includes('--self-test') && process.env['GATE_SELF_TEST_CHILD'] !== '1') {
+        process.exit(selfTest());
+    }
+    process.exit(main(argv));
+}

--- a/taskfiles/ci-fast.yml
+++ b/taskfiles/ci-fast.yml
@@ -1594,6 +1594,11 @@ tasks:
     desc: Stable artifacts must not cite specific files in agents/roadmaps/ (no-roadmap-references rule)
     cmd: ./scripts-run src/scripts/check_no_roadmap_refs
 
+  check-no-stub-inventory-table:
+    silent: true
+    desc: agents/roadmaps/stubs/README.md must not carry an inventory table of its own directory
+    cmd: ./scripts-run src/scripts/check_no_stub_inventory_table {{.QUIET_FLAG}}
+
   lint-documented-commands:
     silent: true
     desc: Every documented package command in shipped skill/rule/command docs resolves (reachability bug class; road-to-reachable-code-memory Phase 1)

--- a/tests/scripts/check_no_stub_inventory_table.test.ts
+++ b/tests/scripts/check_no_stub_inventory_table.test.ts
@@ -1,0 +1,134 @@
+// Tests for src/scripts/check_no_stub_inventory_table.ts.
+//
+// The gate replaces a paragraph that lost. `3793855b3` deleted the stub-inventory
+// table and, in the same change, wrote a note telling future runs not to restore a
+// row; a merge restored one anyway on 2026-08-22 (`28ba2f592`). So the cases below
+// pin both edges deliberately: the shapes that MUST fail, and the ordinary tables
+// in that file that must not — a blanket ban on markdown tables would trade one
+// regression for a permanent block on legitimate documentation.
+//
+// The last describe runs the DEFAULT entry point against the real repository,
+// because a test that only injects a fixture root proves the algorithm and not the
+// gate: that is exactly how 14 gates in this repo came to scan a dead tree and exit
+// green for months.
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { GUARDED, main, ROOT, scan_file } from '../../src/scripts/check_no_stub_inventory_table.js';
+
+const GUARDED_REL = GUARDED[0]!;
+
+/** Kinds the line trips, in the order the scanner reports them. */
+function kinds(line: string): string[] {
+    return scan_file('x.md', line).map((f) => f.kind);
+}
+
+describe('scan_file — inventory shapes that must fail', () => {
+    it('flags the transfer-table header the deleted table used', () => {
+        expect(
+            kinds('| Stub | Transferred from | Outcome state | Re-entry gate (its own probe) |'),
+        ).toEqual(['inventory-header']);
+    });
+
+    it('flags the org-mode header the OTHER deleted table used', () => {
+        // Both historical tables opened with a `Stub` first cell; the gate keys on
+        // that rather than on the remaining column names, which differed.
+        expect(kinds('| Stub | Triggers org-mode surface | Gates |')).toEqual([
+            'inventory-header',
+        ]);
+    });
+
+    it('flags a body row linking to a sibling stub', () => {
+        expect(
+            kinds(
+                '| [`road-to-org-telemetry-sink.md`](road-to-org-telemetry-sink.md) | parent | `transferred` | probe |',
+            ),
+        ).toEqual(['inventory-row']);
+    });
+
+    it('flags a sibling link without the backtick styling', () => {
+        expect(kinds('| [road-to-x.md](road-to-x.md) | y |')).toEqual(['inventory-row']);
+    });
+
+    it('reports every row of a restored table, not just the first', () => {
+        const table = [
+            '| Stub | Transferred from |',
+            '|---|---|',
+            '| [`road-to-a.md`](road-to-a.md) | p |',
+            '| [`road-to-b.md`](road-to-b.md) | q |',
+        ].join('\n');
+        expect(scan_file('x.md', table)).toHaveLength(3);
+    });
+});
+
+describe('scan_file — legitimate tables that must pass', () => {
+    // Review asked for the narrow structure, not a table ban. Each of these is a
+    // table a future author could reasonably want in the guarded file.
+    const allowed: ReadonlyArray<[string, string]> = [
+        ['a two-column glossary', '| capability-gated | the scope decision is made |'],
+        ['a glossary header', '| Term | Meaning |'],
+        ['a delimiter row', '|---|---|'],
+        [
+            'a row citing a PARENT roadmap one directory up',
+            '| [`road-to-estate-drawdown.md`](../archive/road-to-estate-drawdown.md) | 2.1 |',
+        ],
+        [
+            'a row citing a pathed target elsewhere in the tree',
+            '| [`ADR-241`](../../../docs/decisions/ADR-241-no-union-merge.md) | blocked |',
+        ],
+        ['prose naming a stub without a table', 'See [`road-to-a.md`](road-to-a.md) for the probe.'],
+        ['a header whose first cell merely CONTAINS the word', '| Stub kind | Meaning |'],
+    ];
+
+    for (const [label, line] of allowed) {
+        it(`ignores ${label}`, () => {
+            expect(kinds(line)).toEqual([]);
+        });
+    }
+});
+
+describe('main — fixture root', () => {
+    let root: string;
+
+    beforeEach(() => {
+        root = fs.mkdtempSync(path.join(os.tmpdir(), 'stub-inv-'));
+        fs.mkdirSync(path.dirname(path.join(root, GUARDED_REL)), { recursive: true });
+    });
+
+    afterEach(() => {
+        fs.rmSync(root, { recursive: true, force: true });
+    });
+
+    it('exits 0 on a guarded file with no inventory table', () => {
+        fs.writeFileSync(path.join(root, GUARDED_REL), '# Stubs\n\nThe directory is the index.\n');
+        expect(main(['--quiet'], root)).toBe(0);
+    });
+
+    it('exits 1 on a reintroduced table', () => {
+        fs.writeFileSync(
+            path.join(root, GUARDED_REL),
+            '| Stub | Transferred from |\n|---|---|\n| [`road-to-a.md`](road-to-a.md) | p |\n',
+        );
+        expect(main(['--quiet'], root)).toBe(1);
+    });
+
+    it('exits 1 — never 0 — when the guarded file does not exist', () => {
+        // The `check_safety_floor_untouched` failure mode: a one-path guard whose
+        // path moved announced success while guarding nothing. A rename must red.
+        expect(main(['--quiet'], root)).toBe(1);
+    });
+});
+
+describe('main — the default entry point, against the real repository', () => {
+    it('resolves its guarded path and passes on the committed tree', () => {
+        // Not a tautology: this is the invocation CI runs, and it is the half a
+        // fixture-only test cannot prove. If the guarded file is ever moved without
+        // updating GUARDED, this case fails rather than the gate going quiet.
+        expect(fs.existsSync(path.join(ROOT, GUARDED_REL))).toBe(true);
+        expect(main(['--quiet'])).toBe(0);
+    });
+});


### PR DESCRIPTION
Follow-up to #1525, which landed the removal. This is the part that removal could not carry: a mechanism.

## Why a gate and not another paragraph

The paragraph was tried. `3793855b3` deleted the stub-inventory table on 2026-08-21 and, in the same change, wrote into `agents/evidence/notes/drain-run-handoff.md`: *"Do not add a row and do not restore one."* On 2026-08-22 a merge restored one — `28ba2f592` (PR #1505), whose body records it as *"regenerated, not hand-merged"*. **Both parents of that merge lacked the table**, so it was a deliberate restore taken against a note written for the express purpose of preventing it.

Prose cannot refuse. Both seats of the neutral review on #1525 said so independently, and `codex-default` made it the condition of its APPROVE:

> a narrowly scoped check that rejects reintroduction of this inventory table

## What it rejects — the structure, never "tables"

Two signatures over one watch-list file, `agents/roadmaps/stubs/README.md`:

| Signature | Why this one |
|---|---|
| table header whose first cell is exactly `Stub` | the header **both** deleted tables used (`\| Stub \| Transferred from \| … \|` and `\| Stub \| Triggers org-mode surface \| Gates \|`) |
| table body row whose first cell links to a `.md` file in the **same directory** | an inventory row by construction |

`[^)/]*` in the second pattern is load-bearing: `](../archive/road-to-x.md)` does **not** match, so a prose table citing parent roadmaps still passes. The narrowness is the ask — `codex-default` explicitly warned that a blanket ban on markdown tables in the file *"could block legitimate future documentation"*.

## Proven by sabotage, not by a green run

Three probes were run by hand before this landed, and all three are now pinned as `--self-test` cases so the verification is not a one-time claim in a commit message:

| Fixture | Result |
|---|---|
| the restored 12-row table | **red**, 13 findings (1 header + 12 rows) |
| the inventory header alone | **red** |
| guarded file moved away | **red** — *"the guard is watching phantoms and can never fire"* |
| clean file | green |
| glossary table **+** a table citing `../archive/road-to-x.md` | green |

The third is the `check_safety_floor_untouched` failure mode — a one-path guard whose path moved announced *"4 rules guarded"* while guarding none. `assertWatchlistResolves` makes a rename red this gate instead of retiring it silently. The suite refuses to run below its declared floor (5 cases, 3 rejecting), so deleting cases is not a route to green.

16 unit tests alongside it, including one that drives the **default** entry point against the real repository — a fixture-only test proves the algorithm and not the gate, which is exactly how 14 gates in this tree came to scan a dead root and exit green for months.

## Registration — six surfaces, because five is a silent degradation

- `src/config/gate-coverage.yml` row, argv `["--quiet"]` — **CI-identical**, and `--quiet` is parsed by NAME. The `lint_handoffs` defect was `args[0]` becoming the scan root while the Taskfile injects `--quiet` first: red under the argv CI runs, green under a bare probe.
- `taskfiles/ci-fast.yml` task + `Taskfile.yml` `ci` list.
- A `.github/workflows/rule-backstops.yml` step — **not** local-only. A gate `task ci` runs and no workflow does is its own violation under `ci-parity:local-only` (165, shrink-only).
- `// ledger-exempt:` with the reason (one watch-list file is not a collected population; same shape as `check_branch_freshness`), keeping `check_gate_completeness` at **215**, where the note says headroom is zero.
- `--self-test` **adopted** rather than exempted, keeping `gate-self-test:registered-non-adopters` at **24**.

`min_scanned: 1` is the true corpus, not a weak floor — the scope is one known file, and the collapse the manifest's rule 3 guards against is covered by the watch-list assert rather than by the number. No `canary:` recipe: the guarded path already exists and the canary contract is create-only, so it reports UNPROVEN there rather than green — the honest state, and the same choice `check_source_size_budget` documents.

## The header figures are recounted, not incremented

Four numbers in `gate-coverage.yml`'s coverage paragraph were wrong **before** this change. That paragraph documents the same drift three times and asks to be computed rather than adjusted; this is the fourth occurrence.

| Figure | Was | Is | Why it moved by more than one |
|---|---|---|---|
| population | 269 | **272** | two scripts had landed since 2026-08-21 without touching the prose |
| listed rows | 42 | **44** | the file already held 43 — the prose had again been adjusted by one |
| emitters | 45 | **47** | 44 listed + 3 deliberately unlisted |
| coverage | ~16 % | **~17 %** | derived |

Both are reproducible: `grep -c '^  - id:' src/config/gate-coverage.yml` and `count_gate_scripts()`.

## Prose now points at the mechanism

The README's conflict-resolution imperative and the drain-run handoff note both name the gate, so neither stands alone any more. The handoff note says it plainly: *"This note is no longer the only thing holding it. It was, and it lost."*

## Verification

`--self-test` 5/5 (3 rejecting) · 16 unit tests · `check_gate_coverage` 44 enforced, every floor cleared · `check_ci_local_parity`, `check_gate_completeness` (215), `check_source_size_budget`, `lint_workflow_paths` green · `tsc --noEmit` and `eslint` clean · `check_md_language` clean · `task preflight` exit 0.

One advisory from preflight is **not** discharged and is named rather than hidden: `lint_evidence_artifacts` reports no completion-review artifact for this scope (2 code paths of 8 changed files). The review that exists is the cross-model council pass on #1525, which reviewed the *removal*, not this gate.
