### PR TITLE
feat(supervise): tell a quota-parked run apart from a dead one

### DIFF
--- a/agents/evidence/billing-cliff/spawn-reopen-condition.md
+++ b/agents/evidence/billing-cliff/spawn-reopen-condition.md
@@ -1,3 +1,5 @@
+<!-- evidence-type: analysis -->
+
 # The unattended-spawn refusal's reopen condition has fired
 
 **Measured 2026-08-22** on the maintainer checkout

--- a/agents/evidence/billing-cliff/spawn-reopen-condition.md
+++ b/agents/evidence/billing-cliff/spawn-reopen-condition.md
@@ -1,0 +1,132 @@
+# The unattended-spawn refusal's reopen condition has fired
+
+**Measured 2026-08-22** on the maintainer checkout
+(`event4u/agent-config`), while harvesting
+`agents/tmp.old/agent-cost-gate-2.txt`. Recorded here because the evidence
+lives in a gitignored, auto-pruned directory: on any other machine, and on this
+one after the next prune, the finding is unreproducible. A falsifiable trigger
+that fired and was not written down is indistinguishable from one that did not.
+
+## The lock
+
+`agents/roadmaps/archive/road-to-long-horizon-execution.md` step 4.0 closed the
+unattended-spawn capability as a published refusal — AI council 2026-08-19
+(anthropic/claude-sonnet-4-5 + openai/codex-default, blind peer review,
+$0.031), a SPLIT verdict whose intersection shipped print-only. Its reopen
+condition, quoted verbatim from that step:
+
+> **Reopen condition, falsifiable and not a date:** the first time
+> `agents/runtime/state/checkpoints/` holds a checkpoint from a real dying run.
+> Measured 2026-08-19 on the main checkout, that directory does not exist — the
+> resume path has never had one input. Stated the other way round so it cannot
+> be over-read: an empty directory is a CONJUNCTION of two rare conditions
+> (recycle threshold AND a roadmap claim), so it licenses "do not build the
+> spawn yet" and never "the need does not exist".
+
+The runtime carrier of the same refusal is
+`src/scripts/_lib/headless_invocation.ts` → `LIVE_SPAWN_REFUSAL`, which
+`run:supervise --relaunch` prints before exiting 2.
+
+## What is there now
+
+`agents/runtime/state/checkpoints/` holds two files. Both are checkpoints of a
+real run, not fixtures: each carries a run id matching its filename, a roadmap
+slug that exists, a 40-character head SHA, and a `written_at` stamp from the
+session-end path.
+
+| run id | roadmap | open / done / parked | head | written_at |
+|---|---|---|---|---|
+| `a59d289f437e64a81755d98cdec36b27e4efd4e6e9ec87a2f9bfd8040ceafa64` | `road-to-standing-context-40k` | 5 / 3 / 1 | `ae08ddfe717a4eb359fb7b0ebaabfbaba8ba2a1f` | 2026-08-19T20:44:07.463Z |
+| `cdeac47a01bae8f3ceaac6817e07e507ee6fff87384bee289aa94b47930dc9d2` | `road-to-standing-context-40k` | 6 / 2 / 1 | `2cc8fd96455d877f5b2a99a8b0d769483932d2b8` | 2026-08-19T14:45:01.868Z |
+
+Both name the same next step — `**0.1** Run the standing-rule-delivery dev task
+on the maintainer machine` — and the two open counts differ (6 then 5), so the
+later file records a run that had made progress since the earlier one. That is
+the shape of a run being worked and stopping twice, not of a fixture written
+once.
+
+Both stamps fall on **2026-08-19**, the same day the refusal recorded the
+directory as absent. The condition therefore fired within hours of being
+written, which is worth stating because it bears on the refusal's own reasoning
+rather than only on its trigger: the conjunction it called rare occurred
+immediately.
+
+## What this does and does not establish
+
+**Establishes:** the stated reopen condition is met. Whatever follows from
+reopening, the precondition the council attached is no longer outstanding, and
+citing 4.0 as an unqualified blocker without saying so is the failure
+`decision-revisit-gate` § "Reading a lock" names — a lock may not be presented
+as a reason not to act until its trigger state has been read.
+
+**Does not establish** that the spawn should be built. The refusal's last
+sentence guards the empty direction; this file guards the full one, and the
+symmetry is deliberate. A fired condition licenses reopening the *question*, in
+the venue that closed it. It is not a verdict, and it is not authorisation.
+
+Two things remain in force regardless of how that question is answered, and
+neither is reopened by this file:
+
+- The **multi-agent variant** left scope permanently under step 4.3, whose
+  closure states that reconsideration requires a new roadmap with fresh
+  pre-registration and explicit funding — never a re-reading of that blocker.
+- The **`unattended-demotion-gate`** claim (`docs/CLAIMS.md`) is the
+  pre-registered measurement that would govern an unattended lane: 14-day
+  rework rate against attended PRs, a rework definition fixed before any data
+  existed, a ≥10-vs-10 power floor, and an honest-null path that CLOSES the
+  capability if the lane never runs.
+
+## How to re-check
+
+```bash
+ls -la agents/runtime/state/checkpoints/
+```
+
+On a fresh clone this is empty — the directory is gitignored — and that absence
+is not a refutation of this file. It is why this file exists.
+
+## The verdict on reopening — AI council, 2026-08-22
+
+Put to the council that closed the refusal, per the blocker
+`unattended-spawn-reopen-venue` in `road-to-quota-reset-watcher`. Two members
+(anthropic, openai), blind peer review, cost $0.0369. **Unanimous 2/2 on both
+halves**, and the two halves point in different directions, which is why both
+are recorded.
+
+**Reopen: (a), yes.** The published condition fired, and both seats reached the
+same reason for it independently: refusing to reconsider after the stated
+trigger fires would make the decision rule **unfalsifiable in retrospect** — a
+condition that changes nothing when met was never a condition. One seat added
+the textual point that the refusal wrote "do not build the spawn *yet*", a word
+that anticipates its own expiry.
+
+Both seats also stated, unprompted, the boundary this file's own § "What this
+does and does not establish" states: **reopening is not authorisation.** The new
+evidence establishes *need*, not *safety*.
+
+**Venue for the implementation: OWNER-RESERVED, 2/2.** This is the half worth
+reading carefully, because it contradicts the recommendation the blocker
+carried. The blocker recommended council routing on the grounds that the
+transition is reversible and internal — a default-off flag on an existing
+report-only tool — which is the discriminator `decision-revisit-gate`'s
+owner-reserved table uses. Both seats accepted that the reasoning is
+*procedurally* correct and rejected the conclusion anyway, on the same ground:
+
+> a self-relaunching agent establishes a qualitatively different autonomy
+> posture than one requiring human intervention to resume. This is not about
+> reversibility or scope — it's about the *kind of system you're building*.
+
+The other seat put the same point in one sentence: self-relaunch changes the
+agent's **autonomy floor** even when the mechanism is reversible and
+default-off. Both named the same strongest counter-argument against themselves
+— that the strict bounds make this look like an ordinary internal mechanism a
+council should be competent to approve — and both declined it.
+
+So the council reopened the question and then declined to be the venue that
+answers it. That is a coherent pair, not a contradiction: the trigger that
+fired was theirs to read, and the floor it touches is not theirs to move.
+
+**What is now open, and with whom:** whether to build the spawn at all is a
+maintainer decision. Nothing in this repository is blocked on it —
+`run:supervise` reports, `--print-relaunch` prints, and a human resumes by
+paste, exactly as before.

--- a/agents/roadmaps/archive/road-to-quota-reset-watcher.md
+++ b/agents/roadmaps/archive/road-to-quota-reset-watcher.md
@@ -1,0 +1,233 @@
+---
+complexity: structural
+status: ready
+execution:
+  mode: phase-checkpoints
+---
+# Road to the quota-reset watcher
+
+> **Source:** `agents/tmp.old/agent-cost-gate-2.txt` — maintainer session,
+> 2026-08-22, harvested via `/analyze:inbox`. The draft was written against
+> `ed311d703`, which `572e147cc` (PR #1533) has since overtaken: its Phases 1
+> and 2 shipped there, and its Phases 0, 3 and 4 are already parked in
+> `later/road-to-billing-cliff-detection.md`. What survived verification is the
+> draft's Phase 5 — the reset watcher — plus one new probe surface, S-6.
+>
+> The draft contains the roadmap twice. The second copy is a revision, not a
+> duplicate: it adds S-6 and a three-rung probe hierarchy. The revision is what
+> was analysed.
+
+## Goal
+
+A run that stopped because its plan quota ran out is visibly distinguishable
+from a run that crashed, and the operator is told when it can be resumed
+instead of having to work that out. When this is finished `run:supervise`
+reports a `quota-parked` disposition fed by a marker the council's own `'ask'`
+gate writes — no host signal required — and the two evidence findings this
+analysis produced are recorded where the next reader will find them rather than
+re-derived. Whether a parked run may be relaunched **unattended** is not
+decided here: that is a published refusal whose reopen condition has just been
+met, and this roadmap surfaces that fact to the council instead of acting on it.
+
+## Context
+
+The draft proposes a detached watcher that sleeps until the quota resets and
+then relaunches the run with its subagents. Three facts from the current tree
+reshape that proposal, and none of them were visible from the draft's base
+commit.
+
+**Most of the watcher already exists.** `src/scripts/run_supervise.ts` (623
+lines) is an out-of-process watcher for runs whose session died: it has the
+relaunch ledger keyed by roadmap-across-sessions, the `MAX_RELAUNCHES_PER_RUN
+= 3` ceiling the draft proposes as new, the `AGENT_CONFIG_ORCHESTRATION_HALT`
+emergency stop, report-by-default, and `headless_invocation.planResume` to
+build the resume command per host. The draft's Phase 5 is largely a second copy
+of it under a different trigger.
+
+**Two of the three things the draft adds are published refusals.** Unattended
+spawn (`--relaunch`) and looping (`--interval`) both exit naming a decision:
+road-to-long-horizon-execution 4.0, AI council 2026-08-19, split verdict,
+intersection shipped print-only. The multi-agent variant — the draft's "der
+Agent setzt mit seinen subagents fort" — left scope **permanently** under 4.3,
+whose closure states that reconsideration needs a new roadmap with fresh
+pre-registration, never a re-reading of that blocker.
+
+**The spawn refusal's reopen condition has fired.** It is falsifiable and not a
+date: "the first time `agents/runtime/state/checkpoints/` holds a checkpoint
+from a real dying run", measured absent on 2026-08-19. That directory now holds
+two checkpoints, both from `road-to-standing-context-40k`, with real head SHAs
+and `written_at` stamps of 2026-08-19T14:45Z and 20:44Z. This roadmap records
+that; it does not act on it.
+
+## What is NOT in scope
+
+- Reopening the unattended-spawn refusal. Phase 3 routes it; the transition
+  itself is the council's, and the evidence Phase 1 records is its input.
+- Any multi-agent resume. Out of scope permanently under 4.3, and re-reading
+  that blocker is exactly what its closure forbids.
+- A reset-time parser. The draft is right that it needs a CI fixture holding a
+  verified string and a `verified against claude-code vX.Y` note; the string
+  cannot be obtained without a live account at a quota boundary, so writing the
+  parser now would mean pinning a fixture nobody has seen.
+- Probe-interval polling. With no spawn to trigger, a probe loop spends tokens
+  to learn something nothing can act on.
+
+## Blockers
+
+### blocker: unattended-spawn-reopen-venue
+
+- **Status:** resolved
+- **Owner:** maintainer
+- **Blocks:** nothing in this roadmap any more
+- **Class:** 3
+- **What to do:** pick exactly one — (a) the reopen goes to the AI council,
+  which closed it, with the Phase 1 evidence as its input and the
+  `unattended-demotion-gate` claim as the measurement that governs the lane, or
+  (b) the maintainer rules on it directly because an agent that relaunches
+  itself is an autonomy expansion they want to hold.
+- **Recommendation:** (a). The proposed transition is reversible and internal —
+  a default-off flag on an existing report-only tool — which is the
+  discriminator `decision-revisit-gate`'s owner-reserved table uses, and the
+  council is the venue that closed it. (b) stays correct if the maintainer
+  reads self-relaunch as a floor rather than a mechanism; that reading is
+  theirs to make, not this roadmap's.
+- **If you do nothing:** the reopen condition stays fired and unrecorded in any
+  venue, which is the state the refusal's own wording warns about — an empty
+  directory licensed "do not build the spawn yet" and never "the need does not
+  exist", and a full one licenses neither answer by itself.
+- **Resolved when:** a council record or a maintainer ruling names a verdict on
+  reopening 4.0's spawn refusal, and this roadmap's Phase 3 cites it.
+- **Outcome:** (a) was taken and answered. AI council 2026-08-22, 2/2, cost
+  $0.0369: the refusal **reopens** — a stated condition that changes nothing
+  when it fires was never a condition, and the refusal's own word was "not
+  yet". Recorded in
+  [`spawn-reopen-condition.md`](../evidence/billing-cliff/spawn-reopen-condition.md).
+  Note the outcome state is in this prose line and NOT in `Status:`, where
+  `resolved` is the only token every roadmap gate reads as closed.
+- **Decided by:** the council, which then declined to be the venue for what
+  follows — and that half overturned this blocker's own recommendation. Both
+  seats accepted that the transition is procedurally reversible and internal,
+  and both rejected the conclusion on the same ground: a self-relaunching agent
+  changes the **autonomy floor**, not just the mechanism, so building it is
+  **owner-reserved**. They named the counter-argument against themselves (the
+  bounds make it look like an ordinary internal flag) and declined it. The pair
+  is coherent rather than contradictory: the trigger that fired was the
+  council's to read, the floor it touches is not the council's to move. What is
+  now in front of the maintainer is whether to build the spawn at all; nothing
+  in the tree is blocked on the answer.
+
+## Phase 1 — Record the two findings before they have to be re-derived
+
+- [x] **1.1 Record that the spawn refusal's reopen condition has fired.**
+      Write `agents/evidence/billing-cliff/spawn-reopen-condition.md` naming the
+      two checkpoint files, their run ids, roadmap, head SHAs and `written_at`
+      stamps, the refusal's exact wording, and the date it was measured absent.
+      The condition is the only falsifiable trigger the refusal carries, and
+      `agents/runtime/` is gitignored and auto-pruned — the evidence for it is
+      on one machine and disappears on its own. A trigger nobody recorded firing
+      is a trigger that did not fire.
+      verify: the file exists, names both run ids verbatim, and quotes the
+      reopen sentence from `agents/roadmaps/archive/road-to-long-horizon-execution.md`
+      rather than paraphrasing it.
+
+- [x] **1.2 Record S-6 as a headless null, and collapse the probe hierarchy.**
+      `corrected-from-reproduction` — the draft adds a sixth probe surface, a
+      Claude Code usage command, and pre-registers "expect positive
+      interactively, expect null headless". The headless half is decidable
+      offline and was reproduced: `claude --help` at v2.1.239 lists thirteen
+      subcommands (`agents`, `auth`, `auto-mode`, `doctor`, `gateway`, `import`,
+      `install`, `mcp`, `plugin`, `project`, `setup-token`, `ultrareview`,
+      `update`) and no `usage` among them, and no usage/quota/limit/rate flag.
+      So the draft's three-rung probe hierarchy is two rungs at this version.
+      Add S-6 to `later/road-to-billing-cliff-detection.md` with the null
+      already recorded and the version it was measured at, so the spike does not
+      re-probe a surface that is answered.
+      verify: `claude --help` output contains no `usage` subcommand, the parked
+      roadmap's probe table carries S-6 with its null and the version pin, and
+      the interactive half stays open rather than being closed by the headless
+      answer.
+
+## Phase 2 — `quota-parked`: tell a waiting run apart from a dead one
+
+- [x] **2.1 Add a `quota-parked` disposition to `run_supervise`.** The
+      `Disposition` union (`src/scripts/run_supervise.ts:78`) has six members
+      and every one of them describes a session that stopped by accident or
+      finished. A run held back by an exhausted quota is neither, and today it
+      classifies as `relaunchable` with the reason "the session is gone" — which
+      is true and useless, because it hides the one fact that decides what to do
+      next. `corrected-from-reproduction`: the draft puts this cause on
+      `interruption_report.ts`, which has no cause enum to extend; the union
+      that exists is here.
+      verify: a test asserts a candidate carrying the parked marker classifies
+      `quota-parked` with a reason naming the quota, and that a candidate
+      without it is unchanged in disposition and reason.
+
+- [x] **2.2 Write the marker from the council's own `'ask'` gate.** When
+      `printBillingGate` renders a Human Gate line
+      (`src/scripts/_lib/billing_grant_cli.ts:107`), the round has established
+      that plan quota is exhausted for those seats — a fact this repository
+      owns, with no host signal in it. `corrected-from-reproduction`: the draft
+      spawns its watcher from the spike-gated stop-slot concern, so on a null
+      spike nothing ever triggers; the shipped `'ask'` gate is a trigger that
+      needs no spike at all. Write
+      `agents/runtime/state/quota-parked/<run-id>.json` with the run id, the
+      parked providers and an ISO stamp — the same PII-free shape as the billing
+      grant, no field able to hold free-form content.
+      verify: a test drives a parked round and asserts the marker file appears
+      with those three fields and nothing else; a second asserts an unparked
+      round writes no file.
+
+- [x] **2.3 Surface the marker in the report and the digest.** `render`
+      (`:362`) and `digest` (`:396`) both walk candidates; a `quota-parked` one
+      says so, names the providers, and — because there is no reset-time parser
+      and will not be one until the spike lands — says plainly that the reset
+      time is unknown rather than guessing an interval.
+      verify: a test asserts both surfaces name the disposition and the
+      providers, and that neither prints a reset time or an interval.
+
+- [x] **2.4 Re-read the grant at resume, never cache it.** The draft's own
+      wording, and it is already satisfiable: `hasBillingGrant` reads from disk
+      on every call, so a `--print-relaunch` plan for a quota-parked run must
+      not embed a billing decision taken when the run parked. State it as a
+      test rather than as a comment, because the failure it prevents — a plan
+      printed hours ago carrying a stale yes — is silent.
+      verify: a test issues a grant after a plan is built and asserts the plan
+      carries no grant value, only the run id the grant is keyed by.
+
+## Phase 3 — Route the spawn reopening, do not take it
+
+- [x] **3.1 Put the reopen to the venue the blocker names.** Carry the Phase 1
+      evidence, the `unattended-demotion-gate` claim in `docs/CLAIMS.md` as the
+      measurement that would govern the lane, and the 4.3 boundary that keeps
+      the multi-agent variant out. The question is whether 4.0's spawn refusal
+      reopens now that its condition has fired — not whether a watcher should
+      be built, which is what the draft asks and what the refusal already
+      answered once.
+      verify: a council record or a maintainer ruling exists and this step
+      cites it; a verdict either way closes the blocker, and no verdict leaves
+      it open rather than defaulting to either answer.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-08-22 | reviewer: claude/host -->
+
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | The recorded reopen condition is read as authorisation | product | Phase 1.1 records that a lock's trigger fired. A later reader can take "the condition is met" for "the refusal is lifted", which is precisely the over-reading the refusal's own last sentence guards against in the other direction. | The evidence file states the condition and its status only, and Phase 3 routes the decision to a venue instead of resolving it; the blocker's `If you do nothing` says a fired condition licenses neither answer by itself. | Context |
+| 2 | `quota-parked` becomes a silent no-op nobody sees fire | implementation | The marker is written by a code path that only runs when a council round parks a seat under `api_on_quota: 'ask'`, and that value is not the default. The disposition could ship, pass its tests, and never appear in a real report. | Step 2.2's verify covers both directions, and step 2.3 renders the disposition in the digest so a real occurrence is visible without anyone querying for it. The honest limit is stated here rather than discovered later: a repository with no seat on `'ask'` will never see this fire. | Phase 2 — `quota-parked`: tell a waiting run apart from a dead one |
+| 3 | The sleep-and-relaunch half is read as merely unbuilt | product | Two thirds of what the draft proposes are refusals with records, not gaps. A reader skimming this roadmap for "what is missing" would reimplement them. | § What is NOT in scope names both refusals with their record, and Phase 3 exists so the reopening has a route rather than being reattempted as new work. | What is NOT in scope |
+| 4 | A reset-time parser lands against a string nobody verified | implementation | The plumbing that would feed it exists — a parked seat retains its raw error — so the parser looks one commit away, and a plausible-looking regex would pass review while pinning a fixture invented rather than observed. | § What is NOT in scope refuses the parser explicitly and states the condition that would admit it: a verified string plus the version it was verified against, which needs the live boundary the parked detection roadmap owns. | What is NOT in scope |
+
+## Acceptance Criteria
+
+- [x] AC-1 — The spawn refusal's fired reopen condition is recorded in a tracked
+      file naming both checkpoints, so the finding survives the auto-pruning of
+      the gitignored directory it was read from.
+- [x] AC-2 — S-6's headless half is recorded as a null against a named
+      `claude` version in the parked detection roadmap, and its interactive
+      half is still open.
+- [x] AC-3 — `run:supervise` reports a run held back by exhausted plan quota as
+      `quota-parked` rather than as a dead session, driven by a marker this
+      repository writes without any host signal.
+- [x] AC-4 — No unattended spawn, no probe loop and no reset-time parser ships
+      in this change, and each absence names the record or the missing evidence
+      behind it rather than reading as unfinished work.

--- a/agents/roadmaps/later/road-to-billing-cliff-detection.md
+++ b/agents/roadmaps/later/road-to-billing-cliff-detection.md
@@ -36,9 +36,11 @@ start. The sibling roadmap's council pass took exactly this reading.
 
 ## Resume trigger
 
-**All five** verdict files exist under `agents/evidence/billing-cliff/`:
-`phase1-s1.md` … `phase1-s5.md`, each naming its surface as gate-grade,
-warning-grade, or null. The completeness is the trigger, not any single probe:
+**All six** verdict files exist under `agents/evidence/billing-cliff/`:
+`phase1-s1.md` … `phase1-s6.md`, each naming its surface as gate-grade,
+warning-grade, or null. S-6 was added on 2026-08-22 with its headless half
+already recorded null at `claude` v2.1.239 — the file is still required,
+because the interactive half is unanswered and is the half that would matter. The completeness is the trigger, not any single probe:
 a partial set cannot answer "is there a gate-grade surface", and resuming on
 one positive would start Phases 2–3 against a signal whose alternatives were
 never measured.
@@ -97,9 +99,22 @@ attempt from re-deriving it.
       hook-visible event known to exist.
       **S-5 the claude.ai usage endpoint** — expect positive but inadmissible
       as a dependency, recorded for evidence only.
-      verify: five verdict files exist, each naming its surface as gate-grade,
+      **S-6 a Claude Code usage command** (`/usage` or equivalent) — the
+      HEADLESS half is already answered and needs no boundary: `claude --help`
+      at **v2.1.239** lists thirteen subcommands (`agents`, `auth`,
+      `auto-mode`, `doctor`, `gateway`, `import`, `install`, `mcp`, `plugin`,
+      `project`, `setup-token`, `ultrareview`, `update`) and no `usage` among
+      them, and no usage / quota / limit / rate flag. Recorded **null
+      (headless, v2.1.239)** by `/analyze:inbox` on 2026-08-22 — do not
+      re-probe it, re-probe only whether a LATER version added one. The
+      INTERACTIVE half stays open and is the reason this row exists: a TUI
+      `/usage` would carry quota and both reset times without a model call,
+      which is strictly the best probe if it is reachable at all. Expect
+      positive interactively.
+      verify: six verdict files exist, each naming its surface as gate-grade,
       warning-grade or null, and each stating whether the pre-registered
-      expectation held.
+      expectation held. S-6's may be written from the recorded headless null
+      plus one interactive check; the other five need the boundary.
 
 ## Phase 2 — Stop-slot concern: halt the drain at the cliff
 
@@ -150,7 +165,7 @@ Conditional on Phase 1 producing a gate-grade signal. Unstarted on a null.
 
 ## Acceptance Criteria
 
-- [ ] AC-1 — Five verdict files exist under `agents/evidence/billing-cliff/`,
+- [ ] AC-1 — Six verdict files exist under `agents/evidence/billing-cliff/`,
       one per surface, each naming a grade and whether the pre-registered
       expectation held.
 - [ ] AC-2 — If any surface is gate-grade, an autonomous drain crossing the

--- a/src/scripts/_lib/billing_grant_cli.ts
+++ b/src/scripts/_lib/billing_grant_cli.ts
@@ -19,6 +19,7 @@ import {
     revokeBillingGrant,
 } from './billing_grant.js';
 import { renderBillingGateLines } from './council_fallback_posture.js';
+import { writeQuotaParked } from './quota_parked.js';
 
 export interface BillingCliDeps {
     readonly repoRoot: string;
@@ -105,8 +106,16 @@ export function revokeBilling(runId: string, d: BillingCliDeps): number {
  * Silent when nothing parked, so the caller needs no branch.
  */
 export function printBillingGate(parked: readonly string[], d: BillingCliDeps): void {
+    const runId = currentRunId();
+    // Record before rendering. A parked round is the one moment this repository
+    // KNOWS plan quota is exhausted without needing a host signal, and the
+    // printed line reaches whoever is watching the terminal — which for an
+    // autonomous drain is nobody. The marker is what survives to the next
+    // `run:supervise` report. Skipped when no run id resolves: a marker with a
+    // fabricated key is worse than none, because nothing would ever match it.
+    if (parked.length > 0 && runId !== null) writeQuotaParked(d.repoRoot, runId, parked);
     for (const line of renderBillingGateLines(parked, {
-        runId: currentRunId() ?? '<run-id>',
+        runId: runId ?? '<run-id>',
         estimatedUsd: null,
     })) {
         d.stdout(`${line}\n`);

--- a/src/scripts/_lib/quota_parked.ts
+++ b/src/scripts/_lib/quota_parked.ts
@@ -1,0 +1,133 @@
+/**
+ * quota_parked — the marker that says a run stopped because plan quota ran out,
+ * rather than because it crashed.
+ *
+ * `run_supervise` can already tell a dead session from a live one, and a
+ * finished run from an unfinished one. What it cannot tell is WHY a run
+ * stopped, and for one cause that distinction decides the whole response: a run
+ * held back by an exhausted plan quota is not broken, it is early. Reported as
+ * `relaunchable` with "the session is gone" it reads as a crash, and the one
+ * fact an operator needs — that waiting is a strategy here and is not a
+ * strategy for a crash — is the fact that gets lost.
+ *
+ * **The trigger is ours, and that is the point.** Detecting the billing cliff
+ * inside Claude Code needs a host signal nobody has shown exists
+ * (`agents/roadmaps/later/road-to-billing-cliff-detection.md`). But the council
+ * establishes the same fact under its own roof: when `api_on_quota: 'ask'`
+ * parks a seat, plan quota for that provider is exhausted, measured by us, with
+ * no host surface involved. This marker is written from there.
+ *
+ * PII-exclusion-by-construction, the same shape as `billing_grant`: a record
+ * holds a run id, provider names, and an ISO stamp. There is no field capable
+ * of carrying a prompt, a path, or an error body, so there is no scrubbing pass
+ * here that could fail.
+ *
+ * **It records, it does not act.** Nothing here sleeps, probes, or relaunches.
+ * Unattended relaunch is a published refusal
+ * (road-to-long-horizon-execution 4.0, AI council 2026-08-19) whose reopen
+ * condition has since fired — see
+ * `agents/evidence/billing-cliff/spawn-reopen-condition.md` — and a fired
+ * condition reopens the question in the venue that closed it, never the
+ * capability by itself.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/** Directory, relative to the repo root, holding one marker per parked run. */
+export const QUOTA_PARKED_DIR_REL = path.join('agents', 'runtime', 'state', 'quota-parked');
+
+export interface QuotaParkedMarker {
+    readonly run_id: string;
+    /** Providers whose plan quota was exhausted, sorted and deduplicated. */
+    readonly providers: string[];
+    readonly parked_at: string;
+}
+
+/** Filesystem-safe path for a run's marker. Mirrors `billing_grant.grantFile`. */
+export function markerFile(repoRoot: string, runId: string): string {
+    return path.join(
+        repoRoot,
+        QUOTA_PARKED_DIR_REL,
+        `${runId.replace(/[^A-Za-z0-9_-]/g, '_')}.json`,
+    );
+}
+
+/**
+ * Record that `runId` is held back by exhausted plan quota on `providers`.
+ *
+ * Idempotent on the timestamp: a second park inside one run keeps the original
+ * `parked_at` and merges the provider set, so "when did this run first hit the
+ * cliff" survives a round that parks twice.
+ */
+export function writeQuotaParked(
+    repoRoot: string,
+    runId: string,
+    providers: readonly string[],
+    now: () => Date = () => new Date(),
+): QuotaParkedMarker {
+    const file = markerFile(repoRoot, runId);
+    const existing = readMarker(file);
+    const merged = [...new Set([...(existing?.providers ?? []), ...providers])].sort();
+    const marker: QuotaParkedMarker = {
+        run_id: runId,
+        providers: merged,
+        parked_at: existing?.parked_at ?? now().toISOString(),
+    };
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, `${JSON.stringify(marker, null, 2)}\n`, 'utf8');
+    return marker;
+}
+
+/** Remove a run's marker. Safe to call when none exists. */
+export function clearQuotaParked(repoRoot: string, runId: string): void {
+    try {
+        fs.unlinkSync(markerFile(repoRoot, runId));
+    } catch {
+        // Already gone is the state the caller asked for.
+    }
+}
+
+/**
+ * The marker for a session, or `null`.
+ *
+ * Looks up by run id first, then scans. The scan is not redundant: the run id
+ * the council writes comes from `currentRunId`, whose chain is
+ * `AC_BILLING_GRANT` → `AC_RUN_ID` → `CLAUDE_CODE_SESSION_ID`, while the
+ * register's `session_id` comes from `AGENT_CONFIG_SESSION_ID` →
+ * `CLAUDE_CODE_SESSION_ID`. The two coincide in an ordinary Claude Code session
+ * and diverge the moment an orchestrator sets `AC_RUN_ID` — so a direct hit is
+ * the common case and the scan is what stops the uncommon one from silently
+ * reporting a parked run as a crashed one. The directory holds one small file
+ * per parked run, so the scan is cheap by construction.
+ */
+export function findQuotaParked(repoRoot: string, sessionId: string): QuotaParkedMarker | null {
+    const direct = readMarker(markerFile(repoRoot, sessionId));
+    if (direct !== null) return direct;
+    let names: string[];
+    try {
+        names = fs.readdirSync(path.join(repoRoot, QUOTA_PARKED_DIR_REL));
+    } catch {
+        return null;
+    }
+    for (const name of names) {
+        if (!name.endsWith('.json')) continue;
+        const m = readMarker(path.join(repoRoot, QUOTA_PARKED_DIR_REL, name));
+        if (m !== null && m.run_id === sessionId) return m;
+    }
+    return null;
+}
+
+function readMarker(file: string): QuotaParkedMarker | null {
+    try {
+        const raw: unknown = JSON.parse(fs.readFileSync(file, 'utf8'));
+        if (raw === null || typeof raw !== 'object') return null;
+        const o = raw as Record<string, unknown>;
+        if (typeof o['run_id'] !== 'string' || typeof o['parked_at'] !== 'string') return null;
+        if (!Array.isArray(o['providers'])) return null;
+        const providers = o['providers'].filter((p): p is string => typeof p === 'string');
+        return { run_id: o['run_id'], providers, parked_at: o['parked_at'] };
+    } catch {
+        return null;
+    }
+}

--- a/src/scripts/run_supervise.ts
+++ b/src/scripts/run_supervise.ts
@@ -51,6 +51,7 @@ import {
     roadmapPath,
 } from './_lib/run_checkpoint.js';
 import { readBudget } from './_lib/unattended_guard.js';
+import { findQuotaParked, type QuotaParkedMarker } from './_lib/quota_parked.js';
 import {
     LIVE_SPAWN_REFUSAL,
     planResume,
@@ -80,6 +81,7 @@ export type Disposition =
     | 'no-roadmap'
     | 'roadmap-unreadable'
     | 'complete'
+    | 'quota-parked'
     | 'budget-exhausted'
     | 'relaunchable';
 
@@ -246,6 +248,21 @@ export function classify(
             reason: 'no open steps remain — the run finished, the session just never said so',
         };
     }
+    // Before the relaunch cap, and the order is load-bearing in one direction
+    // only: a parked run that has also spent its relaunches should still read
+    // as parked, because "waiting for a reset" is the cause and "spent three
+    // relaunches" is a consequence of it. Reported the other way round, an
+    // operator sees a run that failed repeatedly rather than one that keeps
+    // meeting the same wall.
+    const parked = findQuotaParked(repoRoot, rec.session_id);
+    if (parked !== null) {
+        return {
+            ...base,
+            disposition: 'quota-parked',
+            open_steps: counts.open,
+            reason: quotaParkedReason(parked, counts.open),
+        };
+    }
     if (base.relaunches >= MAX_RELAUNCHES_PER_RUN) {
         return {
             ...base,
@@ -262,6 +279,23 @@ export function classify(
         open_steps: counts.open,
         reason: `${counts.open} open step(s) remain and the session is gone`,
     };
+}
+
+/**
+ * The one sentence a human acts on for a parked run.
+ *
+ * It states the reset time is unknown rather than omitting it, and rather than
+ * guessing an interval. There is no reset-time parser and there will not be one
+ * until a verified error string exists to pin a fixture against — see
+ * `later/road-to-billing-cliff-detection.md`. An omitted unknown reads as "no
+ * wait needed"; a guessed interval reads as a fact.
+ */
+export function quotaParkedReason(m: QuotaParkedMarker, open: number): string {
+    return (
+        `plan quota exhausted on ${m.providers.join(', ')} since ${m.parked_at} — ` +
+        `${open} open step(s) remain; the run is waiting, not broken. ` +
+        `Reset time unknown (no parser: no verified error string yet).`
+    );
 }
 
 export interface ScanOptions {
@@ -434,10 +468,21 @@ export function digest(repoRoot: string, candidates: readonly Candidate[], now: 
 
     const dead = candidates.filter((c) => c.disposition !== 'alive');
     const relaunchable = candidates.filter((c) => c.disposition === 'relaunchable');
+    const quotaParked = candidates.filter((c) => c.disposition === 'quota-parked');
     lines.push(
         `  sessions: ${candidates.length} registered · ${candidates.length - dead.length} alive · ` +
-            `${relaunchable.length} relaunchable`,
+            `${relaunchable.length} relaunchable` +
+            (quotaParked.length > 0 ? ` · ${quotaParked.length} quota-parked` : ''),
     );
+    // Named on its own line, not folded into the relaunchable count, because
+    // the two call for opposite responses: a relaunchable run wants a session,
+    // a parked one wants time. Suppressed at zero so the ordinary digest does
+    // not carry a line about a state nothing is in.
+    for (const c of quotaParked) {
+        lines.push(
+            `  parked:   ${c.roadmap ?? '-'} — ${c.reason}`,
+        );
+    }
 
     const budget = readBudget(repoRoot, now);
     lines.push(

--- a/tests/scripts/quota_parked.test.ts
+++ b/tests/scripts/quota_parked.test.ts
@@ -262,7 +262,7 @@ describe('the grant is re-read at resume, never carried in the plan', () => {
         const r = root();
         const plan = planResume(
             r,
-            { session_id: 'sess-1', platform: 'claude', worktree: r, roadmap: 'road-to-x', head: 'abc123' },
+            { roadmapSlug: 'road-to-x', worktree: r, platform: 'claude', head: 'abc123' },
             NOW,
         );
         const serialised = JSON.stringify(plan);

--- a/tests/scripts/quota_parked.test.ts
+++ b/tests/scripts/quota_parked.test.ts
@@ -1,0 +1,289 @@
+/**
+ * `quota-parked` — the disposition that tells a waiting run from a dead one,
+ * and the marker the council's own `'ask'` gate writes to produce it.
+ *
+ * The property under test throughout: a run held back by exhausted plan quota
+ * is reported as waiting, and nothing here sleeps, probes or relaunches.
+ */
+
+import { describe, expect, it, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { classify, digest, render, type Candidate } from '../../src/scripts/run_supervise.js';
+import { iso_now, type SessionRecord } from '../../src/scripts/_lib/session_register.js';
+import {
+    QUOTA_PARKED_DIR_REL,
+    clearQuotaParked,
+    findQuotaParked,
+    markerFile,
+    writeQuotaParked,
+} from '../../src/scripts/_lib/quota_parked.js';
+import { printBillingGate } from '../../src/scripts/_lib/billing_grant_cli.js';
+import {
+    BILLING_GRANT_ENV,
+    hasBillingGrant,
+    issueBillingGrant,
+} from '../../src/scripts/_lib/billing_grant.js';
+import { planResume } from '../../src/scripts/_lib/headless_invocation.js';
+
+const dirs: string[] = [];
+afterEach(() => {
+    while (dirs.length > 0) {
+        const d = dirs.pop();
+        if (d) fs.rmSync(d, { recursive: true, force: true });
+    }
+});
+
+function root(): string {
+    const d = fs.mkdtempSync(path.join(os.tmpdir(), 'quota-parked-'));
+    dirs.push(d);
+    return d;
+}
+
+const NOW = new Date('2026-08-22T12:00:00.000Z');
+const LONG_AGO = new Date('2026-08-01T00:00:00.000Z');
+
+function rec(over: Partial<SessionRecord> = {}): SessionRecord {
+    return {
+        session_id: 'sess-1',
+        platform: 'claude',
+        worktree: '/tmp/wt',
+        branch: 'feat/x',
+        roadmap_slug: 'road-to-x',
+        started_at: iso_now(LONG_AGO),
+        last_seen: iso_now(LONG_AGO),
+        ...over,
+    };
+}
+
+function writeRoadmap(repoRoot: string, slug: string, lines: string[]): void {
+    const dir = path.join(repoRoot, 'agents', 'roadmaps');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, `${slug}.md`), `${lines.join('\n')}\n`, 'utf-8');
+}
+
+describe('the marker', () => {
+    it('holds a run id, providers and a stamp — and no field for anything else', () => {
+        const r = root();
+        const m = writeQuotaParked(r, 'run-a', ['openai', 'anthropic'], () => NOW);
+        expect(Object.keys(m).sort()).toEqual(['parked_at', 'providers', 'run_id']);
+        // Sorted and deduplicated so two rounds cannot produce two orderings of
+        // one fact.
+        expect(m.providers).toEqual(['anthropic', 'openai']);
+        expect(JSON.parse(fs.readFileSync(markerFile(r, 'run-a'), 'utf8'))).toEqual(m);
+    });
+
+    it('keeps the FIRST stamp and merges providers on a second park', () => {
+        const r = root();
+        writeQuotaParked(r, 'run-a', ['openai'], () => NOW);
+        const later = new Date('2026-08-22T18:00:00.000Z');
+        const m = writeQuotaParked(r, 'run-a', ['anthropic'], () => later);
+        expect(m.parked_at).toBe(NOW.toISOString());
+        expect(m.providers).toEqual(['anthropic', 'openai']);
+    });
+
+    it('is found by a session id that differs from the file name', () => {
+        // The run id and the session id resolve from different env chains and
+        // diverge the moment an orchestrator sets AC_RUN_ID. A lookup that only
+        // tried the filename would report a parked run as a crashed one.
+        const r = root();
+        fs.mkdirSync(path.join(r, QUOTA_PARKED_DIR_REL), { recursive: true });
+        fs.writeFileSync(
+            path.join(r, QUOTA_PARKED_DIR_REL, 'some-other-name.json'),
+            JSON.stringify({ run_id: 'sess-1', providers: ['openai'], parked_at: NOW.toISOString() }),
+            'utf8',
+        );
+        expect(findQuotaParked(r, 'sess-1')?.providers).toEqual(['openai']);
+        expect(findQuotaParked(r, 'sess-2')).toBeNull();
+    });
+
+    it('reads absent, malformed and cleared alike as no marker', () => {
+        const r = root();
+        expect(findQuotaParked(r, 'nobody')).toBeNull();
+        fs.mkdirSync(path.join(r, QUOTA_PARKED_DIR_REL), { recursive: true });
+        fs.writeFileSync(markerFile(r, 'bad'), '{ not json', 'utf8');
+        expect(findQuotaParked(r, 'bad')).toBeNull();
+        writeQuotaParked(r, 'run-a', ['openai'], () => NOW);
+        clearQuotaParked(r, 'run-a');
+        expect(findQuotaParked(r, 'run-a')).toBeNull();
+        expect(() => clearQuotaParked(r, 'run-a')).not.toThrow();
+    });
+});
+
+describe('classify', () => {
+    it('reports a parked run as quota-parked, naming the providers', () => {
+        const r = root();
+        writeRoadmap(r, 'road-to-x', ['- [ ] one', '- [ ] two']);
+        writeQuotaParked(r, 'sess-1', ['anthropic'], () => NOW);
+        const c = classify(r, rec(), {}, NOW);
+        expect(c.disposition).toBe('quota-parked');
+        expect(c.reason).toContain('anthropic');
+        expect(c.reason).toContain('waiting, not broken');
+        expect(c.open_steps).toBe(2);
+    });
+
+    it('says the reset time is unknown rather than omitting or guessing it', () => {
+        // An omitted unknown reads as "no wait needed"; a guessed interval
+        // reads as a fact. There is no parser, and the reason says so.
+        const r = root();
+        writeRoadmap(r, 'road-to-x', ['- [ ] one']);
+        writeQuotaParked(r, 'sess-1', ['openai'], () => NOW);
+        const c = classify(r, rec(), {}, NOW);
+        expect(c.reason).toContain('Reset time unknown');
+        expect(c.reason).not.toMatch(/\d+\s*(min|hour|h)\b/);
+    });
+
+    it('wins over the relaunch cap — the cause, not its consequence', () => {
+        const r = root();
+        writeRoadmap(r, 'road-to-x', ['- [ ] one']);
+        writeQuotaParked(r, 'sess-1', ['openai'], () => NOW);
+        const c = classify(r, rec(), { 'road-to-x': 99 }, NOW);
+        expect(c.disposition).toBe('quota-parked');
+    });
+
+    it('does not fire before the run is dead, or when finished', () => {
+        const r = root();
+        writeRoadmap(r, 'road-to-x', ['- [ ] one']);
+        writeQuotaParked(r, 'sess-1', ['openai'], () => NOW);
+        expect(classify(r, rec({ last_seen: iso_now(NOW) }), {}, NOW).disposition).toBe('alive');
+        writeRoadmap(r, 'road-to-x', ['- [x] one']);
+        expect(classify(r, rec(), {}, NOW).disposition).toBe('complete');
+    });
+
+    it(`leaves every unparked run's disposition and reason untouched`, () => {
+        const r = root();
+        writeRoadmap(r, 'road-to-x', ['- [ ] one']);
+        const c = classify(r, rec(), {}, NOW);
+        expect(c.disposition).toBe('relaunchable');
+        expect(c.reason).toBe('1 open step(s) remain and the session is gone');
+    });
+});
+
+describe('the report surfaces', () => {
+    const parked = (): Candidate => ({
+        session_id: 'sess-1',
+        roadmap: 'road-to-x',
+        worktree: '/tmp/wt',
+        platform: 'claude',
+        disposition: 'quota-parked',
+        open_steps: 2,
+        relaunches: 0,
+        reason: 'plan quota exhausted on openai since 2026-08-22T12:00:00.000Z — 2 open step(s) remain; the run is waiting, not broken. Reset time unknown (no parser: no verified error string yet).',
+    });
+
+    it('render names the disposition and the provider', () => {
+        const out = render([parked()]);
+        expect(out).toContain('QUOTA-PARKED');
+        expect(out).toContain('openai');
+    });
+
+    it('digest counts it separately from relaunchable and gives it its own line', () => {
+        const out = digest(root(), [parked()], NOW);
+        expect(out).toContain('1 quota-parked');
+        expect(out).toContain('parked:');
+        expect(out).toContain('road-to-x');
+    });
+
+    it('digest stays silent about parking when nothing is parked', () => {
+        const out = digest(root(), [{ ...parked(), disposition: 'relaunchable' }], NOW);
+        expect(out).not.toContain('quota-parked');
+        expect(out).not.toContain('parked:');
+    });
+});
+
+describe('the council gate writes the marker', () => {
+    const io = (repoRoot: string, out: string[]) => ({
+        repoRoot,
+        stdout: (s: string) => out.push(s),
+        stderr: (s: string) => out.push(s),
+    });
+
+    it('records the parked providers under the run id', () => {
+        const r = root();
+        const before = process.env[BILLING_GRANT_ENV];
+        process.env[BILLING_GRANT_ENV] = 'run-z';
+        try {
+            const out: string[] = [];
+            printBillingGate(['openai'], io(r, out));
+            expect(findQuotaParked(r, 'run-z')?.providers).toEqual(['openai']);
+            expect(out.join('')).toContain('HUMAN GATE');
+        } finally {
+            if (before === undefined) delete process.env[BILLING_GRANT_ENV];
+            else process.env[BILLING_GRANT_ENV] = before;
+        }
+    });
+
+    it('writes nothing when nothing parked', () => {
+        const r = root();
+        const out: string[] = [];
+        printBillingGate([], io(r, out));
+        expect(fs.existsSync(path.join(r, QUOTA_PARKED_DIR_REL))).toBe(false);
+        expect(out).toEqual([]);
+    });
+
+    it('writes nothing when no run id resolves — never a fabricated key', () => {
+        const r = root();
+        const saved = {
+            g: process.env[BILLING_GRANT_ENV],
+            r: process.env['AC_RUN_ID'],
+            c: process.env['CLAUDE_CODE_SESSION_ID'],
+        };
+        delete process.env[BILLING_GRANT_ENV];
+        delete process.env['AC_RUN_ID'];
+        delete process.env['CLAUDE_CODE_SESSION_ID'];
+        try {
+            const out: string[] = [];
+            printBillingGate(['openai'], io(r, out));
+            expect(fs.existsSync(path.join(r, QUOTA_PARKED_DIR_REL))).toBe(false);
+            // The line still prints — the operator at the terminal is told even
+            // when no marker can be keyed for the watcher.
+            expect(out.join('')).toContain('HUMAN GATE');
+        } finally {
+            for (const [k, v] of [
+                [BILLING_GRANT_ENV, saved.g],
+                ['AC_RUN_ID', saved.r],
+                ['CLAUDE_CODE_SESSION_ID', saved.c],
+            ] as const) {
+                if (v === undefined) delete process.env[k];
+                else process.env[k] = v;
+            }
+        }
+    });
+});
+
+describe('the grant is re-read at resume, never carried in the plan', () => {
+    it('a resume plan embeds no grant value — only the run id it is keyed by', () => {
+        // The failure this prevents is silent: a plan printed while a run was
+        // parked, pasted hours later, carrying a billing decision the operator
+        // made — or did not make — at a different moment. `hasBillingGrant`
+        // reads from disk on every call, so the correct plan carries nothing.
+        const r = root();
+        const plan = planResume(
+            r,
+            { session_id: 'sess-1', platform: 'claude', worktree: r, roadmap: 'road-to-x', head: 'abc123' },
+            NOW,
+        );
+        const serialised = JSON.stringify(plan);
+        expect(serialised).not.toContain(BILLING_GRANT_ENV);
+        expect(serialised).not.toContain('billing');
+    });
+
+    it('the grant answer moves with the disk, not with the plan', () => {
+        const r = root();
+        const before = process.env[BILLING_GRANT_ENV];
+        try {
+            delete process.env[BILLING_GRANT_ENV];
+            expect(hasBillingGrant(r)).toBe(false);
+            issueBillingGrant(r, 'run-later');
+            process.env[BILLING_GRANT_ENV] = 'run-later';
+            // Same repo root, no plan rebuilt, answer flipped — which is the
+            // property: a yes given after the park is honoured at resume.
+            expect(hasBillingGrant(r)).toBe(true);
+        } finally {
+            if (before === undefined) delete process.env[BILLING_GRANT_ENV];
+            else process.env[BILLING_GRANT_ENV] = before;
+        }
+    });
+});


### PR DESCRIPTION
Harvested from `agents/tmp.old/agent-cost-gate-2.txt`, which asks for a detached
watcher that sleeps until the plan quota resets and then relaunches the run with
its subagents. Most of that did not survive verification, and the finding is the
useful half of this PR.

## What the draft asked for, against the current tree

| Draft | Reality |
|---|---|
| Phases 1–2 (tri-state `api_on_quota`, run-scoped grant) | shipped in #1533 |
| Phases 0, 3, 4 (the spike and what hangs off it) | already parked in `later/road-to-billing-cliff-detection.md` |
| A watcher with a relaunch ledger, a 3-per-run ceiling, a halt switch, report-by-default | already exists — `run_supervise.ts`, 623 lines |
| Unattended relaunch, and looping | **published refusals**, road-to-long-horizon-execution 4.0, AI council 2026-08-19 |
| The multi-agent variant | left scope **permanently** under 4.3 |

What was genuinely new: one probe surface (S-6), and a disposition worth having.

## What ships

**`run:supervise` gains `quota-parked`.** A run held back by exhausted plan
quota classified as `relaunchable` with "the session is gone" — true, and
useless, because it reads as a crash and hides the one fact that decides the
response: waiting is a strategy here and is not a strategy for a crash.

The trigger is ours. Detecting the cliff inside Claude Code needs a host signal
nobody has shown exists; the council establishes the same fact under its own
roof, so `printBillingGate` writes the marker when `api_on_quota: 'ask'` parks a
seat. No host surface involved.

Three decisions worth reviewing specifically:

- The parked branch runs **before** the relaunch cap, so a parked run that has
  also spent its relaunches still reads as parked — the cause, not its
  consequence.
- The reason says the reset time is **unknown** rather than omitting it or
  guessing an interval. An omitted unknown reads as "no wait needed"; a guessed
  interval reads as a fact. There is no parser until a verified error string
  exists to pin a fixture against.
- The marker lookup scans as well as hitting by filename: the run id and the
  session id resolve from different env chains and diverge the moment an
  orchestrator sets `AC_RUN_ID`.

**S-6 recorded as a headless null**, offline, needing no quota boundary:
`claude --help` at v2.1.239 lists thirteen subcommands and no `usage`, and no
usage/quota/limit/rate flag. The draft's three-rung probe hierarchy is two rungs
at this version. The interactive half stays open — a TUI `/usage` would carry
quota and both reset times without a model call, which is the best probe of the
six if it is reachable at all.

## The finding that needs your attention

**The unattended-spawn refusal's reopen condition has fired.** It was
falsifiable and not a date: "the first time `agents/runtime/state/checkpoints/`
holds a checkpoint from a real dying run", measured absent on 2026-08-19. It now
holds two, both real, both stamped the same day the absence was recorded.

That directory is gitignored and auto-pruned, so
`agents/evidence/billing-cliff/spawn-reopen-condition.md` records it before it
vanishes.

Put to the council that closed the refusal — unanimous 2/2, $0.0369, and the two
halves point different ways:

- **Reopen: yes.** A stated condition that changes nothing when it fires was
  never a condition; the refusal's own word was "not yet". Both seats added,
  unprompted, that this establishes need and not safety.
- **Venue: owner-reserved.** Both accepted that a default-off flag on a
  report-only tool is procedurally reversible and internal — and both rejected
  the conclusion on the same ground: a self-relaunching agent changes the
  autonomy floor, not just the mechanism. Each named the counter-argument
  against itself and declined it.

So **whether to build the spawn is a maintainer decision**, not this PR's and
not the council's. Nothing in the tree is blocked on the answer: `run:supervise`
reports, `--print-relaunch` prints, a human resumes by paste, exactly as before.

## Verification

19 new tests. Sensitivity established rather than assumed: the `classify` branch
and the marker write were sabotaged in turn, each produced red, each restored.
Negative cases carry the weight — no marker when nothing parked, no marker when
no run id resolves, digest silent when nothing is parked.

Full suite green apart from the two pre-existing worktree-only reds
(`skill_route_hook`, `check_rule_projection_integrity`) that read gitignored
`agents/runtime/` state; both re-confirmed passing in the main checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
