### PR TITLE
fix(tests): retry the temp-repo remove that ENOTEMPTY'd on three PRs

### DIFF
--- a/tests/_lib/rm_temp_repo.ts
+++ b/tests/_lib/rm_temp_repo.ts
@@ -1,0 +1,28 @@
+import { rmSync } from 'node:fs';
+
+/**
+ * Remove a temp directory that had a git repository in it.
+ *
+ * `rmSync(dir, { recursive: true, force: true })` is not enough for a `.git`
+ * tree and CI proved it: `ENOTEMPTY: directory not empty, rmdir
+ * the .git dir of a /tmp/ratchet-baseref-XXXX fixture` on both ubuntu and macOS, on three separate
+ * pull requests, while the same suite passed locally every time. The mechanism
+ * is a race, not a bug in the walk — git can leave work in flight (an auto-gc,
+ * an index lock, a packed-refs rewrite) after the `spawnSync` that started it
+ * has returned, so a file can appear inside a directory between the moment the
+ * walk empties it and the moment it calls `rmdir`.
+ *
+ * `maxRetries` + `retryDelay` is Node's own documented remedy for exactly this
+ * class (`EBUSY`, `EMFILE`, `ENFILE`, `ENOTEMPTY`, `EPERM`), and it belongs in
+ * one place rather than at each call site.
+ *
+ * **Population, measured rather than guessed:** 44 test files in this tree call
+ * `rmSync(..., { recursive: true, force: true })` on a temp dir AND run `git` in
+ * it, and none of them passed `maxRetries` before this helper existed. Only
+ * `ratchet_base_ref.test.ts` has been OBSERVED failing, so only it is migrated
+ * here — the other 43 are a latent population, named so the next one to flake
+ * has somewhere to go instead of being diagnosed from scratch.
+ */
+export function rmTempRepo(dir: string): void {
+    rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+}

--- a/tests/scripts/ratchet_base_ref.test.ts
+++ b/tests/scripts/ratchet_base_ref.test.ts
@@ -12,6 +12,8 @@
  */
 import { execFileSync } from 'node:child_process';
 import { mkdtempSync, mkdirSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+
+import { rmTempRepo } from '../_lib/rm_temp_repo.js';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -52,7 +54,11 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-    rmSync(repo, { recursive: true, force: true });
+    // Retrying remove: git can still be finishing work in this `.git` after the
+    // spawnSync that started it returned, and a plain recursive rmSync then
+    // fails ENOTEMPTY. Observed on ubuntu and macOS across three PRs while the
+    // same suite passed locally every time. See `rmTempRepo`.
+    rmTempRepo(repo);
 });
 
 const opts = () => ({ baselinePath: 'src/config/allow.json', baseRef: 'base', repoRoot: repo });


### PR DESCRIPTION
Not roadmap work — a blocking test defect found while draining. It has reddened `Node Tests` on **three** separate pull requests (#1532 macOS, #1534 ubuntu, #1536 ubuntu) while the same suite passed locally every time.

## The failure

```
ENOTEMPTY: directory not empty, rmdir  … /ratchet-baseref-XXXX/.git
```

`tests/scripts/ratchet_base_ref.test.ts`, in its own `afterEach`. Not a product failure — the assertions that "fail" are the ones whose teardown throws.

## The mechanism

A race, not a bug in the walk. `git` can leave work in flight — an auto-gc, an index lock, a `packed-refs` rewrite — after the `spawnSync` that started it has returned. So a file can appear inside a directory between the moment the recursive walk empties it and the moment it calls `rmdir`.

`maxRetries` + `retryDelay` is Node's own documented remedy for exactly this class (`EBUSY`, `EMFILE`, `ENFILE`, `ENOTEMPTY`, `EPERM`). `tests/_lib/rm_temp_repo.ts` puts it in one place.

## Scope — one file changed, and the population named

**44 test files** call `rmSync(..., { recursive: true, force: true })` on a temp dir **and** run `git` in it. **None** passed `maxRetries` before this helper existed. Only `ratchet_base_ref.test.ts` has been *observed* failing, so only it is migrated.

The other 43 are a latent population, recorded in the helper's docstring so the next one to flake has somewhere to go instead of being diagnosed from scratch. Sweeping all 44 on one observation would be the drive-by this repo's diff rules refuse — and it would touch 44 files to fix a defect measured in one.

## Verification

20/20 locally. The honest limit: **a race cannot be proven fixed by a passing run**, since the same run passed before the change on this machine. What the change does is give the remove ten chances over ~500 ms instead of one, which is the documented remedy for the documented error code. The evidence that it was needed is three CI failures on two platforms; the evidence it is sufficient will be their absence.

## One authoring note worth keeping

The first version of the helper's docstring quoted the failing path literally, and `-*/.git` **closed the block comment early**. esbuild caught it and the whole file collected zero tests. A path containing a glob does not belong inside `/** */`.