### PR TITLE
fix(tests): retry the fixture-repo removal that ENOTEMPTY'd on three PRs

### DIFF
--- a/tests/_lib/rm_fixture_repo.ts
+++ b/tests/_lib/rm_fixture_repo.ts
@@ -1,0 +1,28 @@
+import { rmSync } from 'node:fs';
+
+/**
+ * Remove a fixture directory that had a git repository in it.
+ *
+ * `rmSync(dir, { recursive: true, force: true })` is not enough for a `.git`
+ * tree and CI proved it: `ENOTEMPTY: directory not empty, rmdir
+ * the .git dir of a /tmp/ratchet-baseref-XXXX fixture` on both ubuntu and macOS, on three separate
+ * pull requests, while the same suite passed locally every time. The mechanism
+ * is a race, not a bug in the walk — git can leave work in flight (an auto-gc,
+ * an index lock, a packed-refs rewrite) after the `spawnSync` that started it
+ * has returned, so a file can appear inside a directory between the moment the
+ * walk empties it and the moment it calls `rmdir`.
+ *
+ * `maxRetries` + `retryDelay` is Node's own documented remedy for exactly this
+ * class (`EBUSY`, `EMFILE`, `ENFILE`, `ENOTEMPTY`, `EPERM`), and it belongs in
+ * one place rather than at each call site.
+ *
+ * **Population, measured rather than guessed:** 44 test files in this tree call
+ * `rmSync(..., { recursive: true, force: true })` on a temp dir AND run `git` in
+ * it, and none of them passed `maxRetries` before this helper existed. Only
+ * `ratchet_base_ref.test.ts` has been OBSERVED failing, so only it is migrated
+ * here — the other 43 are a latent population, named so the next one to flake
+ * has somewhere to go instead of being diagnosed from scratch.
+ */
+export function rmFixtureRepo(dir: string): void {
+    rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
+}

--- a/tests/scripts/ratchet_base_ref.test.ts
+++ b/tests/scripts/ratchet_base_ref.test.ts
@@ -12,6 +12,8 @@
  */
 import { execFileSync } from 'node:child_process';
 import { mkdtempSync, mkdirSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+
+import { rmFixtureRepo } from '../_lib/rm_fixture_repo.js';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -52,7 +54,11 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-    rmSync(repo, { recursive: true, force: true });
+    // Retrying remove: git can still be finishing work in this `.git` after the
+    // spawnSync that started it returned, and a plain recursive rmSync then
+    // fails ENOTEMPTY. Observed on ubuntu and macOS across three PRs while the
+    // same suite passed locally every time. See `rmFixtureRepo`.
+    rmFixtureRepo(repo);
 });
 
 const opts = () => ({ baselinePath: 'src/config/allow.json', baseRef: 'base', repoRoot: repo });


### PR DESCRIPTION
Not roadmap work — a blocking test defect found while draining. It has reddened `Node Tests` on **three** separate pull requests (#1532 macOS, #1534 ubuntu, #1536 ubuntu) while the same suite passed locally every time.

Supersedes #1539, which carried the same change under a commit subject the repo's blocklist rejects (`temp`). The gate's own fix instruction is `rebase -i` + reword; rewriting history is not something this session does unasked, so this is a fresh branch and the helper is renamed `rmFixtureRepo` to match.

## The failure

```
ENOTEMPTY: directory not empty, rmdir  … /ratchet-baseref-XXXX/.git
```

`tests/scripts/ratchet_base_ref.test.ts`, in its own `afterEach`. Not a product failure — the assertions that "fail" are the ones whose teardown throws.

## The mechanism

A race, not a bug in the walk. `git` can leave work in flight — an auto-gc, an index lock, a `packed-refs` rewrite — after the `spawnSync` that started it has returned. So a file can appear inside a directory between the moment the recursive walk empties it and the moment it calls `rmdir`.

`maxRetries` + `retryDelay` is Node's own documented remedy for exactly this class (`EBUSY`, `EMFILE`, `ENFILE`, `ENOTEMPTY`, `EPERM`). `tests/_lib/rm_fixture_repo.ts` puts it in one place.

## Scope — one test file changed, and the population named

**44 test files** call `rmSync(..., { recursive: true, force: true })` on a fixture dir **and** run `git` in it. **None** passed `maxRetries` before this helper existed. Only `ratchet_base_ref.test.ts` has been *observed* failing, so only it is migrated.

The other 43 are a latent population, recorded in the helper's docstring so the next one to flake has somewhere to go instead of being diagnosed from scratch. Sweeping all 44 on one observation would be the drive-by this repo's diff rules refuse — 44 files touched to fix a defect measured in one.

## Verification, and its honest limit

20/20 locally. **A race cannot be proven fixed by a passing run**, since the same run passed before the change on this machine. What the change does is give the removal ten attempts over ~500 ms instead of one, which is the documented remedy for the documented error code. The evidence it was needed is three CI failures on two platforms; the evidence it is sufficient will be their absence.

## One authoring note worth keeping

The helper's first docstring quoted the failing path literally, and `-*/.git` **closed the block comment early** — the whole file then collected zero tests until esbuild said so. A path containing a glob does not belong inside a `/** */` block.