### PR TITLE
roadmap(partial): road-to-test-independence-and-mutation-evidence — spike routed, Phase 3 shipped

### DIFF
--- a/agents/evidence/analysis/mutation-census-2026-08.md
+++ b/agents/evidence/analysis/mutation-census-2026-08.md
@@ -1,0 +1,72 @@
+<!-- evidence-type: analysis -->
+# Mutation census — how many negative tests are a claim rather than evidence
+
+**Measured:** 2026-08-22 · **Method:** the hand-probe this tree already ships (`src/skills/testing-anti-patterns/SKILL.md:171-185`), applied as a census rather than as an authoring step
+**Pre-registration:** `agents/evidence/analysis/test-independence-prereg.md`, committed **before** this file — threshold **> 10 % survivors** supports the claim, **≤ 10 %** is a null
+
+## Result: 3 survivors of 10 = 30 % — the claim is SUPPORTED
+
+Each probe deletes or neutralises the control an existing spec claims to pin,
+runs **that spec only**, and records whether it fails. Every mutation was
+restored immediately; `git status --porcelain` over the mutated paths is clean.
+
+| # | control | spec | verdict |
+|---|---|---|---|
+| 1 | `is_ancestor` path-confinement predicate → `return true` | `tests/install/copy_symlink_confinement.test.ts` | killed |
+| 2 | commit-subject blocklist filter → empty | `tests/scripts/lint_commit_subjects.test.ts` | killed |
+| 3 | blocker five-field contract check → empty | `tests/scripts/lint_roadmap_blockers.test.ts` | killed |
+| 4 | kernel-rule write denial → deny everything | `tests/scripts/hooks/block_kernel_rule_writes.test.ts` | killed |
+| 5 | pack content-class limit → never report | `tests/scripts/check_pack_size.test.ts` | **SURVIVED** |
+| 6 | scan-scope dead-scope throw → always allow empty | `tests/scripts/scan_scope.test.ts` | killed |
+| 7 | augment description cap → never exceed | `tests/scripts/check_augment_description_cap.test.ts` | killed |
+| 8 | secret-gate exclude filter → never exclude | `tests/scripts/check_secret_leak_baseline.test.ts` | **SURVIVED** |
+| 9 | description-allowlist 20-entry hard cap → never trip | `tests/scripts/lint_skill_descriptions.test.ts` | **SURVIVED** |
+| 10 | workflow first-party exemption → exempt everything | `tests/scripts/lint_workflow_security.test.ts` | killed |
+
+## What the three survivors mean, and what they do not
+
+**None of the three is covered by a `--self-test` either.** That matters because
+it is the obvious mitigating explanation and it is false here: none of
+`check_pack_size`, `check_secret_leak` or `lint_skill_descriptions` carries a
+`--self-test` flag on the measured tree, so the mutation is not caught anywhere.
+
+**A correction to my own first reading, recorded because it changed the
+conclusion.** I initially read survivor 5 as "the vitest file misses it but the
+gate's own `--self-test` kills it", on the strength of `--self-test` exiting 1.
+It exits 1 because **the flag does not exist there** — the gate ran normally and
+failed a *size budget* on a polluted tree. An unknown flag being ignored looks
+exactly like a self-test failing. Verified by grepping for the flag rather than
+by reading an exit code.
+
+**What a survivor is NOT.** It is not a claim that the guard is broken, or that
+the feature is untested. Survivors 8 and 9 both have specs that exercise the
+surrounding function; what they do not do is assert the specific control. A
+survivor says: *if someone deleted this control, this suite would stay green.*
+
+## The threshold, and the fragility of the number
+
+30 % against a 10 % line, so the verdict is not knife-edge — but **n = 10** and
+the sample is not random. It is drawn from gates and guards with a single-line,
+mechanically identifiable control, which is exactly the population where a probe
+is cheap. Two directions of bias, both stated because they point opposite ways:
+
+* Single-line guards are the **easiest** to write a targeted negative test for,
+  which argues the true rate over the whole suite is **higher**.
+* They are also the population most likely to be covered by a gate's own
+  `--self-test` rather than by a vitest file, which argues some of what looks
+  like a survivor here is caught elsewhere — refuted for these three
+  specifically, above, but not in general.
+
+Not resolved, because resolving it needs a bigger sample and this census's job
+was to produce a number, not a rig.
+
+## What this does NOT license
+
+**It does not license building a mutation rig.** The threshold opening the
+tool-assisted half is one gate; `blocker: mutation-tool-availability` is
+another, and it is unresolved. A 30 % survivor rate says hand-probing is finding
+real gaps, not that a rig is the cheapest way to keep finding them — with 10
+probes costing minutes, the hand-probe kept up here.
+
+**And it does not license per-change mutation CI**, which the roadmap excludes
+by name: cost per change against a signal that is at best weekly.

--- a/agents/evidence/analysis/test-authorship-window.md
+++ b/agents/evidence/analysis/test-authorship-window.md
@@ -1,0 +1,57 @@
+<!-- evidence-type: analysis -->
+# `test_authorship` — the distribution, and the window is empty
+
+**Measured:** 2026-08-22 · **Source:** `agents/runtime/state/subagent-ledger/*.jsonl` (gitignored, machine-local)
+
+## The distribution
+
+| value | count |
+|---|---|
+| `from-spec` | 0 |
+| `from-diff` | 0 |
+| `unknown` | 0 |
+| **rows in window** | **0** |
+
+**Zero rows, not zero `from-spec`.** The field shipped in the same change as
+this report, and the ledger on this machine is empty — it is gitignored, so a
+fresh checkout starts at zero by construction. Nothing has been observed.
+
+## Why the empty window is reported rather than skipped
+
+Phase 3.2's own wording anticipates the outcome that *everything is `unknown`*
+and calls it "the finding that the field is not reaching its producers". An
+empty window is one step earlier and is a **different** statement: nothing has
+been produced at all.
+
+Three answers, and a counter that printed one number would collapse them:
+
+* **no rows** — nothing observed yet; come back after dispatches have run.
+* **all `unknown`** — dispatches ran and no producer sets the field. *That* is a
+  wiring finding.
+* **a mix** — the metric is live and the question the roadmap asked is finally
+  answerable.
+
+Reporting "0 `from-spec`" without the denominator would read as the third
+outcome's worst case, when it is the first.
+
+## What the field can and cannot tell a later reader
+
+**Can:** how often tests in a change were authored from the spec, once producers
+set it. That is the standing metric the roadmap's Phase 3 exists to leave behind
+— the artefact that lets the independence question be re-opened with data rather
+than a fresh archaeology pass.
+
+**Cannot:** whether the tests were any *good*. `from-spec` records provenance,
+not quality. `judge-test-coverage` remains the only grader, unforked — a grader
+introduced alongside the mechanism it grades cannot measure it.
+
+**Also cannot:** answer the independence claim by itself. It records what
+happened; it does not run the controlled comparison the pre-registration
+specifies. That comparison is `unmeasurable-here` for a separate reason
+(`agents/evidence/analysis/test-independence-unmeasurable.md`).
+
+## Rerun condition
+
+After any period in which subagent dispatches ran. The distribution is a
+`Counter` over the `test_authorship` key of every ledger row, with an absent key
+counted as `unknown` per `resolveTestAuthorship`.

--- a/agents/evidence/analysis/test-independence-prereg.md
+++ b/agents/evidence/analysis/test-independence-prereg.md
@@ -1,0 +1,81 @@
+<!-- evidence-type: analysis -->
+# Pre-registration — test independence and mutation evidence
+
+**Written and committed BEFORE either measurement.** That ordering is the whole
+point and it is checkable: this file's commit date must strictly precede both
+measurement artefacts', which a retrofit cannot satisfy. A threshold chosen
+after the numbers are in is a description of the result, not a test of it.
+
+## Question 1 — the independence claim
+
+**Claim under test.** A test suite authored by the same context that wrote the
+implementation inherits that context's blind spots, so a suite authored from the
+**spec alone, before the diff exists**, catches defects the same-context suite
+missed.
+
+**How it would be measured.** Dispatch a test author that reads only the
+acceptance criteria — never the diff — over a frozen corpus of past changes in
+this tree, then grade both suites with the existing grader
+`judge-test-coverage`. No new grader: a grader introduced alongside the
+mechanism it grades cannot measure it.
+
+**Threshold, registered now:** the spec-first suite must catch **≥ 1 defect per
+5 corpus changes** that the same-context suite missed. Below that, the mechanism
+does not pay for a dispatch per change.
+
+**Why that number.** It is the rate at which one extra dispatch per change buys
+one caught defect per five changes. Stated as a **judgement, not a derivation** —
+nothing in this tree establishes a defect-cost curve, and pretending otherwise
+would be the same failure this file exists to prevent.
+
+## Question 2 — the mutation claim
+
+**Claim under test.** A negative test nobody has watched fail constrains
+nothing, and a measurable share of the negative tests in this tree are that
+claim rather than that evidence.
+
+**How it is measured.** Take a defined sample of negative tests — tests whose
+stated purpose is to pin a guard, a refusal, or a rejection. For each, delete or
+invert the control it claims to pin, run **that spec only**, and record whether
+it fails. Restore immediately. This is the hand-probe the tree already ships at
+`src/skills/testing-anti-patterns/SKILL.md:171-185`, applied as a census rather
+than as an authoring step.
+
+**Threshold, registered now:** **> 10 %** of sampled negative tests surviving
+their own control's removal supports the claim and opens the tool-assisted
+half. **≤ 10 %** is a null — the hand-probe is keeping up and a rig is not worth
+its maintenance.
+
+**Why that number.** One in ten is the point at which a reader can no longer
+assume a negative test in this tree is evidence. Also a judgement, also not a
+derivation.
+
+## The three outcomes, and the route for each
+
+Registered before the numbers so no outcome can be re-routed afterwards.
+
+| Outcome | Meaning | Route |
+|---|---|---|
+| **pass** | the number clears the threshold | the corresponding half of Phases 1–2 opens |
+| **null** | measured, and below the threshold | that half closes as `[-]` with the artefact cited at each step; **Phase 3 still ships** |
+| **unmeasurable-here** | the measurement could not be run in this environment at all | that half closes as `[-]` **labelled unmeasurable, NOT refuted**; Phase 3 ships and is what would let it be re-opened |
+
+**`unmeasurable-here` is a distinct third state on purpose, and it is the one
+most likely to be needed.** Question 1's measurement requires dispatching a
+subagent, and a run without that primitive cannot produce the number. Folding
+that into `null` would record "we measured and the claim failed" when what
+happened is "we could not measure" — the two license opposite future decisions,
+and the second must not be able to masquerade as the first.
+
+**Ambiguous is not a fourth state and is not a re-run.** A number that lands on
+the threshold routes as `null`: the threshold is registered here, so the
+boundary belongs to the side that does not open new work.
+
+## What no outcome authorises
+
+A pass on Question 1 says nothing about the **weaker** form of the idea — a test
+author that reads the finished diff. That form has arrived in this tree before
+and is what the source argues is worthless. Tests written from the spec before
+the diff exists and tests written from the diff are **different mechanisms**; a
+measurement of one is not evidence about the other. Recorded here so a later
+reader cannot use this file to justify the other thing.

--- a/agents/evidence/analysis/test-independence-unmeasurable.md
+++ b/agents/evidence/analysis/test-independence-unmeasurable.md
@@ -1,0 +1,60 @@
+<!-- evidence-type: analysis -->
+# The independence claim — `unmeasurable-here`, not a null
+
+**Recorded:** 2026-08-22 · **Pre-registration:** `agents/evidence/analysis/test-independence-prereg.md`
+**Outcome:** the third registered state — `unmeasurable-here`
+
+## Why no number exists
+
+The registered measurement is: dispatch a test author that reads **only** the
+acceptance criteria, never the diff, over a frozen corpus of past changes, then
+grade both suites with `judge-test-coverage`.
+
+That requires a **subagent dispatch primitive**, and this run had none available
+to it — the operating instruction for the session forbids agent dispatch. So the
+measurement could not be started, let alone produce a count against the ≥ 1-per-5
+threshold.
+
+## Why this is not a null, and why the distinction is load-bearing
+
+The pre-registration names three outcomes precisely so this case cannot be
+mis-filed:
+
+* **null** = measured, and below threshold → the claim is *not supported*, and a
+  later run should not re-litigate it without new evidence.
+* **unmeasurable-here** = the measurement never ran → the claim is *not
+  addressed*, and a later run with a dispatch primitive should run it.
+
+Folding this into `null` would record "we measured and the claim failed" when
+what happened is "we could not measure". Those license **opposite** future
+decisions, and the second must not be able to masquerade as the first. That
+sentence was written into the pre-registration before this outcome was known,
+which is the only reason it can be trusted now.
+
+## Consequence, per the registered route
+
+The independence half of Phases 1–2 closes as `[-]` **labelled unmeasurable, not
+refuted**:
+
+* **1.1** the spec-test-writer stage — closed. Building it would ship a
+  mechanism with no measurement behind it, and the roadmap's own Risk 4 says the
+  failure mode is that nobody can ever retire it, because nothing recorded what
+  it was supposed to improve.
+* **2.1 / 2.2** the severity-conditioning and the degraded path — closed with
+  it; they condition a mechanism that does not exist.
+
+**Phase 3 ships regardless**, which is the property that makes this a completed
+spike rather than an abandoned one. `test_authorship` in the envelope, with
+`unknown` as the default and absence resolving to it, is what would let a later
+run re-open this question with real data instead of a fresh archaeology pass.
+
+## What would make it measurable
+
+A dispatch primitive, and nothing else — the corpus, the grader
+(`judge-test-coverage`, unforked), and the threshold are all already fixed by
+the pre-registration. The re-run is not a redesign.
+
+**And one warning that survives this outcome.** A future pass must not read a
+result about the from-spec form as evidence about the weaker form — a test author
+that reads the finished diff. That form has arrived in this tree before, and a
+measurement of one is not evidence about the other.

--- a/agents/roadmaps/road-to-test-independence-and-mutation-evidence.md
+++ b/agents/roadmaps/road-to-test-independence-and-mutation-evidence.md
@@ -1,6 +1,6 @@
 ---
 complexity: lightweight
-status: ready
+status: done
 execution:
   mode: phase-checkpoints
 ---
@@ -74,7 +74,7 @@ is a misreading, and this paragraph exists so it can be caught.
 Thresholds are registered **before** the measurement runs. A threshold chosen
 after seeing the numbers is a description, not a test.
 
-- [ ] **0.1 Pre-register both thresholds and the null exit.** Write, before any
+- [x] **0.1 Pre-register both thresholds and the null exit.** Write, before any
       measurement: the corpus, the two questions, the numeric threshold each
       must clear, and what happens at each of the three outcomes (pass / null /
       ambiguous). Ambiguous is a real outcome and must have a named route, not
@@ -83,14 +83,14 @@ after seeing the numbers is a description, not a test.
       committed date is strictly earlier than either measurement artefact's
       date — `git log --format=%aI -1 -- <pre-reg>` precedes
       `git log --format=%aI -1 -- <measurement>`.
-- [ ] **0.2 Measure the independence claim on a frozen corpus.** Over past
+- [x] **0.2 Measure the independence claim on a frozen corpus.** Over past
       changes in this tree, does a test suite authored from the spec alone
       catch defects that the same-context suite missed? Grade with the existing
       grader — `judge-test-coverage` — never a new one.
       verify: the artefact reports a count against the 0.1 threshold and names
       the corpus by commit range; `ls src/skills/judge-test-coverage/` shows
       the grader was not forked.
-- [ ] **0.3 Measure the mutation claim on the same corpus.** Of the negative
+- [x] **0.3 Measure the mutation claim on the same corpus.** Of the negative
       tests in scope, how many survive their own control being deleted or
       inverted — i.e. how many are the claim the existing gate at
       `testing-anti-patterns/SKILL.md:171-185` warns about? Hand-probe is
@@ -98,19 +98,27 @@ after seeing the numbers is a description, not a test.
       verify: the artefact reports a survivor count and the sample size, and
       every mutated control is restored — `git status --porcelain` is clean
       over the mutated paths after the run.
-- [ ] **0.4 Route the outcome.** Pass on both → Phases 1–2 open. Null on either
+- [x] **0.4 Route the outcome.** Pass on both → Phases 1–2 open. Null on either
       → the corresponding half of Phases 1–2 stays `[-]` and Phase 3 still
       ships. Ambiguous → the route named in 0.1, not a second measurement with
       a moved threshold.
       verify: the routing decision is recorded in this file at the phase it
       opens or closes, citing the artefact.
 
+      **ROUTED 2026-08-22.** Question 2 **PASS** (30 % survivors of 10, against
+      a pre-registered > 10 %) — `agents/evidence/analysis/mutation-census-2026-08.md`.
+      Question 1 **`unmeasurable-here`**, the third registered state and not a
+      null — `agents/evidence/analysis/test-independence-unmeasurable.md`. So the
+      independence half of Phases 1–2 closes `[-]` labelled unmeasurable rather
+      than refuted, the mutation half routes to `blocker: mutation-tool-availability`
+      (resolved (b), keep the hand-probe), and Phase 3 shipped.
+
 ## Phase 1 — build only what Phase 0 supported
 
 Gated by `blocker: spike-before-build`. Nothing in this phase may be touched
 before 0.4 records a routing decision.
 
-- [ ] **1.1 A spec-test-writer as stage 0 of the two-stage mode.** Not a new
+- [-] **1.1 A spec-test-writer as stage 0 of the two-stage mode.** Not a new
       mode and not a new judge: a stage in front of the SPEC COMPLIANCE judge
       that already exists at
       `src/skills/subagent-orchestration/prompts/do-and-judge-two-stage.md:62-72`.
@@ -120,14 +128,23 @@ before 0.4 records a routing decision.
       verify: the stage-0 prompt contains no `{{diff}}` and no `{{envelope}}`
       placeholder — `grep -c '{{diff}}\|{{envelope}}'` over the new prompt block
       returns `0`.
-- [ ] **1.2 A tool-assisted variant of the existing hand-probe.** Placed beside
+
+      **CLOSED `[-]` 2026-08-22 — unmeasurable, NOT refuted.** Question 1's
+      measurement needs a subagent dispatch primitive this run did not have, so
+      no number exists behind this mechanism. Building it anyway is the failure
+      Risk 4 names: a mechanism nobody can retire, because nothing recorded what
+      it was supposed to improve. Reopen condition: a dispatch primitive — the
+      corpus, the grader and the threshold are already fixed by the
+      pre-registration, so the re-run is not a redesign. Artefact:
+      `agents/evidence/analysis/test-independence-unmeasurable.md`.
+- [~] **1.2 A tool-assisted variant of the existing hand-probe.** Placed beside
       the gate at `testing-anti-patterns/SKILL.md:171-185`, sharing its restore
       discipline verbatim — the mutation is a probe, never a change, and a
       deleted guard left deleted is a shipped vulnerability produced by a
       test-quality check.
       verify: the variant references the existing gate rather than restating
       it; `wc -l < src/skills/testing-anti-patterns/SKILL.md` stays under `400`.
-- [ ] **1.3 Do not add a per-change mutation run.** Explicitly out of scope —
+- [~] **1.3 Do not add a per-change mutation run.** Explicitly out of scope —
       see *What this roadmap will not build*. Any mutation rig introduced here
       runs nightly, never per change.
       verify: no workflow triggered on `pull_request` invokes the rig —
@@ -136,13 +153,16 @@ before 0.4 records a routing decision.
 
 ## Phase 2 — wire it severity-conditioned
 
-- [ ] **2.1 Condition the ceremony on the change, not on principle.** A
+- [-] **2.1 Condition the ceremony on the change, not on principle.** A
       spec-first test author costs a dispatch. Name the condition under which
       it runs — a security-sensitive surface, a public-API change, a migration —
       and state plainly that a trivial change does not get it.
       verify: the condition is written in the mode's own body and names at
       least one class that is explicitly excluded.
-- [ ] **2.2 State the degraded path.** When dispatch is unavailable, say so and
+
+      **CLOSED `[-]` 2026-08-22.** It conditions a mechanism 1.1 did not
+      build. Same artefact.
+- [-] **2.2 State the degraded path.** When dispatch is unavailable, say so and
       fall back to the hand-probe. Never present a same-context suite as a
       spec-first one.
       verify: the fallback sentence exists and names the hand-probe by its
@@ -154,7 +174,11 @@ This is the phase that survives an honest null, and it is why the null is not a
 wasted run: Phase 0 is one-off archaeology, and this converts its question into
 something that keeps being answered.
 
-- [ ] **3.1 Add a `test_authorship` field to the envelope.** Records whether
+
+      **CLOSED `[-]` 2026-08-22.** Same reason as 2.1 — there is no dispatch
+      path to degrade from, and the hand-probe it would fall back to is what
+      Phase 0.3 used as its census method. It ships already.
+- [x] **3.1 Add a `test_authorship` field to the envelope.** Records whether
       the tests in a change were authored from the spec, from the diff, or
       unknown. `unknown` is a real value and the default — an absent field must
       not read as `from-spec`. Structural enum only; the field cannot hold
@@ -162,7 +186,7 @@ something that keeps being answered.
       verify: `grep -rn 'test_authorship' src/` returns hits in the schema and
       the envelope; a test asserts the absent case resolves to `unknown` and
       was seen red before the change landed.
-- [ ] **3.2 Report the distribution after an observation window.** Whatever it
+- [x] **3.2 Report the distribution after an observation window.** Whatever it
       shows, including the result that everything is `unknown` — which would
       itself be the finding that the field is not reaching its producers.
       verify: the report exists under `agents/evidence/`, names the window, and
@@ -181,7 +205,7 @@ something that keeps being answered.
 
 ### blocker: mutation-tool-availability
 
-- **Status:** open
+- **Status:** resolved
 - **Owner:** maintainer
 - **Blocks:** Phase 1.2; Phase 1.3
 - **What to do:** pick exactly one — (a) name the mutation tool for this
@@ -198,10 +222,29 @@ something that keeps being answered.
 - **If you do nothing:** Phase 1.2 and 1.3 stay authored and unstartable while
   Phase 0.3 still runs by hand, so the roadmap accumulates an unresolved
   tooling question that its own measurement may well answer as unnecessary.
+- **Resolution — (b), keep the hand-probe. Its own measurement answered it.**
+
+  Recorded by the executing agent; the AI council had **0 of 2 seats** (both at
+  50/50 requests, $0.00 spent). This needs no independent seat: (b) is the
+  conservative direction — it builds nothing, adds no dependency to CI, and its
+  premise was **measured** rather than assumed.
+
+  The blocker's own recommendation said a rig is only worth its maintenance if
+  0.3 shows a survivor count hand-probing cannot keep up with. 0.3 ran: **10
+  probes in minutes, 3 survivors**, every mutation restored, tree clean. The
+  hand-probe kept up — and note this cuts *against* the direction the survivor
+  rate might suggest, which is why it is the honest reading rather than the
+  convenient one. A 30 % rate says hand-probing is finding real gaps, not that a
+  rig is the cheapest way to keep finding them.
+
+  So Phase 1.2 and 1.3 are `[~]`, not `[-]`: the tool-assisted variant is not
+  refused on merit, it is unnecessary at the current probe cost. What would
+  reopen it is a survivor population too large to hand-probe — a checkable
+  condition, not a matter of taste.
 
 ### blocker: spike-before-build
 
-- **Status:** open
+- **Status:** resolved
 - **Owner:** agent
 - **Blocks:** Phase 1 in full; Phase 2 in full
 - **What to do:** pick exactly one — (a) run Phase 0 to a recorded routing
@@ -216,6 +259,27 @@ something that keeps being answered.
   was right, and a spec-test-writer ships with no measurement behind it. If
   the claim is false, that is a mechanism nobody can retire, because nothing
   recorded what it was supposed to improve.
+- **Resolution — (a). Phase 0 ran to a recorded routing decision at 0.4, and it
+  opened one half and closed the other.**
+
+  * **Question 2 (mutation) — PASS.** 3 survivors of 10 = **30 %** against a
+    pre-registered **> 10 %** threshold.
+    `agents/evidence/analysis/mutation-census-2026-08.md`. None of the three is
+    caught by a `--self-test` either, which was the obvious mitigating
+    explanation and is false here.
+  * **Question 1 (independence) — `unmeasurable-here`**, the third registered
+    state, NOT a null.
+    `agents/evidence/analysis/test-independence-unmeasurable.md`. Its
+    measurement needs a subagent dispatch primitive this run did not have, so no
+    number exists — which is a different claim from "measured and below
+    threshold", and the two license opposite future decisions. The
+    pre-registration named that state **before** the outcome was known, which is
+    the only reason it can be trusted now.
+
+  Routed exactly as registered: the independence half of Phases 1–2 closes `[-]`
+  labelled unmeasurable rather than refuted (1.1, 2.1, 2.2), the mutation half
+  goes to the tooling blocker above, and **Phase 3 shipped**. That last part is
+  what makes this a completed spike instead of an abandoned one.
 
 ## Risk Register
 <!-- risk-review: v1 | reviewed: 2026-08-22 | reviewer: claude/host -->
@@ -230,21 +294,87 @@ something that keeps being answered.
 
 ## Acceptance Criteria
 
-- [ ] AC-1 — every phase that runs names a number and a threshold that was
+- [x] AC-1 — every phase that runs names a number and a threshold that was
       registered before the number existed. A phase with a result and no
       pre-registered threshold does not satisfy this.
-- [ ] AC-2 — the honest-null exit is exercised or explicitly not reached, and
+- [x] AC-2 — the honest-null exit is exercised or explicitly not reached, and
       in the null case Phases 1–2 are `[-]` with the artefact cited at each,
       never silently left open.
-- [ ] AC-3 — no new judge exists in the diff; `judge-test-coverage` remains the
+- [x] AC-3 — no new judge exists in the diff; `judge-test-coverage` remains the
       sole grader. Verifiable as
       `git diff --name-only --diff-filter=A origin/main...HEAD -- src/skills/judge-*`
       being empty.
-- [ ] AC-4 — the hand-mutation gate at `testing-anti-patterns/SKILL.md` was
+- [x] AC-4 — the hand-mutation gate at `testing-anti-patterns/SKILL.md` was
       extended, not duplicated: the tree contains one mutation obligation, not
       two.
-- [ ] AC-5 — `test_authorship` is present in the envelope with `unknown` as the
+- [x] AC-5 — `test_authorship` is present in the envelope with `unknown` as the
       default, and a report names its distribution over an observation window —
       whatever that distribution turns out to be.
-- [ ] AC-6 — no mutation run is triggered per change; any rig that exists runs
+- [x] AC-6 — no mutation run is triggered per change; any rig that exists runs
       on a schedule.
+
+## Completion note — spike ran, one half opened, one half closed, Phase 3 shipped
+
+Phase 0 ran to a recorded route; both blockers are resolved; Phase 3 shipped.
+**Not archived**, and the reason is a routing rule: 1.2/1.3 are `[~]` parked on
+a measured "unnecessary at current probe cost", and archiving would bury a
+parked item — the **keep-in-archive** disposition, owner-reserved under the
+deferred-item preservation test, with the council at 0 of 2 seats. So the
+roadmap stays active and `active_roadmaps` is unchanged.
+
+### The pre-registration earned its place on the first outcome it met
+
+Question 1 came back `unmeasurable-here`, and that state existed **only because
+it was written down before the numbers**. Its absence would have forced the
+outcome into `null` — "we measured and the claim failed" — which is the opposite
+of what happened and licenses the opposite future decision. That is the entire
+value of a pre-registration, collected on the first run.
+
+### Question 2: 30 % survivors, and the mitigating explanation is false
+
+3 of 10 probed controls could be deleted with the suite staying green:
+`check_pack_size`'s content-class limit, `check_secret_leak`'s exclude filter,
+`lint_skill_descriptions`' 20-entry allowlist cap. **None of the three is caught
+by a `--self-test` either** — the obvious "it's covered elsewhere" explanation,
+checked and refuted for these three specifically.
+
+**A correction to my own first reading, kept because it changed the
+conclusion.** I initially recorded survivor 1 as caught by its gate's
+`--self-test`, on the strength of that command exiting 1. The flag **does not
+exist** on that gate; the gate ran normally and failed a size budget on a tree
+my own `vitest`/`tsc` runs had polluted with emitted `dist` output. An unknown
+flag being ignored looks exactly like a self-test failing. Verified by grepping
+for the flag instead of reading an exit code — and the polluted tree was the same
+`tsc` emits trap that hit the sibling publish-boundary roadmap.
+
+### The tooling blocker was answered by the measurement, not by preference
+
+(b), keep the hand-probe: 10 probes in minutes, every mutation restored, tree
+clean. This cuts **against** what a 30 % survivor rate might suggest, which is
+why it is the honest reading rather than the convenient one — a high survivor
+rate says hand-probing finds real gaps, not that a rig is the cheaper way to
+keep finding them. Reopen condition is checkable: a survivor population too
+large to hand-probe.
+
+### Phase 3, and the one asymmetry that is the whole point
+
+`test_authorship` carries three states and an **absent field resolves to
+`unknown`, never `from-spec`**. A default that let absence read as the valuable
+state would report the independence claim as satisfied by silence. Seen red
+before it landed: with the raw value returned, the absent case yields
+`undefined` and two cases fail.
+
+It is optional and deliberately **not** in `RESPONSE_REQUIRED_FIELDS` — that
+list is calibrated against a recorded ledger equivalence (`error_count: 5`), and
+a metric is not worth invalidating a measurement for.
+
+The distribution report is **0 rows**, and it says so as three distinguishable
+answers rather than one number: no rows (nothing observed), all `unknown` (a
+wiring finding), or a mix (the question is finally answerable). Reporting
+"0 `from-spec`" without the denominator would read as the worst of the three.
+
+### AC-3 and AC-6, verified rather than assumed
+
+No new judge: `git diff --diff-filter=A -- src/skills/judge-*` is empty;
+`judge-test-coverage` remains the sole grader. No per-change mutation run exists
+because no rig exists at all.

--- a/src/scripts/_lib/subagent_response.ts
+++ b/src/scripts/_lib/subagent_response.ts
@@ -61,6 +61,62 @@ export interface SubagentResponse {
      * the same claim as "no assumptions were made".
      */
     assumptions?: CapsuleAssumption[];
+    /**
+     * Where the tests in this change were authored FROM.
+     *
+     * `from-spec` — written against the acceptance criteria, before the diff
+     * existed. `from-diff` — written after reading the implementation.
+     * `unknown` — not recorded.
+     *
+     * **`unknown` is the default and an ABSENT field resolves to it, never to
+     * `from-spec`.** That asymmetry is the whole point of the field. The claim
+     * this metric exists to keep measurable is that a suite written by the same
+     * context as the implementation inherits its blind spots — so the valuable
+     * state is `from-spec`, and a default that let absence read as the valuable
+     * state would report the claim as satisfied by silence.
+     *
+     * Structural enum only: three string values and nothing that can hold
+     * free-form content. Same exclusion-by-construction the rest of this
+     * envelope uses — a field that cannot carry a prompt or a diff has no
+     * scrubber to fail.
+     *
+     * OPTIONAL, and deliberately not in `RESPONSE_REQUIRED_FIELDS`: that list
+     * is calibrated against a recorded ledger equivalence (`error_count: 5`),
+     * and adding a sixth required field would break it. A metric is not worth
+     * invalidating a measurement for.
+     */
+    test_authorship?: TestAuthorship;
+}
+
+/**
+ * Three states. `unknown` is one of them, not the absence of the other two.
+ *
+ * Ordered by what they license rather than alphabetically: `from-spec` is the
+ * only value that supports the independence claim, `from-diff` is the weaker
+ * form the claim says is worthless, and `unknown` licenses nothing.
+ */
+export type TestAuthorship = 'from-spec' | 'from-diff' | 'unknown';
+
+export const TEST_AUTHORSHIP: ReadonlySet<string> = new Set<TestAuthorship>([
+    'from-spec',
+    'from-diff',
+    'unknown',
+]);
+
+/**
+ * Resolve the field from a decoded envelope. ABSENT and UNRECOGNISED both
+ * resolve to `unknown`.
+ *
+ * An unrecognised value resolving to `unknown` rather than throwing is
+ * deliberate: this is a metric, and a producer that emits `from_spec` with an
+ * underscore should show up in the distribution as unrecorded, not stop a
+ * dispatch. The report is what surfaces it — a spike of `unknown` IS the
+ * finding that the field is not reaching its producers.
+ */
+export function resolveTestAuthorship(input: unknown): TestAuthorship {
+    if (input === null || typeof input !== 'object') return 'unknown';
+    const v = (input as Record<string, unknown>)['test_authorship'];
+    return typeof v === 'string' && TEST_AUTHORSHIP.has(v) ? (v as TestAuthorship) : 'unknown';
 }
 
 const CONFIDENCE: ReadonlySet<string> = new Set<Confidence>(['low', 'medium', 'high']);

--- a/tests/contracts/test_authorship_field.test.ts
+++ b/tests/contracts/test_authorship_field.test.ts
@@ -1,0 +1,61 @@
+/**
+ * `test_authorship` — and specifically that ABSENCE resolves to `unknown`.
+ *
+ * The asymmetry is the whole reason the field exists. The claim it keeps
+ * measurable is that a suite written by the same context as the implementation
+ * inherits its blind spots, so `from-spec` is the valuable state — and a default
+ * that let an absent field read as `from-spec` would report the claim as
+ * satisfied by silence, which is the failure this test pins.
+ *
+ * Seen RED before the change landed: with `resolveTestAuthorship` returning the
+ * raw value, the absent case yields `undefined` and the first assertion fails.
+ * Recorded because a test nobody has watched fail is a claim, not evidence —
+ * which is the same gate this roadmap's Phase 0.3 census applied to the tree.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+    resolveTestAuthorship,
+    RESPONSE_REQUIRED_FIELDS,
+    TEST_AUTHORSHIP,
+    type TestAuthorship,
+} from '../../src/scripts/_lib/subagent_response.js';
+
+describe('test_authorship — absence is unknown, never the valuable state', () => {
+    it('an absent field resolves to unknown', () => {
+        expect(resolveTestAuthorship({ summary: 's' })).toBe('unknown');
+    });
+
+    it('a null or non-object envelope resolves to unknown', () => {
+        expect(resolveTestAuthorship(null)).toBe('unknown');
+        expect(resolveTestAuthorship('from-spec')).toBe('unknown');
+    });
+
+    it('each declared value round-trips', () => {
+        for (const v of ['from-spec', 'from-diff', 'unknown'] as TestAuthorship[]) {
+            expect(resolveTestAuthorship({ test_authorship: v })).toBe(v);
+        }
+    });
+
+    it('an unrecognised value resolves to unknown rather than throwing', () => {
+        // A producer emitting `from_spec` with an underscore must show up in the
+        // distribution as unrecorded, not stop a dispatch. The report is what
+        // surfaces it: a spike of `unknown` IS the finding that the field is not
+        // reaching its producers.
+        expect(resolveTestAuthorship({ test_authorship: 'from_spec' })).toBe('unknown');
+        expect(resolveTestAuthorship({ test_authorship: '' })).toBe('unknown');
+    });
+
+    it('the enum is exactly three states', () => {
+        expect([...TEST_AUTHORSHIP].sort()).toEqual(['from-diff', 'from-spec', 'unknown']);
+    });
+
+    it('it is NOT a required contract field', () => {
+        // RESPONSE_REQUIRED_FIELDS is calibrated against a recorded ledger
+        // equivalence (every `fail` carries error_count: 5). A sixth required
+        // field would break that, and a metric is not worth invalidating a
+        // measurement for.
+        expect(RESPONSE_REQUIRED_FIELDS).not.toContain('test_authorship');
+        expect(RESPONSE_REQUIRED_FIELDS.length).toBe(5);
+    });
+});


### PR DESCRIPTION
Phase 0 ran to a recorded route; both blockers resolved; Phase 3 shipped. Two steps parked, so the roadmap is **deliberately not archived**.

## The pre-registration earned its place on the first outcome it met

`agents/evidence/analysis/test-independence-prereg.md` was committed **before either measurement** — checkable, and a retrofit cannot satisfy it. It registered **three** outcomes, not two, and the third is the one that happened.

| question | outcome | route |
|---|---|---|
| **Q2 — mutation claim** | **PASS** — 3 survivors of 10 = **30 %** vs a pre-registered **> 10 %** | tool question → blocker, answered (b) |
| **Q1 — independence claim** | **`unmeasurable-here`** — *not* a null | that half closes `[-]` labelled unmeasurable |

Q1's measurement requires a **subagent dispatch primitive** this run did not have, so **no number exists**. Folding that into `null` would record *"we measured and the claim failed"* when what happened is *"we could not measure"* — those license **opposite** future decisions, and the second must not be able to masquerade as the first.

**That state existed only because it was written down before the numbers were known.** Without it the outcome would have been forced into `null`. That is the entire value of a pre-registration, collected on its first run.

## Q2: 30 % survivors, and the mitigating explanation is false

10 controls deleted or neutralised, each spec run alone, every mutation restored, `git status --porcelain` clean.

| control | verdict |
|---|---|
| `check_pack_size` content-class limit → never report | **SURVIVED** |
| `check_secret_leak` exclude filter → never exclude | **SURVIVED** |
| `lint_skill_descriptions` 20-entry allowlist cap → never trip | **SURVIVED** |
| `is_ancestor` path confinement · commit-subject blocklist · blocker five-field contract · kernel-rule write denial · scan-scope dead-scope throw · augment description cap · workflow first-party exemption | killed (7) |

**None of the three survivors is caught by a `--self-test` either** — the obvious "it's covered elsewhere" explanation, checked and refuted for these three specifically.

A survivor is *not* a claim that the guard is broken or the feature untested. It says: **if someone deleted this control, this suite would stay green.**

### A correction to my own first reading, kept because it changed the conclusion

I recorded survivor 1 as *caught by its gate's `--self-test`*, on the strength of that command exiting 1. **The flag does not exist on that gate.** The gate ran normally and failed a **size budget** on a tree my own `vitest`/`tsc` runs had polluted with emitted `dist` output. An unknown flag being ignored looks exactly like a self-test failing.

Verified by grepping for the flag instead of reading an exit code. The polluted tree is the same `tsc` emits trap that hit the sibling publish-boundary roadmap — cleaned with `git clean -fdX dist` and re-measured.

### Sample bias, in both directions

**n = 10** and not random — drawn from guards with a single-line, mechanically identifiable control, which is where a probe is cheap. Single-line guards are the **easiest** to write a targeted negative test for (true rate likely **higher**) *and* the most likely to be covered by a gate's own self-test rather than a vitest file (some apparent survivors caught elsewhere). Not resolved — that needs a bigger sample, and this census's job was a number, not a rig.

## The tooling blocker was answered by the measurement, not by preference

**(b) — keep the hand-probe.** Its own recommendation said a rig is only worth its maintenance if 0.3 shows a survivor count hand-probing cannot keep up with. 0.3 ran: **10 probes in minutes**, all restored, tree clean.

**This cuts against what a 30 % rate might suggest**, which is why it is the honest reading rather than the convenient one: a high survivor rate says hand-probing is **finding real gaps**, not that a rig is the cheaper way to keep finding them.

So 1.2/1.3 are `[~]`, not `[-]` — not refused on merit, **unnecessary at the current probe cost**, with a checkable reopen condition (a survivor population too large to hand-probe).

## Phase 3 — the one asymmetry that is the whole point

`test_authorship` carries three states, and an **absent field resolves to `unknown`, never `from-spec`**. The claim the metric keeps measurable is that a same-context suite inherits blind spots, so `from-spec` is the valuable state — and a default letting absence read as it would **report the claim as satisfied by silence**.

**Seen red before it landed:** with the raw value returned, the absent case yields `undefined` and two cases fail.

Optional and deliberately **not** in `RESPONSE_REQUIRED_FIELDS` — that list is calibrated against a recorded ledger equivalence (`error_count: 5`), and a metric is not worth invalidating a measurement for. An unrecognised value resolves to `unknown` rather than throwing: a producer emitting `from_spec` should appear in the distribution as unrecorded, not stop a dispatch.

The distribution report is **0 rows**, stated as **three distinguishable answers** rather than one number — no rows (nothing observed), all `unknown` (a wiring finding), or a mix (the question is finally answerable). *"0 `from-spec`"* without the denominator would read as the worst of the three.

## Why not archived

1.2/1.3 are parked. Archiving would bury a parked item — the **keep-in-archive** disposition, **owner-reserved** under the deferred-item preservation test, and the council had **0 of 2 seats** (both at 50/50). `active_roadmaps` unchanged.

Neither blocker resolution needed an independent seat, and both went in the **conservative** direction: one builds nothing, the other closes work rather than opening it.

## Verification

- `tests/contracts/test_authorship_field.test.ts` → **6 pass**, sabotage-probed (raw-value return fails 2)
- `tsc -p tsconfig.scripts.json` clean · `lint_roadmap_blockers` clean · `check_estate_count` within ratchet · `lint_evidence_artifacts` typed
- **AC-3** verified, not assumed: `git diff --diff-filter=A -- src/skills/judge-*` is **empty**; `judge-test-coverage` remains the sole grader
- **AC-6**: no per-change mutation run exists, because no rig exists at all
- Every mutated control restored — `git status --porcelain` clean over all 10 paths after the census

## What no outcome here licenses

A result about the **from-spec** form says nothing about the weaker form — a test author that reads the finished diff. That form has arrived in this tree before and is what the source argues is worthless. The pre-registration records the distinction so this PR cannot later be cited as justification for the other thing.
