### PR TITLE
fix(packs): regenerate token passports after the description-ceiling change

### DIFF
--- a/src/domains/ai-video/pack.yaml
+++ b/src/domains/ai-video/pack.yaml
@@ -18,9 +18,9 @@ suggests: []
 surface_tier: lab
 token_passport:
   basis: chars/4
-  catalog_tokens: 526
+  catalog_tokens: 524
   commands_tokens: 0
   other_tokens: 0
   rules_tokens: 3115
-  total_tokens: 3641
+  total_tokens: 3639
 trust_level_default: experimental

--- a/src/domains/engineering-base/pack.yaml
+++ b/src/domains/engineering-base/pack.yaml
@@ -15,9 +15,9 @@ suggests: []
 surface_tier: core
 token_passport:
   basis: chars/4
-  catalog_tokens: 4431
+  catalog_tokens: 4422
   commands_tokens: 1808
   other_tokens: 0
   rules_tokens: 37432
-  total_tokens: 43671
+  total_tokens: 43662
 trust_level_default: core

--- a/src/domains/gtm-marketing/pack.yaml
+++ b/src/domains/gtm-marketing/pack.yaml
@@ -17,9 +17,9 @@ suggests:
 surface_tier: core
 token_passport:
   basis: chars/4
-  catalog_tokens: 463
+  catalog_tokens: 461
   commands_tokens: 985
   other_tokens: 0
   rules_tokens: 0
-  total_tokens: 1448
+  total_tokens: 1446
 trust_level_default: professional

--- a/src/domains/laravel/pack.yaml
+++ b/src/domains/laravel/pack.yaml
@@ -17,9 +17,9 @@ suggests:
 surface_tier: core
 token_passport:
   basis: chars/4
-  catalog_tokens: 1087
+  catalog_tokens: 1086
   commands_tokens: 0
   other_tokens: 0
   rules_tokens: 486
-  total_tokens: 1573
+  total_tokens: 1572
 trust_level_default: professional

--- a/src/domains/legal-review-prep/pack.yaml
+++ b/src/domains/legal-review-prep/pack.yaml
@@ -22,9 +22,9 @@ suggests: []
 surface_tier: lab
 token_passport:
   basis: chars/4
-  catalog_tokens: 252
+  catalog_tokens: 250
   commands_tokens: 0
   other_tokens: 0
   rules_tokens: 1678
-  total_tokens: 1930
+  total_tokens: 1928
 trust_level_default: experimental

--- a/src/domains/meta/pack.yaml
+++ b/src/domains/meta/pack.yaml
@@ -95,9 +95,9 @@ suggests: []
 surface_tier: core
 token_passport:
   basis: chars/4
-  catalog_tokens: 3655
+  catalog_tokens: 3647
   commands_tokens: 211988
   other_tokens: 1298
   rules_tokens: 65521
-  total_tokens: 282462
+  total_tokens: 282454
 trust_level_default: core

--- a/src/domains/product-discovery/pack.yaml
+++ b/src/domains/product-discovery/pack.yaml
@@ -15,9 +15,9 @@ suggests: []
 surface_tier: core
 token_passport:
   basis: chars/4
-  catalog_tokens: 208
+  catalog_tokens: 207
   commands_tokens: 0
   other_tokens: 0
   rules_tokens: 0
-  total_tokens: 208
+  total_tokens: 207
 trust_level_default: professional

--- a/src/packs/ops-people/pack.yaml
+++ b/src/packs/ops-people/pack.yaml
@@ -18,9 +18,9 @@ suggests: []
 surface_tier: core
 token_passport:
   basis: chars/4
-  catalog_tokens: 407
+  catalog_tokens: 405
   commands_tokens: 0
   other_tokens: 0
   rules_tokens: 0
-  total_tokens: 407
+  total_tokens: 405
 trust_level_default: professional

--- a/src/packs/python/pack.yaml
+++ b/src/packs/python/pack.yaml
@@ -15,9 +15,9 @@ suggests: []
 surface_tier: core
 token_passport:
   basis: chars/4
-  catalog_tokens: 55
+  catalog_tokens: 54
   commands_tokens: 0
   other_tokens: 0
   rules_tokens: 0
-  total_tokens: 55
+  total_tokens: 54
 trust_level_default: professional


### PR DESCRIPTION
## What

Regenerates the nine stale `pack.yaml` token passports. No hand edits — `./scripts-run src/scripts/generate_pack_manifests`, then `--check` green.

## Root cause

`a7c0f2e32` ("feat(descriptions): ceiling 220 -> 200, and price the lever honestly", merged in #1546 as `d98a0dae3`) shortened 27 skill descriptions under `src/skills/` and `dist/agent-src/skills/` and did **not** rerun `generate_pack_manifests`.

`token_passport.catalog_tokens` is derived per skill from `- <name>: <description>\n` (`src/scripts/generate_pack_manifests.ts:299`), so shortening a description silently invalidates every pack that claims it.

## Impact this fixes

- **CI red on `main`** — the `Consistency` workflow ("Sync + Generate Tools Consistency") has failed on every `main` commit since `d98a0dae3`; its diff is exactly these nine files (run 32610751753).
- **Fresh clones are dirty** — any `task sync` on a clean checkout of `main` immediately reports nine modified `pack.yaml` files.

## Verification

- `./scripts-run src/scripts/generate_pack_manifests --check` — no drift.
- `./scripts-run src/scripts/check_pack_passport_reconciliation` — exit 0.