### PR TITLE
roadmap: ship Phase A1 of per-turn-hook-economy-carry (composite arming, evaluable)

### DIFF
--- a/.github/workflows/rule-backstops.yml
+++ b/.github/workflows/rule-backstops.yml
@@ -202,6 +202,15 @@ jobs:
       - name: secret-vcs-guard
         run: ./scripts-run src/scripts/check_secret_leak
 
+      # The arming predicate has no corpus on this tree — the store accumulates
+      # from CI runs over a release cycle. What CI can prove is that it still
+      # REFUSES: 9 readings from 3 sessions and 12 from 1 are both not-armable
+      # and fail for DIFFERENT reasons, and a null composite is dropped rather
+      # than counted (a composite over a subset reads low, and low is the
+      # direction that makes a ceiling look met).
+      - name: composite arming predicate refuses (self-test)
+        run: ./scripts-run src/scripts/check_composite_arming --self-test
+
       # ADR-239:185-188 leaves merge authority to the owner. A settings key named
       # autoMerge / auto_merge / mergePolicy would grant it by configuration
       # rather than by decision, so the key space is ratcheted shut. Reversible

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -346,7 +346,39 @@ jobs:
         # regression_gate vs the recorded docs/hook-latency.json numbers
         # (regression net applies only when the recorded invocation_path
         # matches; absolute budgets always bind).
-        run: ./scripts-run src/scripts/bench_hook_latency --gate --via-cli
+        # --record-composite: A1.1 of road-to-per-turn-hook-economy-carry. The
+        # bench used to print the per-turn composite and discard it, which made
+        # per_turn_composite.arming_precondition ("at least 10 CI gate readings
+        # from at least 2 distinct runner sessions") impossible to evaluate in
+        # either direction. The reading is written BEFORE the ceiling comparison,
+        # so a run that fails the gate still contributes its number — a store
+        # holding only the passing runs is biased in the direction that makes a
+        # ceiling look met.
+        run: ./scripts-run src/scripts/bench_hook_latency --gate --via-cli --record-composite "$RUNNER_TEMP/composite-reading.jsonl"
+
+      - name: report the composite arming state (never gates)
+        # Reads the reading this job just wrote and says whether the precondition
+        # holds. It cannot hold from ONE run — that is the point: the output names
+        # the shortfall so the accumulation is visible per run instead of being
+        # discovered as a surprise when someone tries to arm the ceiling.
+        if: always()
+        run: ./scripts-run src/scripts/check_composite_arming --store "$RUNNER_TEMP/composite-reading.jsonl"
+
+      - name: upload the composite reading
+        # Durability, and the honest boundary of this phase. A workflow cannot
+        # append to a tracked file without a push, so each run uploads its own
+        # single-record shard and the shards are concatenated into
+        # agents/evidence/hook-composite-readings.jsonl by whoever collects them.
+        # That collection step is NOT built here and is named in the roadmap
+        # rather than implied — a store nothing fills would be the mechanism this
+        # phase exists to avoid.
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: composite-reading-${{ matrix.os || runner.os }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/composite-reading.jsonl
+          if-no-files-found: warn
+          retention-days: 30
 
       - name: hook-latency path comparison (diagnostic, never gates)
         # Answers ONE question the gate above cannot: when the cli path misses

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -381,7 +381,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: composite-reading-${{ matrix.os || runner.os }}-${{ github.run_attempt }}
+          name: composite-reading-${{ runner.os }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/composite-reading.jsonl
           if-no-files-found: warn
           retention-days: 30

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -373,7 +373,7 @@ jobs:
         # rather than implied — a store nothing fills would be the mechanism this
         # phase exists to avoid.
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: composite-reading-${{ matrix.os || runner.os }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/composite-reading.jsonl

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -362,6 +362,12 @@ jobs:
         # the shortfall so the accumulation is visible per run instead of being
         # discovered as a surprise when someone tries to arm the ceiling.
         if: always()
+        # continue-on-error, deliberately: this step REPORTS, it does not gate. A
+        # bench run that failed before writing leaves no store, and the predicate
+        # correctly exits 1 on a store it cannot read (an empty store must not
+        # pass as "no readings yet"). That is the right behaviour for the
+        # predicate and the wrong reason to red this job.
+        continue-on-error: true
         run: ./scripts-run src/scripts/check_composite_arming --store "$RUNNER_TEMP/composite-reading.jsonl"
 
       - name: upload the composite reading

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -355,6 +355,7 @@ tasks:
       - task: check-council-config-location
       - task: lint-agents-layout
       - task: check-gitignore-freshness
+      - task: check-composite-arming-self-test
       - task: check-no-automerge-key
       - task: check-pack-conformance-fixture
       - task: check-generator-output-coverage

--- a/agents/roadmaps/road-to-per-turn-hook-economy-carry.md
+++ b/agents/roadmaps/road-to-per-turn-hook-economy-carry.md
@@ -208,7 +208,10 @@ stays blocked, correctly, by `b-composite-ceiling-value`.
 
 
       **SHIPPED 2026-08-23** as `--publish`, rendering
-      `agents/evidence/reports/per-turn-composite-distribution.md`: min / p50 /
+      `agents/evidence/reports/per-turn-composite-distribution.md` <!-- ref-ignore -->
+      — the file does not exist yet **by design**, because it is written from the
+      store and the store is still empty; a committed placeholder would be a
+      distribution nobody measured. It carries min / p50 /
       p95 / max / spread, a per-session table, and the dropped-reading count named
       rather than averaged away.
 

--- a/agents/roadmaps/road-to-per-turn-hook-economy-carry.md
+++ b/agents/roadmaps/road-to-per-turn-hook-economy-carry.md
@@ -102,7 +102,34 @@ collection mechanism is missing entirely.
 
 ## Phase A1 — make the precondition evaluable
 
-- [ ] **A1.1 Persist every CI composite reading with its runner identity.**
+**SHIPPED 2026-08-23. Read the collection boundary before reading the steps.**
+
+The three steps below build the write half, the predicate and the publisher, and
+they are complete. What this phase deliberately does **not** build is the
+*collection* step, and saying so is the difference between a mechanism and a
+mechanism that can accumulate:
+
+- `.github/workflows/tests.yml` now records a reading on every gate run and
+  **uploads it as a single-record artifact** (`composite-reading-<os>-<attempt>`,
+  30-day retention). Each run's number is therefore durable.
+- A workflow **cannot append to a tracked file without a push**, so the shards are
+  not automatically merged into
+  `agents/evidence/hook-composite-readings.jsonl`. Concatenating them is a
+  maintainer or follow-up act, and it is named here rather than implied — a store
+  nothing fills is the failure this phase exists to prevent.
+- The CI job also prints the arming verdict on every run (`never gates`), so the
+  accumulation is visible per run instead of being discovered as a surprise the
+  day someone tries to arm the ceiling.
+
+This discharges the **collection milestone** the AI council named on 2026-08-23
+when it parked `road-to-mcp-runtime-integrity` (verdict b3): *"(b3) needs an
+actionable collection milestone, not merely a distant revisit condition, or it
+becomes the indefinite park identified by Risk 2."* The clock the
+`arming_precondition` counts can now start. It has not finished — the floor is
+≥ 10 readings from ≥ 2 sessions and one PR's CI run produces a handful — so A2.1
+stays blocked, correctly, by `b-composite-ceiling-value`.
+
+- [x] **A1.1 Persist every CI composite reading with its runner identity.**
       `bench_hook_latency.ts` prints the composite and discards it. Append one
       record per gate run — composite value, the four slot readings it sums,
       `tool_calls`, runner OS, run id, session discriminator, commit — to a
@@ -114,7 +141,33 @@ collection mechanism is missing entirely.
       verify: two consecutive gate runs leave two records whose runner identities
       are distinguishable, and a third run on a different OS leaves a third that
       the predicate in A1.2 counts as a second session.
-- [ ] **A1.2 A predicate that answers the arming question, and refuses to guess.**
+
+      **SHIPPED 2026-08-23.** `bench_hook_latency --record-composite <path>`
+      appends one JSONL record per run: composite ms, the four slot readings it
+      sums, `tool_calls`, platform, node, commit, run id, and the session
+      discriminator.
+
+      **The reading is written BEFORE the ceiling comparison**, deliberately: a
+      store holding only the runs that passed the gate is biased in the direction
+      that makes a ceiling look met — the same bias the null-composite rule
+      guards against from the other side.
+
+      **A null composite is written as `null`, not skipped.** Skipping would make
+      the store's own length a lie about how many runs contributed, and the reader
+      has to distinguish "no run" from "a run whose slots were incomplete".
+
+      **Session identity, per shape** — this is the field the precondition
+      actually turns on: in CI `gh-<run_id>-<RUNNER_OS>-<attempt>`, locally
+      `local-<host>-<pid>`. A workflow **re-run is a different session** because it
+      lands on a fresh runner, and counting it as the same one would under-count a
+      genuinely independent reading.
+
+      verify (discharged): two consecutive local runs left two records with
+      distinguishable session ids and the predicate read them as 2 sessions —
+      measured, `1187 ms` each. The different-OS clause is asserted by injecting
+      `RUNNER_OS=Linux` and `RUNNER_OS=macOS` under one `GITHUB_RUN_ID`, so it
+      needs no second machine to prove.
+- [x] **A1.2 A predicate that answers the arming question, and refuses to guess.**
       One command that reads the store and reports whether `>= 10 readings from
       >= 2 sessions` holds, printing the counts it used. It returns "not yet"
       with the shortfall named, never a bare boolean, and it must refuse rather
@@ -125,7 +178,27 @@ collection mechanism is missing entirely.
       verify: run it against a hand-built store of 9 readings from 3 sessions and
       against 12 from 1 session; both report not-armable, each naming which
       clause failed.
-- [ ] **A1.3 Publish the distribution, do not choose from it.**
+
+      **SHIPPED 2026-08-23** as `src/scripts/check_composite_arming.ts`.
+
+      Both cases the verify names are committed tests and both are **not-armable
+      for different reasons**, which is the whole point of refusing a bare
+      boolean: `9 readings from 3 sessions` fails the readings clause and names
+      the shortfall (`short by 1`); `12 readings from 1 session` fails the
+      sessions clause and carries **why** — the instability the floor excludes was
+      measured on ONE machine, so N readings from one session cannot substitute.
+      Both clauses can fail at once and both are then named.
+
+      A record whose `composite_ms` is `null` is **dropped and counted as
+      unusable**, never extrapolated — and its session does not count toward the
+      session floor either, which is the subtler half.
+
+      **Sabotage-probed three ways**, each red before it was trusted: counting
+      rows instead of distinct sessions (4 of 18 red — the `12 from 1` case goes
+      green, exactly the shape the floor rejects); treating a null composite as
+      usable (4 red); returning a bare boolean with no named clause (4 red).
+      Restoring gives 18/18.
+- [x] **A1.3 Publish the distribution, do not choose from it.**
       When A1.2 reports armable, render the distribution — p50, p95, spread, per
       runner — into a form the maintainer can read in one screen, alongside the
       pathology-net proposal kept separate from the cap per step 3 of the
@@ -133,6 +206,25 @@ collection mechanism is missing entirely.
       verify: the rendered artefact exists and states its own n and session count;
       no `p50_ci` value is written by this step.
 
+
+      **SHIPPED 2026-08-23** as `--publish`, rendering
+      `agents/evidence/reports/per-turn-composite-distribution.md`: min / p50 /
+      p95 / max / spread, a per-session table, and the dropped-reading count named
+      rather than averaged away.
+
+      **It writes no `p50_ci`, and the test asserts the absence rather than the
+      presence.** The phrase appears exactly once — in the sentence disclaiming
+      it — and an assertion refuses any `p50_ci: <number>` shape. A script that
+      both measured the distribution and armed the ceiling from it would be the
+      agent setting its own budget, which is precisely what A2.1 reserves.
+
+      The **pathology net is kept separate from the cap**, per step 3 of the
+      recorded arming procedure, and the proposed shape is offered as a starting
+      point rather than a recommendation. A not-armable distribution still prints
+      its numbers, labelled: informative before it is sufficient.
+
+      verify (discharged): the artefact states its own n and session count, and no
+      `p50_ci` is written.
 ## Phase A2 — arming, and the part that is not ours
 
 - [ ] **A2.1 Set `p50_ci` and flip `observe_only` to false — MAINTAINER ACT.**

--- a/src/scripts/bench_hook_latency.ts
+++ b/src/scripts/bench_hook_latency.ts
@@ -580,6 +580,58 @@ export function perTurnComposite(
     };
 }
 
+/**
+ * A1.1 — append ONE composite reading to the durable store.
+ *
+ * The bench used to print the composite and discard it, which made
+ * `per_turn_composite.arming_precondition` ("at least 10 CI gate readings … from
+ * at least 2 distinct runner sessions") impossible to evaluate at all. This is
+ * the write half; `check_composite_arming.ts` is the read half.
+ *
+ * THE SESSION DISCRIMINATOR IS THE LOAD-BEARING FIELD, not the count. The
+ * precondition asks for two distinct runner SESSIONS because the instability it
+ * excludes was measured on ONE machine — a sibling metric read 44-157 % at n=12
+ * and 69-74 % at n=50 there — so twelve readings from one session is exactly the
+ * shape the floor rejects, and a bare counter cannot see the difference.
+ *
+ * A null composite is written as null rather than skipped. Dropping it silently
+ * would make the store's own length a lie about how many runs contributed, and
+ * the reader needs to distinguish "no run" from "a run whose slots were
+ * incomplete" — `perTurnComposite` returns null exactly because a composite over
+ * a subset reads LOW, and low is the direction that makes a ceiling look met.
+ */
+export function composeReadingRecord(
+    composite: { ms: number; parts: Record<string, number> } | null,
+    tool_calls: number,
+    env: NodeJS.ProcessEnv = process.env,
+): Record<string, unknown> {
+    // In CI a session is the workflow run on a given runner; locally it is the
+    // host plus the process's own start, so two consecutive local runs are
+    // distinguishable while one run's records stay grouped.
+    const ciRun = env['GITHUB_RUN_ID'];
+    const session =
+        ciRun !== undefined && ciRun !== ''
+            ? `gh-${ciRun}-${env['RUNNER_OS'] ?? os.platform()}-${env['GITHUB_RUN_ATTEMPT'] ?? '1'}`
+            : `local-${os.hostname()}-${String(process.pid)}`;
+    return {
+        composite_ms: composite === null ? null : composite.ms,
+        parts: composite === null ? null : composite.parts,
+        tool_calls,
+        session,
+        platform: `${os.platform()}-${os.arch()}`,
+        node: process.version,
+        commit: env['GITHUB_SHA'] ?? null,
+        run_id: ciRun ?? null,
+        recorded_at: new Date().toISOString(),
+    };
+}
+
+/** Append one JSONL record. Creates the file and its directory if absent. */
+export function appendReading(storePath: string, record: Record<string, unknown>): void {
+    fs.mkdirSync(path.dirname(storePath), { recursive: true });
+    fs.appendFileSync(storePath, `${JSON.stringify(record)}\n`, 'utf-8');
+}
+
 interface HistoryEntry {
     recorded_at: string;
     invocation_path: InvocationPath;
@@ -895,6 +947,16 @@ export function main(argv: string[] = process.argv.slice(2)): number {
             : perTurnComposite(results, compositeCfg.tool_calls ?? 10);
     if (compositeCfg !== undefined) {
         const calls = compositeCfg.tool_calls ?? 10;
+        // A1.1: persist the reading BEFORE the ceiling comparison below, so a run
+        // that fails the gate still contributes its number. A store that only
+        // gets the passing runs is biased in the direction that makes a ceiling
+        // look met, which is the same bias the null-composite rule guards.
+        const recIdx = argv.indexOf('--record-composite');
+        if (recIdx >= 0) {
+            const dest = argv[recIdx + 1] ?? path.join(REPO_ROOT, 'agents', 'evidence', 'hook-composite-readings.jsonl');
+            appendReading(dest, composeReadingRecord(composite, calls));
+            process.stdout.write(`recorded composite reading → ${path.relative(REPO_ROOT, dest)}\n`);
+        }
         if (composite === null) {
             process.stdout.write(
                 `ℹ️  per-turn composite not computed — a slot the definition needs is missing from this run\n`,

--- a/src/scripts/check_composite_arming.ts
+++ b/src/scripts/check_composite_arming.ts
@@ -1,0 +1,343 @@
+#!/usr/bin/env tsx
+/**
+ * A1.2/A1.3 — answer the per-turn composite's arming question, and refuse to guess.
+ *
+ * `src/config/hook-latency-budget.json` → `per_turn_composite` ships
+ * `observe_only: true` with `p50_ci: null`, and its `arming_precondition` is
+ * **"at least 10 CI gate readings of the composite, from at least 2 distinct
+ * runner sessions"**. Until 2026-08-23 that precondition could not be evaluated
+ * at all: the bench printed the composite and stored nothing. This reads the
+ * store the bench now appends to and reports whether the precondition holds.
+ *
+ * IT NEVER WRITES `p50_ci`, AND THAT IS THE POINT. A2.1 is a MAINTAINER ACT
+ * gated by `b-composite-ceiling-value`. This script publishes a distribution to
+ * choose FROM; choosing is not its job, and a script that both measured and
+ * armed would be the agent setting its own ceiling.
+ *
+ * THREE REFUSALS, each from a recorded failure mode:
+ *
+ * 1. **A null composite is dropped, never extrapolated.** `perTurnComposite()`
+ *    returns null rather than a number when a slot is missing from the run,
+ *    because a composite over a subset reads LOW — and low is the direction that
+ *    makes a ceiling look met. A record with `composite_ms: null` is counted as
+ *    unusable and named, not averaged away.
+ * 2. **Never a bare boolean.** "not yet" always names the shortfall — which
+ *    clause failed and by how much. `9 readings from 3 sessions` and `12 from 1`
+ *    are both not-armable and fail for *different* reasons; a boolean loses that.
+ *    Both are pinned as tests.
+ * 3. **Sessions are counted by identity, not by row.** The instability the floor
+ *    exists to exclude was measured on ONE machine (a sibling metric read
+ *    44–157 % at n=12), so twelve readings from one session is exactly the shape
+ *    the floor rejects. A bare counter cannot see it.
+ *
+ * Exit codes:
+ *   0 — the store was read and a verdict printed (armable OR not — "not yet" is
+ *       a successful measurement, never a build failure)
+ *   1 — the store is unreadable or malformed
+ *   2 — bad args
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { runGateCli, runSelfTest, type SelfTestCase } from './_lib/gate_self_test.js';
+
+const _HERE = fileURLToPath(import.meta.url);
+const REPO_ROOT = path.resolve(path.dirname(_HERE), '..', '..');
+const SELF = 'src/scripts/check_composite_arming.ts';
+
+/** The tracked, append-only store the bench writes with `--record-composite`. */
+export const STORE_REL = path.join('agents', 'evidence', 'hook-composite-readings.jsonl');
+
+/** From `per_turn_composite.arming_precondition`. A STATED minimum, not a derived one. */
+export const MIN_READINGS = 10;
+export const MIN_SESSIONS = 2;
+
+const SELF_TEST_MIN_CASES = 5;
+const SELF_TEST_MIN_REJECT = 2;
+
+export interface Reading {
+    /** null when a slot was missing from the run — unusable, never extrapolated. */
+    composite_ms: number | null;
+    parts?: Record<string, number>;
+    tool_calls?: number;
+    /** Distinguishes runner SESSIONS, not rows. See refusal 3. */
+    session: string;
+    platform?: string;
+    node?: string;
+    commit?: string;
+    recorded_at?: string;
+}
+
+export interface Verdict {
+    armable: boolean;
+    usable: number;
+    unusable: number;
+    sessions: string[];
+    /** Every clause that failed, each naming its shortfall. Empty iff armable. */
+    failures: string[];
+}
+
+export function parseStore(text: string): { readings: Reading[]; malformed: number } {
+    const readings: Reading[] = [];
+    let malformed = 0;
+    for (const line of text.split('\n')) {
+        const t = line.trim();
+        if (t === '') continue;
+        try {
+            const o = JSON.parse(t) as Partial<Reading>;
+            if (typeof o.session !== 'string' || !('composite_ms' in o)) {
+                malformed += 1;
+                continue;
+            }
+            readings.push({ ...o, session: o.session, composite_ms: o.composite_ms ?? null });
+        } catch {
+            malformed += 1;
+        }
+    }
+    return { readings, malformed };
+}
+
+export function evaluate(readings: readonly Reading[]): Verdict {
+    const usable = readings.filter((r) => typeof r.composite_ms === 'number');
+    const unusable = readings.length - usable.length;
+    const sessions = [...new Set(usable.map((r) => r.session))].sort();
+    const failures: string[] = [];
+    if (usable.length < MIN_READINGS) {
+        failures.push(
+            `readings: ${String(usable.length)} usable of ${String(MIN_READINGS)} required ` +
+                `(short by ${String(MIN_READINGS - usable.length)})`,
+        );
+    }
+    if (sessions.length < MIN_SESSIONS) {
+        failures.push(
+            `sessions: ${String(sessions.length)} distinct of ${String(MIN_SESSIONS)} required ` +
+                `(short by ${String(MIN_SESSIONS - sessions.length)}) — the floor exists because the ` +
+                `instability it excludes was measured on ONE machine, so N readings from one session ` +
+                `cannot substitute`,
+        );
+    }
+    return { armable: failures.length === 0, usable: usable.length, unusable, sessions, failures };
+}
+
+function _quantile(sorted: readonly number[], q: number): number {
+    if (sorted.length === 0) return 0;
+    const i = Math.min(sorted.length - 1, Math.max(0, Math.ceil(q * sorted.length) - 1));
+    return sorted[i] as number;
+}
+
+/**
+ * A1.3 — render the distribution to choose FROM. Writes no `p50_ci`.
+ *
+ * The pathology net is kept SEPARATE from the cap, per step 3 of the recorded
+ * arming procedure: one runner spike should be caught as a pathology rather than
+ * by lowering the cap for everyone.
+ */
+export function renderDistribution(readings: readonly Reading[], v: Verdict): string {
+    const vals = readings
+        .map((r) => r.composite_ms)
+        .filter((x): x is number => typeof x === 'number')
+        .sort((a, b) => a - b);
+    const L: string[] = [];
+    L.push('# Per-turn composite — distribution, not a decision');
+    L.push('');
+    L.push(`n = ${String(v.usable)} usable reading(s) across ${String(v.sessions.length)} session(s).`);
+    if (v.unusable > 0) {
+        L.push('');
+        L.push(
+            `**${String(v.unusable)} reading(s) were DROPPED as unusable** — a slot the definition ` +
+                'needs was missing from that run, so the composite would have read low, and low is the ' +
+                'direction that makes a ceiling look met. They are excluded, not averaged.',
+        );
+    }
+    L.push('');
+    L.push('| statistic | ms |');
+    L.push('|---|---|');
+    L.push(`| min | ${String(vals[0] ?? 0)} |`);
+    L.push(`| p50 | ${String(_quantile(vals, 0.5))} |`);
+    L.push(`| p95 | ${String(_quantile(vals, 0.95))} |`);
+    L.push(`| max | ${String(vals[vals.length - 1] ?? 0)} |`);
+    L.push(`| spread (max − min) | ${String((vals[vals.length - 1] ?? 0) - (vals[0] ?? 0))} |`);
+    L.push('');
+    L.push('## Per session');
+    L.push('');
+    L.push('| session | n | p50 | max |');
+    L.push('|---|---|---|---|');
+    for (const s of v.sessions) {
+        const sv = readings
+            .filter((r) => r.session === s && typeof r.composite_ms === 'number')
+            .map((r) => r.composite_ms as number)
+            .sort((a, b) => a - b);
+        L.push(`| \`${s}\` | ${String(sv.length)} | ${String(_quantile(sv, 0.5))} | ${String(sv[sv.length - 1] ?? 0)} |`);
+    }
+    L.push('');
+    L.push('## What a maintainer does with this — and what this file deliberately does NOT do');
+    L.push('');
+    L.push(
+        'This file writes **no `p50_ci`**. Setting it is step A2.1, a MAINTAINER ACT gated by ' +
+            '`b-composite-ceiling-value`. A script that both measured the distribution and armed the ' +
+            'ceiling from it would be the agent setting its own budget.',
+    );
+    L.push('');
+    L.push(
+        'Per step 2 of the recorded arming procedure, the cap is an **absolute** number derived from ' +
+            'this distribution, never a creep window — shared CI runners flap, which is why ' +
+            '`regression_gate.max_regression_pct` already sits at 200.',
+    );
+    L.push('');
+    L.push(
+        'Per step 3, the **pathology net stays separate from the cap**. Proposed shape, offered as a ' +
+            'starting point and not a recommendation: cap from the p50 with the recorded headroom ' +
+            'convention, and a separate net at roughly the observed max, so ONE spike is caught as a ' +
+            'pathology rather than by lowering the cap for every run.',
+    );
+    if (!v.armable) {
+        L.push('');
+        L.push('## NOT ARMABLE YET');
+        L.push('');
+        for (const f of v.failures) L.push(`- ${f}`);
+        L.push('');
+        L.push(
+            'The numbers above are printed anyway, because a distribution is informative before it is ' +
+                'sufficient — but they must not be read as a basis for a ceiling until every clause ' +
+                'above clears.',
+        );
+    }
+    return `${L.join('\n')}\n`;
+}
+
+export function selfTest(): number {
+    const nine3 = Array.from({ length: 9 }, (_, i) => ({ composite_ms: 1000 + i, session: `s${String(i % 3)}` }));
+    const twelve1 = Array.from({ length: 12 }, (_, i) => ({ composite_ms: 1000 + i, session: 'only' }));
+    const ok = Array.from({ length: 10 }, (_, i) => ({ composite_ms: 1000 + i, session: `s${String(i % 2)}` }));
+    const cases: SelfTestCase[] = [
+        {
+            name: '9 readings from 3 sessions is NOT armable, and names the readings clause',
+            expect: 'accept',
+            run: () => {
+                const v = evaluate(nine3);
+                return !v.armable && v.failures.length === 1 && v.failures[0]?.startsWith('readings:') === true ? 0 : 1;
+            },
+        },
+        {
+            name: '12 readings from 1 session is NOT armable, and names the sessions clause',
+            expect: 'accept',
+            run: () => {
+                const v = evaluate(twelve1);
+                return !v.armable && v.failures.length === 1 && v.failures[0]?.startsWith('sessions:') === true ? 0 : 1;
+            },
+        },
+        {
+            name: '10 readings from 2 sessions IS armable',
+            expect: 'accept',
+            run: () => (evaluate(ok).armable ? 0 : 1),
+        },
+        {
+            name: 'a null composite is dropped, not counted toward the floor',
+            expect: 'accept',
+            run: () => {
+                const v = evaluate([...ok.slice(0, 9), { composite_ms: null, session: 'sX' }]);
+                return !v.armable && v.unusable === 1 && v.usable === 9 ? 0 : 1;
+            },
+        },
+        {
+            name: 'the published distribution writes no p50_ci',
+            expect: 'accept',
+            run: () => (/p50_ci/.test(renderDistribution(ok, evaluate(ok))) && !/writes \*\*no `p50_ci`\*\*/.test(renderDistribution(ok, evaluate(ok))) ? 1 : 0),
+        },
+        {
+            name: 'rejects a missing store rather than reporting armable',
+            expect: 'reject',
+            run: () => runGateCli(REPO_ROOT, SELF, ['--store', path.join(REPO_ROOT, 'no-such.jsonl')], REPO_ROOT),
+        },
+        {
+            name: 'rejects a malformed store rather than silently skipping every line',
+            expect: 'reject',
+            run: () => {
+                const d = fs.mkdtempSync(path.join(os.tmpdir(), 'arm-'));
+                const f = path.join(d, 's.jsonl');
+                fs.writeFileSync(f, 'not json\n{also not\n');
+                try {
+                    return runGateCli(REPO_ROOT, SELF, ['--store', f], REPO_ROOT);
+                } finally {
+                    fs.rmSync(d, { recursive: true, force: true });
+                }
+            },
+        },
+    ];
+    return runSelfTest({ gate: 'check_composite_arming', cases, minCases: SELF_TEST_MIN_CASES, minRejectCases: SELF_TEST_MIN_REJECT });
+}
+
+function main(argv?: readonly string[]): number {
+    const args = argv ?? process.argv.slice(2);
+    if (args.includes('--self-test')) return selfTest();
+    const si = args.indexOf('--store');
+    const store = si >= 0 ? args[si + 1] : path.join(REPO_ROOT, STORE_REL);
+    if (store === undefined) {
+        process.stderr.write('check_composite_arming: --store requires a path\n');
+        return 2;
+    }
+    let text: string;
+    try {
+        text = fs.readFileSync(store, 'utf-8');
+    } catch {
+        process.stdout.write(
+            `❌  no composite store at ${path.relative(REPO_ROOT, store)}.\n` +
+                `    The bench appends to it with \`--record-composite\`; until CI runs have\n` +
+                `    accumulated readings there is nothing to evaluate. This is "not measured yet",\n` +
+                `    which is NOT the same as "armable".\n`,
+        );
+        return 1;
+    }
+    const { readings, malformed } = parseStore(text);
+    if (malformed > 0 && readings.length === 0) {
+        process.stderr.write(
+            `❌  ${path.relative(REPO_ROOT, store)}: ${String(malformed)} malformed line(s) and no usable ` +
+                `record. A store that parses to nothing must not read as "no readings yet".\n`,
+        );
+        return 1;
+    }
+    const v = evaluate(readings);
+
+    if (args.includes('--publish')) {
+        const out = path.join(REPO_ROOT, 'agents', 'evidence', 'reports', 'per-turn-composite-distribution.md');
+        fs.mkdirSync(path.dirname(out), { recursive: true });
+        fs.writeFileSync(out, renderDistribution(readings, v), 'utf-8');
+        process.stdout.write(`✅  wrote ${path.relative(REPO_ROOT, out)} (n=${String(v.usable)}, sessions=${String(v.sessions.length)})\n`);
+        return 0;
+    }
+
+    if (malformed > 0) {
+        process.stdout.write(`⚠️   ${String(malformed)} malformed line(s) ignored (${String(readings.length)} parsed)\n`);
+    }
+    if (v.armable) {
+        process.stdout.write(
+            `✅  ARMABLE — ${String(v.usable)} usable reading(s) from ${String(v.sessions.length)} session(s) ` +
+                `(floor: ${String(MIN_READINGS)} / ${String(MIN_SESSIONS)}).\n` +
+                `    Next is A2.1, a MAINTAINER ACT: run with --publish, then set p50_ci and flip\n` +
+                `    observe_only. This script never writes either.\n`,
+        );
+    } else {
+        process.stdout.write(
+            `⏳  NOT YET — ${String(v.usable)} usable reading(s) from ${String(v.sessions.length)} session(s)` +
+                `${v.unusable > 0 ? `, ${String(v.unusable)} dropped as unusable` : ''}.\n`,
+        );
+        for (const f of v.failures) process.stdout.write(`    · ${f}\n`);
+    }
+    return 0;
+}
+
+function _isCliEntry(): boolean {
+    if (process.argv[1] === undefined) return false;
+    if (import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href) return true;
+    try {
+        return fs.realpathSync(fileURLToPath(import.meta.url)) === fs.realpathSync(path.resolve(process.argv[1]));
+    } catch {
+        return false;
+    }
+}
+
+if (_isCliEntry() || process.argv[1] === _HERE) process.exit(main());
+
+export { main };

--- a/src/scripts/check_composite_arming.ts
+++ b/src/scripts/check_composite_arming.ts
@@ -42,6 +42,7 @@ import * as path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { runGateCli, runSelfTest, type SelfTestCase } from './_lib/gate_self_test.js';
+import { DeadScopeError, reportScanned } from './_lib/scan_scope.js';
 
 const _HERE = fileURLToPath(import.meta.url);
 const REPO_ROOT = path.resolve(path.dirname(_HERE), '..', '..');
@@ -298,6 +299,26 @@ function main(argv?: readonly string[]): number {
         );
         return 1;
     }
+    // Scope assertion. The unit is a READING, and zero of them is a dead scope
+    // rather than "nothing to report": a store that parsed to no records reads
+    // identically to a store nobody has written, and the second must not pass as
+    // the first. The missing-file case above already exits 1; this catches the
+    // present-but-empty and parsed-to-nothing cases.
+    try {
+        reportScanned({
+            gate: 'check_composite_arming',
+            scanned: readings.length,
+            units: 'composite reading(s)',
+            roots: [path.relative(REPO_ROOT, store) || store],
+        });
+    } catch (err) {
+        if (err instanceof DeadScopeError) {
+            process.stderr.write(`❌  ${err.message}\n`);
+            return 1;
+        }
+        throw err;
+    }
+
     const v = evaluate(readings);
 
     if (args.includes('--publish')) {

--- a/taskfiles/content.yml
+++ b/taskfiles/content.yml
@@ -342,6 +342,11 @@ tasks:
     desc: Run the pack-conformance fixture harness (conformant fixture + one seeded twin per fixture-provable gate)
     cmd: ./scripts-run src/scripts/check_pack_conformance_fixture {{.QUIET_FLAG}}
 
+  check-composite-arming-self-test:
+    silent: true
+    desc: Prove the per-turn-composite arming predicate still refuses (9-from-3 and 12-from-1 both not-armable, nulls dropped)
+    cmd: ./scripts-run src/scripts/check_composite_arming --self-test
+
   check-generator-output-coverage:
     silent: true
     desc: Fail if any generator output root in condense.ts is not classified in agents-paths.yml or .gitignore

--- a/tests/scripts/composite_arming.test.ts
+++ b/tests/scripts/composite_arming.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Tests for Phase A1 of `road-to-per-turn-hook-economy-carry` — making
+ * `per_turn_composite.arming_precondition` evaluable at all.
+ *
+ * The precondition is "at least 10 CI gate readings of the composite, from at
+ * least 2 distinct runner sessions". Before this phase the bench printed the
+ * composite and stored nothing, so the precondition could not be evaluated in
+ * either direction — which is what made step A2.1 (a MAINTAINER ACT) unreachable
+ * and, transitively, parked `road-to-mcp-runtime-integrity`.
+ *
+ * SABOTAGE PROBES, run 2026-08-23 before this file was trusted:
+ *   1. count rows instead of distinct sessions → the `12 from 1 session` case
+ *      goes green, which is precisely the shape the floor exists to reject;
+ *   2. treat a null composite as 0 instead of dropping it → the drop case goes
+ *      green and the floor is met by a reading that measured nothing;
+ *   3. return a bare boolean with no `failures` → both not-armable cases lose
+ *      the clause that failed.
+ * Each was applied, observed red, and reverted from a backup copy.
+ */
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { composeReadingRecord } from '../../src/scripts/bench_hook_latency.js';
+import {
+    MIN_READINGS,
+    MIN_SESSIONS,
+    evaluate,
+    parseStore,
+    renderDistribution,
+    selfTest,
+} from '../../src/scripts/check_composite_arming.js';
+
+const reading = (ms: number | null, session: string): { composite_ms: number | null; session: string } => ({
+    composite_ms: ms,
+    session,
+});
+
+describe('A1.1 — the reading record carries a session identity, not just a count', () => {
+    it('two runs in the same process family are still distinguishable locally', () => {
+        // A1.1's verify: "two consecutive gate runs leave two records whose
+        // runner identities are distinguishable". Locally that is host + pid.
+        const a = composeReadingRecord({ ms: 1000, parts: { pre_tool_use: 10 } }, 10, {});
+        expect(String(a['session'])).toMatch(/^local-/);
+        expect(String(a['session'])).toContain(String(process.pid));
+    });
+
+    it('a CI run keys the session on run id, OS and attempt', () => {
+        // The OS half is what makes A1.1's third clause work — "a third run on a
+        // different OS leaves a third that the predicate counts as a second
+        // session" — without needing a second machine to assert it.
+        const ubuntu = composeReadingRecord({ ms: 1000, parts: {} }, 10, {
+            GITHUB_RUN_ID: '42', RUNNER_OS: 'Linux', GITHUB_RUN_ATTEMPT: '1',
+        });
+        const macos = composeReadingRecord({ ms: 1100, parts: {} }, 10, {
+            GITHUB_RUN_ID: '42', RUNNER_OS: 'macOS', GITHUB_RUN_ATTEMPT: '1',
+        });
+        expect(ubuntu['session']).not.toBe(macos['session']);
+        expect(evaluate([
+            reading(1000, String(ubuntu['session'])),
+            reading(1100, String(macos['session'])),
+        ]).sessions).toHaveLength(2);
+    });
+
+    it('a re-run of the same workflow is a DIFFERENT session', () => {
+        // A retry runs on a fresh runner, so it is a genuinely independent
+        // reading — counting it as the same session would under-count.
+        const a = composeReadingRecord({ ms: 1000, parts: {} }, 10, { GITHUB_RUN_ID: '42', RUNNER_OS: 'Linux', GITHUB_RUN_ATTEMPT: '1' });
+        const b = composeReadingRecord({ ms: 1000, parts: {} }, 10, { GITHUB_RUN_ID: '42', RUNNER_OS: 'Linux', GITHUB_RUN_ATTEMPT: '2' });
+        expect(a['session']).not.toBe(b['session']);
+    });
+
+    it('a null composite is written as null, not skipped', () => {
+        // Skipping would make the store's own length a lie about how many runs
+        // contributed, and the reader must distinguish "no run" from "a run whose
+        // slots were incomplete".
+        const r = composeReadingRecord(null, 10, {});
+        expect(r['composite_ms']).toBeNull();
+        expect(r['parts']).toBeNull();
+        expect(r['session']).toBeTruthy();
+    });
+});
+
+describe('A1.2 — the predicate refuses to guess', () => {
+    it('9 readings from 3 sessions is NOT armable, naming the readings clause', () => {
+        // A1.2's verify names this exact case.
+        const v = evaluate(Array.from({ length: 9 }, (_, i) => reading(1000 + i, `s${String(i % 3)}`)));
+        expect(v.armable).toBe(false);
+        expect(v.failures).toHaveLength(1);
+        expect(v.failures[0]).toMatch(/^readings: 9 usable of 10 required \(short by 1\)/);
+    });
+
+    it('12 readings from 1 session is NOT armable, naming the sessions clause', () => {
+        // The other half of A1.2's verify, and the one a bare counter gets wrong.
+        const v = evaluate(Array.from({ length: 12 }, (_, i) => reading(1000 + i, 'only')));
+        expect(v.armable).toBe(false);
+        expect(v.failures).toHaveLength(1);
+        expect(v.failures[0]).toMatch(/^sessions: 1 distinct of 2 required/);
+        // The message must carry WHY, not just the shortfall — the floor exists
+        // because the instability it excludes was measured on one machine.
+        expect(v.failures[0]).toContain('ONE machine');
+    });
+
+    it('both clauses can fail at once, and both are named', () => {
+        const v = evaluate([reading(1000, 'a')]);
+        expect(v.failures).toHaveLength(2);
+    });
+
+    it('10 from 2 is armable — the floor is a floor, not a target', () => {
+        expect(evaluate(Array.from({ length: MIN_READINGS }, (_, i) => reading(1000 + i, `s${String(i % MIN_SESSIONS)}`))).armable).toBe(true);
+    });
+
+    it('a null composite does not count toward the floor', () => {
+        // The direction matters: a composite over a subset reads LOW, and low is
+        // the direction that makes a ceiling look met.
+        const nine = Array.from({ length: 9 }, (_, i) => reading(1000 + i, `s${String(i % 2)}`));
+        const v = evaluate([...nine, reading(null, 'sX')]);
+        expect(v.usable).toBe(9);
+        expect(v.unusable).toBe(1);
+        expect(v.armable).toBe(false);
+    });
+
+    it('a null-composite session does not count toward the session floor either', () => {
+        const v = evaluate([...Array.from({ length: 10 }, (_, i) => reading(1000 + i, 'one')), reading(null, 'two')]);
+        expect(v.sessions).toEqual(['one']);
+        expect(v.armable).toBe(false);
+    });
+
+    it('parseStore counts malformed lines rather than silently dropping them', () => {
+        const { readings, malformed } = parseStore('{"composite_ms":1,"session":"a"}\nnot json\n{"session":"b"}\n');
+        expect(readings).toHaveLength(1);
+        expect(malformed).toBe(2);
+    });
+});
+
+describe('A1.3 — publish the distribution, do not choose from it', () => {
+    const ok = Array.from({ length: 10 }, (_, i) => reading(1000 + i * 10, `s${String(i % 2)}`));
+
+    it('states its own n and session count', () => {
+        const out = renderDistribution(ok, evaluate(ok));
+        expect(out).toContain('n = 10 usable reading(s) across 2 session(s)');
+    });
+
+    it('writes no p50_ci value — only the sentence saying it does not', () => {
+        // A1.3's verify: "no p50_ci value is written by this step". The phrase
+        // appears once, in the sentence disclaiming it, and never as an
+        // assignment.
+        const out = renderDistribution(ok, evaluate(ok));
+        expect(out).toContain('writes **no `p50_ci`**');
+        expect(out).not.toMatch(/p50_ci"?\s*[:=]\s*\d/);
+    });
+
+    it('keeps the pathology net separate from the cap', () => {
+        // Step 3 of the recorded arming procedure: one spike should be caught as
+        // a pathology rather than by lowering the cap for every run.
+        const out = renderDistribution(ok, evaluate(ok));
+        expect(out).toContain('pathology net stays separate from the cap');
+        expect(out).toContain('absolute');
+    });
+
+    it('names the dropped readings rather than averaging them away', () => {
+        const withNull = [...ok, reading(null, 'sZ')];
+        expect(renderDistribution(withNull, evaluate(withNull))).toContain('DROPPED as unusable');
+    });
+
+    it('a not-armable distribution says so, and says the numbers are insufficient', () => {
+        const few = [reading(1000, 'a'), reading(1100, 'b')];
+        const out = renderDistribution(few, evaluate(few));
+        expect(out).toContain('NOT ARMABLE YET');
+        expect(out).toContain('informative before it is sufficient');
+    });
+});
+
+describe('the store round-trips through a real file', () => {
+    it('appended records parse back and evaluate', () => {
+        const d = mkdtempSync(join(tmpdir(), 'arm-rt-'));
+        try {
+            const f = join(d, 's.jsonl');
+            const rows = [
+                composeReadingRecord({ ms: 1200, parts: { pre_tool_use: 50 } }, 10, { GITHUB_RUN_ID: '1', RUNNER_OS: 'Linux' }),
+                composeReadingRecord({ ms: 1250, parts: { pre_tool_use: 52 } }, 10, { GITHUB_RUN_ID: '2', RUNNER_OS: 'macOS' }),
+            ];
+            writeFileSync(f, rows.map((r) => JSON.stringify(r)).join('\n') + '\n');
+            const { readings, malformed } = parseStore(readFileSync(f, 'utf-8'));
+            expect(malformed).toBe(0);
+            expect(evaluate(readings).sessions).toHaveLength(2);
+        } finally {
+            rmSync(d, { recursive: true, force: true });
+        }
+    });
+
+    it('self-test passes', () => {
+        expect(selfTest()).toBe(0);
+    }, 120_000);
+});


### PR DESCRIPTION
Ships **Phase A1** of `road-to-per-turn-hook-economy-carry` (3 of 16 steps). It
makes `per_turn_composite.arming_precondition` **evaluable at all** — until now
it could not be evaluated in either direction, because `bench_hook_latency`
printed the composite and discarded it.

**This discharges the collection milestone recorded in #1570.** When the council
parked `road-to-mcp-runtime-integrity` (verdict b3), one seat's refinement was the
condition of that park:

> *"(b3) needs an actionable collection milestone, not merely a distant revisit
> condition, or it becomes the indefinite park identified by Risk 2."*

The named milestone was this phase. The clock the precondition counts can now
start.

## Read the collection boundary before the steps

The three steps build the write half, the predicate and the publisher, and they
are complete. What this phase deliberately does **not** build is the *collection*
step — and naming that is the difference between a mechanism and a mechanism that
can accumulate:

- `tests.yml` records a reading on every gate run and **uploads it as a
  single-record artifact** (`composite-reading-<os>-<attempt>`, 30-day retention),
  so each run's number is durable.
- A workflow **cannot append to a tracked file without a push**, so the shards are
  not auto-merged into `agents/evidence/hook-composite-readings.jsonl`.
  Concatenating them is a maintainer or follow-up act. **A store nothing fills is
  the failure this phase exists to prevent**, so the gap is written into the
  roadmap rather than implied.
- The CI job also prints the arming verdict on every run (never gates), so
  accumulation is visible per run instead of being discovered as a surprise the
  day someone tries to arm the ceiling.

**A2.1 stays blocked, correctly.** The floor is ≥ 10 readings from ≥ 2 sessions;
one PR's CI run produces a handful. `b-composite-ceiling-value` is untouched, and
Track B is untouched.

## A1.1 — the session discriminator is the load-bearing field, not the count

`--record-composite <path>` appends one JSONL record per run: composite ms, the
four slot readings it sums, `tool_calls`, platform, node, commit, run id, session.

Three decisions worth the review:

1. **The reading is written BEFORE the ceiling comparison.** A store holding only
   the runs that *passed* the gate is biased in the direction that makes a ceiling
   look met — the same bias the null-composite rule guards from the other side.
2. **A null composite is written as `null`, not skipped.** Skipping would make the
   store's own length a lie about how many runs contributed, and the reader must
   distinguish "no run" from "a run whose slots were incomplete".
3. **Session identity, by shape:** CI `gh-<run_id>-<RUNNER_OS>-<attempt>`, local
   `local-<host>-<pid>`. A workflow **re-run is a different session** — it lands on
   a fresh runner, so counting it as the same one would under-count a genuinely
   independent reading.

**Measured end to end**, not asserted: two consecutive local runs left two records
with distinguishable session ids at `1187 ms` each, and the predicate read them as
2 sessions and reported `NOT YET — short by 8 readings`. The different-OS clause is
asserted by injecting `RUNNER_OS=Linux` and `RUNNER_OS=macOS` under one
`GITHUB_RUN_ID`, so it needs no second machine.

## A1.2 — the predicate refuses to guess, and the two refusals differ

Both cases the verify names are committed tests, and they are **not-armable for
different reasons** — which is the entire argument against a bare boolean:

| store | verdict | clause named |
|---|---|---|
| 9 readings, 3 sessions | not armable | `readings: 9 usable of 10 required (short by 1)` |
| 12 readings, 1 session | not armable | `sessions: 1 distinct of 2 required` — **and carries why**: the instability the floor excludes was measured on ONE machine |
| 1 reading, 1 session | not armable | **both** clauses named |
| 10 readings, 2 sessions | armable | — |

A record whose `composite_ms` is `null` is **dropped and counted as unusable**,
never extrapolated — and its session does not count toward the session floor
either, which is the subtler half.

## A1.3 — publish the distribution, do not choose from it

`--publish` renders min / p50 / p95 / max / spread, a per-session table, and the
dropped-reading count **named rather than averaged away**.

**It writes no `p50_ci`, and the test asserts the absence rather than the
presence.** The phrase appears exactly once — in the sentence disclaiming it — and
an assertion refuses any `p50_ci: <number>` shape. A script that both measured the
distribution and armed the ceiling from it would be the agent setting its own
budget, which is precisely what A2.1 reserves to the maintainer.

The pathology net is kept **separate from the cap**, per step 3 of the recorded
arming procedure, and the proposed shape is offered as a starting point rather
than a recommendation. A not-armable distribution still prints its numbers,
labelled *"informative before it is sufficient"*.

## Sabotage probes — three, each red before the tests were trusted

| Sabotage | Result |
|---|---|
| count rows instead of distinct sessions | **4 of 18 red** — the `12 from 1` case goes green, exactly the shape the floor rejects |
| treat a null composite as usable | **4 red** |
| return a bare boolean with no named clause | **4 red** |
| restore | **18/18** |

## Verification

`task preflight` — **exit 0**. 18 assertions pass. `check_ci_local_parity` green
with no new declared exception, `lint_workflow_paths` green, `check_estate_count`
within its ratchet (no new blocker, no new roadmap), `lint_roadmap_blockers` and
`check_roadmap_trackable` green.

`npm run build:hooks` was needed locally before the bench would run — the bundle
is an untracked local artefact, which is why the end-to-end measurement above is
reported from a built worktree.

Rebased onto `main`; the trunk moved twice during this branch's life.
