### PR TITLE
roadmap: defer the rtk re-bench on subject, and make the 33% figure carry its scope

### DIFF
--- a/agents/roadmaps/road-to-terminal-token-economy.md
+++ b/agents/roadmaps/road-to-terminal-token-economy.md
@@ -130,25 +130,55 @@ the numbers arrive is not a benchmark.
       run. Explicitly widen past the existing shape: one repo, one machine,
       eight commands is what the current figure rests on.
       verify: the registration file exists under `agents/evidence/analysis/` with a date preceding any results file, and `git log --diff-filter=A --format=%ad -1 -- <registration>` precedes the results file's add date.
-- [ ] **3.2 Run it and publish the number, whatever it is.** A result at or near
+- [~] **3.2 Run it and publish the number, whatever it is.** A result at or near
       zero is a publishable outcome and closes the lever honestly. A result that
       misses the pre-registered bar closes it the same way.
       verify: the results file cites the registration by path and reports the metric against the pre-registered bars, naming any bar it missed.
-- [ ] **3.3 Correct the shipped documentation to whatever 3.2 measured.** The
+- [~] **3.3 Correct the shipped documentation to whatever 3.2 measured.** The
       skill currently carries the 2026-07-28 figure. Replace it with the new one
       and its scope, or — if 3.2 produced a null — replace it with the null and
       the scope, keeping the honest-scoping style the current text already has.
       verify: `grep -n "2026-07-28" src/skills/rtk-output-filtering/SKILL.md` no longer returns the stale figure as the headline; the pre-state is `git show HEAD:src/skills/rtk-output-filtering/SKILL.md | grep -c "2026-07-28"` = 1.
-- [ ] **3.4 Reconcile the upstream-reported range against this tree's own.** The
+- [~] **3.4 Reconcile the upstream-reported range against this tree's own.** The
       skill quotes an upstream 60–90 % range next to a measured 33 %. Whatever
       3.2 produces, state the relationship between the two rather than letting a
       reader pick the flattering one.
       verify: the skill text names both figures with their sources, and `./scripts-run src/scripts/skill_linter src/skills/rtk-output-filtering 2>&1 | tail -3` exits green.
 
+
+      **DEFERRED `[~]` 2026-08-23 — steps 3.2, 3.3 and 3.4, by AI council (b),
+      2 of 2 convergent.** Members anthropic/claude-sonnet-4-5,
+      openai/codex-default; $0.033. Spend was **pre-authorized for the run**, so
+      this is not a budget refusal — the deferral is on **subject**, and both
+      seats called the ordering decisive:
+
+      > Phase 2 *chooses* the wrapper mechanism and Phase 3 benchmarks it. Phase 2
+      > is not done. Benchmarking now would buy a number about a mechanism that
+      > has not been selected, and if Phase 2 picks differently the number is
+      > invalidated.
+
+      One seat added the honest carve-out, which is recorded so a future run does
+      not mistake it for permission: measuring the **current** mechanism could give
+      a baseline, but that would need its **own** pre-registered, explicitly
+      labelled baseline design and must never be presented as the planned widened
+      re-bench.
+
+      **The `Resolved when` half is discharged in this same change**, and it went
+      further than the blocker asked. The blocker wanted the skill's savings
+      paragraph labelled; one seat pointed out that a scope stated only at the
+      canonical definition *"does not survive being copied or summarised"*, so the
+      label had to travel with **every** reader-facing occurrence. Swept
+      `src/` and `docs/`: two sites carry this claim
+      (`src/skills/rtk-output-filtering/SKILL.md`,
+      `docs/contracts/rtk-detection.md`) and **both** now state date, machine,
+      corpus size **and supersession status**. The other six `33 %` hits in the
+      tree are a different claim (judge inconsistency) and were left alone — the
+      count is reported so "I labelled it" is distinguishable from "I labelled the
+      one I happened to see".
 ## Blockers
 
 ### blocker: b-ab-session-spend
-- **Status:** open
+- **Status:** resolved
 - **Owner:** maintainer
 - **Class:** 2 — consent-once (a benchmark run bills real session tokens)
 - **Blocks:** Phase 3 steps 3.2, 3.3 and 3.4. Step 3.1 is the registration and
@@ -172,6 +202,21 @@ the numbers arrive is not a benchmark.
 - **Resolved when:** one of (a) or (b) is recorded at this blocker, and — for (b) —
   the skill's savings paragraph carries the staleness label and steps 3.2–3.4 are
   marked deferred rather than left open-looking.
+- **Resolution 2026-08-23 — (b), AI council, 2 of 2 convergent.** Both halves of
+  the `Resolved when` are discharged in the same change: 3.2-3.4 are `[~]` with
+  the reasoning at 3.4, and the staleness label is on the number at **every**
+  reader-facing site rather than only the canonical one.
+
+  **Spend was pre-authorized, and the deferral is still correct** — that is the
+  part worth recording. The mandate for this run pre-authorizes benchmark spend,
+  so the council decided *how*, not *whether*. Both seats concluded that
+  pre-authorized budget is *"permission without reason"*: it does not refute a
+  methodological objection, and the objection here is ordering — Phase 2 has not
+  chosen the mechanism Phase 3 exists to benchmark.
+
+  What (b) bought immediately: the live misreading is gone. An unqualified "33 %"
+  was reading as this package's general measured claim while being a one-machine,
+  eight-command, month-old spot measurement.
 
 ## Risk Register
 <!-- risk-review: v1 | reviewed: 2026-08-22 | reviewer: claude/host -->

--- a/dist/agent-src/skills/rtk-output-filtering/SKILL.md
+++ b/dist/agent-src/skills/rtk-output-filtering/SKILL.md
@@ -28,12 +28,20 @@ commands through intelligent output filtering (whitespace, boilerplate,
 comments, duplicate log messages). Single Rust binary, <10ms startup overhead.
 **Third-party Apache-2.0 tool** (rtk-ai upstream — an external project, not part of this package).
 
-**Savings, honestly stated:** upstream reports 60-90% (their estimate —
-"actual savings vary"). agent-config's own scoped spot-measurement
-(2026-07-28, one repo, one macOS machine, 8-command corpus) landed at
-**33% overall, 0-57% per command** — verbose commands (`git status`,
-`git log`, `ls -la`) save ~55%, already-compact output (`--oneline`,
-`--stat`) passes through at ~0%. See `internal/bench/rtk-savings/RESULTS.md`.
+**Savings — STALE, and scoped. Do not quote the number without this label.**
+Upstream reports 60-90% (their estimate — "actual savings vary").
+agent-config's own figure is **33% overall, 0-57% per command**, and it is a
+**single spot-measurement from 2026-07-28: one repo, one macOS machine, an
+8-command corpus.** It has **not** been superseded by a wider run, and the
+widened re-bench is **deferred** — `road-to-terminal-token-economy` steps
+3.2-3.4, deferred by AI council on 2026-08-23 because Phase 2 has not yet chosen
+the wrapper mechanism, so a re-bench today would measure the wrong subject.
+
+Treat it as an order of magnitude for *that* corpus, never as this package's
+general claim. Verbose commands (`git status`, `git log`, `ls -la`) save ~55%;
+already-compact output (`--oneline`, `--stat`) passes through at ~0%, which is
+why an overall percentage is meaningless without the corpus that produced it.
+See `internal/bench/rtk-savings/RESULTS.md`.
 
 **Docs:** https://www.mintlify.com/rtk-ai/rtk
 **Repo:** https://github.com/rtk-ai/rtk

--- a/docs/contracts/rtk-detection.md
+++ b/docs/contracts/rtk-detection.md
@@ -99,4 +99,10 @@ Any user-facing savings figure is **attributed to upstream** ("upstream
 reports 60–90% — their estimate") unless agent-config has published its own
 measurement. agent-config's scoped spot-measurement lives at
 [`internal/bench/rtk-savings/RESULTS.md`](../../internal/bench/rtk-savings/RESULTS.md)
-(2026-07-28: 33% overall on an 8-command corpus, 0–57% per command).
+(2026-07-28: 33% overall on an 8-command corpus, 0–57% per command, **one repo
+on one macOS machine**). That figure is **stale and not superseded**: the widened
+re-bench is `road-to-terminal-token-economy` steps 3.2–3.4, deferred by AI council
+on 2026-08-23 until Phase 2 chooses the wrapper mechanism. The label travels with
+the number by design — a scope stated only at the canonical definition does not
+survive being copied or summarised, which is how an unqualified "33 %" reaches a
+reader in the first place.

--- a/src/skills/rtk-output-filtering/SKILL.md
+++ b/src/skills/rtk-output-filtering/SKILL.md
@@ -28,12 +28,20 @@ commands through intelligent output filtering (whitespace, boilerplate,
 comments, duplicate log messages). Single Rust binary, <10ms startup overhead.
 **Third-party Apache-2.0 tool** (rtk-ai upstream — an external project, not part of this package).
 
-**Savings, honestly stated:** upstream reports 60-90% (their estimate —
-"actual savings vary"). agent-config's own scoped spot-measurement
-(2026-07-28, one repo, one macOS machine, 8-command corpus) landed at
-**33% overall, 0-57% per command** — verbose commands (`git status`,
-`git log`, `ls -la`) save ~55%, already-compact output (`--oneline`,
-`--stat`) passes through at ~0%. See `internal/bench/rtk-savings/RESULTS.md`.
+**Savings — STALE, and scoped. Do not quote the number without this label.**
+Upstream reports 60-90% (their estimate — "actual savings vary").
+agent-config's own figure is **33% overall, 0-57% per command**, and it is a
+**single spot-measurement from 2026-07-28: one repo, one macOS machine, an
+8-command corpus.** It has **not** been superseded by a wider run, and the
+widened re-bench is **deferred** — `road-to-terminal-token-economy` steps
+3.2-3.4, deferred by AI council on 2026-08-23 because Phase 2 has not yet chosen
+the wrapper mechanism, so a re-bench today would measure the wrong subject.
+
+Treat it as an order of magnitude for *that* corpus, never as this package's
+general claim. Verbose commands (`git status`, `git log`, `ls -la`) save ~55%;
+already-compact output (`--oneline`, `--stat`) passes through at ~0%, which is
+why an overall percentage is meaningless without the corpus that produced it.
+See `internal/bench/rtk-savings/RESULTS.md`.
 
 **Docs:** https://www.mintlify.com/rtk-ai/rtk
 **Repo:** https://github.com/rtk-ai/rtk


### PR DESCRIPTION
Resolves `b-ab-session-spend` on `road-to-terminal-token-economy` as **(b)** and
discharges both halves of its `Resolved when` in the same change. Steps 3.2–3.4
are `[~]`; the immediate value is that a **live misreading is gone**.

## The deferral is on SUBJECT, not on budget — and that distinction is the point

This drain run has **benchmark spend pre-authorized**, so the council decided
*how*, never *whether*. It still deferred, and both seats gave the same reason:

> Phase 2 *chooses* the wrapper mechanism and Phase 3 benchmarks it. **Phase 2 is
> not done.** Benchmarking now buys a number about a mechanism nobody has
> selected, and a different Phase 2 choice invalidates it.

Both seats put the general form plainly: pre-authorized budget is **"permission
without reason"** — it does not refute a methodological objection.

One seat added a carve-out, recorded so a future run does not read it as
permission: measuring the **current** mechanism could give a baseline, but that
needs its **own** pre-registered, explicitly labelled baseline design and must
never be presented as the planned widened re-bench.

Council: anthropic/claude-sonnet-4-5 + openai/codex-default, 2 rounds, blind
chairman, 2 of 2 convergent, $0.033.

## What (b) bought today: the 33 % figure now carries its own scope

An unqualified **"33% overall"** was reading as this package's general measured
claim. It is a single spot-measurement from **2026-07-28 — one repo, one macOS
machine, an 8-command corpus** — and it has **not** been superseded.

**The council widened the ask, and this is the part worth reviewing.** The blocker
only required the *skill's savings paragraph* to be labelled. One seat pointed out
that a scope stated only at the canonical definition *"does not survive being
copied or summarised"* — which is exactly how an unqualified figure reaches a
reader. So the label had to travel with **every** reader-facing occurrence, and
carry **date, machine, corpus size and supersession status**.

### The sweep, with its count

`grep -rn '33 *%\|33%' src/ docs/` returns **8 sites**. Two carry this claim and
both are now labelled:

| Site | Before | After |
|---|---|---|
| `src/skills/rtk-output-filtering/SKILL.md` | scoped, but presented as current | **STALE, and scoped** — date, machine, corpus, not-superseded, and the deferred re-bench named |
| `docs/contracts/rtk-detection.md` | date + corpus size only | adds machine and supersession status |

The other **six** are a **different claim** — judge inconsistency, `72.33 %` in a
sanitizer comment, a pack-size rationale — and were left alone. The count is
reported so *"I labelled it"* is distinguishable from *"I labelled the one I
happened to see"*.

The skill also now states **why an overall percentage is meaningless for this tool
without its corpus**: verbose commands (`git status`, `git log`, `ls -la`) save
~55 % while already-compact output (`--oneline`, `--stat`) passes through at ~0 %,
so the aggregate is a property of the command mix, not of the tool.

## Verification

`task preflight` — **exit 0**. `skill_linter` on the edited skill: 1 pass, 0 warn,
0 fail. `lint_roadmap_blockers`, `check_references` green. The skill is 221 lines,
well inside its cap.

`dist/agent-src/skills/rtk-output-filtering/SKILL.md` is regenerated and committed
— `dist == rewrite(src)` is a CI gate and the pre-push hook caught the stale
projection before it became a red run.

The council response file is gitignored (`agents/runtime/council/` is local-only
and auto-pruned); the verdict, both rationales, the carve-out and the `revisit-if`
are reproduced above and at the blocker.

**What stays open:** Phases 1 and 2 of this roadmap are untouched and unblocked —
Phase 1 probes the host rewrite contract, Phase 2 chooses the wrapper mechanism.
Phase 3 reopens when Phase 2 has chosen, which is the `revisit-if` recorded at the
blocker.
