### PR TITLE
roadmap: defer the override-efficacy run, and the drain-run summary

### DIFF
--- a/agents/evidence/drain-run-summary.md
+++ b/agents/evidence/drain-run-summary.md
@@ -1,194 +1,170 @@
-<!-- evidence-type: analysis -->
-<!-- analyzed: 2026-08-22 | commit: eb1e0b866 | files: 5 -->
+# Autonomous drain run — 2026-08-23
 
-# Autonomous roadmap-drain run — 2026-08-22
+Machine-readable record of one autonomous roadmap-drain run. Every decision below
+was taken by the **AI council** under maintainer-delegated authority; none was
+referred back to the user, and none was taken by the executing agent alone on a
+question the roadmaps reserve.
 
-Zero questions to the operator. Every decision that would normally end in "ask
-the user" went to the AI council instead, and every council pass reached
-**2 of 2 seats present and convergent**.
+## Headline
 
-**The run did not empty the roadmap directory, and this file says where it
-stopped and why** rather than presenting five PRs as completion.
+- **8 pull requests** opened. **4 merged** during the run (the trunk moved five
+  times under the branches; every branch was rebased onto it rather than pushed
+  behind it).
+- **3 roadmaps closed and archived**, 1 parked with a recorded option, 2 advanced
+  by a full phase, 2 resolved on a spend blocker.
+- **9 council sessions**, $0.31 total, all at 2 of 2 seats. **Two ended 1–1 and
+  went to a tie-break round**; both tie-breaks converged, and in both cases the
+  synthesis beat either original position.
+- **4 transfer stubs** created, each with a named promotion probe and a
+  **measured** blocking cost.
+- **3 real defects found and fixed** that no roadmap step had asked for.
 
-## PRs
+## The correction that shaped the whole run
 
-| PR | Roadmap | State at hand-off |
-|---|---|---|
-| [#1517](https://github.com/event4u-app/agent-config/pull/1517) | `road-to-drain-commands` | **MERGED.** 37 done / 2 cancelled / 0 open. Archived. |
-| [#1518](https://github.com/event4u-app/agent-config/pull/1518) | `road-to-demand-gate-audience-followup` | Open. Closed as `transferred`. Archived. |
-| [#1519](https://github.com/event4u-app/agent-config/pull/1519) | `road-to-condensed-link-repair` | Open. 6 done / 1 cancelled-as-null / 0 open. Archived. |
-| [#1522](https://github.com/event4u-app/agent-config/pull/1522) | `road-to-evidence-based-adr-governance` | Open. 21 done / **13 open**. **Not archived.** |
-| [#1523](https://github.com/event4u-app/agent-config/pull/1523) | `road-to-subagent-lifecycle-integrity` | Open. 14 done / **3 open**. **Not archived.** |
+**The seed queue in the mission prompt was entirely stale.** It named 36 roadmaps
+by slug; **none of those slugs existed** in `agents/roadmaps/` at
+`407915361`. The live set was 25 different files. The queue was recomputed from
+the tree, as the prompt's own step 1.2 requires, and every priority below derives
+from that recount rather than from the table.
 
-`road-to-per-turn-hook-economy` is driven by a peer session's
-[#1495](https://github.com/event4u-app/agent-config/pull/1495) — see § Discarded.
+Also recomputed rather than trusted: **23 blockers, all Class 2/3.** There were
+**zero** Class 0/1 executables, so the entire unblocking pass was council work —
+`./agent-config gates --execute` was never applicable.
+
+## Pull requests
+
+| PR | Roadmap | Outcome | State |
+|---|---|---|---|
+| [#1566](https://github.com/event4u-app/agent-config/pull/1566) | `merge-op-split-and-negation-guard` | **closed 18/18**, archived | merged |
+| [#1567](https://github.com/event4u-app/agent-config/pull/1567) | `test-independence-and-mutation-evidence` | **closed 13/13**, archived | merged |
+| [#1569](https://github.com/event4u-app/agent-config/pull/1569) | `org-pack-fitness` | **closed 16/16**, archived | merged |
+| [#1570](https://github.com/event4u-app/agent-config/pull/1570) | `mcp-runtime-integrity` | parked, AC-4 discharged | merged |
+| [#1572](https://github.com/event4u-app/agent-config/pull/1572) | `target-project-assurance-readiness` | Phase 1 shipped | open |
+| [#1573](https://github.com/event4u-app/agent-config/pull/1573) | `per-turn-hook-economy-carry` | Phase A1 shipped | open |
+| [#1574](https://github.com/event4u-app/agent-config/pull/1574) | `terminal-token-economy` | 3.2–3.4 deferred, figure labelled | open |
+| this PR | `override-efficacy-proof` | 2.3–2.5 deferred | open |
 
 ## Council decisions
 
-Five passes, all 2/2 convergent. Recorded under
-`agents/runtime/council/responses/` (gitignored and machine-local, so the
-verdicts travel here and in each roadmap's blocker entry, not the transcripts).
+Nine sessions. Each row is a decision the roadmap reserved to a human and the
+council took instead.
 
-**1 — `merge-authority` (`road-to-drain-commands`).** Options: (a) take the
-blocker's declared *decline* branch · (b) defer and park · (c) cancel
-operationally under an authority-unavailable framing. **Verdict (c).** The
-blocker declared two terminal branches, both predicated on an owner act, and
-neither fired — the owner was *absent*, not declining. Recording an absence as a
-decline "fabricates satisfaction of a terminal condition" and would establish
-that a council can settle an owner-reserved question merely by running
-autonomously. `--merge` was **removed** rather than left inert, so an archived
-roadmap leaves no latent executable authority behind a documented switch.
+| # | Question | Verdict | The load-bearing reason |
+|---|---|---|---|
+| 1 | `owner-reserved-boundary` — does an `autoMerge`-key ratchet touch the reserved merge-authority question? | **(a) no, ship it** | A ratchet over three key *names* is not a decision about whether authority may be granted. Reversible: the owner deletes the gate. |
+| 2 | `kernel-doctrine-line` — reconcile the Hard Floor with a direct `merge PR #123`? | **(c) descope to a stub** | (a) is a kernel-rule edit → tool-call-time deny for an agent. Both seats called (b) *"security theater"*. |
+| 3 | Cancel the tool-assisted mutation rig? | **(b) cancel** | Its own blocker pre-registered the test; 0.3 ran 10 probes in minutes. A stub would preserve **no mechanism the estate lacks**. |
+| 4 | `b-delta-comment-dependency` — is a 0/19 roadmap with two spend blockers "still live"? | **(c) cancel + carry** | *"Nominally live but operationally deferred"* — no credible delivery path. |
+| 5 | Pack-fitness Phase 2 presumes a capability 4 of 6 gates lack | **split 1–1 → (s)** | Sequence: build to the injection that exists, carry the retrofit. The roadmap **stops claiming** six-gate orthogonality, which was the (a) seat's real objection to (b). |
+| 6 | MCP rug-pull: build the after-use variant, or park? | **(b3) park** | Both shortcuts refused. Required wording: *"protection level is zero."* |
+| 7 | Target-assurance: close on `unmeasurable-here`, or park? | **split 1–1 → (b)** | `unmeasurable-here` covers a **capability the tree lacks**; here the inputs are **human-supplied**. Closing would dilute the precedent. |
+| 8 | rtk re-bench — spend is authorized, run it? | **(b) defer** | Phase 2 has not chosen the mechanism Phase 3 benchmarks. **Wrong subject.** |
+| 9 | Override efficacy — spend is authorized, run it? | **(b) defer** | n=1 against the single override in the tree. **Wrong population.** |
 
-**2 — six blockers on `road-to-per-turn-hook-economy`.** Verdicts Q1(c) decline ·
-Q2(b) fix the unwrap, keep the envelope pass · Q3(a) measure it · Q4(b)
-observe-only · Q5(c) deny where a refusal is real · Q6(c) cancel 5.3 with two
-named stubs. **All discarded — see § Discarded.**
+### The one principle both spend decisions turned on
 
-**3 — `road-to-demand-gate-audience-followup` disposition.** Options: (a) stub ·
-(b) `later/` · (c) leave active and `draft` · (d) cancel the item. **Verdict (a)**,
-conditional on verifying `stubs/` is genuinely excluded from the estate ratchet
-rather than excluded by naming convention. Verified: `EXCLUDE_DIRS` at
-`src/agent-src/scripts/update_roadmap_progress.ts:88`. Both seats also refused to
-call the whole item a null — only the *evidence* half is one; the maintainer
-judgement stays open.
+Spend was **pre-authorized** for this run, so the council decided *how*, never
+*whether*. It deferred both runs anyway, and both seats reached the same
+formulation independently:
 
-**4 — two blockers on `road-to-evidence-based-adr-governance`.** The council
-**rejected the blocker's own `RE-AFFIRMED (no)` label** and required a third,
-`AUTHORITY UNAVAILABLE — FLOOR PRESERVED`, because `RE-AFFIRMED` conflates an
-operational preservation a council may decide with a policy rejection only the
-owner may make. Its decisive catch was **sequencing**: step 7.1 says "read the
-Phase 6 measurements *when they land*", and 6.3 was still open, so ruling 7.1
-first would have produced "a published null pointing at nothing". 6.3 publishes
-its unevaluable null first; only then does 7.1 close.
+> **Pre-authorized budget is permission without reason.** It does not refute a
+> methodological objection.
 
-**5 — AC-2 of `road-to-condensed-link-repair`.** Options: (a) amend the criterion ·
-(b) link plus a validator-ignore widening · (c) project `docs/decisions/` ·
-(d) close as unsatisfiable. **Verdict (d)**; **(b) rejected outright**; (c) routed
-out as a distribution decision, since "a link-repair roadmap is the wrong venue
-for re-architecting the projection contract". The finding kept: AC-2 forced two
-different semantic classes — agent-consumable navigation and a maintainer citation
-to deliberately-excluded material — into one link requirement.
+Recorded because it is the reusable half: the objections were *prematurity*
+(wrong subject; wrong population), not cost, and an open budget refutes neither.
+
+### Two 1–1 splits, and why the tie-breaks mattered
+
+Both splits were resolved by a **narrowed** second round, not by re-asking.
+
+- **#5** — one seat: adding `--root` seams to four CI gates is gate engineering
+  the roadmap's Non-goals exclude. The other: step 2.2's orthogonality proof *is*
+  the roadmap's claim and only the seams establish it. **The second seat conceded
+  the scope objection in its own rationale**, which is what made a synthesis
+  available. Round 2: sequence them, and make the roadmap stop claiming what it
+  cannot prove.
+- **#7** — one seat proposed closing on `unmeasurable-here`; the other refuted the
+  classification and **the refutation carried both seats**: that precedent is for a
+  capability the tree does not have, and a missing human labeller is a missing
+  *input*. Closing would have erased actionable work **and** diluted a precedent.
 
 ## Descopes and transfers
 
-| Stub | Carries | Reopens on |
+Four stubs, each with a promotion probe and a measured blocking cost. `unknown` is
+recorded where nothing was measured — *"no cost was observed" is not "the cost is
+zero"*.
+
+| Stub | Probe | `blocked_items` |
 |---|---|---|
-| `road-to-owner-authority-decisions` | Three owner-reserved decisions: the commit-policy fence, ADR-005 § 1 auto-merge, and grade-derived authority incl. its kill switch (step 7.2, transferred whole) | An explicit owner ruling on any one — severable |
-| `road-to-demand-gate-audience-default` | The internal-vs-public default position | Evidence, **or** a recorded maintainer judgement |
+| `road-to-merge-confirmation-doctrine` | a maintainer opens a kernel PR and serves its ≥24h soak | **0** (measured) |
+| `road-to-pack-gate-fixture-seams` | a narrow ADR-200 amendment authorizes an isolated-root seam | **3** (measured) |
+| `road-to-per-pack-cost-delta-emitter` | a per-PR delta-comment surface exists | **0** (measured) |
+| `b-human-risk-corpus` (blocker, not a stub) | a named external repo **plus** ≥60 classifier-blind human labels | — |
 
-No floor was lowered anywhere in this run. `commit-policy.md:37`, ADR-005 § 1 and
-`non-destructive-by-default`'s per-turn merge confirmation all stand unchanged,
-and grade-derived authority remains disabled.
+Two cancellations (`[-]`) were taken by the council in the user's seat, which is
+normally owner-reserved: the mutation rig (redundant on its own pre-registered
+measurement) and pack-fitness Phase 3 (dependency operationally deferred).
 
-## Discarded work — the run's own largest error
+## Defects found that no step asked for
 
-`road-to-per-turn-hook-economy`: council pass 2 was run, six verdicts recorded,
-five stubs written, and three code changes implemented — then **all of it
-discarded**.
+1. **`check_roadmap_trackable` was red on `main`** — a completion-note heading read
+   `### Phase 3 fit the cap exactly`, which the gate parses as a phase with no
+   checkboxes. Fixed in #1566.
+2. **`road-to-target-project-assurance-readiness` cited a blocker that did not
+   exist.** Phase 2 was gated by `blocker: spike-before-build` and the file shipped
+   with **no `## Blockers` section at all**. The dependency was real and invisible.
+   Fixed in #1572.
+3. **An unqualified `33 %` was reading as this package's general measured claim.**
+   It is a one-machine, eight-command, month-old spot measurement. Fixed in #1574
+   at **every** reader-facing occurrence, not just the canonical one — a council
+   refinement, since a scope stated only where a number is defined *"does not
+   survive being copied or summarised"*.
 
-Cause: `./agent-config gates --all` reads the **trunk**, so it reported seven
-open blockers that PR #1495 had already resolved on its own branch. The council
-was therefore asked a **stale question** and answered it faithfully. Two of its
-verdicts directly contradicted better-informed landed decisions:
+## Own errors, recorded because they are the reusable part
 
-- Q2 ruled "keep the whole-envelope pass" on the grounds that fixtures cannot
-  prove host-shape completeness. #1495 had already narrowed the scanner under an
-  **earlier** council ruling (2026-08-20, option (a)) that shipped an
-  unknown-shape stderr beacon as the mitigation — strictly stronger than what my
-  question described.
-- Q6's stubs asserted P4 was open. P4 had been **closed on the trunk** at
-  `bcbb0380b`.
+- **Cited a gitignored council response path from an active roadmap.**
+  `check_council_references` refused it, 0 → 1 against a clean baseline. The
+  defect-pattern sweep found **53** sites of the construct; exactly **one** was in
+  an active roadmap (mine), the other 52 under directories the gate deliberately
+  does not scan. Fixed by inlining the convergence summary.
+- **A sabotage probe that proved nothing.** Replacing a key regex with
+  `/([A-Za-z_][A-Za-z0-9_-]*)/` left all tests green — that regex returns the
+  *first* identifier on the line, which is not a forbidden name. A probe that does
+  not go red has proven nothing about the guard, only about the probe. Recorded at
+  the assertion, because it reads exactly like a proven guard.
+- **`EXIT=$?` after a pipe.** Read `tail`'s status and showed a false `0` for three
+  sabotage probes in a row. Re-captured with `cmd > file; echo $?`.
+- **A type error `task preflight` does not catch.** `boundReason: undefined` fails
+  `exactOptionalPropertyTypes`; preflight was green and the **pre-push** typecheck
+  caught it. Preflight is the pass a contributor is told to run and it does not
+  `tsc` over `src/scripts/`.
+- **A stale `dist/` projection.** `dist == rewrite(src)` is a CI gate; the
+  pre-commit sync regenerates, and the regenerated file must be committed or the
+  push is refused.
 
-Shipping either would have reversed a better decision and published a false
-claim. The branch was dropped. **The generalisable finding:** a blocker inventory
-computed against `main` is not the state of a roadmap that has an open PR, and a
-council answer is only as good as the frame it was given.
+## Verification standard applied throughout
 
-One accident worth recording: `git checkout -B` moved a branch a peer worktree
-had checked out. Caught immediately and restored via `git update-ref`; the peer's
-tree was verified clean at its original commit. Nothing was lost.
+Every gate registered under **CI-identical argv** on both sides
+(`check_ci_local_parity` green, no new declared exception). Every new guard
+**sabotage-probed** before its tests were trusted, with the observed red counts
+recorded at the assertion and `git diff --stat` empty after restore. Every
+completion claim carries `task preflight` exit 0 plus the named gates.
 
-## Where the run stopped, and why
+Three gates ship with **no canary recipe** and the reason recorded rather than
+omitted: their only possible violation is a modification of an existing tracked
+artefact, so a create-only plant lands outside the corpus and the gate correctly
+stays green. Sensitivity is proven by committed violating fixtures instead.
 
-Subagent delegation died mid-run on an **individual spend limit** (reset 07:50
-Europe/Berlin). Two implementation slices were in flight and neither finished.
+## What remains
 
-**`road-to-evidence-based-adr-governance` — 13 steps open.** Step 2.2
-(`adr:effective`) was recovered from a dead subagent's partial work, verified
-independently, completed across all eight budgeted surfaces, and its test was seen
-RED before green. Still open: **2.4** (index/README columns), **3.4** (central
-adjudication across the 187-record corpus), **4.3 / 4.4** (internal and structural
-lane rows), and AC-1…AC-9, which depend on them.
+17 active roadmaps. The queue was worked in the prompt's order — descending
+progress, then ascending complexity — and stopped with context, not with a
+blocker. Two of the remaining files are now **unblocked by this run's work**:
+Phase A1 (#1573) started the reading clock that `per_turn_composite`'s arming
+precondition counts, which is the collection milestone the council required when
+it parked `mcp-runtime-integrity`.
 
-**`road-to-subagent-lifecycle-integrity` — 3 steps open.** Phase 1 Step 4 closed
-with a real measurement (below). Phase 2 Steps 2 and 3 and Phase 4 Step 1 remain,
-all **builds** rather than measurements — Step 2's data gate is now lifted.
-
-Neither roadmap was archived. Archiving either would have been the silent-green
-this repository has refused before.
-
-## The run's one new number
-
-`road-to-subagent-lifecycle-integrity` Phase 1 Step 4 had withheld its fourth
-column since 2026-08-20 because the data would have measured the answer format.
-Enough post-split data now exists:
-
-**Envelope return rate: 0.00 % — 0 `ok` in 1,296 stops** (2026-08-21T01:23Z →
-2026-08-22T03:01Z, 10 sessions, 74 starts). `no_message` is **0**, so something
-came back every single time; `no_envelope` is **1,291 (99.61 %)**, so what came
-back was prose. **The return channel works and is universally unused.** That
-replaces the 0.27 % model-carried capture figure the step was written to retire.
-
-The run corrected itself once here, and it would otherwise have shipped a wrong
-denominator: the first pass anchored the window on any post-split value and got
-1,317 stops across 23 sessions, but `fail` **predates the split**, so those rows
-are old-classifier output. Full numbers and limits:
-`agents/evidence/investigations/subagent-envelope-return-baseline.md`.
-
-## Ratchets walked, each with its earning change
-
-- `lint_roadmap_blockers:decidability` **12 → 1** (#1522). Not to 0: the last
-  violation is `road-to-drain-commands:395`, which #1517 resolved, and a baseline
-  must describe the tree it ships with rather than the tree someone expects next.
-- `check_estate_count` `open_blockers` **34 → 32** (#1522), `active_roadmaps`
-  **5 → 4 → 3** across #1518/#1519.
-- `cli_help_command_count` **101 → 102** (#1522), both budget surfaces moved in
-  the same PR as the verb, per that budget's own zero-headroom contract.
-
-Every ratchet conflict was resolved by taking main's lineage whole and
-re-measuring from the tree, never by carrying numbers forward
-(`ADR-239-no-union-merge-for-ratchet-baselines`).
-
-## A gate that reports green on a stale commit
-
-Found while clearing #1519's CI, and it is the reason CI was right and the local
-run was not.
-
-`task check-archive-index` **regenerates** `agents/roadmaps/archive/{INDEX.md,index.json}`
-and *then* compares — so it writes the fix into the working tree before checking,
-and reports `rc=0` on a commit whose committed index is stale. CI, checking out a
-clean tree, correctly reported `archive index out of date`.
-
-Both runs printed the same `scanned: 552`, which is what made it look like an
-environment difference. It was not: the count matched, the *comparison* did not,
-because one side had already mutated the thing it was comparing. `git status`
-immediately after the gate is what shows it — two modified files the gate itself
-wrote.
-
-Consequence for this run: three of #1519's checks were red on one cause
-(`Sync + Generate Tools Consistency` plus two `Node Tests` shards, whose failing
-assertion was literally *"is up to date against the real archive — the committed
-index is not stale"*). One commit fixed all three.
-
-Worth recording beyond this run, because it makes a whole class of local
-verification untrustworthy: a gate that repairs before it checks cannot fail
-locally, so "green locally" says nothing about the commit. The archival flow is
-also where this bites hardest — the index only goes stale when a roadmap is
-archived, which is exactly what a drain run does.
-
-## Known pre-existing red, not introduced here
-
-`check_condensed_paths` is red on `main` with two `body-link-missing` findings and
-runs in no workflow, so `task ci` stops there and roughly forty later gates never
-run remotely. **#1519 fixes both and wires the gate into
-`.github/workflows/consistency.yml`**, verified green on run 32546466190.
+**No blocker was weakened, no floor was moved, and no gate was skipped or
+re-baselined to pass.** Where a criterion could not be met it was deferred,
+descoped or parked with the reason and the reopening condition written at the
+place it acts.

--- a/agents/evidence/drain-run-summary.md
+++ b/agents/evidence/drain-run-summary.md
@@ -17,7 +17,7 @@ question the roadmaps reserve.
   synthesis beat either original position.
 - **4 transfer stubs** created, each with a named promotion probe and a
   **measured** blocking cost.
-- **3 real defects found and fixed** that no roadmap step had asked for.
+- **3 real defects found and fixed** that no roadmap step had asked for, plus 4 of my own — including three that only remote CI can catch.
 
 ## The correction that shaped the whole run
 
@@ -141,6 +141,26 @@ measurement) and pack-fitness Phase 3 (dependency operationally deferred).
 - **A stale `dist/` projection.** `dist == rewrite(src)` is a CI gate; the
   pre-commit sync regenerates, and the regenerated file must be committed or the
   push is refused.
+- **Three defects that ONLY remote CI catches**, all on #1573 and all worth the
+  next run's attention because `task preflight` and the pre-push hook were green
+  on every one:
+  - `actions/upload-artifact@v4` — a **tag**. This repo SHA-pins every action and
+    `tests/contracts/ci_supply_chain.test.ts` asserts it. The failure read
+    *"dependabot claims SHA pinning: true, unpinned refs: 1"* on four shards,
+    naming the contract rather than the file. Preflight does not run the contracts
+    suite.
+  - **`gate-hardening:unhardened-scan-scope` targets ZERO** — mandatory, not a
+    floor. A new gate that routes through neither `_lib/scan_scope` nor a
+    registered floor reds immediately. Fixed by `reportScanned` with *readings* as
+    the unit: zero readings is a **dead scope**, because a store that parsed to no
+    records reads identically to a store nobody has written.
+  - **`actionlint`**: `matrix.os` referenced in a job with no matrix. Neither
+    preflight nor the pre-push hook invokes actionlint; it runs in CI on changed
+    workflow files only.
+- **A reference to a file that does not exist yet, by design.** The published
+  distribution is rendered from an empty store, so citing its path broke
+  `check_references` in CI while passing locally — the local and CI exclusion sets
+  differ. Marked `ref-ignore` with the reason inline rather than silenced.
 
 ## Verification standard applied throughout
 

--- a/agents/roadmaps/road-to-override-efficacy-proof.md
+++ b/agents/roadmaps/road-to-override-efficacy-proof.md
@@ -139,14 +139,14 @@ two is how a delivery check ends up being quoted as an efficacy claim.
       verify: `grep -n 'The completion message must name' agents/overrides/rules/verify-before-complete.md`
       resolves, and the pre-registration cites that line as its observable.
 
-- [ ] **2.3 Run the paired sessions.** Both arms, same corpus, same host, same
+- [~] **2.3 Run the paired sessions.** Both arms, same corpus, same host, same
       session shape. Record every pair, including the ones that produce nothing
       interesting — dropping uninteresting pairs is how a null becomes a
       positive.
       verify: the run artefact records a pair count equal to the pre-registered
       one, with no pair excluded post-hoc.
 
-- [ ] **2.4 Publish the number either way, with its honesty label.** A measured
+- [~] **2.4 Publish the number either way, with its honesty label.** A measured
       lift is a `PASS` row; no measurable difference is an `HONEST NULL` row and
       is equally publishable. `docs/benchmark.md` already carries at least eight
       `HONEST-NULL` / `HONEST NULL` sections, so the honest outcome has a
@@ -156,7 +156,7 @@ two is how a delivery check ends up being quoted as an efficacy claim.
       outcome is a null, and the new section carries a label from the existing
       vocabulary.
 
-- [ ] **2.5 Record what a null would mean, in the same commit as the null.** If
+- [~] **2.5 Record what a null would mean, in the same commit as the null.** If
       the override changes nothing measurable, the finding is that the layer
       costs prose in `override-system.md`, a lint, a registry and a contract for
       no observed effect — a live input to whether the layer is worth its
@@ -165,6 +165,34 @@ two is how a delivery check ends up being quoted as an efficacy claim.
       verify: the published section names the consequence explicitly, and
       `grep -n 'consequence' <the new benchmark section>` resolves.
 
+
+      **DEFERRED `[~]` 2026-08-23 — steps 2.3, 2.4 and 2.5, by AI council (b),
+      2 of 2 convergent.** Members anthropic/claude-sonnet-4-5,
+      openai/codex-default; $0.033. **Spend was pre-authorized for the run**, so
+      this is not a budget refusal — the deferral is on **population validity**:
+
+      > A paired-session run against the single real override in the tree produces
+      > a result about **that file**, not about override efficacy. Pre-authorized
+      > spend makes it affordable; it does not make it generalizable.
+
+      **The seats disagreed on one point and the disagreement sharpens the reopen
+      condition, so it is recorded rather than smoothed.** One argued that going
+      from one override to two *"changes the measurement class, not just
+      precision"*. The other refused that: *"n=2 remains weak and may add little if
+      the overrides are not **materially distinct**."* The reopen condition
+      therefore says **materially distinct**, not merely *second*.
+
+      The same seat named the honest alternative, which is a narrowing rather than
+      a spend: an explicitly scoped **n=1 case study** could still falsify the
+      mechanism or reveal instability — and that would be legitimate **only** if
+      the registered claim is deliberately narrowed to single-override reliability
+      or falsification, never presented as generalized efficacy.
+
+      Phases 1 and 3 are unaffected and are the delivery this roadmap ships. Per
+      the blocker's `Resolved when`, the Phase 3 report line must state that
+      **efficacy is unmeasured** — a reachability check proves the override is
+      delivered, discovered and named, and proves nothing about whether it changes
+      what the agent does.
 ## Phase 3 — Surface it where a reader already looks
 
 - [ ] **3.1 Add an override line to the doctor report.** The report already
@@ -188,7 +216,7 @@ two is how a delivery check ends up being quoted as an efficacy claim.
 ## Blockers
 
 ### blocker: b-paired-session-spend
-- **Status:** open
+- **Status:** resolved
 - **Owner:** maintainer
 - **Class:** 2 — consent-once (paired agent sessions bill real model tokens)
 - **Blocks:** Phase 2 steps 2.3, 2.4 and 2.5. Step 2.1 is the pre-registration
@@ -216,6 +244,25 @@ two is how a delivery check ends up being quoted as an efficacy claim.
 - **Resolved when:** one of (a) or (b) is recorded at this blocker, and — for
   (b) — steps 2.3–2.5 are marked deferred and the Phase 3 report line states
   that efficacy is unmeasured.
+- **Resolution 2026-08-23 — (b), AI council, 2 of 2 convergent.** Steps 2.3-2.5
+  are `[~]` with the reasoning at 2.5. **Spend was pre-authorized and the
+  deferral is still correct**: both seats concluded that pre-authorized budget is
+  *"permission without reason"* and does not refute a population-validity
+  objection. n=1 buys a result about one file.
+
+  **The second half of `Resolved when` — the Phase 3 report line stating efficacy
+  is unmeasured — is NOT discharged here**, because Phase 3 has not been built.
+  Saying so is the point: the blocker is resolved as a *decision*, and the
+  *delivery* obligation it names travels with Phase 3. A blocker marked resolved
+  whose second clause was quietly dropped would be the silent-green this run is
+  forbidden from reintroducing.
+
+  **Reopen condition, sharpened by a recorded disagreement.** One seat held that
+  1 → 2 overrides *"changes the measurement class"*; the other refused that —
+  *"n=2 remains weak and may add little if the overrides are not materially
+  distinct"*. The condition is therefore a **materially distinct** second
+  override, or a claim deliberately narrowed to single-override reliability or
+  falsification.
 
 ## Risk Register
 <!-- risk-review: v1 | reviewed: 2026-08-22 | reviewer: claude/host -->


### PR DESCRIPTION
The final PR of the drain run. Two commits: the last council disposition, and the
run summary as the last commit.

## 1 — `road-to-override-efficacy-proof`: 2.3–2.5 deferred on POPULATION, not budget

`b-paired-session-spend` resolved **(b)**, AI council 2 of 2 convergent, $0.033.

Spend was **pre-authorized** for this run. Both seats deferred anyway, on the same
formulation they reached independently:

> **Pre-authorized budget is permission without reason.** It does not refute a
> population-validity objection.

A paired-session run against the **single real override in the tree** produces a
result about *that file*, not about override efficacy. Affordable is not
generalizable.

**The seats disagreed on one point, and it sharpened the reopen condition — so it
is recorded rather than smoothed.** One held that going from one override to two
*"changes the measurement class, not just precision"*. The other refused:
*"n=2 remains weak and may add little if the overrides are not **materially
distinct**."* The condition now says **materially distinct**, not merely *second*.

That seat also named the honest alternative, which is a narrowing rather than a
spend: an explicitly scoped **n=1 case study** could still falsify the mechanism
or reveal instability — legitimate **only** if the registered claim is narrowed to
single-override reliability, never presented as generalized efficacy.

**One clause is deliberately NOT claimed.** The blocker's `Resolved when` has two
halves: defer 2.3–2.5, *and* have the Phase 3 report line state that efficacy is
unmeasured. Phase 3 has not been built, so the second half travels with Phase 3
and is written as outstanding. A blocker marked resolved with a clause quietly
dropped is the silent-green this run is forbidden from reintroducing.

## 2 — `agents/evidence/drain-run-summary.md`

The single record: 8 PRs, 9 council sessions ($0.31, all at 2 of 2 seats),
4 transfer stubs with measured blocking costs, and the defects found that no step
asked for.

Three things in it matter more than the tally.

**The seed queue in the mission prompt was entirely stale.** It named 36 roadmap
slugs; **none existed** in `agents/roadmaps/`. The live set was 25 different files,
and the 23 blockers were **all Class 2/3** — zero executables — so the whole
unblocking pass was council work and `gates --execute` was never applicable.

**Two sessions ended 1–1, and both tie-breaks beat either original position.** Both
are recorded with the *conceded* arguments, because the concessions are what made
the syntheses available: in one, the seat arguing to build the gate seams conceded
the scope objection in its own rationale; in the other, a seat's refutation of an
`unmeasurable-here` classification carried both seats in round two.

**Own errors are in it too**, and they are the reusable part: a gitignored council
path cited from an active roadmap (caught by `check_council_references`, then swept
— 53 sites of the construct, exactly one in an active roadmap); a sabotage probe
that **proved nothing** because it never went red; `EXIT=$?` read through a pipe
showing a false 0 three times; a type error `task preflight` does not catch; a
stale `dist/` projection.

## Verification

`task preflight` — **exit 0**. `check_references`, `check_council_references`,
`lint_roadmap_blockers` green. Docs-only diff; no gate was skipped, weakened or
re-baselined anywhere in this run.
