### PR TITLE
docs(evidence): PR drain run summary — 2026-08-23

### DIFF
--- a/agents/evidence/pr-drain-run-summary.md
+++ b/agents/evidence/pr-drain-run-summary.md
@@ -547,3 +547,181 @@ The consequence for the run brief's terminating condition is worth stating
 plainly: "drain to zero" is not reachable by one session while another is
 producing PRs into the same queue faster than merges retire them. Recomputing
 after every merge keeps a pass honest, but it does not make the queue converge.
+
+---
+
+# PR drain run — 2026-08-23
+
+A second autonomous run over the same queue, authorised for the whole run with
+the pre-push authorization ledger's TTL raised to 6h. Scope: every open PR at
+each recompute, merged one at a time, each synced onto the `main` the previous
+merge had just moved.
+
+**Nine PRs processed, nine merged, zero closed, zero deferred. The queue reached
+zero and stayed there.**
+
+Two things shape every row below and are stated once here rather than repeated.
+**A second live session worked the same repository throughout** — it merged four
+of the PRs this session had just synced and conflict-resolved, and it twice
+rebuilt `drain/repo-playbooks` over commits this session had pushed. Merge
+authorship is therefore recorded per row, because "who merged it" and "who
+unblocked it" are not the same fact. And **the queue kept growing during the
+run**: #1583/#1584 arrived after #1582, #1585/#1586 after those, #1588 after
+#1587's branch, #1589 and #1590 later still. Unlike the 2026-08-20 pass, no
+cutoff was drawn — each arrival was processed, and the queue converged because
+the other session stopped producing before this one stopped merging.
+
+## Merged
+
+Every SHA is the merge commit on `main`. "Conflicts" lists the files that
+actually collided, not the files changed. "CI iters" counts pushes that waited
+on a full CI run, a rerun-for-flake included.
+
+| # | PR | Sync conflicts | Resolution class | CI iters | Disposition |
+|---|---|---|---|---|---|
+| 1 | #1579 | none (fast-forward merge of `main`) | — | 1 | merged `ff7e95632` |
+| 2 | #1582 | none (already carried `main`) | — | 1 | merged `fd42264a9` — peer session |
+| 3 | #1584 | none | — | 1 | merged `04ad15110` |
+| 4 | #1583 | none | — | 2 (1 flake rerun) | merged `e5e7abc5a` — peer session |
+| 5 | #1586 | `gate-violation-baselines.json` | measured-the-merged-tree | 1 | merged `0add46119` — peer session |
+| 6 | #1585 | `.github/workflows/rule-backstops.yml` | union | 1 | merged `b7ac471fd` — peer session |
+| 7 | #1589 | `engineering-base/pack.yaml` | regenerated | 3 | merged `cc1e0376b` |
+| 8 | #1588 | README · index · catalog · pack.yaml | regenerated | 3 | merged `c7e82087e` |
+| 9 | #1590 | 12 generated artefacts | regenerated | 3 | merged `e7c437fe5` |
+
+The six PRs the run brief names as already merged this run — #1493, #1488,
+#1480, #1489, #1482, #1499 — are rows 1–6 of the 2026-08-20/21 table above and
+are not restated here. #1499 (`dd6a14406`) was already `MERGED` when this pass
+began; the brief's instruction to "merge #1499 first" was answered by a live
+state check rather than by a merge.
+
+## Not merged
+
+None. No PR was closed as superseded, none was blocked externally, and none
+exhausted its CI-fix budget. The largest budget spend was 3 iterations on each
+of the last three PRs, against a cap of 6.
+
+## Root-cause fixes that were not conflict resolution
+
+Six gates went red for reasons the merges themselves created. Each was fixed at
+the root; no baseline was raised without a stated reason, no test was skipped,
+and no threshold was loosened.
+
+**1. `check_source_size_budget` — two lowerings met in one merge (#1586).**
+`main` had reached 18,573 (−1, road-to-override-efficacy-proof); the branch had
+reached 18,572 (−2, road-to-council-evidence-integrity). Neither number
+describes the merged tree, and `check_source_size_budget.test.ts` asserts
+`baseline == live total`, so picking a side reds the test **and** silently gives
+back the other branch's gain. Resolved by measuring: the gate reports 18,571 on
+the merged tree, which is exactly 18,574 − 1 − 2. The note records both
+derivations rather than replacing one with the other.
+
+**2. `check_depth_budget` — a fifth over-ceiling file (#1589).** Phase 0
+migrated the artefact-maturity axis into `design-fidelity-mechanics.md`, taking
+it 15,265 → 16,524 chars past the 16,000 per-file ceiling; the ratchet's next
+failure is by construction a *fifth* file, so it reds, and
+`check_depth_budget.test.ts` reds with it. Paid the way the same file paid the
+same gate before — `design-handover-extraction.md` is the precedent — by moving
+the asset & imagery block whole into
+`docs/guidelines/design-asset-discipline.md`, verbatim, with a pointer left
+where it stood. Nothing was compressed: ADR-205's third-party-delivery ownership
+sentence and every `daf-*` fixture id survive at the new path. Mechanics back to
+14,598. Counts and index regenerated in the same commit (guidelines 108 → 109).
+
+**3. `check_rule_stub_ceiling` — a migrated rule outgrew its pointer (#1589).**
+The same phase added the maturity-vs-mandate Iron Law and its two discriminator
+clauses to `src/rules/design-fidelity.md` (+295 tokens). The gate offers two
+legal fixes; **move** was the one not available, because the lookup half had
+already gone to the pointer target and that migration is what caused finding 2.
+Raised with a `history` entry stating exactly that, then `--write-baseline`,
+which refuses a raise no history covers.
+
+**4. `check_rule_activation_census` — a new unconditional rule (#1588).**
+`playbook-precedence` ships with ADR-244 and grew the unconditional corpus by
+2,687 tokens, over the 2,000 drift allowance. Re-anchored with the reason, and
+the reason names the mechanism rather than the rule: all seven of its triggers
+are keywords or phrases, so the emitter writes **no** `paths:` block and the
+host loads it every session — the identical cost `ui-audit-gate` and
+`design-review-after-ui-write` each paid before being re-scoped in
+road-to-mixed-trigger-activation-cost Phase 2. The entry records the
+path-scoped form as the next candidate rather than absorbing the number
+silently. Re-cutting the trigger set inside a merge-queue drain was rejected:
+it would change routing behaviour nobody reviewed.
+
+**5. `lint_token_budget_discipline` — a rich skill over ADR-217's band (#1590).**
+The owned-components inventory took `design-system-capture/SKILL.md` to 3,764
+tokens against the 3,500 rich ceiling. The gate's own instruction is "split by
+responsibility, or argue the ceiling in a decision record — not in this file";
+split was correct here because the import material is read only when an import
+is requested. The import contract, supply path, five-step procedure and two
+source shapes moved into `references/import-procedure.md`, the same lazy-load
+posture the schema reference already had. Now 3,371.
+
+**6. Four generators nothing else reaches (#1588, #1589, #1590).** Three
+distinct staleness reds traced to generators that `task sync` and
+`update_counts` do not cover: `build_proof` (`docs/proof.md`, which failed twice
+— once as `demo-commands-still-pass`, once as `build_proof.test.ts`'s drift
+guard, same cause), `generate_capabilities_index` (`CAPABILITIES.yaml` still
+said 292 skills), and `audit_skill_overlap`
+(`agents/reports/skill-overlap.{json,md}`). Worth recording as a class: when a
+merge moves an artefact count, `update_counts` is necessary and not sufficient,
+and each of these three has its own entry point.
+
+## Flakes
+
+One, cleared by a single rerun as the brief allows: `spawnSync bash EPIPE` in
+`tests/install/claude_settings_hooks.test.ts` on #1583's ubuntu shard 1/4. Read
+as environmental rather than assumed to be: the PR's diff touches
+`_cli/cmd_doctor.ts`, `doctor_overrides.ts`, `lint_override_kernel_guard.ts` and
+an override-reachability test, and none of them is on the path that test
+exercises. The rerun passed.
+
+## Dropped edits
+
+None. Every conflict was either a generated artefact regenerated from the merged
+tree, a union of two additive blocks (#1585's two workflow steps, kept in
+landing order), or a measured value (#1586). No hand-merge of generated content
+was performed, and no branch's content was discarded to resolve a conflict.
+
+## The blocker this run surfaced, and did not fix
+
+`task sync` writes `.augment/rules` with all 119 rules while the host's global
+layer `~/.augment/rules` already delivers 103 of them. The Claude emitter
+respects the ADR-236 partition — `.claude/rules` holds 15 — and the Augment
+emitter in `condense.ts` does not. `check_rule_layer_partition` therefore reds
+`task preflight`, which makes **every push from an affected machine fail,
+on any branch, including `main`**. CI cannot see it: the comparison is against
+`$HOME`, and no CI leg installs at user scope.
+
+It surfaced mid-run because the global layer gained those rules while the run
+was in progress, so the first six pushes preceded it and the last two did not.
+Both documented bypasses were unavailable — `--no-verify` is refused by the
+`block-no-verify` guard, and the tool's own
+`AGENT_CONFIG_SKIP_PREPUSH_PREFLIGHT=1` was refused by the harness. It was
+surfaced to the maintainer, who authorised the skip flag for the remaining two
+pushes; #1590's CI ran unchanged and green.
+
+**This is a real defect and is left open deliberately.** Fixing it means making
+the Augment emitter consult the partition the way the Claude emitter does —
+a change to `condense.ts` with its own blast radius, entirely unrelated to any
+PR in this queue, and exactly the drive-by a merge-queue drain must not make.
+It wants its own change, and the reproduction is one line: `task sync` in a
+clean checkout, then `ls .augment/rules | wc -l` against
+`ls ~/.augment/rules | wc -l`.
+
+## Two-session collision — what it cost, measured
+
+Recorded because the cost was real and is invisible from the merge log. #1588
+was rebuilt over this session's commits twice; the first rebuild discarded a
+merge and a census re-anchor, the second retained the re-anchor (verified with
+`git merge-base --is-ancestor`). #1590's branch tip moved under an in-flight
+sync once. Each collision costs a full CI cycle (~20–25 min over 38–44 checks),
+and every merge into `main` makes every remaining PR `BEHIND`, which costs
+another. That, not the fixing, is where this run's wall-clock went: nine PRs at
+1–3 CI cycles each, plus four cycles lost to work the other session redid.
+
+The mitigation that worked was mechanical, not social: every PR was synced in
+its **own detached worktree**, never in the shared checkout, so a peer's tip
+moving under an in-flight merge cost a re-run rather than a corrupted index. The
+one thing that would have cost less is a claim protocol on the PR itself, which
+this repository does not have for PRs — only for roadmaps.


### PR DESCRIPTION
The run brief's only required deliverable: one row per PR of the 2026-08-23
drain, appended to the existing `agents/evidence/pr-drain-run-summary.md`
rather than overwriting the 2026-08-20/21 pass.

**Nine PRs processed, nine merged, queue reached zero.** No PR was closed as
superseded, none blocked externally, none exhausted its CI-fix budget (max spend
3 of 6).

What the section records beyond the table:

- **Six root-cause gate fixes**, each with the reasoning that made it the correct
  fix rather than the convenient one — a size baseline *measured* on the merged
  tree instead of picked from a side, a depth-ceiling breach paid by extraction
  following the same file's own precedent, and two ratchets re-anchored with
  stated reasons because the alternative move was structurally unavailable.
- **One real defect, left open with its reproduction.** `task sync` writes
  `.augment/rules` unpartitioned while the host's global layer already delivers
  103 of those rules, so `check_rule_layer_partition` reds `task preflight` for
  every push on an affected machine — on any branch, including `main`. CI cannot
  see it. Fixing it means changing `condense.ts`, which is exactly the drive-by
  a merge-queue drain must not make.
- **The two-session collision cost, measured** rather than implied: four CI
  cycles lost to work a parallel session redid, and the mitigation that actually
  worked (a detached worktree per PR, never the shared checkout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)