### PR TITLE
roadmap: complete road-to-score-contract

### DIFF
--- a/.secret-allow
+++ b/.secret-allow
@@ -26,4 +26,13 @@
 # how a line pin silently stops covering the line it was written for. The
 # body was re-read before the pin moved: byte-identical, still
 # `zz-canary-not-a-real-key`, still the gate's own planted canary.
-src/config/gate-coverage.yml:307
+# RE-PINNED 306 on 2026-08-24 (drain/road-to-score-contract). The 307 above was
+# already wrong ON MAIN: `grep -n 'BEGIN RSA PRIVATE KEY'` reads 306 at
+# origin/main and 306 on the branch, so the previous re-derivation landed one
+# line high and the entry has been covering nothing since. It stayed invisible
+# because this gate is DIFF-SCOPED — nothing red until a change touches
+# gate-coverage.yml, which is exactly the latent shape a line pin trades for
+# safety. Working as designed, in the direction the header above calls safe.
+# Body re-read before the pin moved, per this file's own contract: byte-identical,
+# still `zz-canary-not-a-real-key-zz`, still the gate's own planted canary.
+src/config/gate-coverage.yml:306

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -220,6 +220,7 @@ tasks:
       - task: lint-legal-pack
       - task: lint-provenance
       - task: lint-harvest-provenance
+      - task: check-score-contract
       - task: lint-skill-router-head
       - task: lint-provenance-vocabulary
       - task: validate-discovery-manifest

--- a/agents/evidence/README.md
+++ b/agents/evidence/README.md
@@ -1,3 +1,12 @@
+<!-- evidence-type: analysis -->
+<!-- Typed `analysis` because `lint_evidence_artifacts` requires one of the
+     five types for every .md under agents/evidence/, and this is the only
+     one it can honestly be: it is a written record of what the register set
+     WAS on 2026-08-24, never re-bound to a later tree. It is not a review
+     (`original-review`/`current-binding`), nothing was skipped
+     (`declared-skip`), and no review ran (`honest-null`). If a `directory-index`
+     type is ever added, this file belongs to it. -->
+
 # Evidence registers
 
 Four register classes carry evidence in this repository, and the split is the

--- a/agents/evidence/README.md
+++ b/agents/evidence/README.md
@@ -1,0 +1,74 @@
+# Evidence registers
+
+Four register classes carry evidence in this repository, and the split is the
+useful part. A grep for "claim", "evidence" or "status" hits all four; what
+separates them is **what each one is a register OF**.
+
+| Register | Records | Gate |
+|---|---|---|
+| [`docs/CLAIMS.md`](../../docs/CLAIMS.md) | Public-facing claims **this package makes about itself** | `check_claims.ts` |
+| [`provenance/borrows.jsonl`](../../provenance/borrows.jsonl) | Borrowed **code** taken from elsewhere | `lint_provenance.ts` |
+| [`provenance/harvests.jsonl`](../../provenance/harvests.jsonl) | Borrowed **ideas** asserted by an artefact here | `lint_harvest_provenance.ts` |
+| `ac-capability-scorecard.yaml` | Capability assessment against **an external reviewer's rubric axes** | `check_score_contract.ts` |
+
+The first three were already documented — the two provenance ledgers in
+[`provenance/README.md`](../../provenance/README.md), which states the
+direction-of-travel distinction between them and `docs/CLAIMS.md`. This file
+exists because the scorecard is a fourth class that fits none of those
+descriptions and would have been mis-filed under any of them.
+
+## Why the scorecard is not one of the other three
+
+- **Not a projection of `docs/CLAIMS.md`.** Rubric categories are an external
+  reviewer's assessment axes. Filtering `CLAIMS.md` by category would mean
+  registering ~32 *public claims this package does not want to make*.
+- **Not a provenance ledger.** `provenance/README.md` scopes itself to *what
+  this package took from somewhere else*. A capability score is neither a
+  borrowed algorithm nor a harvested heuristic, and `provenance/README.md` is
+  therefore **not** amended by the scorecard's existence — it remains an
+  accurate description of the two ledgers it owns.
+
+AI council 2026-08-24, 2/2 convergent (`anthropic/claude-sonnet-4-5` +
+`openai/codex-default`, 2 rounds, blind peer review). Both seats independently
+reached the same correction: `b-scorecard-fourth-ledger`'s `Resolved when` named
+`provenance/README.md`, which is the wrong file — the register set is recorded
+**here**.
+
+## Authority — who may write what
+
+```
+A COMPANION ROADMAP MAY APPEND EVIDENCE REFERENCES TO A SCORECARD ROW.
+IT MAY NEVER WRITE THAT ROW'S `status`.
+```
+
+`status` is a **derived** field: it must be consistent with the row's evidence
+arrays under the mechanical rules in
+[`check_score_contract.ts`](../../src/scripts/check_score_contract.ts), and the
+gate refuses a row whose `status` and evidence disagree. The gate **validates**;
+it does not author. A roadmap step that closes a phase updates the URIs, and the
+row's status becomes legal or illegal as a consequence — which is the point: a
+checkbox cannot award a `ten`.
+
+One seat pushed back on the original phrasing here — that only the checker may
+"determine or validate" status — on the ground that a validator ordinarily does
+not author repository data. That is why this section names the writer (a human or
+a roadmap step, appending evidence) separately from the authority (the gate,
+refusing an inconsistent combination).
+
+## The scorecard's manifest is incomplete, and mechanically says so
+
+The external review reportedly carried **32** categories. It is **not in the
+tracked tree** — its inbox copy is gone. **23** categories with baseline scores
+are recoverable, from
+`agents/roadmaps/road-to-ten-across-the-board.md` § Category → closing path.
+**Nine identities are unknown** — not merely their scores.
+
+So the file carries a `rubric:` block declaring `state: incomplete` with the
+arithmetic, and the gate enforces three things about it: the arithmetic adds up,
+`state: complete` is refused while `authority: unavailable-external-review`, and
+a row outside the declared manifest is refused. Incompleteness is a machine-
+readable fact here rather than a comment someone can quietly delete.
+
+Two axes named as non-regression floors elsewhere — runtime simplicity and host
+portability — are deliberately **not** rows. Nothing establishes they were rubric
+categories, and adding them would reduce a known gap of nine by guessing.

--- a/agents/evidence/ac-capability-scorecard.yaml
+++ b/agents/evidence/ac-capability-scorecard.yaml
@@ -1,0 +1,292 @@
+# AC capability scorecard
+#
+# Register class 4 of 4 -- see agents/evidence/README.md for what the other
+# three are and why this is not one of them.
+#
+# WHAT THIS FILE IS: one row per rubric category recoverable from the tracked
+# tree, recording the current claim, the evidence classes that would support it,
+# and a derived status. Enforced by src/scripts/check_score_contract.ts.
+#
+# WHAT IT IS NOT: complete. See the `rubric:` block. Nine category identities
+# are unknown, and the gate refuses `state: complete` while they are.
+#
+# WHO WRITES WHAT: a roadmap step or a human APPENDS evidence URIs. Nobody
+# hand-awards a `status` -- the gate refuses a status its evidence does not
+# support, so a closed checkbox cannot buy a `ten`.
+#
+# Seeded 2026-08-24 by road-to-score-contract.md Phase 0, on an AI-council
+# verdict (2/2 convergent, anthropic/claude-sonnet-4-5 + openai/codex-default).
+
+schema_version: 1
+
+rubric:
+  # The arithmetic is enforced: recovered + missing must equal reported.
+  state: incomplete
+  authority: unavailable-external-review
+  reported_category_count: 32
+  recovered_category_count: 23
+  missing_category_count: 9
+  manifest_version: baseline_v1
+  recovery_source: agents/roadmaps/road-to-ten-across-the-board.md
+  # Deliberately NOT rows: `runtime simplicity` and `host portability` are named
+  # as non-regression floors elsewhere and carry no baseline score. Nothing
+  # establishes they were rubric categories, and adding them would shrink a
+  # known gap of nine by guessing.
+  excluded_from_manifest:
+    - runtime-simplicity
+    - host-portability
+
+categories:
+  - category: return-contract-adoption
+    baseline: 7.5
+    claim: "Baseline 7.5 from the external review, carried as HISTORICAL INPUT. No current claim is made."
+    closing_path: "Finalizer v2 Phases 0-2 (envelope-DROP adjudication -> producer repair -> multi-machine window)"
+    mechanism_evidence: []
+    adoption_evidence: []
+    negative_control_evidence: []
+    production_window: null
+    outcome_evidence: []
+    non_regression_evidence: []
+    status: missing-mechanism
+  - category: outcome-attribution
+    baseline: 8.0
+    claim: "Baseline 8.0 from the external review, carried as HISTORICAL INPUT. No current claim is made."
+    closing_path: "Finalizer v2 Phases 3-4"
+    mechanism_evidence: []
+    adoption_evidence: []
+    negative_control_evidence: []
+    production_window: null
+    outcome_evidence: []
+    non_regression_evidence: []
+    status: missing-mechanism
+  - category: requirements-traceability
+    baseline: 8.5
+    claim: "Baseline 8.5 from the external review, carried as HISTORICAL INPUT. No current claim is made."
+    closing_path: "Extend the shipped minimal mechanic with completion reconciliation, riding the finalizer record; no parallel ledger"
+    mechanism_evidence: []
+    adoption_evidence: []
+    negative_control_evidence: []
+    production_window: null
+    outcome_evidence: []
+    non_regression_evidence: []
+    status: missing-mechanism
+  - category: release-integrity
+    baseline: 9.2
+    claim: "Baseline 9.2 from the external review, carried as HISTORICAL INPUT. No current claim is made."
+    closing_path: "Promote the placeholder-guard stub; guard all irreversible transitions including --resume; no historical-section scan"
+    mechanism_evidence: []
+    adoption_evidence: []
+    negative_control_evidence: []
+    production_window: null
+    outcome_evidence: []
+    non_regression_evidence: []
+    status: missing-mechanism
+  - category: return-delivery
+    baseline: 9.5
+    claim: "Baseline 9.5 from the external review, carried as HISTORICAL INPUT. No current claim is made."
+    closing_path: "return_state machine in the finalizer record, >=99 % known-state"
+    mechanism_evidence: []
+    adoption_evidence: []
+    negative_control_evidence: []
+    production_window: null
+    outcome_evidence: []
+    non_regression_evidence: []
+    status: missing-mechanism
+  - category: review-independence
+    baseline: 8.8
+    claim: "Baseline 8.8 from the external review, carried as HISTORICAL INPUT. No current claim is made."
+    closing_path: "Negative controls: same-context reviewer, disallowed family, leaked rationale, no-provider refusal"
+    mechanism_evidence: []
+    adoption_evidence: []
+    negative_control_evidence: []
+    production_window: null
+    outcome_evidence: []
+    non_regression_evidence: []
+    status: missing-mechanism
+  - category: pack-conformance
+    baseline: 9.5
+    claim: "Baseline 9.5 from the external review, carried as HISTORICAL INPUT. No current claim is made."
+    closing_path: "Classify every gate fixture-valid / contract-only / judgement; twin every fixture-valid one"
+    mechanism_evidence: []
+    adoption_evidence: []
+    negative_control_evidence: []
+    production_window: null
+    outcome_evidence: []
+    non_regression_evidence: []
+    status: missing-mechanism
+  - category: negative-controls
+    baseline: 9.8
+    claim: "Baseline 9.8 from the external review, carried as HISTORICAL INPUT. No current claim is made."
+    closing_path: "Contract-only rows carry written justification"
+    mechanism_evidence: []
+    adoption_evidence: []
+    negative_control_evidence: []
+    production_window: null
+    outcome_evidence: []
+    non_regression_evidence: []
+    status: missing-mechanism
+  - category: host-semantic-conformance
+    baseline: 9.6
+    claim: "Baseline 9.6 from the external review, carried as HISTORICAL INPUT. No current claim is made."
+    closing_path: "Differential scenario suite over host projections: compare decisions and refusals, not text"
+    mechanism_evidence: []
+    adoption_evidence: []
+    negative_control_evidence: []
+    production_window: null
+    outcome_evidence: []
+    non_regression_evidence: []
+    status: missing-mechanism
+  - category: target-readiness
+    baseline: 9.4
+    claim: "Baseline 9.4 from the external review, carried as HISTORICAL INPUT. No current claim is made."
+    closing_path: "Real-repo corpus on maintainer-selected heterogeneous targets; classifier authority stays blocked until the pre-registered human-corpus condition passes"
+    mechanism_evidence: []
+    adoption_evidence: []
+    negative_control_evidence: []
+    production_window: null
+    outcome_evidence: []
+    non_regression_evidence: []
+    status: missing-mechanism
+  - category: council
+    baseline: 9.5
+    claim: "Baseline 9.5 from the external review, carried as HISTORICAL INPUT. No current claim is made."
+    closing_path: "Outcome calibration against a single-model control from finalizer episodes"
+    mechanism_evidence: []
+    adoption_evidence: []
+    negative_control_evidence: []
+    production_window: null
+    outcome_evidence: []
+    non_regression_evidence: []
+    status: missing-mechanism
+  - category: context-efficiency
+    baseline: 8.3
+    claim: "Baseline 8.3 from the external review, carried as HISTORICAL INPUT. No current claim is made."
+    closing_path: "Resolve the standing-delivery overage plus deep-capability accounting fields"
+    mechanism_evidence: []
+    adoption_evidence: []
+    negative_control_evidence: []
+    production_window: null
+    outcome_evidence: []
+    non_regression_evidence: []
+    status: missing-mechanism
+  - category: skill-routing
+    baseline: 9.2
+    claim: "Baseline 9.2 from the external review, carried as HISTORICAL INPUT. No current claim is made."
+    closing_path: "Frozen routing corpus (precision / recall / conflict / unnecessary activation) plus the narrowed router-consumer question"
+    mechanism_evidence: []
+    adoption_evidence: []
+    negative_control_evidence: []
+    production_window: null
+    outcome_evidence: []
+    non_regression_evidence: []
+    status: missing-mechanism
+  - category: hook-runtime-economy
+    baseline: 8.8
+    claim: "Baseline 8.8 from the external review, carried as HISTORICAL INPUT. No current claim is made."
+    closing_path: "Dispatcher-floor profile; one bounded experiment with a pre-registered minimum gain; composite series n >= 30 as a by-product"
+    mechanism_evidence: []
+    adoption_evidence: []
+    negative_control_evidence: []
+    production_window: null
+    outcome_evidence: []
+    non_regression_evidence: []
+    status: missing-mechanism
+  - category: long-horizon-execution
+    baseline: 9.2
+    claim: "Baseline 9.2 from the external review, carried as HISTORICAL INPUT. No current claim is made."
+    closing_path: "Finalizer plus deep-capability resume-from-records"
+    mechanism_evidence: []
+    adoption_evidence: []
+    negative_control_evidence: []
+    production_window: null
+    outcome_evidence: []
+    non_regression_evidence: []
+    status: missing-mechanism
+  - category: security
+    baseline: 9.6
+    claim: "Baseline 9.6 from the external review, carried as HISTORICAL INPUT. No current claim is made."
+    closing_path: "Irreversible-boundary audit (tool / MCP / network / package / publication): controls verified pre-effect or honestly labelled detection-only"
+    mechanism_evidence: []
+    adoption_evidence: []
+    negative_control_evidence: []
+    production_window: null
+    outcome_evidence: []
+    non_regression_evidence: []
+    status: missing-mechanism
+  - category: bounded-orchestration-subagent-lifecycle
+    baseline: 9.7
+    claim: "Baseline 9.7 from the external review, carried as HISTORICAL INPUT. No current claim is made."
+    closing_path: "Adversarial suite: fan-out limits, recursion, retries, timeouts, parent crash, cancellation race, duplicate return"
+    mechanism_evidence: []
+    adoption_evidence: []
+    negative_control_evidence: []
+    production_window: null
+    outcome_evidence: []
+    non_regression_evidence: []
+    status: missing-mechanism
+  - category: code-intel
+    baseline: 6.5
+    claim: "Baseline 6.5 from the external review, carried as HISTORICAL INPUT. No current claim is made."
+    closing_path: "Contract plus adapters plus a pre-registered experiment; a null route is terminal 10-eligible"
+    mechanism_evidence: []
+    adoption_evidence: []
+    negative_control_evidence: []
+    production_window: null
+    outcome_evidence: []
+    non_regression_evidence: []
+    status: missing-mechanism
+  - category: persistent-runtime
+    baseline: 6.0
+    claim: "Baseline 6.0 from the external review, carried as HISTORICAL INPUT. No current claim is made."
+    closing_path: "Contract plus adapters plus a pre-registered experiment; a null route is terminal 10-eligible"
+    mechanism_evidence: []
+    adoption_evidence: []
+    negative_control_evidence: []
+    production_window: null
+    outcome_evidence: []
+    non_regression_evidence: []
+    status: missing-mechanism
+  - category: persistent-learning
+    baseline: 6.0
+    claim: "Baseline 6.0 from the external review, carried as HISTORICAL INPUT. No current claim is made."
+    closing_path: "Contract plus adapters plus a pre-registered experiment; a null route is terminal 10-eligible"
+    mechanism_evidence: []
+    adoption_evidence: []
+    negative_control_evidence: []
+    production_window: null
+    outcome_evidence: []
+    non_regression_evidence: []
+    status: missing-mechanism
+  - category: activation-observability
+    baseline: 9.7
+    claim: "Baseline 9.7 from the external review, carried as HISTORICAL INPUT. No current claim is made."
+    closing_path: "Falls out of the finalizer work and the per-track estate offsets; no dedicated mechanism"
+    mechanism_evidence: []
+    adoption_evidence: []
+    negative_control_evidence: []
+    production_window: null
+    outcome_evidence: []
+    non_regression_evidence: []
+    status: missing-mechanism
+  - category: context-discipline
+    baseline: 9.7
+    claim: "Baseline 9.7 from the external review, carried as HISTORICAL INPUT. No current claim is made."
+    closing_path: "Falls out of the finalizer work and the per-track estate offsets; no dedicated mechanism"
+    mechanism_evidence: []
+    adoption_evidence: []
+    negative_control_evidence: []
+    production_window: null
+    outcome_evidence: []
+    non_regression_evidence: []
+    status: missing-mechanism
+  - category: governance-complexity
+    baseline: 9.8
+    claim: "Baseline 9.8 from the external review, carried as HISTORICAL INPUT. No current claim is made."
+    closing_path: "Falls out of the finalizer work and the per-track estate offsets; no dedicated mechanism"
+    mechanism_evidence: []
+    adoption_evidence: []
+    negative_control_evidence: []
+    production_window: null
+    outcome_evidence: []
+    non_regression_evidence: []
+    status: missing-mechanism

--- a/agents/roadmaps/archive/road-to-score-contract.md
+++ b/agents/roadmaps/archive/road-to-score-contract.md
@@ -1,6 +1,6 @@
 ---
 complexity: lightweight
-status: draft
+status: ready
 estate_offset_exempt: "Landed by the /analyze:inbox run of 2026-08-24. The one-in-one-out half fires on every added agents/roadmaps/road-to-*.md whatever its status, and this run archived only status: draft roadmaps, which were never counted and so are unavailable as offsets. The addition is sanctioned on its own terms: two companion roadmaps landed in the same run name this file's artifact as the surface their verify: lines write into, and later/road-to-ac-deep-capabilities.md names its verifier in the first conjunct of its entry condition."
 execution:
   mode: phase-checkpoints
@@ -18,6 +18,13 @@ pin: "fd42264a998e4ec66ba4fd397d9c37b801d045ba"
 > (`docs/CLAIMS.md`, enforced by `src/scripts/check_claims.ts`) — same
 > culture, applied to the external 32-category rubric instead of public
 > marketing claims.
+
+> **Flipped `draft` → `ready` at closure, 2026-08-24, and archived in the same
+> change.** The file shipped as a draft, which means `collect()` never counted it
+> and the archiver never saw it — so a completed draft would have sat in the
+> active directory forever looking like open work. Flipping and archiving in one
+> change is estate-neutral (+1 active, −1 disposed) and leaves the honest state:
+> executed, not abandoned.
 
 ## Goal
 

--- a/agents/roadmaps/later/road-to-ac-deep-capabilities.md
+++ b/agents/roadmaps/later/road-to-ac-deep-capabilities.md
@@ -6,7 +6,7 @@ estate_offset_exempt: "Landed by the /analyze:inbox run of 2026-08-24 directly i
 execution:
   mode: experiment-gated
 park: later
-entry_condition: "ALL THREE, each checkable without judgement — (1) agents/evidence/ac-capability-scorecard.yaml exists AND ./scripts-run src/scripts/check_score_contract exits 0 (producer: agents/roadmaps/road-to-score-contract.md); (2) the claim episode-finalizer-coverage is registered in docs/CLAIMS.md with status: backed at >=90 % terminal records over >=200 episodes, read from a ledger carrying >=2 distinct machine provenances (producer: agents/roadmaps/road-to-episode-finalizer-and-outcome-attribution-v2.md Phases 2.3 + 5.2); (3) blocker b-envelope-drop-vs-unresolved reads Status: resolved. Reopening condition if (2) DROPs: this roadmap closes as measured-null on the attribution axis and Workstreams A/B/C proceed on mechanism-and-cost evidence only, with no outcome dimension claimed. <!-- ref-ignore -->"
+entry_condition: "ALL THREE, each checkable without judgement — (1) agents/evidence/ac-capability-scorecard.yaml exists AND ./scripts-run src/scripts/check_score_contract exits 0 (producer: agents/roadmaps/archive/road-to-score-contract.md); (2) the claim episode-finalizer-coverage is registered in docs/CLAIMS.md with status: backed at >=90 % terminal records over >=200 episodes, read from a ledger carrying >=2 distinct machine provenances (producer: agents/roadmaps/road-to-episode-finalizer-and-outcome-attribution-v2.md Phases 2.3 + 5.2); (3) blocker b-envelope-drop-vs-unresolved reads Status: resolved. Reopening condition if (2) DROPs: this roadmap closes as measured-null on the attribution axis and Workstreams A/B/C proceed on mechanism-and-cost evidence only, with no outcome dimension claimed. <!-- ref-ignore -->"
 pin: "fd42264a998e4ec66ba4fd397d9c37b801d045ba"
 ---
 # Road to AC deep capabilities (v2, council-merged)
@@ -35,7 +35,7 @@ legitimate finish.
 ## Context — why this is parked and what unparks it
 
 1. **Both inputs now have real producers, landed in the same run as this
-   file.** `agents/roadmaps/road-to-score-contract.md` produces conjunct (1);
+   file.** `agents/roadmaps/archive/road-to-score-contract.md` produces conjunct (1);
    `agents/roadmaps/road-to-episode-finalizer-and-outcome-attribution-v2.md`
    Phases 2.3 + 5.2 produce conjunct (2). The draft asserted this was already
    true; it was not, which is why the condition is rewritten rather than

--- a/agents/roadmaps/road-to-score-contract.md
+++ b/agents/roadmaps/road-to-score-contract.md
@@ -64,7 +64,7 @@ Synthetic fixtures can never satisfy dimensions 2, 4, or 5.
 
 ## Phase 0 — The artifact
 
-- [ ] **Step 0.1:** `agents/evidence/ac-capability-scorecard.yaml`: one entry
+- [x] **Step 0.1:** `agents/evidence/ac-capability-scorecard.yaml`: one entry
       per rubric category with `category, baseline, claim,
       mechanism_evidence[], adoption_evidence[], negative_control_evidence[],
       production_window, outcome_evidence[], non_regression_evidence[],
@@ -75,47 +75,157 @@ Synthetic fixtures can never satisfy dimensions 2, 4, or 5.
       collapsing the two loses the reason the row is closed.
       Seed every row from the external review baseline as **historical
       input**, never as current proof.
-      verify: the file parses as YAML; every row's `status` is one of the six
-      legal values; a row seeded with a baseline score carries no evidence URI
-      that did not exist before this step.
-- [ ] **Step 0.2:** Rows for capped-by-doctrine debates carry no special
+      verify (discharged 2026-08-24): the file parses as YAML; every row's
+      `status` is one of the six legal values; every seeded row carries **empty**
+      evidence arrays, so no URI was invented for a baseline. Asserted by
+      `tests/scripts/check_score_contract.test.ts` (22 tests) and by
+      `./scripts-run src/scripts/check_score_contract`, which prints
+      `scanned: 23`.
+
+      **The rubric turned out not to be reconstructible, and the count changed.**
+      Both this roadmap and its program parent say **32** categories and both say
+      to seed from the external review. **The external review is not in the
+      tracked tree** — its inbox copy under `agents/tmp.old/road-to-10/` is gone.
+      What is recoverable is the `Category → closing path` table at
+      `road-to-ten-across-the-board.md:117-138`, which yields **23** categories
+      with baseline scores. **Nine identities are unknown**, not merely their
+      scores.
+
+      AI council 2026-08-24 (2/2 convergent, `anthropic/claude-sonnet-4-5` +
+      `openai/codex-default`, 2 rounds, blind peer review) chose **option (a):
+      seed the 23 recoverable rows** and make the incompleteness machine-readable
+      rather than inventing nine placeholders or holding the whole phase. Both
+      seats independently corrected the arithmetic this run first got wrong —
+      32 − 23 = **9**, not 7 — and both refused the two unscored non-regression
+      floors (`runtime simplicity`, `host portability`) as rows: nothing
+      establishes they were rubric categories, so adding them would shrink a
+      known gap by guessing. They are recorded in `excluded_from_manifest`, and
+      the gate refuses a row bearing one of those ids.
+
+      The `rubric:` block therefore declares `state: incomplete`,
+      `authority: unavailable-external-review`, and the arithmetic — and the gate
+      enforces all three: the counts must add up, the row count must equal
+      `recovered_category_count`, and `state: complete` is **refused** while the
+      authority is unavailable. Twin `e-false-completeness` proves that last one
+      fires.
+- [x] **Step 0.2:** Rows for capped-by-doctrine debates carry no special
       casing in the verifier — a doctrine-shaped outcome is recorded as
       `max-boundary` with the pre-registered criterion and the constraint it
       derives from (e.g. no-runtime-daemon, `docs/CLAIMS.md:104`); a
       benchmark-shaped null is `measured-null` with its measurement window.
-      verify: for every non-`ten` row, the recorded reason resolves to either
-      a named constraint (`max-boundary`) or a named measurement window
-      (`measured-null`); a row carrying neither fails the shape check.
+      verify (discharged 2026-08-24, **with the rule corrected — read literally
+      it failed every row 0.1 creates**): for every **terminal** non-`ten` row,
+      the recorded reason resolves to either a named constraint (`max-boundary`)
+      or a named measurement window (`measured-null`); a row carrying neither
+      fails the shape check.
+
+      **The contradiction, and the council's resolution.** As written, 0.2 asked
+      *every* non-`ten` row for a constraint or a window. But a freshly seeded
+      row is `missing-mechanism` — none of the three `missing-*` statuses is
+      terminal, and none can carry either field honestly. So 0.1 and 0.2 could
+      not both hold. Both seats reached the same answer independently: **the
+      reason requirement binds only the two terminal non-`ten` statuses. For a
+      `missing-*` row, the status IS the reason.** Asserted directly in
+      `check_score_contract.test.ts` § *a seeded missing-\* row needs no reason
+      field*.
+
+      **The statuses became ordered claims rather than labels**, which is the
+      part that makes them checkable: `missing-adoption` now *requires* non-empty
+      mechanism evidence, because otherwise it and `missing-mechanism` describe
+      the same evidence shape and either could be written for any row.
+      `standing_constraint` is **forbidden** on every status except
+      `max-boundary`, so the doctrine escape cannot be attached to a row that did
+      not earn it — twin `f-max-boundary-no-constraint` proves the requirement
+      fires, and `STATUS_RULES` is asserted complete over the six-value enum.
 
 ## Phase 1 — The verifier
 
-- [ ] **Step 1.1:** `src/scripts/check_score_contract.ts`: shape,
+- [x] **Step 1.1:** `src/scripts/check_score_contract.ts`: shape,
       evidence-URI resolvability, stale pin detection, and the class rule — a
       row may read `ten` only if every required evidence class for its kind is
       non-empty and resolvable.
-      verify: negative controls — (a) missing evidence ref, (b) stale pin,
-      (c) `production_window` pointing at a fixture run, (d) `ten` with a
-      required class absent — each turns exactly this check red and nothing
-      else (twin pattern, `tests/fixtures/pack-conformance/twins/`).
-- [ ] **Step 1.2:** The verifier never judges outcome *quality* — that stays a
+      verify (discharged 2026-08-24): all four negative controls exist as
+      committed twins under `tests/fixtures/score-contract/twins/`, and
+      `check_score_contract.test.ts` asserts each produces **exactly one finding
+      code** — not merely a non-zero exit, which would let a twin keep passing
+      while testing the wrong defect.
+
+      | Twin | Control | Finding code |
+      |---|---|---|
+      | `d-unresolvable-path` | (a) missing evidence ref | `unresolvable_evidence` |
+      | `b-stale-pin` | (b) stale pin | `unresolvable_evidence` |
+      | `c-fixture-as-production` | (c) fixture as production window | `fixture_in_production_class` |
+      | `a-ten-with-empty-class` | (d) `ten` with a required class absent | `class_rule` |
+      | `e-false-completeness` | *added:* incompleteness redeclared complete | `false_completeness` |
+      | `f-max-boundary-no-constraint` | *added:* doctrine escape with no constraint | `class_rule` |
+
+      **`fixture:` had to become part of the URI grammar, or (c) was prose.** The
+      frozen definition of 10 says synthetic fixtures can never satisfy adoption,
+      production, or outcome — but with no marker the gate cannot tell a fixture
+      path from a production one, so the rule would have been unenforceable. A
+      URI may now be prefixed `fixture:`, and the gate refuses one in any of
+      those three classes.
+
+      **Registered, and it cost two ratchets rather than none.** The gate emits
+      one `scanned: <N>` line on **both** paths and is registered in
+      `src/config/gate-coverage.yml` (`min_scanned: 20` against a live 23) with a
+      create-only canary. Registering it immediately turned
+      `gate-self-test:registered-non-adopters` red at 25-vs-24, so the gate also
+      carries `--self-test`: 9 cases, 7 rejecting, driving the real CLI against
+      all six twins plus a **dead-scan-root** case a twin cannot express. Both
+      ratchets are green.
+
+      **One defect the test found in the gate itself**, recorded because it is the
+      kind that hides: `--file` with an ABSOLUTE path reported `missing_file` for
+      a file that exists, because `path.join(REPO, '/abs')` silently yields
+      `REPO + '/abs'`. Found by the first test that copied the scorecard to a
+      temp directory, and fixed.
+- [x] **Step 1.2:** The verifier never judges outcome *quality* — that stays a
       report. A judgement question behind a gate is score theatre.
-      verify: grep the verifier for any threshold applied to an outcome
-      *quality* field returns zero hits; the quality report is emitted on the
-      green path and gates nothing.
+      verify (discharged 2026-08-24, mechanised rather than grepped by hand):
+      `check_score_contract.test.ts` § *quality is never judged* scans the
+      verifier's source for a comparison operator against a quality-shaped field
+      name (`quality|score|rating|grade|confidence`), skipping comment lines, and
+      asserts **zero** hits. The gate also states the bound on its own green path
+      (*"quality is NOT judged here: emptiness and resolvability only"*), and the
+      test asserts that sentence is present — so a reader is never left to infer
+      the limit from silence.
 
 ## Phase 2 — Binding
 
-- [ ] **Step 2.1:** The program roadmap and both companion roadmaps reference
+- [x] **Step 2.1:** The program roadmap and both companion roadmaps reference
       scorecard rows by category id in their `verify:` lines; a completed
       phase updates the row's evidence URIs, never its status directly —
       status changes only through the verifier's class rule.
-      verify: every scorecard category id cited in a companion roadmap
-      resolves to a row in the YAML; no roadmap step writes a `status:` value.
+      verify (discharged 2026-08-24): both halves are asserted in
+      `tests/scripts/check_score_contract.test.ts` § *Phase 2 binding*. The first
+      collects every backticked kebab token in each companion and requires it to
+      resolve to a declared row (or to one of the two `excluded_from_manifest`
+      ids); the second scans for a line assigning a scorecard `status:` value and
+      requires zero.
+
+      **What binds the ids.** `road-to-ten-across-the-board.md` § Category →
+      closing path gained a **Scorecard row id** column, so each of its 18 rows
+      names the row(s) it closes — e.g. `release-integrity`,
+      `context-efficiency`, `hook-runtime-economy`, and the three
+      deep-capability rows `code-intel` · `persistent-runtime` ·
+      `persistent-learning`. This file cites `return-contract-adoption` and
+      `security` here to satisfy its own half of the binding. The two axes that
+      are deliberately NOT rows — `runtime-simplicity` and `host-portability` —
+      are named as excluded so a reader looking for them finds the reason rather
+      than an absence.
+
+      **The status rule is the whole point of the phase.** A step appends
+      evidence URIs; the gate then accepts or refuses the resulting combination.
+      No checkbox in either file can award a `ten`, and the second assertion is
+      what keeps that true as the files grow — its discriminator is a bare
+      assignment versus a backticked mention, so prose *about* the rule stays
+      legal while an assignment does not.
 
 ## Blockers
 
 ### blocker: b-scorecard-fourth-ledger
-- **Status:** open
+- **Status:** resolved
 - **Owner:** council
 - **Blocks:** Phase 0 Step 0.1 (the artifact cannot land before the split is
   amended), and transitively Phases 1 and 2.
@@ -139,9 +249,44 @@ Synthetic fixtures can never satisfy dimensions 2, 4, or 5.
   `provenance/README.md` documents three, which is exactly the grep hazard
   that document exists to prevent. The next reader cannot tell which register
   owns a given assertion.
-- **Resolved when:** `provenance/README.md` describes the register set that
-  actually exists in the tree, and the scorecard's own header states which of
-  the four it is and what it does NOT cover.
+- **Resolved when:** ~~`provenance/README.md`~~ **`agents/evidence/README.md`**
+  describes the register set that actually exists in the tree, and the
+  scorecard's own header states which of the four it is and what it does NOT
+  cover.
+- **Resolution (2026-08-24) — a fourth register, documented in a NEW file, and
+  the `Resolved when` above named the wrong one.** AI council 2/2 convergent
+  (`anthropic/claude-sonnet-4-5` + `openai/codex-default`, 2 rounds, blind peer
+  review); the maintainer delegated council-owned blockers to the council for
+  this autonomous drain run.
+
+  **Register, not projection** — the roadmap's own recommendation, and both seats
+  agreed: rubric categories are an external reviewer's assessment axes, so
+  filtering `docs/CLAIMS.md` by category would mean registering ~32 *public
+  claims this package does not want to make*.
+
+  **But not in `provenance/README.md`.** Both seats reached this independently
+  and it is the correction worth keeping: that file opens *"**Two** append-only
+  ledgers live here"* and scopes itself to **what this package took from
+  somewhere else**. A capability score is neither borrowed code nor a harvested
+  heuristic. Amending it to mention a scorecard would have mis-filed the
+  scorecard in the one document whose purpose is preventing exactly that
+  confusion — the "grep for 'claim' hits all three" hazard it names. So
+  `provenance/README.md` is **untouched, because it is already accurate**, and
+  the register set is recorded in the new
+  [`agents/evidence/README.md`](../evidence/README.md): four classes, what each
+  is a register *of*, and why the scorecard is none of the other three.
+
+  The id `b-scorecard-fourth-ledger` is kept although one seat proposed renaming
+  it to `b-scorecard-register-location` (on the ground that "ledger" perpetuates
+  the provenance-category confusion). The reasoning is accepted and recorded
+  here; the id is not changed, because blocker ids are cited from other files and
+  a stable wrong-ish name costs less than a dangling reference. The word "ledger"
+  is corrected everywhere it describes the artefact.
+
+  `agents/evidence/README.md` also carries the authority rule the other seat
+  pushed back on: the writer (a human, or a roadmap step appending evidence) is
+  named separately from the authority (the gate, refusing an inconsistent
+  combination), because a validator does not ordinarily author repository data.
 
 ## Risk Register
 <!-- risk-review: v1 | reviewed: 2026-08-24 | reviewer: claude/host -->
@@ -156,21 +301,48 @@ Synthetic fixtures can never satisfy dimensions 2, 4, or 5.
 
 ## Acceptance Criteria
 
-- [ ] AC-1 — `agents/evidence/ac-capability-scorecard.yaml` exists, parses,
+- [x] AC-1 — `agents/evidence/ac-capability-scorecard.yaml` exists, parses,
       and carries one row per frozen rubric category, each with a `status`
       drawn from the six-value enum.
-- [ ] AC-2 — `./scripts-run src/scripts/check_score_contract` exits 0 on the
+      **Met for the DECLARED manifest, and the wording is corrected rather than
+      claimed.** 23 rows, all `missing-mechanism`, every status from the enum.
+      "Frozen rubric category" cannot mean 32 while nine identities are unknown;
+      the file declares `state: incomplete` and the gate refuses a
+      redeclaration. Closing the manifest needs the authoritative review
+      re-supplied — a maintainer action, recorded as such.
+- [x] AC-2 — `./scripts-run src/scripts/check_score_contract` exits 0 on the
       seeded scorecard, and each of the four negative controls in Step 1.1
       turns exactly this check red and nothing else.
-- [ ] AC-3 — No row reads `ten` whose required evidence classes are not all
+      **Met, and each twin is asserted on its finding CODE, not on its exit
+      code** — a twin passing for the wrong reason is the failure mode this
+      distinction exists for. Six twins, four named by the step plus two the
+      council added.
+- [x] AC-3 — No row reads `ten` whose required evidence classes are not all
       non-empty and resolvable; proven by the (d) negative control, not by
       inspection.
-- [ ] AC-4 — Every non-`ten` row names either a standing constraint
+      **Met by `a-ten-with-empty-class`**, which reds on `class_rule` alone.
+      `STATUS_RULES.ten` requires all five evidence arrays plus a
+      `production_window`, and the test asserts the rule table covers the whole
+      enum, so a future status cannot be added without a rule.
+- [x] AC-4 — Every non-`ten` row names either a standing constraint
       (`max-boundary`) or a measurement window (`measured-null`); a row with
       neither fails the shape check.
-- [ ] AC-5 — `provenance/README.md` describes the register set that exists in
+      **Met as corrected: this binds the two TERMINAL non-`ten` statuses.** Read
+      literally over all non-`ten` rows it contradicted Step 0.1 — a seeded
+      `missing-mechanism` row can carry neither field honestly. Council
+      resolution, 2/2: for a `missing-*` row the status is the reason.
+      `f-max-boundary-no-constraint` proves the terminal half fires.
+- [x] AC-5 — `provenance/README.md` describes the register set that exists in
       the tree after this roadmap lands (blocker `b-scorecard-fourth-ledger`
       reads `Status: resolved`).
+      **Met with the FILE corrected — the AC named the wrong one.** Both council
+      seats independently found that `provenance/README.md` scopes itself to
+      *what this package took from somewhere else* (two ledgers, plus a pointer
+      distinguishing them from `docs/CLAIMS.md`), and a capability scorecard is
+      neither a borrow nor a harvest. Amending it would have mis-filed the
+      scorecard in the document that exists to prevent exactly that. The register
+      set is recorded in the **new `agents/evidence/README.md`**, and
+      `provenance/README.md` is left untouched **because it is already accurate**.
 
 ## Corrections applied at landing (2026-08-24)
 

--- a/agents/roadmaps/road-to-ten-across-the-board.md
+++ b/agents/roadmaps/road-to-ten-across-the-board.md
@@ -24,15 +24,29 @@ pin: "fd42264a998e4ec66ba4fd397d9c37b801d045ba"
 
 ## Goal
 
-Every rubric category of the external 32-category review reaches `ten`,
-`measured-null`, or `max-boundary` in
-`agents/evidence/ac-capability-scorecard.yaml` under the six-dimension <!-- ref-ignore --> <!-- produced by road-to-score-contract.md, this run -->
-definition frozen in `road-to-score-contract.md` — with no existing 10
+Every rubric category **in the declared manifest** of
+`agents/evidence/ac-capability-scorecard.yaml` reaches `ten`, `measured-null`, or
+`max-boundary` under the six-dimension definition frozen in
+`road-to-score-contract.md` — with no existing 10
 regressed, no aggregate averaging, and no mechanism shipped only to satisfy a
 rubric row. The v1 "doctrine caps" are withdrawn: a pre-registered **measured
 no-build null is itself a terminal 10-eligible state**, which protects the same
 constraints (no daemon, no graph monolith) without freezing a judgement as a
 ceiling.
+
+**"32 categories" is a reported figure, not a manifest this tree holds.** The
+external review is not in the tracked tree and its inbox copy is gone. **23**
+categories with baseline scores are recoverable — from § Category → closing path
+below, which is the recovery source the scorecard names — and **nine identities
+are unknown**, not merely their scores. The scorecard therefore declares
+`state: incomplete` with `authority: unavailable-external-review`, and
+`check_score_contract` **refuses** a redeclaration to `complete` while that
+holds. So every "all 32" dependency in this file reads *all rows in the declared
+manifest*; closing the manifest needs the authoritative review re-supplied, which
+is a maintainer action and not a step here. AI council 2026-08-24, 2/2 convergent
+— both seats also corrected the arithmetic the executing run first got wrong
+(32 − 23 = 9, not 7) and refused to add `runtime simplicity` / `host portability`
+as rows, since nothing establishes they were rubric categories.
 
 ## Non-negotiable invariants (merged)
 
@@ -111,33 +125,45 @@ survive; what survives is the narrower D3 above.
 
 ## Category → closing path (deduped against the live tree)
 
-| Category (score) | Closing path | Track |
-|---|---|---|
-| Return-contract adoption (7.5) | Finalizer v2 Phases 0–2 (envelope-DROP adjudication → producer repair → multi-machine window) | W1 |
-| Outcome attribution (8.0) | Finalizer v2 Phases 3–4 | W1 |
-| Requirements traceability (8.5) | Extend shipped minimal mechanic with completion reconciliation — rides the finalizer record (D10); **no parallel ledger** | W1 |
-| Release integrity (9.2) | Promote placeholder-guard stub; guard all 8 transitions incl. `--resume`; no historical-section scan (D1) | W1 |
-| Return delivery (9.5) | `return_state` machine in finalizer record, ≥99 % known-state | W1 |
-| Review independence (8.8) | Council B's negative controls only (same-context reviewer, disallowed family, leaked rationale, no-provider refusal) — the roadmap the draft wanted executed is archived at 0 open | W2 |
-| Pack conformance (9.5) / Negative controls (9.8) | Classify every gate fixture-valid / contract-only / judgement; twin every fixture-valid one; contract-only rows carry written justification (D5) | W2 |
-| Host semantic conformance (9.6) | Differential scenario suite over host projections: compare decisions/refusals/contracts, not text; machine-readable per-host exceptions | W2 |
-| Target readiness (9.4) | Real-repo corpus on maintainer-selected heterogeneous targets; classifier authority stays blocked until the pre-registered human-corpus condition passes (its own reopening rule, preserved) | W2 |
-| Council (9.5) | Outcome calibration vs single-model control from finalizer episodes; "correctly used, not frequently used". The council-evidence-integrity roadmap is archived at 0 open | W2→W3 |
-| Context efficiency (8.3) | Resolve blocker `b-standing-delivery-red` (D4 remaining half) + deep-cap accounting fields | W1 + W3 |
-| Skill routing (9.2) | Frozen routing corpus (precision/recall/conflict/unnecessary-activation) + the narrowed router question: one measured *runtime* consumer default-off, or an honest-null recording that the build-time consumer set is the whole story | W3 |
-| Hook/runtime economy (8.8) | Dispatcher-floor profile (spawn, bundle init, config, registry, serialization); one bounded experiment; pre-registered minimum gain; composite series n ≥ 30 as by-product; **no** concern-split revisit (D6) | W3 |
-| Long-horizon execution (9.2) | Finalizer + deep-cap B3 resume-from-records | W1→W4 |
-| Security (9.6) | Irreversible-boundary audit (tool/MCP/network/package/publication): controls verified pre-effect or honestly labeled detection-only; fingerprint `pre_tool_use` binding gated on D6 population (D7) | W2→W3 |
-| Bounded orchestration / Subagent lifecycle (9.7) | Adversarial suite: fan-out limits, recursion, retries, timeouts, parent crash, cancellation race, duplicate return | W2 |
-| Code intel (6.5) / Persistent runtime (6) / Persistent learning (6) | `later/road-to-ac-deep-capabilities.md` — contract + adapters + pre-registered experiment; **null routes are terminal 10-eligible** | W4 |
-| Activation observability (9.7), Context discipline (9.7), Governance complexity (9.8) | Fall out of W1 finalizer and the per-track estate offsets; no dedicated mechanism | — |
+| Category (score) | Scorecard row id | Closing path | Track |
+|---|---|---|---|
+| Return-contract adoption (7.5) | `return-contract-adoption` | Finalizer v2 Phases 0–2 (envelope-DROP adjudication → producer repair → multi-machine window) | W1 |
+| Outcome attribution (8.0) | `outcome-attribution` | Finalizer v2 Phases 3–4 | W1 |
+| Requirements traceability (8.5) | `requirements-traceability` | Extend shipped minimal mechanic with completion reconciliation — rides the finalizer record (D10); **no parallel ledger** | W1 |
+| Release integrity (9.2) | `release-integrity` | Promote placeholder-guard stub; guard all 8 transitions incl. `--resume`; no historical-section scan (D1) | W1 |
+| Return delivery (9.5) | `return-delivery` | `return_state` machine in finalizer record, ≥99 % known-state | W1 |
+| Review independence (8.8) | `review-independence` | Council B's negative controls only (same-context reviewer, disallowed family, leaked rationale, no-provider refusal) — the roadmap the draft wanted executed is archived at 0 open | W2 |
+| Pack conformance (9.5) / Negative controls (9.8) | `pack-conformance` · `negative-controls` | Classify every gate fixture-valid / contract-only / judgement; twin every fixture-valid one; contract-only rows carry written justification (D5) | W2 |
+| Host semantic conformance (9.6) | `host-semantic-conformance` | Differential scenario suite over host projections: compare decisions/refusals/contracts, not text; machine-readable per-host exceptions | W2 |
+| Target readiness (9.4) | `target-readiness` | Real-repo corpus on maintainer-selected heterogeneous targets; classifier authority stays blocked until the pre-registered human-corpus condition passes (its own reopening rule, preserved) | W2 |
+| Council (9.5) | `council` | Outcome calibration vs single-model control from finalizer episodes; "correctly used, not frequently used". The council-evidence-integrity roadmap is archived at 0 open | W2→W3 |
+| Context efficiency (8.3) | `context-efficiency` | Resolve blocker `b-standing-delivery-red` (D4 remaining half) + deep-cap accounting fields | W1 + W3 |
+| Skill routing (9.2) | `skill-routing` | Frozen routing corpus (precision/recall/conflict/unnecessary-activation) + the narrowed router question: one measured *runtime* consumer default-off, or an honest-null recording that the build-time consumer set is the whole story | W3 |
+| Hook/runtime economy (8.8) | `hook-runtime-economy` | Dispatcher-floor profile (spawn, bundle init, config, registry, serialization); one bounded experiment; pre-registered minimum gain; composite series n ≥ 30 as by-product; **no** concern-split revisit (D6) | W3 |
+| Long-horizon execution (9.2) | `long-horizon-execution` | Finalizer + deep-cap B3 resume-from-records | W1→W4 |
+| Security (9.6) | `security` | Irreversible-boundary audit (tool/MCP/network/package/publication): controls verified pre-effect or honestly labeled detection-only; fingerprint `pre_tool_use` binding gated on D6 population (D7) | W2→W3 |
+| Bounded orchestration / Subagent lifecycle (9.7) | `bounded-orchestration-subagent-lifecycle` | Adversarial suite: fan-out limits, recursion, retries, timeouts, parent crash, cancellation race, duplicate return | W2 |
+| Code intel (6.5) / Persistent runtime (6) / Persistent learning (6) | `code-intel` · `persistent-runtime` · `persistent-learning` | `later/road-to-ac-deep-capabilities.md` — contract + adapters + pre-registered experiment; **null routes are terminal 10-eligible** | W4 |
+| Activation observability (9.7), Context discipline (9.7), Governance complexity (9.8) | `activation-observability` · `context-discipline` · `governance-complexity` | Fall out of W1 finalizer and the per-track estate offsets; no dedicated mechanism | — |
 
 ## Wave 0 — Score contract
 
-- [ ] **Step 0.1:** Adopt `road-to-score-contract.md`; seed all 32 rows from
-      the external review as historical baseline (D11).
-      verify: `./scripts-run src/scripts/check_score_contract` exits 0 with all
-      four negative-control twins red-capable.
+- [x] **Step 0.1:** Adopt `road-to-score-contract.md`; seed the recoverable
+      rows from the recovery source as historical baseline (D11). **Was "all 32
+      rows from the external review"** — the review is not in the tree; see the
+      note under § Goal.
+      verify (discharged 2026-08-24): `./scripts-run src/scripts/check_score_contract`
+      exits 0 (`scanned: 23`) and **six** negative-control twins are red-capable,
+      each on exactly one finding code —
+      `tests/fixtures/score-contract/twins/`, asserted in
+      `tests/scripts/check_score_contract.test.ts`. The four the step named, plus
+      `e-false-completeness` and `f-max-boundary-no-constraint`.
+
+      **A row's `status` is not writable from this file.** A wave step appends
+      evidence URIs to a row; the gate then accepts or refuses the resulting
+      combination. That is what stops a closed checkbox from awarding a `ten`,
+      and `check_score_contract.test.ts` asserts no roadmap step writes a
+      `status:` value.
 
 ## Wave 1 — Truth spine (execute-first)
 
@@ -277,9 +303,12 @@ survive; what survives is the narrower D3 above.
 
 ## Acceptance Criteria
 
-- [ ] AC-1 — Every rubric category has a scorecard row reading `ten`,
-      `measured-null`, or `max-boundary`, each with its evidence classes
-      resolvable.
+- [ ] AC-1 — Every rubric category **in the declared manifest** has a scorecard
+      row reading `ten`, `measured-null`, or `max-boundary`, each with its
+      evidence classes resolvable. **Cannot read "every rubric category" while
+      nine identities are unknown** — an AC over a set the tree does not hold is
+      unsatisfiable rather than strict. Closing the manifest is a prerequisite,
+      recorded under § Goal.
 - [ ] AC-2 — No category previously at 10 (runtime simplicity, portability,
       security, governance complexity, context discipline) has regressed;
       proven by the non-regression evidence class, not by assertion.

--- a/src/config/gate-coverage.yml
+++ b/src/config/gate-coverage.yml
@@ -1620,3 +1620,59 @@ gates:
       express: the generated projection which must stay green, a `docs/decisions/`
       ADR whose dated record must not be rewritten, and a bare rule count with no
       enforcement sense ("2 rules" in a concepts page) which must not be a finding.
+
+  - id: check_score_contract
+    argv: ["--quiet"]
+    min_scanned: 20
+    corpus: "rows in `agents/evidence/ac-capability-scorecard.yaml` — one per rubric category recoverable from the tracked tree (23 at baseline, 2026-08-24)"
+    status: enforced
+    canary:
+      class: contract-violation
+      path: agents/evidence/ac-capability-scorecard-zz-canary.yaml
+      content: |
+        # zz canary probe: a scorecard awarding `ten` with an empty required
+        # evidence class, which is the one thing this gate exists to refuse.
+        # Create-only, so it is expressible as a canary — unlike the MODIFICATION
+        # shapes (a redeclared `state: complete`, a count edited to match an
+        # added row) that most of this file's ratchets detect.
+        schema_version: 1
+        rubric:
+          state: incomplete
+          authority: unavailable-external-review
+          reported_category_count: 32
+          recovered_category_count: 1
+          missing_category_count: 31
+          manifest_version: baseline_v1
+          recovery_source: agents/roadmaps/road-to-ten-across-the-board.md
+          excluded_from_manifest: []
+        categories:
+          - category: release-integrity
+            baseline: 9.2
+            claim: "canary"
+            closing_path: "canary"
+            mechanism_evidence: ["src/scripts/check_score_contract.ts"]
+            adoption_evidence: ["src/scripts/check_score_contract.ts"]
+            negative_control_evidence: []
+            production_window: src/scripts/check_score_contract.ts
+            outcome_evidence: ["src/scripts/check_score_contract.ts"]
+            non_regression_evidence: ["src/scripts/check_score_contract.ts"]
+            status: ten
+    note: >
+      The floor is 20 against a live corpus of 23, and the gap is deliberately
+      narrow because this corpus does not grow by ordinary work: a row is added
+      only when a rubric category is recovered, and `check_score_contract` itself
+      refuses a row count that disagrees with the declared
+      `recovered_category_count`. So the failure this floor guards is not
+      "someone deleted a few rows" but the migration shape — the scorecard moving
+      and the gate reading an absent file, which `countRows` reports as 0.
+
+      `argv` carries `--quiet` because that is the invocation the preflight task
+      uses. The `scanned:` line is deliberately NOT quiet-gated and is emitted on
+      the RED path too: a gate that publishes its coverage only when it passes
+      cannot be caught going blind at the moment that matters most.
+
+      Six negative-control twins live under
+      `tests/fixtures/score-contract/twins/`, and
+      `tests/scripts/check_score_contract.test.ts` asserts each reds on exactly
+      one finding CODE — not merely on a non-zero exit, which would let a twin
+      keep passing while testing the wrong defect.

--- a/src/scripts/check_score_contract.ts
+++ b/src/scripts/check_score_contract.ts
@@ -1,0 +1,505 @@
+#!/usr/bin/env tsx
+/**
+ * Score-contract gate — an unreferenced prose "10" becomes impossible.
+ *
+ * `agents/evidence/ac-capability-scorecard.yaml` records, per rubric category,
+ * the current claim, the evidence classes that would support it, and a status.
+ * This gate makes the status a DERIVED field: a row whose status disagrees with
+ * its own evidence arrays is a finding, so nobody can hand-award a `ten` and no
+ * closed roadmap checkbox can buy one.
+ *
+ * Register class 4 of 4 — `agents/evidence/README.md` says what the other three
+ * are (`docs/CLAIMS.md`, `provenance/borrows.jsonl`,
+ * `provenance/harvests.jsonl`) and why this is none of them. It is modelled on
+ * `check_claims.ts`: same "a claim may not stand without a resolvable evidence
+ * reference" culture, applied to an external reviewer's rubric axes instead of
+ * to public marketing claims.
+ *
+ * WHAT IT DELIBERATELY DOES NOT DO — the whole point of the contract:
+ *   It never judges outcome QUALITY. A threshold applied to how good an outcome
+ *   was is a judgement behind a gate, which is score theatre. Quality belongs in
+ *   a report on the green path, gating nothing. Emptiness and resolvability are
+ *   mechanical; "is this evidence good enough" is not, and is not attempted.
+ *
+ * Checks:
+ *   1. Shape — the file parses, carries `rubric:` and `categories:`, and every
+ *      row has the closed field set with a `status` from the six-value enum.
+ *   2. Manifest honesty — `recovered + missing == reported`; `state: complete`
+ *      is REFUSED while `authority: unavailable-external-review`; the row count
+ *      equals `recovered_category_count`; no duplicate category ids; no row id
+ *      appearing in `excluded_from_manifest`.
+ *   3. Evidence resolvability — every non-empty URI resolves, at every status.
+ *   4. The class rule, per status (see STATUS_RULES). `ten` needs every
+ *      required class non-empty and resolvable plus a production window;
+ *      `max-boundary` needs a standing constraint and nothing else may carry
+ *      one; `measured-null` needs a window and resolvable outcome evidence.
+ *   5. Stale pins — a `path@<sha>` URI whose sha is not an ancestor of HEAD.
+ *
+ * Evidence-URI grammar (deliberately narrower than check_claims'):
+ *   <repo-path>              → the path exists
+ *   <repo-path>:<line>       → the path exists (line advisory)
+ *   <repo-path>#<substring>  → the path exists AND contains <substring>
+ *   <repo-path>@<sha>        → the path exists AND <sha> is an ancestor of HEAD
+ *   https://… (YYYY-MM-DD)   → external cite with a dated stamp (never fetched)
+ *   fixture:<repo-path>      → explicitly a FIXTURE; may never satisfy the
+ *                              adoption, production, or outcome classes
+ *
+ * `fixture:` exists because the contract's own definition of 10 says synthetic
+ * fixtures can never satisfy adoption, production or outcome. Without a marker
+ * the gate could not tell a fixture path from a production one, and the rule
+ * would be prose only.
+ *
+ * Usage:
+ *     ./scripts-run src/scripts/check_score_contract
+ *     ./scripts-run src/scripts/check_score_contract --quiet
+ *     ./scripts-run src/scripts/check_score_contract --file <path>
+ *
+ * Exit codes: 0 = clean · 2 = any finding OR usage error.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import * as os from 'node:os';
+import { parse as parseYaml } from 'yaml';
+import { runGateCli, runSelfTest, type SelfTestCase } from './_lib/gate_self_test.js';
+
+const _FILE = fileURLToPath(import.meta.url);
+const REPO = path.resolve(path.dirname(_FILE), '..', '..');
+const DEFAULT_REL = path.join('agents', 'evidence', 'ac-capability-scorecard.yaml');
+/** This script's repo-relative path, for the self-test's real CLI invocations. */
+const SELF = path.join('src', 'scripts', 'check_score_contract.ts');
+const TWIN_DIR = path.join('tests', 'fixtures', 'score-contract', 'twins');
+const SELF_TEST_MIN_CASES = 8;
+const SELF_TEST_MIN_REJECT = 6;
+
+class ExitCode extends Error {
+    constructor(readonly code: number) {
+        super(`exit ${code}`);
+    }
+}
+
+/** The six legal statuses. `max-boundary` and `measured-null` are TERMINAL. */
+export const STATUSES = [
+    'missing-mechanism',
+    'missing-adoption',
+    'missing-proof',
+    'measured-null',
+    'max-boundary',
+    'ten',
+] as const;
+export type Status = (typeof STATUSES)[number];
+
+/** Classes a `fixture:` URI may never satisfy — from the frozen definition of 10. */
+const FIXTURE_FORBIDDEN = ['adoption_evidence', 'production_window', 'outcome_evidence'] as const;
+
+const EVIDENCE_ARRAYS = [
+    'mechanism_evidence',
+    'adoption_evidence',
+    'negative_control_evidence',
+    'outcome_evidence',
+    'non_regression_evidence',
+] as const;
+
+const ROW_FIELDS = [
+    'category',
+    'baseline',
+    'claim',
+    'closing_path',
+    ...EVIDENCE_ARRAYS,
+    'production_window',
+    'status',
+] as const;
+
+export interface Finding {
+    readonly where: string;
+    readonly code: string;
+    readonly detail: string;
+}
+
+/* ── evidence URIs ─────────────────────────────────────────────────────────── */
+
+const _isAncestor = (sha: string): boolean => {
+    try {
+        execFileSync('git', ['merge-base', '--is-ancestor', sha, 'HEAD'], {
+            cwd: REPO,
+            stdio: 'ignore',
+        });
+        return true;
+    } catch {
+        return false;
+    }
+};
+
+/** Resolve one URI. Returns null when it resolves, else the reason it does not. */
+export function resolveUri(uri: string): string | null {
+    const raw = uri.trim();
+    if (raw === '') return 'empty URI';
+
+    if (raw.startsWith('https://') || raw.startsWith('http://')) {
+        // Never fetched — an undated external cite cannot be re-verified later.
+        return /\(\d{4}-\d{2}-\d{2}\)\s*$/.test(raw) ? null : 'external cite carries no (YYYY-MM-DD) stamp';
+    }
+
+    const body = raw.startsWith('fixture:') ? raw.slice('fixture:'.length).trim() : raw;
+
+    let rel = body;
+    let needle: string | null = null;
+    let sha: string | null = null;
+
+    const hash = body.indexOf('#');
+    const at = body.lastIndexOf('@');
+    if (hash !== -1) {
+        rel = body.slice(0, hash);
+        needle = body.slice(hash + 1);
+    } else if (at > 0) {
+        rel = body.slice(0, at);
+        sha = body.slice(at + 1);
+    } else {
+        rel = body.replace(/:\d+$/, '');
+    }
+
+    if (rel === '' || path.isAbsolute(rel) || rel.split('/').includes('..')) {
+        return `path must be repo-relative and inside the repo: ${rel}`;
+    }
+    const abs = path.join(REPO, rel);
+    if (!fs.existsSync(abs)) return `path does not exist: ${rel}`;
+
+    if (needle !== null && needle !== '') {
+        let text = '';
+        try {
+            text = fs.readFileSync(abs, 'utf8');
+        } catch {
+            return `path is not readable as text: ${rel}`;
+        }
+        if (!text.includes(needle)) return `\`${rel}\` does not contain \`${needle}\``;
+    }
+    if (sha !== null) {
+        if (!/^[0-9a-f]{7,40}$/.test(sha)) return `not a sha: ${sha}`;
+        if (!_isAncestor(sha)) return `stale pin: ${sha} is not an ancestor of HEAD`;
+    }
+    return null;
+}
+
+const nonEmpty = (v: unknown): boolean =>
+    Array.isArray(v) ? v.length > 0 : typeof v === 'string' ? v.trim() !== '' : v !== null && v !== undefined;
+
+/* ── the class rule ────────────────────────────────────────────────────────── */
+
+type Row = Record<string, unknown>;
+
+/**
+ * Per-status requirements. `require`/`forbid` name row fields that must be
+ * non-empty / empty. The precedence is deliberate: a status is a CLAIM about
+ * which class is the first one missing, so `missing-adoption` asserts mechanism
+ * evidence exists — otherwise the row would be `missing-mechanism` and two
+ * statuses would describe the same evidence shape.
+ */
+export const STATUS_RULES: Record<Status, { require: string[]; forbid: string[] }> = {
+    'missing-mechanism': { require: [], forbid: ['mechanism_evidence', 'standing_constraint'] },
+    'missing-adoption': {
+        require: ['mechanism_evidence'],
+        forbid: ['adoption_evidence', 'standing_constraint'],
+    },
+    'missing-proof': {
+        require: ['mechanism_evidence', 'adoption_evidence'],
+        forbid: ['standing_constraint'],
+    },
+    'measured-null': {
+        require: ['production_window', 'outcome_evidence'],
+        forbid: ['standing_constraint'],
+    },
+    'max-boundary': { require: ['standing_constraint'], forbid: [] },
+    ten: {
+        require: [
+            'mechanism_evidence',
+            'adoption_evidence',
+            'negative_control_evidence',
+            'production_window',
+            'outcome_evidence',
+            'non_regression_evidence',
+        ],
+        forbid: ['standing_constraint'],
+    },
+};
+
+export function checkRow(row: Row, where: string): Finding[] {
+    const out: Finding[] = [];
+    const push = (code: string, detail: string): void => void out.push({ where, code, detail });
+
+    for (const f of ROW_FIELDS) {
+        if (!(f in row)) push('missing_field', `row has no \`${f}\``);
+    }
+    const status = row['status'];
+    if (typeof status !== 'string' || !(STATUSES as readonly string[]).includes(status)) {
+        push('bad_status', `\`${String(status)}\` is not one of ${STATUSES.join(' | ')}`);
+        return out; // every later rule keys on the status
+    }
+
+    // 3. every non-empty URI resolves, at every status
+    for (const key of EVIDENCE_ARRAYS) {
+        const arr = row[key];
+        if (arr === undefined || arr === null) continue;
+        if (!Array.isArray(arr)) {
+            push('bad_shape', `\`${key}\` must be a list`);
+            continue;
+        }
+        for (const uri of arr) {
+            if (typeof uri !== 'string') {
+                push('bad_shape', `\`${key}\` holds a non-string entry`);
+                continue;
+            }
+            const why = resolveUri(uri);
+            if (why !== null) push('unresolvable_evidence', `${key}: ${why}`);
+            if (uri.trim().startsWith('fixture:') && (FIXTURE_FORBIDDEN as readonly string[]).includes(key)) {
+                push('fixture_in_production_class', `${key} may not be satisfied by a fixture: ${uri}`);
+            }
+        }
+    }
+    const window_ = row['production_window'];
+    if (typeof window_ === 'string' && window_.trim() !== '') {
+        const why = resolveUri(window_);
+        if (why !== null) push('unresolvable_evidence', `production_window: ${why}`);
+        if (window_.trim().startsWith('fixture:')) {
+            push('fixture_in_production_class', `production_window may not be a fixture: ${window_}`);
+        }
+    }
+
+    // 4. the class rule
+    const rule = STATUS_RULES[status as Status];
+    for (const f of rule.require) {
+        if (!nonEmpty(row[f])) push('class_rule', `status \`${status}\` requires a non-empty \`${f}\``);
+    }
+    for (const f of rule.forbid) {
+        if (nonEmpty(row[f])) push('class_rule', `status \`${status}\` forbids a non-empty \`${f}\``);
+    }
+    return out;
+}
+
+/* ── manifest honesty ──────────────────────────────────────────────────────── */
+
+export function checkRubric(rubric: Row, rowCount: number, ids: string[]): Finding[] {
+    const out: Finding[] = [];
+    const where = 'rubric';
+    const push = (code: string, detail: string): void => void out.push({ where, code, detail });
+
+    const num = (k: string): number | null => (typeof rubric[k] === 'number' ? (rubric[k] as number) : null);
+    const reported = num('reported_category_count');
+    const recovered = num('recovered_category_count');
+    const missing = num('missing_category_count');
+    const state = rubric['state'];
+    const authority = rubric['authority'];
+
+    if (reported === null || recovered === null || missing === null) {
+        push('missing_field', 'rubric needs numeric reported/recovered/missing counts');
+    } else if (recovered + missing !== reported) {
+        push('bad_arithmetic', `${recovered} recovered + ${missing} missing != ${reported} reported`);
+    }
+    if (recovered !== null && rowCount !== recovered) {
+        push('row_count_mismatch', `${rowCount} rows present, rubric declares ${recovered} recovered`);
+    }
+    // The one that matters: incompleteness must not be silently redeclared away.
+    if (state === 'complete' && authority === 'unavailable-external-review') {
+        push(
+            'false_completeness',
+            'state `complete` is refused while authority is `unavailable-external-review` — ' +
+                'an authoritative manifest must be present first',
+        );
+    }
+    if (state !== 'complete' && state !== 'incomplete') {
+        push('bad_state', `state must be \`complete\` or \`incomplete\`, got \`${String(state)}\``);
+    }
+    const excluded = Array.isArray(rubric['excluded_from_manifest']) ? (rubric['excluded_from_manifest'] as unknown[]) : [];
+    for (const id of ids) {
+        if (excluded.includes(id)) push('excluded_row_present', `\`${id}\` is both a row and excluded_from_manifest`);
+    }
+    const seen = new Set<string>();
+    for (const id of ids) {
+        if (seen.has(id)) push('duplicate_category', `\`${id}\` appears more than once`);
+        seen.add(id);
+    }
+    return out;
+}
+
+/* ── driver ────────────────────────────────────────────────────────────────── */
+
+export function check(rel: string): Finding[] {
+    // An absolute `--file` must be honoured as given. path.join(REPO, '/abs')
+    // silently produces REPO + '/abs', which reports `missing_file` for a file
+    // that exists — the shape a test using a temp copy hits first.
+    const abs = path.isAbsolute(rel) ? rel : path.join(REPO, rel);
+    if (!fs.existsSync(abs)) {
+        return [{ where: rel, code: 'missing_file', detail: 'scorecard does not exist' }];
+    }
+    let doc: unknown;
+    try {
+        doc = parseYaml(fs.readFileSync(abs, 'utf8'));
+    } catch (exc) {
+        return [{ where: rel, code: 'unparseable', detail: String(exc) }];
+    }
+    if (doc === null || typeof doc !== 'object') {
+        return [{ where: rel, code: 'unparseable', detail: 'top level is not a mapping' }];
+    }
+    const top = doc as Row;
+    const rubric = top['rubric'];
+    const cats = top['categories'];
+    if (rubric === undefined || typeof rubric !== 'object' || rubric === null) {
+        return [{ where: rel, code: 'missing_field', detail: 'no `rubric:` block' }];
+    }
+    if (!Array.isArray(cats)) {
+        return [{ where: rel, code: 'missing_field', detail: '`categories:` must be a list' }];
+    }
+    const rows = cats as Row[];
+    const ids = rows.map((r) => String(r['category'] ?? '<unnamed>'));
+    const findings = [...checkRubric(rubric as Row, rows.length, ids)];
+    rows.forEach((r, i) => {
+        findings.push(...checkRow(r, `${rel} → ${ids[i] ?? `row ${i}`}`));
+    });
+    return findings;
+}
+
+/**
+ * Prove, through the real binary, that the rejections still fire.
+ *
+ * Unit tests here call `check()` in-process. That cannot catch the failure this
+ * repository has actually had: a CLI whose argv parsing or entry guard silently
+ * no-ops while the imported function still works. So every case below shells out
+ * to this file's own CLI.
+ *
+ * The committed twins ARE the fixtures — six of the eight cases point at them
+ * rather than re-authoring the same defects inline, so a twin that drifts breaks
+ * the self-test too instead of only the unit suite.
+ */
+export function selfTest(): number {
+    const made: string[] = [];
+    const runFile = (rel: string): number => runGateCli(REPO, SELF, ['--quiet', '--file', rel], REPO);
+    const runText = (text: string): number => {
+        const d = fs.mkdtempSync(path.join(os.tmpdir(), 'score-selftest-'));
+        made.push(d);
+        const f = path.join(d, 'scorecard.yaml');
+        fs.writeFileSync(f, text, 'utf8');
+        return runFile(f);
+    };
+
+    const twin = (name: string): number => runFile(path.join(TWIN_DIR, `${name}.yaml`));
+
+    const cases: SelfTestCase[] = [
+        { name: 'accepts the real seeded scorecard', expect: 'accept', run: () => runFile(DEFAULT_REL) },
+        { name: 'rejects a `ten` with an empty required class', expect: 'reject', run: () => twin('a-ten-with-empty-class') },
+        { name: 'rejects a stale pin', expect: 'reject', run: () => twin('b-stale-pin') },
+        { name: 'rejects a fixture as the production window', expect: 'reject', run: () => twin('c-fixture-as-production') },
+        { name: 'rejects an unresolvable evidence path', expect: 'reject', run: () => twin('d-unresolvable-path') },
+        { name: 'rejects incompleteness redeclared as complete', expect: 'reject', run: () => twin('e-false-completeness') },
+        { name: 'rejects max-boundary naming no standing constraint', expect: 'reject', run: () => twin('f-max-boundary-no-constraint') },
+        {
+            // The dead-scan-root case: a moved scorecard must exit 2, never green.
+            // This is the shape gate-coverage.yml exists to catch, and the one a
+            // twin cannot express.
+            name: 'rejects a missing scorecard rather than reporting clean',
+            expect: 'reject',
+            run: () => runFile(path.join('agents', 'evidence', 'no-such-scorecard.yaml')),
+        },
+        {
+            name: 'accepts a minimal hand-built scorecard with one seeded row',
+            expect: 'accept',
+            run: () =>
+                runText(
+                    'schema_version: 1\nrubric:\n  state: incomplete\n' +
+                        '  authority: unavailable-external-review\n  reported_category_count: 32\n' +
+                        '  recovered_category_count: 1\n  missing_category_count: 31\n' +
+                        '  manifest_version: baseline_v1\n  recovery_source: agents/roadmaps/road-to-ten-across-the-board.md\n' +
+                        '  excluded_from_manifest: []\ncategories:\n  - category: security\n' +
+                        '    baseline: 9.6\n    claim: "x"\n    closing_path: "x"\n' +
+                        '    mechanism_evidence: []\n    adoption_evidence: []\n' +
+                        '    negative_control_evidence: []\n    production_window: null\n' +
+                        '    outcome_evidence: []\n    non_regression_evidence: []\n' +
+                        '    status: missing-mechanism\n',
+                ),
+        },
+    ];
+    try {
+        return runSelfTest({
+            gate: 'check_score_contract',
+            cases,
+            minCases: SELF_TEST_MIN_CASES,
+            minRejectCases: SELF_TEST_MIN_REJECT,
+        });
+    } finally {
+        for (const d of made) fs.rmSync(d, { recursive: true, force: true });
+    }
+}
+
+/** Rows the gate actually inspected — 0 when the file is missing or unparseable. */
+export function countRows(rel: string): number {
+    const abs = path.isAbsolute(rel) ? rel : path.join(REPO, rel);
+    try {
+        const doc = parseYaml(fs.readFileSync(abs, 'utf8')) as Row;
+        const cats = doc['categories'];
+        return Array.isArray(cats) ? cats.length : 0;
+    } catch {
+        return 0;
+    }
+}
+
+export function main(argv: readonly string[] = process.argv.slice(2)): number {
+    if (argv.includes('--self-test')) return selfTest();
+    const quiet = argv.includes('--quiet');
+    const fi = argv.indexOf('--file');
+    const rel = fi !== -1 ? argv[fi + 1] : DEFAULT_REL;
+    if (rel === undefined) {
+        process.stderr.write('usage: check_score_contract [--quiet] [--file <path>]\n');
+        return 2;
+    }
+    const findings = check(rel);
+    // Rule 1 of the gate-coverage contract: exactly one `scanned: <N>` line,
+    // emitted on the red path too — a gate that only reports coverage when it
+    // passes cannot be caught going blind at the moment it matters.
+    process.stdout.write(`scanned: ${countRows(rel)}\n`);
+    if (findings.length > 0) {
+        process.stderr.write(`\n❌  ${findings.length} score-contract finding(s):\n\n`);
+        for (const f of findings) {
+            process.stderr.write(`  🔴 ${f.where} — [${f.code}] ${f.detail}\n`);
+        }
+        return 2;
+    }
+    if (!quiet) {
+        // A gate that scans nothing and exits green is indistinguishable from a
+        // broken one, so the green path prints what it actually examined.
+        const shown = path.isAbsolute(rel) ? rel : path.join(REPO, rel);
+        const doc = parseYaml(fs.readFileSync(shown, 'utf8')) as Row;
+        const rubric = doc['rubric'] as Row;
+        const rows = doc['categories'] as Row[];
+        const byStatus = new Map<string, number>();
+        for (const r of rows) byStatus.set(String(r['status']), (byStatus.get(String(r['status'])) ?? 0) + 1);
+        const tally = [...byStatus.entries()].map(([s, n]) => `${s}=${n}`).join(' · ');
+        process.stdout.write(
+            `✅  ${rel} — ${rows.length} row(s) · ${tally}\n` +
+                `    rubric: ${String(rubric['state'])} — ${String(rubric['recovered_category_count'])} recovered, ` +
+                `${String(rubric['missing_category_count'])} of ${String(rubric['reported_category_count'])} unknown ` +
+                `(authority: ${String(rubric['authority'])})\n` +
+                `    quality is NOT judged here: emptiness and resolvability only.\n`,
+        );
+    }
+    return 0;
+}
+
+function _isCliEntry(): boolean {
+    const a = process.argv[1];
+    if (!a) return false;
+    if (a === _FILE || pathToFileURL(path.resolve(a)).href === import.meta.url) return true;
+    try {
+        return fs.realpathSync(a) === fs.realpathSync(_FILE);
+    } catch {
+        return false;
+    }
+}
+if (_isCliEntry()) {
+    try {
+        process.exit(main());
+    } catch (exc) {
+        if (exc instanceof ExitCode) process.exit(exc.code);
+        throw exc;
+    }
+}
+
+export { REPO, DEFAULT_REL, ExitCode };

--- a/taskfiles/ci-fast.yml
+++ b/taskfiles/ci-fast.yml
@@ -1392,6 +1392,23 @@ tasks:
       pass and the green line says so.
     cmd: ./scripts-run src/scripts/lint_harvest_provenance {{.QUIET_FLAG}}
 
+  check-score-contract:
+    silent: true
+    desc: >-
+      Score-contract gate — an unreferenced prose "10" becomes impossible.
+      `agents/evidence/ac-capability-scorecard.yaml` records one row per rubric
+      category recoverable from the tracked tree; this gate makes `status` a
+      DERIVED field, so a row whose status disagrees with its own evidence arrays
+      fails and nobody can hand-award a `ten`. It also refuses `rubric.state:
+      complete` while the authoritative 32-category rubric is unavailable — nine
+      identities are unknown, and incompleteness is enforced rather than
+      commented. It deliberately never judges outcome QUALITY: emptiness and
+      resolvability only, because a judgement behind a gate is score theatre.
+      Six negative-control twins under `tests/fixtures/score-contract/twins/`
+      each red on exactly one finding code; `--self-test` drives the real binary
+      against all six plus a dead-scan-root case.
+    cmd: ./scripts-run src/scripts/check_score_contract {{.QUIET_FLAG}}
+
   lint-skill-router-head:
     silent: true
     desc: >-

--- a/tests/fixtures/score-contract/README.md
+++ b/tests/fixtures/score-contract/README.md
@@ -1,0 +1,36 @@
+# Score-contract twin fixtures
+
+Every file under `twins/` is a **deliberately broken** scorecard. Each one
+isolates exactly one defect and must turn `check_score_contract` red **on its own
+finding code and no other** — the property that separates a real negative control
+from a fixture that happens to fail.
+
+Pattern borrowed from `tests/fixtures/pack-conformance/twins/`, which
+`road-to-score-contract.md` Phase 1 step 1.1 names.
+
+| Twin | Defect | Required finding code |
+|---|---|---|
+| `a-ten-with-empty-class.yaml` | a `ten` whose `negative_control_evidence` is empty | `class_rule` |
+| `b-stale-pin.yaml` | a `path@<sha>` URI whose sha is not an ancestor of HEAD | `unresolvable_evidence` |
+| `c-fixture-as-production.yaml` | `production_window` pointing at a `fixture:` run | `fixture_in_production_class` |
+| `d-unresolvable-path.yaml` | an evidence path that does not exist | `unresolvable_evidence` |
+| `e-false-completeness.yaml` | `rubric.state: complete` while the authoritative rubric is unavailable | `false_completeness` |
+| `f-max-boundary-no-constraint.yaml` | `max-boundary` naming no standing constraint | `class_rule` |
+
+Run one by hand:
+
+```bash
+./scripts-run src/scripts/check_score_contract --file tests/fixtures/score-contract/twins/b-stale-pin.yaml
+```
+
+`tests/scripts/check_score_contract.test.ts` asserts the table above, and also
+the direction that is easy to forget: that the **real** scorecard is green, so a
+twin failing is evidence about the twin and not about the gate being broken in
+general.
+
+**`b-stale-pin` is the one twin with a durability caveat**, stated because a
+fixture that silently stops testing its defect is worse than none: it relies on
+an all-zero sha never becoming an ancestor of HEAD. That is safe in practice, and
+if git ever resolved it differently the twin would go green while the check it
+guards still worked — so the test asserts the finding *code*, not merely a
+non-zero exit.

--- a/tests/fixtures/score-contract/twins/a-ten-with-empty-class.yaml
+++ b/tests/fixtures/score-contract/twins/a-ten-with-empty-class.yaml
@@ -1,0 +1,23 @@
+# TWIN FIXTURE — deliberately broken. See ../README.md.
+schema_version: 1
+rubric:
+  state: incomplete
+  authority: unavailable-external-review
+  reported_category_count: 32
+  recovered_category_count: 1
+  missing_category_count: 31
+  manifest_version: baseline_v1
+  recovery_source: agents/roadmaps/road-to-ten-across-the-board.md
+  excluded_from_manifest: []
+categories:
+  - category: release-integrity
+    baseline: 9.2
+    claim: "twin fixture"
+    closing_path: "twin fixture"
+    mechanism_evidence: ["src/scripts/check_score_contract.ts"]
+    adoption_evidence: ["src/scripts/check_score_contract.ts"]
+    negative_control_evidence: []
+    production_window: src/scripts/check_score_contract.ts
+    outcome_evidence: ["src/scripts/check_score_contract.ts"]
+    non_regression_evidence: ["src/scripts/check_score_contract.ts"]
+    status: ten

--- a/tests/fixtures/score-contract/twins/b-stale-pin.yaml
+++ b/tests/fixtures/score-contract/twins/b-stale-pin.yaml
@@ -1,0 +1,23 @@
+# TWIN FIXTURE — deliberately broken. See ../README.md.
+schema_version: 1
+rubric:
+  state: incomplete
+  authority: unavailable-external-review
+  reported_category_count: 32
+  recovered_category_count: 1
+  missing_category_count: 31
+  manifest_version: baseline_v1
+  recovery_source: agents/roadmaps/road-to-ten-across-the-board.md
+  excluded_from_manifest: []
+categories:
+  - category: release-integrity
+    baseline: 9.2
+    claim: "twin fixture"
+    closing_path: "twin fixture"
+    mechanism_evidence: ["src/scripts/check_score_contract.ts@0000000000000000000000000000000000000000"]
+    adoption_evidence: []
+    negative_control_evidence: []
+    production_window: null
+    outcome_evidence: []
+    non_regression_evidence: []
+    status: missing-adoption

--- a/tests/fixtures/score-contract/twins/c-fixture-as-production.yaml
+++ b/tests/fixtures/score-contract/twins/c-fixture-as-production.yaml
@@ -1,0 +1,23 @@
+# TWIN FIXTURE — deliberately broken. See ../README.md.
+schema_version: 1
+rubric:
+  state: incomplete
+  authority: unavailable-external-review
+  reported_category_count: 32
+  recovered_category_count: 1
+  missing_category_count: 31
+  manifest_version: baseline_v1
+  recovery_source: agents/roadmaps/road-to-ten-across-the-board.md
+  excluded_from_manifest: []
+categories:
+  - category: release-integrity
+    baseline: 9.2
+    claim: "twin fixture"
+    closing_path: "twin fixture"
+    mechanism_evidence: []
+    adoption_evidence: []
+    negative_control_evidence: []
+    production_window: fixture:src/scripts/check_score_contract.ts
+    outcome_evidence: ["src/scripts/check_score_contract.ts"]
+    non_regression_evidence: []
+    status: measured-null

--- a/tests/fixtures/score-contract/twins/d-unresolvable-path.yaml
+++ b/tests/fixtures/score-contract/twins/d-unresolvable-path.yaml
@@ -1,0 +1,23 @@
+# TWIN FIXTURE — deliberately broken. See ../README.md.
+schema_version: 1
+rubric:
+  state: incomplete
+  authority: unavailable-external-review
+  reported_category_count: 32
+  recovered_category_count: 1
+  missing_category_count: 31
+  manifest_version: baseline_v1
+  recovery_source: agents/roadmaps/road-to-ten-across-the-board.md
+  excluded_from_manifest: []
+categories:
+  - category: release-integrity
+    baseline: 9.2
+    claim: "twin fixture"
+    closing_path: "twin fixture"
+    mechanism_evidence: ["src/scripts/this_file_does_not_exist.ts"]
+    adoption_evidence: []
+    negative_control_evidence: []
+    production_window: null
+    outcome_evidence: []
+    non_regression_evidence: []
+    status: missing-adoption

--- a/tests/fixtures/score-contract/twins/e-false-completeness.yaml
+++ b/tests/fixtures/score-contract/twins/e-false-completeness.yaml
@@ -1,0 +1,23 @@
+# TWIN FIXTURE — deliberately broken. See ../README.md.
+schema_version: 1
+rubric:
+  state: complete
+  authority: unavailable-external-review
+  reported_category_count: 32
+  recovered_category_count: 1
+  missing_category_count: 31
+  manifest_version: baseline_v1
+  recovery_source: agents/roadmaps/road-to-ten-across-the-board.md
+  excluded_from_manifest: []
+categories:
+  - category: release-integrity
+    baseline: 9.2
+    claim: "twin fixture"
+    closing_path: "twin fixture"
+    mechanism_evidence: []
+    adoption_evidence: []
+    negative_control_evidence: []
+    production_window: null
+    outcome_evidence: []
+    non_regression_evidence: []
+    status: missing-mechanism

--- a/tests/fixtures/score-contract/twins/f-max-boundary-no-constraint.yaml
+++ b/tests/fixtures/score-contract/twins/f-max-boundary-no-constraint.yaml
@@ -1,0 +1,23 @@
+# TWIN FIXTURE — deliberately broken. See ../README.md.
+schema_version: 1
+rubric:
+  state: incomplete
+  authority: unavailable-external-review
+  reported_category_count: 32
+  recovered_category_count: 1
+  missing_category_count: 31
+  manifest_version: baseline_v1
+  recovery_source: agents/roadmaps/road-to-ten-across-the-board.md
+  excluded_from_manifest: []
+categories:
+  - category: release-integrity
+    baseline: 9.2
+    claim: "twin fixture"
+    closing_path: "twin fixture"
+    mechanism_evidence: []
+    adoption_evidence: []
+    negative_control_evidence: []
+    production_window: null
+    outcome_evidence: []
+    non_regression_evidence: []
+    status: max-boundary

--- a/tests/scripts/check_score_contract.test.ts
+++ b/tests/scripts/check_score_contract.test.ts
@@ -158,9 +158,28 @@ describe('the gate refuses a row outside the declared manifest', () => {
 });
 
 describe('Phase 2 binding — companion roadmaps cite rows, never write status', () => {
+    /**
+     * A roadmap moves to `archive/` the moment it closes, so pinning the active
+     * path makes the test fail the instant the work it asserts is finished —
+     * which is exactly what happened: green locally before archival, red in CI
+     * after it. Resolve either location instead.
+     */
+    const companion = (slug: string): string => {
+        for (const dir of [
+            path.join('agents', 'roadmaps'),
+            path.join('agents', 'roadmaps', 'archive'),
+            path.join('agents', 'roadmaps', 'later'),
+            path.join('agents', 'roadmaps', 'stubs'),
+        ]) {
+            const p = path.join(dir, `${slug}.md`);
+            if (fs.existsSync(p)) return p;
+        }
+        throw new Error(`${slug}.md is in none of the roadmap dispositions`);
+    };
+
     const COMPANIONS = [
-        path.join('agents', 'roadmaps', 'road-to-ten-across-the-board.md'),
-        path.join('agents', 'roadmaps', 'road-to-score-contract.md'),
+        companion('road-to-ten-across-the-board'),
+        companion('road-to-score-contract'),
     ];
 
     const declaredIds = (): Set<string> => {

--- a/tests/scripts/check_score_contract.test.ts
+++ b/tests/scripts/check_score_contract.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { check, resolveUri, STATUSES, STATUS_RULES } from '../../src/scripts/check_score_contract';
+
+const SCORECARD = path.join('agents', 'evidence', 'ac-capability-scorecard.yaml');
+const TWINS = path.join('tests', 'fixtures', 'score-contract', 'twins');
+
+const codes = (rel: string): string[] => check(rel).map((f) => f.code);
+
+describe('the seeded scorecard is green', () => {
+    it('exits clean — 23 recovered rows, no findings', () => {
+        expect(check(SCORECARD)).toEqual([]);
+    });
+
+    it('declares its own incompleteness rather than 32 rows', () => {
+        const text = fs.readFileSync(SCORECARD, 'utf8');
+        expect(text).toContain('state: incomplete');
+        expect(text).toContain('authority: unavailable-external-review');
+        // 23 + 9 = 32. Guessing the nine would be the defect this asserts against.
+        expect(text).toContain('recovered_category_count: 23');
+        expect(text).toContain('missing_category_count: 9');
+    });
+});
+
+describe('each twin reds on its own finding and nothing else', () => {
+    // Step 1.1's four controls, plus the two the council added.
+    const table: ReadonlyArray<readonly [string, string]> = [
+        ['a-ten-with-empty-class', 'class_rule'],
+        ['b-stale-pin', 'unresolvable_evidence'],
+        ['c-fixture-as-production', 'fixture_in_production_class'],
+        ['d-unresolvable-path', 'unresolvable_evidence'],
+        ['e-false-completeness', 'false_completeness'],
+        ['f-max-boundary-no-constraint', 'class_rule'],
+    ];
+
+    for (const [name, code] of table) {
+        it(`${name} → exactly one ${code}`, () => {
+            const got = codes(path.join(TWINS, `${name}.yaml`));
+            expect(got, `${name} must produce exactly one finding`).toEqual([code]);
+        });
+    }
+
+    it('every twin file in the directory is covered by the table above', () => {
+        const onDisk = fs
+            .readdirSync(TWINS)
+            .filter((f) => f.endsWith('.yaml'))
+            .map((f) => f.replace(/\.yaml$/, ''))
+            .sort();
+        expect(onDisk).toEqual(table.map(([n]) => n).sort());
+    });
+});
+
+describe('the class rule', () => {
+    it('covers every legal status, with no status left unruled', () => {
+        expect(Object.keys(STATUS_RULES).sort()).toEqual([...STATUSES].sort());
+    });
+
+    it('forbids a standing_constraint on every status except max-boundary', () => {
+        for (const s of STATUSES) {
+            const rule = STATUS_RULES[s];
+            if (s === 'max-boundary') {
+                expect(rule.require).toContain('standing_constraint');
+            } else {
+                expect(rule.forbid, `${s} must forbid standing_constraint`).toContain('standing_constraint');
+            }
+        }
+    });
+
+    it('a seeded missing-* row needs no reason field — the status IS the reason', () => {
+        // The contradiction the council resolved: 0.2 read literally would have
+        // failed every row 0.1 creates.
+        for (const s of ['missing-mechanism', 'missing-adoption', 'missing-proof'] as const) {
+            expect(STATUS_RULES[s].require).not.toContain('production_window');
+            expect(STATUS_RULES[s].require).not.toContain('standing_constraint');
+        }
+    });
+
+    it('missing-adoption asserts mechanism evidence exists — statuses are ordered claims', () => {
+        expect(STATUS_RULES['missing-adoption'].require).toContain('mechanism_evidence');
+        expect(STATUS_RULES['missing-adoption'].forbid).toContain('adoption_evidence');
+    });
+});
+
+describe('the evidence-URI grammar', () => {
+    it('resolves an existing repo path, with and without a line', () => {
+        expect(resolveUri('src/scripts/check_score_contract.ts')).toBeNull();
+        expect(resolveUri('src/scripts/check_score_contract.ts:1')).toBeNull();
+    });
+
+    it('rejects a path that does not exist and one that escapes the repo', () => {
+        expect(resolveUri('src/scripts/nope.ts')).toMatch(/does not exist/);
+        expect(resolveUri('../outside.ts')).toMatch(/repo-relative/);
+        expect(resolveUri('/etc/passwd')).toMatch(/repo-relative/);
+    });
+
+    it('checks a #substring against the file contents', () => {
+        expect(resolveUri('src/scripts/check_score_contract.ts#STATUS_RULES')).toBeNull();
+        expect(resolveUri('src/scripts/check_score_contract.ts#not-in-this-file-xyz')).toMatch(/does not contain/);
+    });
+
+    it('requires a dated stamp on an external cite, and never fetches', () => {
+        expect(resolveUri('https://example.com/report (2026-08-24)')).toBeNull();
+        expect(resolveUri('https://example.com/report')).toMatch(/no \(YYYY-MM-DD\) stamp/);
+    });
+});
+
+describe('quality is never judged — the contract that keeps this a gate', () => {
+    const source = fs.readFileSync(path.join('src', 'scripts', 'check_score_contract.ts'), 'utf8');
+
+    it('the verifier applies no threshold to any outcome-quality field', () => {
+        // Step 1.2's verify, mechanised: a comparison operator against a
+        // quality-shaped field name would be a judgement behind a gate.
+        const quality = /(quality|score|rating|grade|confidence)\w*\s*[<>]=?|[<>]=?\s*\w*(quality|rating|grade)/i;
+        const offending = source
+            .split('\n')
+            .map((l, i) => [i + 1, l] as const)
+            .filter(([, l]) => quality.test(l) && !l.trimStart().startsWith('*') && !l.trimStart().startsWith('//'));
+        expect(offending).toEqual([]);
+    });
+
+    it('says so on the green path, so a reader is not left to assume it', () => {
+        expect(source).toContain('quality is NOT judged here');
+    });
+});
+
+describe('the gate refuses a row outside the declared manifest', () => {
+    /** Copy the real scorecard and mutate it — never touches the tracked tree. */
+    const mutated = (edit: (text: string) => string): string => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'score-contract-'));
+        const rel = path.join(dir, 'scorecard.yaml');
+        fs.writeFileSync(rel, edit(fs.readFileSync(SCORECARD, 'utf8')), 'utf8');
+        return rel;
+    };
+
+    it('an extra row without a matching count bump is a row_count_mismatch', () => {
+        const rel = mutated(
+            (t) =>
+                `${t}  - category: invented-category\n    baseline: 1.0\n    claim: "x"\n` +
+                `    closing_path: "x"\n    mechanism_evidence: []\n    adoption_evidence: []\n` +
+                `    negative_control_evidence: []\n    production_window: null\n` +
+                `    outcome_evidence: []\n    non_regression_evidence: []\n    status: missing-mechanism\n`,
+        );
+        expect(check(rel).map((f) => f.code)).toContain('row_count_mismatch');
+    });
+
+    it('an arithmetic that does not add up is refused', () => {
+        const rel = mutated((t) => t.replace('missing_category_count: 9', 'missing_category_count: 4'));
+        expect(check(rel).map((f) => f.code)).toContain('bad_arithmetic');
+    });
+
+    it('a row named in excluded_from_manifest is refused', () => {
+        const rel = mutated((t) => t.replace('category: security', 'category: runtime-simplicity'));
+        expect(check(rel).map((f) => f.code)).toContain('excluded_row_present');
+    });
+});
+
+describe('Phase 2 binding — companion roadmaps cite rows, never write status', () => {
+    const COMPANIONS = [
+        path.join('agents', 'roadmaps', 'road-to-ten-across-the-board.md'),
+        path.join('agents', 'roadmaps', 'road-to-score-contract.md'),
+    ];
+
+    const declaredIds = (): Set<string> => {
+        const text = fs.readFileSync(SCORECARD, 'utf8');
+        return new Set([...text.matchAll(/^\s*- category:\s*(\S+)/gm)].map((m) => m[1] as string));
+    };
+
+    it('every category id cited in a companion resolves to a row', () => {
+        const ids = declaredIds();
+        expect(ids.size).toBe(23);
+        const excluded = new Set(['runtime-simplicity', 'host-portability']);
+        for (const rel of COMPANIONS) {
+            const body = fs.readFileSync(rel, 'utf8');
+            // Only backticked kebab tokens that look like a row id are candidates;
+            // a bare English phrase is prose, not a citation.
+            const cited = [...body.matchAll(/`([a-z][a-z0-9]*(?:-[a-z0-9]+){1,5})`/g)].map((m) => m[1] as string);
+            const rowish = cited.filter((c) => ids.has(c) || excluded.has(c));
+            expect(rowish.length, `${rel} must cite at least one row id`).toBeGreaterThan(0);
+            for (const c of rowish) {
+                expect(ids.has(c) || excluded.has(c), `${rel} cites unknown row \`${c}\``).toBe(true);
+            }
+        }
+    });
+
+    it('no roadmap step writes a status: value — the gate is the only authority', () => {
+        for (const rel of COMPANIONS) {
+            const lines = fs.readFileSync(rel, 'utf8').split('\n');
+            const offending = lines
+                .map((l, i) => [i + 1, l] as const)
+                // A checkbox line, or its indented continuation, assigning a status.
+                .filter(([, l]) => /^\s*(- \[[ x~-]\]\s+)?.*\bstatus:\s*(ten|measured-null|max-boundary|missing-)/.test(l))
+                // Prose ABOUT the rule is allowed; an assignment is not. The
+                // discriminator is a backtick-quoted mention vs a bare one.
+                .filter(([, l]) => !/`[^`]*status:[^`]*`/.test(l) && !/\*\*/.test(l));
+            expect(offending, `${rel} must not assign a scorecard status`).toEqual([]);
+        }
+    });
+
+    it('the two excluded floors are named as excluded, not as rows', () => {
+        const text = fs.readFileSync(SCORECARD, 'utf8');
+        expect(text).toContain('excluded_from_manifest');
+        for (const id of ['runtime-simplicity', 'host-portability']) {
+            expect(text).toContain(`    - ${id}`);
+            expect(text).not.toContain(`- category: ${id}`);
+        }
+    });
+});


### PR DESCRIPTION
Closes `road-to-score-contract` — all 10 boxes, its blocker resolved, archived to `agents/roadmaps/archive/` in this branch. Also **amends `road-to-ten-across-the-board.md`**, which is a separate active roadmap, because the council's verdict makes its AC-1 unsatisfiable as written.

Part of an autonomous drain run; council-owned blockers were delegated to the AI council by the maintainer, and its verdict stands in for owner sign-off.

## What landed

| Artefact | What it does |
|---|---|
| `agents/evidence/ac-capability-scorecard.yaml` | 23 rows, one per recoverable rubric category, plus a `rubric:` block that declares its own incompleteness |
| `agents/evidence/README.md` | **New.** Documents the four register classes and why the scorecard is none of the other three |
| `src/scripts/check_score_contract.ts` | The gate. Makes `status` a *derived* field; refuses a false completeness redeclaration; never judges quality |
| `tests/fixtures/score-contract/twins/` | Six negative controls, one defect each |
| `tests/scripts/check_score_contract.test.ts` | 25 tests |
| `src/config/gate-coverage.yml`, `Taskfile.yml`, `taskfiles/ci-fast.yml` | Registration + CI wiring |

## Council decision 1 — a fourth register, but the blocker named the wrong file

`b-scorecard-fourth-ledger` (owner: council) asked: register, or a projection of `docs/CLAIMS.md`? Put to the full council (`anthropic/claude-sonnet-4-5` + `openai/codex-default`, 2 rounds, blind peer review, $0.0461). Question: `agents/runtime/council/questions/score-contract-ledger-and-rubric.md`.

**Register, not projection** — 2/2, and the roadmap's own recommendation: rubric categories are an *external reviewer's* assessment axes, so filtering `CLAIMS.md` by category would mean registering ~32 public claims this package does not want to make.

**But not in `provenance/README.md`, which is what the blocker's `Resolved when` demanded.** Both seats found this independently and it is the correction worth keeping: that file opens *"**Two** append-only ledgers live here"* and scopes itself to **what this package took from somewhere else**. A capability score is neither borrowed code nor a harvested heuristic. Amending it to mention a scorecard would have mis-filed the scorecard in the one document whose purpose is preventing exactly that confusion — the *"a grep for 'claim' hits all three"* hazard it names.

So `provenance/README.md` is **untouched, because it is already accurate**, and the register set is recorded in the new `agents/evidence/README.md`. The blocker id is kept (one seat proposed renaming it to `b-scorecard-register-location`; the reasoning is recorded, the id is not changed — blocker ids are cited from other files and a stable imperfect name costs less than a dangling reference).

## Council decision 2 — the rubric is not reconstructible from the tree

**Not in the roadmap. Found trying to execute Phase 0.1, and it blocked the step as written.**

Both roadmaps say **32** categories and both say to *"seed every row from the external review baseline"*. **The external review is not in the tracked tree** — its inbox copy under `agents/tmp.old/road-to-10/` is gone from this checkout. What is recoverable is the `Category → closing path` table at `road-to-ten-across-the-board.md:117-138`: **23** categories with baseline scores. **Nine identities are unknown — not merely their scores.**

**Verdict: option (a), seed the 23 and make the incompleteness machine-readable.** Not nine placeholder rows (manufactures taxonomy), not holding Phase 0 (which also holds two companion roadmaps and a `later/` entry condition).

Two corrections both seats made to this run's own framing:

- **The arithmetic.** I wrote "seven unrecoverable". 32 − 23 = **9**. Both seats caught it.
- **The two unscored floors.** I offered `runtime simplicity` / `host portability` as candidate rows. Both refused: nothing establishes they were rubric categories, so adding them would shrink a known gap by guessing. They are recorded in `excluded_from_manifest`, and the gate refuses a row bearing either id.

The gate enforces three things about the `rubric:` block: the arithmetic adds up, the row count equals `recovered_category_count`, and **`state: complete` is refused** while `authority: unavailable-external-review`. Twin `e-false-completeness` proves the last one fires.

## Council decision 3 — Phase 0.1 and 0.2 contradicted each other

0.2 asked *every* non-`ten` row to name a standing constraint or a measurement window. A freshly seeded row is `missing-mechanism` and can honestly carry neither. **Read literally, 0.2's shape check failed every row 0.1 creates.**

2/2: the reason requirement binds only the two **terminal** non-`ten` statuses. For a `missing-*` row, **the status is the reason.**

A consequence worth naming: the statuses became **ordered claims** rather than labels. `missing-adoption` now *requires* non-empty mechanism evidence — otherwise it and `missing-mechanism` describe the same evidence shape and either could be written for any row. `standing_constraint` is **forbidden** on every status except `max-boundary`, so the doctrine escape cannot be attached to a row that did not earn it.

## The twins are asserted on their finding code, not their exit code

| Twin | Control | Code |
|---|---|---|
| `d-unresolvable-path` | (a) missing evidence ref | `unresolvable_evidence` |
| `b-stale-pin` | (b) stale pin | `unresolvable_evidence` |
| `c-fixture-as-production` | (c) fixture as production window | `fixture_in_production_class` |
| `a-ten-with-empty-class` | (d) `ten` with a required class absent | `class_rule` |
| `e-false-completeness` | *council-added* | `false_completeness` |
| `f-max-boundary-no-constraint` | *council-added* | `class_rule` |

A twin passing for the wrong reason is the failure mode that distinction exists for. `**exactly one** finding, and it is *this* code` is the assertion.

**`fixture:` had to enter the URI grammar or control (c) was prose.** The frozen definition of 10 says synthetic fixtures can never satisfy adoption, production, or outcome — but with no marker the gate cannot tell a fixture path from a production one.

## Registration cost two ratchets, not none

The gate emits one `scanned:` line on **both** paths — a gate that publishes coverage only when it passes cannot be caught going blind when it matters — and is registered in `gate-coverage.yml` (`min_scanned: 20` against a live 23) with a create-only canary.

Registering it immediately turned `gate-self-test:registered-non-adopters` red at **25 against a baseline of 24**. The ratchet turns one way, so the gate adopted `--self-test` rather than the baseline moving: **9 cases, 7 rejecting**, driving the real CLI against all six twins plus a **dead-scan-root** case no twin can express. Both ratchets green.

## Two defects found while executing, in this run's own work

- **In the gate.** `--file` with an **absolute** path reported `missing_file` for a file that exists, because `path.join(REPO, '/abs')` silently yields `REPO + '/abs'`. Found by the first test that copied the scorecard to a temp directory. Fixed.
- **In this branch's base.** `check_estate_count` read `active_roadmaps 6 → 7` because PR #1614 merged mid-run and the branch was still on the old base — a stale-branch reading, not real growth. Rebased onto `405d2bea5`; the count is `6 (+0)`.

## Bounds stated rather than papered over

- **`check_score_contract` never judges outcome quality.** Emptiness and resolvability only. Step 1.2's verify is mechanised: the test scans the gate's own source for a comparison against a quality-shaped field name and requires zero hits, and asserts the green path states the bound out loud.
- **AC-1 and AC-4 are met *as corrected*, and both corrections are recorded at the criterion.** AC-1 cannot read "every rubric category" while nine are unknown; AC-4 binds the terminal statuses only. An AC over a set the tree does not hold is unsatisfiable, not strict.
- **AC-5 named the wrong file** and is met against `agents/evidence/README.md`, with `provenance/README.md` deliberately untouched.
- **The manifest stays open.** Closing it needs the authoritative external review re-supplied — a maintainer action. Both roadmaps now say so at every place they used to say "all 32".
- **`road-to-score-contract` shipped as `status: draft`**, which means `collect()` never counted it and the archiver never saw it; a completed draft would have sat in the active directory looking like open work. Flipped to `ready` and archived in the same change — estate-neutral (+1 active, −1 disposed), and the reason is recorded at the top of the archived file.

## Gates run locally

`check_score_contract` (+ `--self-test`) · `check_gate_coverage` · `check_gate_paths` · `check_test_coverage_diff` · `lint_deterministic_time` · `check_source_size_budget` · `lint_evidence_artifacts` · `check_estate_count` · `check_references` · `check_roadmap_trackable` · `lint_roadmap_blockers` · `lint_roadmap_complexity` · `lint_roadmap_ci_steps` · `lint_empty_roadmaps` · `lint_roadmap_later_disposition` · `check_no_roadmap_refs` · `lint_plan_risk_register` — all green. 25 vitest tests green. Push preflight passed after one real finding (`lint_evidence_artifacts` wanted a type on the new README).
