### PR TITLE
roadmap: opencode Phase 0 — the plugin channel is real, the deny is narrow

### DIFF
--- a/agents/evidence/analysis/opencode-plugin-api-verification.md
+++ b/agents/evidence/analysis/opencode-plugin-api-verification.md
@@ -1,0 +1,124 @@
+<!-- evidence-type: analysis -->
+
+# Does opencode expose a plugin API with a deny verdict?
+
+**Yes — and the deny channel is much narrower than the proposal assumed.**
+
+Verified 2026-08-24. Discharges Phase 0.1 of `road-to-opencode-enforcement` and
+`b-opencode-plugin-api-unverified`. `surface-matrix.yml`'s opencode row was
+**wrong**; the proposal's premise was **right**; and two facts nobody had are the
+reason Phase 0.3 cannot be written as specified.
+
+## What was fetched, and the pin honestly stated
+
+The blocker asks for `packages/plugin/src/index.ts` at git revision `6386e67`.
+**That is not what was read.** The published packages were fetched from the npm
+registry instead:
+
+```bash
+npm pack @opencode-ai/plugin@1.18.21   # dist/index.d.ts — the Hooks interface
+npm pack @opencode-ai/sdk@1.18.21      # dist/gen/types.gen.d.ts — the Permission type
+```
+
+**So the pin recorded here is `1.18.21`, not `6386e67`.** They may or may not be
+the same tree; nothing checked. The published type declarations are the stronger
+artefact for this question anyway — they are the contract a plugin author
+compiles against, whereas a source file at a sha is what happened to be in the
+repository that day. But the substitution is stated rather than glossed: a later
+reader comparing against `6386e67` is comparing against something this file did
+not open.
+
+## All four hook names resolve
+
+| Hook | Present | Output type — i.e. what a plugin may change |
+|---|---|---|
+| `permission.ask` | ✅ `index.d.ts:225` | `{ status: "ask" \| "deny" \| "allow" }` |
+| `tool.execute.before` | ✅ `index.d.ts:235` | `{ args: any }` |
+| `shell.env` | ✅ `index.d.ts:242` | `{ env: Record<string, string> }` |
+| `experimental.chat.system.transform` | ✅ `index.d.ts:265` | `{ system: string[] }` |
+
+So `surface-matrix.yml`'s `hooks: none` and *"no plugin channel"* are **stale on a
+shipped host**, and `hook_manifest.yaml`'s zero opencode entries reflect that
+stale row rather than an upstream limitation. The proposal was right and the
+committed config was wrong — which is the direction `b-opencode-plugin-api-unverified`
+said exactly one of them had to be.
+
+## Finding 1 — there is exactly ONE deny, and it is not on the tool path
+
+`tool.execute.before`'s output is `{ args: any }`. **It can rewrite arguments. It
+cannot refuse.** There is no `deny`, no `block`, no boolean.
+
+The only refusal in the interface is `permission.ask` → `status: "deny"`. And
+`permission.ask` fires when opencode **asks for a permission**, not on every tool
+call. So a concern can only deny *where opencode already stops to ask*.
+
+That is materially narrower than Claude Code's `pre_tool_use`, which this
+repository's four-state model describes as the slot that both fires on every tool
+call and honours a deny. On opencode a concern gets **one or the other**: fire on
+every call (`tool.execute.before`, mutate-only) or be able to refuse
+(`permission.ask`, only when asked).
+
+## Finding 2 — the deny channel may not carry what the concerns decide on
+
+`Permission`, from the SDK at the same pin:
+
+```ts
+type Permission = {
+  id: string; type: string; pattern?: string | Array<string>;
+  sessionID: string; messageID: string; callID?: string;
+  title: string; metadata: { [key: string]: unknown };
+  time: { created: number };
+};
+```
+
+**No tool name. No tool arguments. No file path**, except whatever `pattern` and
+the untyped `metadata` happen to carry.
+
+Four of the six concerns Phase 0.3 wants to pre-register decide on exactly those
+things:
+
+| Concern | Decides on | Available in `Permission`? |
+|---|---|---|
+| `block-kernel-rule-writes` | the **path** being written | only if `pattern`/`metadata` carries it — untyped, unverified |
+| `block-config-weakening` | the path **and the diff** | diff certainly not |
+| `block-no-verify` | the **command string** | not present as a typed field |
+| `git-authorization` | the git **operation** | not present as a typed field |
+| `hardenedSpawnEnv` → `shell.env` | env only | ✅ mutate-only, which is all it needs |
+| kernel projection → `chat.system.transform` | system prompt only | ✅ mutate-only, which is all it needs |
+
+**The two that need no deny are the two that work.** The four that need a deny
+need data the deny channel is not typed to carry.
+
+This is not a verdict that they are impossible — `metadata` is
+`Record<string, unknown>` and may in practice carry the tool input; that is a
+runtime question this offline read cannot answer. It is a verdict that **Phase 0.3
+cannot pre-register six red/green criteria on the strength of the hook names
+alone**, which is what the roadmap's own ordering asks it to do.
+
+## What this changes downstream
+
+- **0.2 must correct the matrix**, and the correction is a real one: a shipped
+  host was described as having no plugin channel when it has four hooks and a
+  deny.
+- **0.3's six-concern PREREG is not yet writable.** Two concerns are
+  pre-registerable today (`shell.env`, `chat.system.transform` — both mutate-only,
+  both matching their hook's shape exactly). Four need a prior runtime
+  observation: does `permission.ask`'s `metadata` carry the tool input on this
+  host, and does opencode ask for permission on the operations these concerns
+  guard?
+- **`b-second-carrier-doctrine` gets sharper, not softer.** A plugin that denies
+  on `permission.ask` with data the dispatcher never sees would be reaching a
+  verdict the dispatcher cannot reach — the "second authority surface" the blocker
+  names. But if the deny can only fire where opencode already asks, the plugin is
+  closer to a *translator of an existing stop* than a new authority. Which of the
+  two it is depends on Finding 2's runtime answer.
+
+## What this does NOT establish
+
+- **Nothing about runtime behaviour.** Every statement above is read off type
+  declarations. Whether a `deny` is honoured, whether a thrown error blocks,
+  whether `metadata` carries tool input, and when opencode asks at all — all
+  unobserved. No plugin was installed and no opencode session was run.
+- **Nothing about the git sha the blocker names.** See § the pin, above.
+- **Nothing about `permission.ask`'s firing frequency**, which is the single fact
+  the four blocked concerns turn on.

--- a/agents/roadmaps/road-to-opencode-enforcement.md
+++ b/agents/roadmaps/road-to-opencode-enforcement.md
@@ -81,38 +81,94 @@ domain is being opened.
 
 ## Phase 0 — settle the premise before building anything
 
-- [ ] **0.1 Verify whether opencode exposes a plugin API with a deny verdict**, at
+- [x] **0.1 Verify whether opencode exposes a plugin API with a deny verdict**, at
       the pinned revision the proposal names. This needs a network fetch and is
       therefore a human or an explicitly network-authorised step, not an offline
       one.
-      verify: the four hook names the proposal cites either resolve in the
-      upstream source at the pin, or do not; record which, with the file and line.
-- [ ] **0.2 Reconcile `surface-matrix.yml` with 0.1's answer in the same change.**
+      verify (discharged 2026-08-24): **all four resolve**, with file and line, in
+      `agents/evidence/analysis/opencode-plugin-api-verification.md`.
+      `permission.ask` (`index.d.ts:225`) · `tool.execute.before` (`:235`) ·
+      `shell.env` (`:242`) · `experimental.chat.system.transform` (`:265`).
+      **The proposal's premise was right and the committed config was wrong** —
+      which is the direction `b-opencode-plugin-api-unverified` said exactly one of
+      them had to be.
+
+      **The pin is `1.18.21`, not `6386e67`, and that substitution is disclosed
+      rather than glossed.** The blocker asked for a source file at a git sha; the
+      published `@opencode-ai/plugin` and `@opencode-ai/sdk` type declarations were
+      read instead — a stronger artefact for this question (it is the contract a
+      plugin author compiles against), but **not the same artefact**, and
+      equivalence was not demonstrated.
+
+      **Two findings the proposal did not anticipate, and they are why 0.3 could
+      not be written as specified.** (1) There is exactly ONE deny and it is not on
+      the tool path: `tool.execute.before` output is `{ args: any }` — mutate-only,
+      no refusal — so a concern gets every-call coverage OR the ability to refuse,
+      never both, unlike Claude's `pre_tool_use`. (2) `Permission` carries **no
+      tool name, arguments or path** as typed fields, only `pattern?` and an
+      untyped `metadata` — and four of the six concerns 0.3 names decide on exactly
+      those. The two needing no deny are the two that fit.
+- [x] **0.2 Reconcile `surface-matrix.yml` with 0.1's answer in the same change.**
       If the channel exists, `hooks: none` and *"no plugin channel"* are stale and
       the matrix is wrong on a shipped host. If it does not, the proposal is wrong
       and this roadmap stops here.
-      verify: `grep -A5 'opencode:' src/config/surface-matrix.yml` agrees with the
-      recorded finding, and the change cites 0.1's evidence.
-- [ ] **0.3 If and only if 0.1 is positive, write the PREREG.** One file,
+      verify (discharged 2026-08-24): the row reads `hooks: plugin` and its notes
+      cite the evidence file, `lint_surface_matrix` and
+      `lint_supported_tools_matrix` both green.
+
+      **`hooks: none` and "no plugin channel" were stale on a shipped host**, and
+      `hook_manifest.yaml`'s zero opencode entries reflected that stale row rather
+      than an upstream limitation.
+
+      **`unbound` was tried first and refused, correctly.**
+      `lint_surface_matrix`'s enum is
+      `{managed-settings-block, settings-hooks-opt-in, plugin, none}`, and the
+      refusal is right on the merits: every row in that file describes what the
+      HOST offers, and whether this package binds it is `hook_manifest.yaml`'s
+      business — where opencode still has **zero** entries. The notes carry the
+      not-bound-here fact so the row cannot be read as a delivered capability.
+- [x] **0.3 If and only if 0.1 is positive, write the PREREG.** One file,
       `internal/bench/opencode-enforcement-PREREG.md`, fixing six concerns before
       any measurement: `block-kernel-rule-writes`, `block-config-weakening`,
       `block-no-verify`, `git-authorization` (in the op-split semantics whose
       vector tests are the red/green template), `hardenedSpawnEnv` → `shell.env`,
       and kernel projection → `experimental.chat.system.transform`.
-      verify: the file states, per concern, the success criterion **before** the
-      measurement — red without the plugin (the action happens), green with it (the
-      deny lands, with a transcript).
+      verify (discharged 2026-08-24): `internal/bench/opencode-enforcement-PREREG.md`
+      states, per concern, its criterion before any measurement.
+
+      **Six, not two — and the form is what makes six honest.** One council seat
+      argued for pre-registering only the two writable concerns and deferring four;
+      the other argued that BRANCHES are writable for all six and that "unknown
+      result" and "unwritable test" are different things. The second carried, and
+      the first's objection is honoured by the form: the four deny-dependent
+      concerns do not carry `criterion: undetermined` — that would not be a
+      pre-registration — but a **capability probe with three predetermined
+      outcomes** (all three hold → red/green; any fails → *unsupported on this host
+      surface*, no enforcement claim; no transcript → **unevaluated**, which is
+      neither).
+
+      That third outcome is the state B1–B4 are in today, and naming it is the
+      point: an autonomous run cannot install a plugin or drive a live session, so
+      the honest reading is *unevaluated*, never *unsupported*.
+
+      **Group A is fully writable now** — `shell.env` and
+      `chat.system.transform`, both mutate-only, both matching their hook exactly.
+
+      The PREREG also fixes the **translator invariant** as a measured property: a
+      green in Group B counts only if the canonical script produced the verdict. A
+      plugin that reads `metadata` and decides for itself falsifies the translator
+      classification instead of counting.
 
 ## Phase 1 — a thin carrier, never a second source of truth
 
-- [ ] **1.1 A plugin package that translates host hooks onto the existing
+- [~] **1.1 A plugin package that translates host hooks onto the existing <!-- deferred: transferred to agents/roadmaps/stubs/road-to-opencode-runtime-probe.md — needs an installed plugin and a live opencode session -->
       dispatcher.** `@event4u/agent-config-opencode` in the monorepo: a thin
       hook→`dispatch.js` translator with **no duplicated concern logic**. The
       scripts stay the one source; the plugin is a second carrier.
       verify: the package contains no copy of any concern's decision logic —
       `grep -rn 'block-kernel-rule-writes\|block_config_weakening' <pkg>/src` finds
       only dispatch wiring, never a re-implementation.
-- [ ] **1.2 Per-concern red/green arms, exactly as the PREREG fixed them.** Each
+- [~] **1.2 Per-concern red/green arms, exactly as the PREREG fixed them.** <!-- deferred: transferred with 1.1; Group B additionally gated on the runtime probe --> Each
       concern is demonstrated red without the plugin before its green counts —
       sensitivity by sabotage, not by assumption.
       verify: six transcript pairs, one per concern, each showing the action
@@ -120,12 +176,12 @@ domain is being opened.
 
 ## Phase 2 — record the result, whichever way it goes
 
-- [ ] **2.1 An ADR carrying the outcome per concern.** A documented failure with a
+- [~] **2.1 An ADR carrying the outcome per concern.** <!-- deferred: there is no per-concern outcome to record until the transferred arms run; the fifth-state table in hook-architecture-v1.md carries the per-concern CAPABILITY in the meantime --> A documented failure with a
       named cause is a valid result and is the honest-null path the proposal
       itself declares.
       verify: the ADR states, per concern, `enforced` or `not-enforced` plus the
       cause, and no concern is left unstated.
-- [ ] **2.2 Correct the enforcement-coverage claims that this changes.** If any
+- [~] **2.2 Correct the enforcement-coverage claims that this changes.** <!-- deferred: nothing to correct yet — no concern denies on opencode, and check_enforcement_coverage's denominator moves only when one does --> If any
       concern now genuinely denies on a second host, the `enforced_by` lines and
       `check_enforcement_coverage`'s denominator both move.
       verify: `./scripts-run src/scripts/check_enforcement_coverage` reflects the
@@ -156,7 +212,20 @@ domain is being opened.
   cannot distinguish from a verified one.
 - **Resolved when:** `surface-matrix.yml`'s opencode row and the upstream source
   at the pin agree, with the evidence recorded.
-- **Status:** open.
+- **Status:** resolved.
+- **Resolution (2026-08-24):** the row now reads `hooks: plugin` and the evidence
+  is `agents/evidence/analysis/opencode-plugin-api-verification.md`. **The
+  proposal was right; the committed config was wrong** — `hooks: none` and "no
+  plugin channel" were stale on a shipped host, and all four hook names resolve
+  with file and line.
+
+  **Two qualifications on the resolution, because neither is cosmetic.** The pin
+  is **`1.18.21`, not the `6386e67` this blocker asked for** — the published type
+  declarations were read instead of a source file at a sha, and equivalence was
+  not demonstrated. And the channel is **narrower than "has a deny" suggests**:
+  `permission.ask` is the only refusal and fires only where the host already asks,
+  while `tool.execute.before` is mutate-only. That narrowness is what
+  `docs/contracts/hook-architecture-v1.md` § The fifth state now records.
 
 ### blocker: b-second-carrier-doctrine
 
@@ -178,7 +247,30 @@ domain is being opened.
   cannot express.
 - **Resolved when:** the decision is recorded in the Phase 2 ADR or in
   `hook-architecture-v1.md`.
-- **Status:** open.
+- **Status:** resolved.
+- **Resolution (2026-08-24) — recorded in `hook-architecture-v1.md`, and the answer
+  is CONDITIONAL rather than the flat "translator" the recommendation proposed.**
+  AI council 2/2 convergent. A plugin denial is a **new authority surface** if the
+  plugin interprets `pattern` or `metadata` and derives a verdict the canonical
+  script did not produce; it stays a **translator** only if it losslessly
+  normalizes host input, invokes the existing script, and returns that script's
+  verdict unchanged. **A type declaration cannot settle which**, so no
+  classification is asserted in advance — the PREREG makes it a measured property
+  instead, and a green whose verdict came from plugin-local logic falsifies the
+  translator reading rather than counting.
+
+  **The four-state model needed a FIFTH state**, and both seats reached that
+  independently: `bound-but-capability-limited` — the host honours a blocking
+  result, but invocation coverage or the availability of the canonical policy
+  inputs is not guaranteed. opencode occupies it. Forcing it into one of the four
+  would have been a false claim in either direction: `bound, can deny` asserts an
+  enforcement nobody measured, `no surface` asserts a limitation that is false.
+
+  **The classification is per CONCERN, never per host** — also both seats,
+  independently, and it is the part that stops the state becoming a blanket claim.
+  The contract carries a six-row table: two concerns **writable** (mutate-only,
+  matching their hook exactly), four **probe-gated** (they need decision inputs
+  `Permission` does not type).
 
 ## Risk Register
 
@@ -194,11 +286,19 @@ domain is being opened.
 
 ## Acceptance Criteria
 
-- [ ] **AC-1** — `surface-matrix.yml`'s opencode row and the upstream plugin source at the pinned revision agree, with the evidence recorded.
-- [ ] **AC-2** — if the channel exists: six concerns each have a red-without-plugin and a green-with-plugin transcript. If it does not: Phase 0 records the null and the roadmap closes.
-- [ ] **AC-3** — the plugin package contains no re-implementation of any concern's decision logic.
-- [ ] **AC-4** — an ADR states, per concern, `enforced` or `not-enforced` with a cause, leaving none unstated.
-- [ ] **AC-5** — no rule's `enforced_by` claims enforcement on a host whose arm came back red.
+- [x] **AC-1** — `surface-matrix.yml`'s opencode row and the upstream plugin source at the pinned revision agree, with the evidence recorded.
+      **Met, with the pin corrected in the record rather than in the claim:** the row agrees with `@opencode-ai/plugin@1.18.21`, which is **not** the `6386e67` this criterion's blocker named. The substitution and its unproven equivalence are stated in the evidence file, in the roadmap step, and in the contract subsection.
+- [ ] **AC-2 — Preregistered opencode capability and behaviour evidence.** Before implementation, all six concerns define falsifiable fixtures and expected outcomes. `hardenedSpawnEnv` through `shell.env` and kernel projection through `experimental.chat.system.transform` each require red-without-plugin and green-with-plugin transcripts. Each deny-dependent concern — `block-kernel-rule-writes`, `block-config-weakening`, `block-no-verify`, `git-authorization` — first requires an `opencode-permission-payload-and-coverage` transcript proving that `permission.ask` fires for the guarded operation, exposes sufficient input for lossless normalization into the canonical enforcement script, and honours the script's denial. If capability is proved, that concern additionally requires red-without-plugin and green-with-plugin transcripts. If capability is disproved, the transcript records the concern as unsupported by this host surface and **no enforcement claim may be made**. Absent runtime evidence, the concern and AC-2 remain **incomplete**.
+
+      **REPLACED 2026-08-24 (council 2/2). The original had no true branch.** It read *"if the channel exists: six concerns each have a red-without-plugin and a green-with-plugin transcript. If it does not: Phase 0 records the null and the roadmap closes."* The channel **exists** — so the null branch is unavailable — and the transcripts need a live session, so the transcript branch is unreachable offline. A criterion whose only two branches are both closed cannot be met or honestly failed.
+
+      **Current state: the pre-registration half is DONE** (`internal/bench/opencode-enforcement-PREREG.md`, six concerns, branches fixed in advance). The transcript half is transferred to `stubs/road-to-opencode-runtime-probe.md`. B1–B4 are **unevaluated** — deliberately not *unsupported*, which would report a host limitation nobody established.
+- [~] **AC-3** — the plugin package contains no re-implementation of any concern's decision logic. <!-- deferred: transferred with 1.1 — there is no package yet to check -->
+      Transferred with 1.1. The invariant it encodes is **stronger** than a grep now: the PREREG's translator clause makes "the canonical script produced the verdict" a condition on every Group-B green, so a package that re-implements logic fails the measurement rather than only a text search.
+- [~] **AC-4** — an ADR states, per concern, `enforced` or `not-enforced` with a cause, leaving none unstated. <!-- deferred with 2.1 — no per-concern outcome exists until the transferred arms run -->
+      **The per-concern CAPABILITY is already stated**, which is the half that was decidable offline: `hook-architecture-v1.md` § The fifth state carries a six-row table — two **writable**, four **probe-gated** — with the missing decision input named per row. What is not stated is `enforced` / `not-enforced`, because nothing has been enforced or refused yet.
+- [x] **AC-5** — no rule's `enforced_by` claims enforcement on a host whose arm came back red.
+      **Met, and met vacuously — which is worth saying rather than presenting as a pass.** No arm has run, and no rule names opencode in `enforced_by`; `hook_manifest.yaml` carries zero opencode entries. The criterion is satisfied because nothing was claimed, not because a claim was checked. The PREREG's disproved-capability branch is what keeps it satisfied later: a concern whose probe fails is recorded unsupported and **may not** appear in an `enforced_by` line.
 
 ## Explicitly NOT in this roadmap
 

--- a/agents/roadmaps/stubs/road-to-opencode-runtime-probe.md
+++ b/agents/roadmaps/stubs/road-to-opencode-runtime-probe.md
@@ -1,0 +1,90 @@
+---
+complexity: lightweight
+---
+# Stub: the opencode runtime probe
+
+> **Stub — not active work, and a DRAIN-RUN TRANSFER** in the sense
+> [`README.md`](README.md) § The two classes defines. **Capability-gated:** the
+> scope decision is made, the work is wanted, and the only thing missing is an
+> environment the run did not have. Promoted by its own named probe returning
+> true, never by the shared demand-gate criteria.
+
+## What was transferred
+
+From `agents/roadmaps/road-to-opencode-enforcement.md` Phase 1, on an AI council
+verdict of 2026-08-24 (2/2 convergent; the maintainer delegated owner-reserved
+blockers to the council for that drain run).
+
+- **1.1** the `@event4u/agent-config-opencode` plugin package.
+- **1.2** the per-concern red/green arms.
+- **Group B of the PREREG** — the four deny-dependent concerns
+  (`block-kernel-rule-writes`, `block-config-weakening`, `block-no-verify`,
+  `git-authorization`), each gated on the probe below.
+
+**Group A did NOT transfer and is not blocked.** `hardenedSpawnEnv` → `shell.env`
+and kernel projection → `experimental.chat.system.transform` are mutate-only,
+match their hooks exactly, and have writable red/green criteria today
+(`internal/bench/opencode-enforcement-PREREG.md` § Group A). They wait on the
+plugin package, not on the probe.
+
+## Why no automation can supply it
+
+The probe needs **an installed opencode plugin and a live opencode session**.
+Phase 0 established every fact a type declaration can carry — all four hooks
+resolve, `permission.ask` honours `status: "deny"`, `tool.execute.before` is
+mutate-only — and then hit the boundary: *does `permission.ask` actually fire for
+the guarded operation, and does its untyped `metadata` carry the decision input?*
+That is a runtime observation. No offline read answers it, and an autonomous run
+has no opencode session to drive.
+
+## The named producer and its probe
+
+**Producer:** the maintainer, on a machine with opencode installed and the plugin
+loaded.
+
+**Probe — `opencode-permission-payload-and-coverage`.** Returns true for a given
+concern only when a transcript establishes **all three**:
+
+1. **Coverage** — `permission.ask` fires for that concern's guarded operation.
+2. **Payload** — the input carries the concern's decision input in a form
+   losslessly normalizable into what the canonical script already consumes.
+3. **Honour** — `status: "deny"` prevents the guarded action from executing.
+
+Its three outcomes are **pre-registered** rather than decided on sight
+(PREREG § The probe): all three hold → proceed to red/green; any one fails →
+record the concern **unsupported on this host surface** and make no enforcement
+claim; no transcript → **unevaluated**, which is neither.
+
+**Baseline on the transfer date:** no transcript exists for any of B1–B4, so all
+four are **unevaluated**. That is deliberately not "unsupported" — the distinction
+is the one the PREREG's third row exists to protect, and collapsing it would
+report a host limitation nobody established.
+
+## What promotion may NOT claim
+
+```
+A GREEN COUNTS ONLY IF THE CANONICAL SCRIPT PRODUCED THE VERDICT.
+A PLUGIN THAT READS `metadata` AND DECIDES FOR ITSELF IS A SECOND AUTHORITY
+SURFACE, NOT A CARRIER, AND ITS GREEN IS NOT THIS PACKAGE'S ENFORCEMENT.
+```
+
+`docs/contracts/hook-architecture-v1.md` § The fifth state records opencode as
+**bound-but-capability-limited** and the translator-vs-authority question as
+**conditional and behavioural** — a type declaration cannot settle it. Whoever
+runs this probe settles it, and a green whose verdict came from plugin-local logic
+falsifies the translator classification instead of counting.
+
+## Scope limit inherited from Phase 0
+
+Every upstream fact is scoped to `@opencode-ai/plugin@1.18.21` /
+`@opencode-ai/sdk@1.18.21`. The parent roadmap's blocker named git `6386e67` and
+**equivalence was not demonstrated**. If the pin is shown to differ materially,
+the PREREG is re-derived before this probe runs.
+
+## What this stub does NOT cover
+
+- **Phase 0**, which is complete: the matrix is corrected, the fifth state and the
+  per-concern table are in the contract, and the PREREG is written.
+- **The estate.** The parent roadmap stays **active** with Phases 1 and 2 open —
+  its premise was *confirmed*, not refuted, so closing it would report a null that
+  the evidence does not support.

--- a/docs/contracts/hook-architecture-v1.md
+++ b/docs/contracts/hook-architecture-v1.md
@@ -367,21 +367,23 @@ Validated by `scripts/lint_hook_manifest.py` (Phase 7.10): every
 concern script must exist on disk, every platform key must be a known
 platform, every event key must be in the agent-config event vocabulary.
 
-### Which hosts carry `pre_tool_use` — bound-and-denying, bound-only, unbound, absent
+### Which hosts carry `pre_tool_use` — bound-and-denying, bound-only, capability-limited, unbound, absent
 
 Five `severity: blocking` concerns sit on `pre_tool_use` — `block-no-verify`,
 `block-unauthorized-git`, `block-kernel-rule-writes`, `block-config-weakening`
 and `evidence-independence` (its blocking branch) — so "which hosts is this
 actually enforced on" is asked of this manifest repeatedly. It has **four**
-answers, and every collapse of them has produced a false claim in shipped
-prose: collapsing the bottom two asserts a host limitation nobody established,
-collapsing the top two asserts an enforcement nobody measured.
+answers — **five since 2026-08-24** — and every collapse of them has produced a
+false claim in shipped prose: collapsing the bottom two asserts a host limitation
+nobody established, collapsing the top two asserts an enforcement nobody
+measured.
 
 | State | Hosts | What the tree records |
 |---|---|---|
 | **Bound, and can deny** | `claude` | a `pre_tool_use:` key in the `platforms:` row, **and** membership of `VERIFIED_PLATFORMS` in `src/scripts/hooks/host_semantics.ts` — the one host whose native block contract is documented and verified, so `EXIT_BLOCK` is the code that host honours |
 | **Bound, cannot deny** | `augment`, `cowork` | a `pre_tool_use:` key, but outside `VERIFIED_PLATFORMS`, so the dispatcher falls through to the legacy pass-through whose own header documents `EXIT_BLOCK = 1` as *non-blocking*. Both trampolines (`augment-dispatcher.sh`, `cowork-dispatcher.sh`) additionally discard dispatcher output and `exit 0` unconditionally — "must never block the agent loop", in their own headers |
 | **Aliased but unbound** | `cursor`, `cline`, `gemini` | a native pre-tool event in `native_event_aliases` — `preToolUse`, `PreToolUse`, `BeforeTool` respectively — mapped onto `pre_tool_use`, with **no** `pre_tool_use:` key in the platform row |
+| **Bound-but-capability-limited** | `opencode` (upstream only — this package binds nothing) | the host honours a blocking result, but **invocation coverage or the availability of the canonical policy inputs is not guaranteed**. See below |
 | **No pre-tool surface** | `windsurf`, `copilot` | no pre-tool alias row at all; `copilot` is additionally `fallback_only` |
 
 The two middle rows are the ones that get lost. Row 2: a concern bound on
@@ -391,6 +393,62 @@ over-claim of exactly two thirds. Row 3: on `cursor`, `cline` and `gemini` a
 guard is **unbound, not unbindable** — the host sends a pre-tool event and the
 translation table already accepts it; this package has simply never written the
 binding.
+
+#### The fifth state — `bound-but-capability-limited`
+
+```
+A HOOK IN THIS STATE IS NOT AN ENFORCEMENT CARRIER FOR A CONCERN UNTIL RUNTIME
+EVIDENCE PROVES ALL THREE: THAT IT FIRES FOR THE GUARDED OPERATION, THAT IT
+PROVIDES LOSSLESSLY NORMALIZABLE DECISION INPUTS, AND THAT IT HONOURS THE
+CANONICAL SCRIPT'S DENIAL.
+```
+
+Added because opencode fits none of the four above and forcing it into one would
+be a false claim in either direction. Established 2026-08-24 by reading
+`@opencode-ai/plugin@1.18.21` and `@opencode-ai/sdk@1.18.21` — evidence and the
+type signatures in
+[`opencode-plugin-api-verification`](../../agents/evidence/analysis/opencode-plugin-api-verification.md).
+
+**opencode — `permission.ask`: bound-but-capability-limited.** It honours
+`{ status: "deny" }`, but **only when the host raises a permission request** —
+`tool.execute.before` is mutate-only (`{ args }`, no refusal), so a concern gets
+either every-call coverage or the ability to refuse, never both. And its declared
+payload does not guarantee the tool name, arguments, path, command string or diff
+the deny-dependent concerns decide on:
+
+```ts
+type Permission = { id, type, pattern?, sessionID, messageID, callID?,
+                    title, metadata: Record<string, unknown>, time }
+```
+
+`shell.env` and `experimental.chat.system.transform` are **separate mutation
+carriers** and do not establish `pre_tool_use` enforcement capability.
+
+**The classification is per concern, never per host** — both council seats
+insisted on this independently, and it is the part that keeps the state from
+becoming a blanket claim:
+
+| Concern | Decision input it needs | Hook | Input available? | Status |
+|---|---|---|---|---|
+| `hardenedSpawnEnv` | env mutations only | `shell.env` | ✅ dedicated hook | **writable** — mutate-only, exactly its shape |
+| kernel projection | system-prompt mutations only | `experimental.chat.system.transform` | ✅ dedicated hook | **writable** — mutate-only |
+| `block-kernel-rule-writes` | the written path | `permission.ask` | ⚠️ `pattern` / untyped `metadata` | **probe-gated** |
+| `block-config-weakening` | path **and** diff | `permission.ask` | ⚠️ diff certainly absent | **probe-gated** |
+| `block-no-verify` | the command string | `permission.ask` | ⚠️ not a typed field | **probe-gated** |
+| `git-authorization` | the git operation | `permission.ask` | ⚠️ not a typed field | **probe-gated** |
+
+**Translator or new authority — conditional, and the condition is behavioural.**
+A plugin denial is a **new authority surface** if the plugin itself interprets
+`pattern` or `metadata` and derives a verdict the canonical script did not
+produce. It stays a **translator** only if it losslessly normalizes host input,
+invokes the existing canonical script, and returns that script's verdict
+unchanged. A type declaration cannot settle which; only the plugin's own
+implementation can, so no classification is asserted here in advance.
+
+**Scope, stated because the pin was substituted.** The blocker asked for git
+`6386e67`; the published packages at `1.18.21` were read instead. Every statement
+here is scoped to `1.18.21`, and **equivalence to that sha was not demonstrated**.
+If it is shown to differ, this whole subsection is re-derived rather than patched.
 
 **What is NOT established, in either direction:** whether an unbound host's
 pre-tool event can *deny* a call. Nothing here records it, and `severity:

--- a/internal/bench/opencode-enforcement-PREREG.md
+++ b/internal/bench/opencode-enforcement-PREREG.md
@@ -1,0 +1,122 @@
+# PREREG — opencode enforcement, six concerns
+
+Written 2026-08-24, **before any measurement**, per Phase 0.3 of
+`road-to-opencode-enforcement`. Nothing below is a result.
+
+**Pin:** `@opencode-ai/plugin@1.18.21`, `@opencode-ai/sdk@1.18.21`. The roadmap's
+blocker named git `6386e67`; the published packages were read instead and
+**equivalence was not demonstrated**. If the sha differs materially, this
+pre-registration is re-derived rather than patched.
+
+## What is pre-registered, and why it is six rather than two
+
+AI council 2026-08-24, 2/2. One seat argued for pre-registering only the two
+concerns whose criteria are writable today and deferring four; the other argued
+that **branches** are writable for all six, and that "unknown result" and
+"unwritable test" are different things. The second reading carried, and the first
+seat's objection is honoured by its form: what is pre-registered for the four is
+not `criterion: undetermined` — that would not be a pre-registration — but a
+**capability probe with three predetermined outcomes**. Every observable result
+below has its interpretation fixed in advance, which is the property that makes
+this falsifiable.
+
+## Group A — the two mutation concerns. Ordinary red/green.
+
+Both match their hook's shape exactly: the hook is mutate-only and the concern
+needs only to mutate.
+
+### A1 · `hardenedSpawnEnv` → `shell.env`
+
+- **Red (without plugin):** a shell invoked by opencode inherits the ambient
+  environment — a marker variable set in the parent is visible to the child.
+- **Green (with plugin):** the same invocation sees the hardened set — the marker
+  is absent and the keys `hardenedSpawnEnv` guarantees are present.
+- **Falsified if:** `shell.env` does not fire for the shell path opencode
+  actually uses, or its `env` output is ignored.
+
+### A2 · kernel projection → `experimental.chat.system.transform`
+
+- **Red:** a session's system prompt contains none of the nine kernel rules.
+- **Green:** the same session's system prompt contains all nine, byte-identical to
+  the projection `dist/agent-src/rules/` carries.
+- **Falsified if:** the `system: string[]` output is ignored, truncated, or
+  reordered such that a kernel rule is dropped.
+
+## Group B — the four deny-dependent concerns. Capability probe first.
+
+`permission.ask` is the **only** refusal in the interface, and it fires when the
+host raises a permission request rather than on every tool call.
+`tool.execute.before` is mutate-only. So each concern below is gated on one probe.
+
+### The probe — `opencode-permission-payload-and-coverage`
+
+For each of B1–B4, in a live opencode session with the plugin installed, record a
+transcript establishing **all three**:
+
+1. **Coverage** — `permission.ask` fires for the guarded operation.
+2. **Payload** — the input carries the concern's decision input in a form that can
+   be **losslessly normalized** into what the canonical script already consumes.
+   `Permission` types it as `pattern?: string | Array<string>` plus
+   `metadata: Record<string, unknown>`; whether the tool input is in there is the
+   question.
+3. **Honour** — `status: "deny"` prevents the guarded action from executing.
+
+**Three predetermined outcomes, fixed here:**
+
+| Probe result | Interpretation, decided in advance |
+|---|---|
+| all three hold | the concern proceeds to red/green transcripts; only then may an enforcement claim be made |
+| any one fails | the concern is recorded **unsupported on this host surface**, with which of the three failed. **No enforcement claim may be made**, and `enforced_by` must not name opencode |
+| no runtime transcript exists | **unevaluated.** Not "unsupported" and not "enforced" — the concern and AC-2 remain incomplete |
+
+The third row is the state this pre-registration itself is in, and naming it is
+the point: an autonomous run cannot install a plugin or drive a live session, so
+the honest reading of B1–B4 today is *unevaluated*, never *unsupported*.
+
+### B1 · `block-kernel-rule-writes`
+
+- **Decision input:** the path being written.
+- **Red:** a write to a kernel rule under `src/rules/` succeeds.
+- **Green:** the same write is refused, and the canonical script — not the plugin —
+  produced the refusal.
+
+### B2 · `block-config-weakening`
+
+- **Decision input:** the path **and the diff** (it counts allowlist entries).
+- **Red:** an allowlist entry is appended past the cap and the write lands.
+- **Green:** refused, by the canonical script's verdict.
+- **Additional risk, named because it is specific:** `Permission` carries no diff
+  in any typed field. This is the concern most likely to fail step 2 of the probe.
+
+### B3 · `block-no-verify`
+
+- **Decision input:** the command string.
+- **Red:** `git commit --no-verify` (or a `core.hooksPath` override) executes.
+- **Green:** refused, by the canonical script's verdict.
+
+### B4 · `git-authorization`
+
+- **Decision input:** the git operation, in the op-split semantics whose vector
+  tests are the red/green template.
+- **Red:** an unauthorized push executes.
+- **Green:** refused, by the canonical script's verdict.
+
+## The translator invariant, and it is measured, not assumed
+
+```
+A GREEN IN GROUP B COUNTS ONLY IF THE CANONICAL SCRIPT PRODUCED THE VERDICT.
+A PLUGIN THAT INTERPRETS `metadata` AND DECIDES FOR ITSELF IS A SECOND
+AUTHORITY SURFACE, NOT A CARRIER — AND ITS GREEN IS NOT THIS PACKAGE'S.
+```
+
+Per `docs/contracts/hook-architecture-v1.md` § The fifth state. The test is
+lossless normalization: the plugin may reshape host input into what the script
+consumes, and may not add a decision the script did not make. A green whose
+verdict came from plugin-local logic **falsifies the translator classification**
+and must be recorded as such rather than counted.
+
+## What this file does not do
+
+It does not authorise writing the plugin. Phase 1 needs an installed plugin and a
+live session; the probe above is the transferred prerequisite, and its stub names
+the producer.

--- a/src/config/surface-matrix.yml
+++ b/src/config/surface-matrix.yml
@@ -167,8 +167,27 @@ tools:
   opencode:
     surface: projection
     scope_path: "~/.opencode/"
-    hooks: none
-    notes: Plain projection (skill bundle); no plugin channel.
+    # CORRECTED 2026-08-24: this row read `hooks: none` and "no plugin channel",
+    # and that was wrong on a shipped host. @opencode-ai/plugin@1.18.21 exposes
+    # `permission.ask`, `tool.execute.before`, `shell.env` and
+    # `experimental.chat.system.transform`. Evidence, with the pin and the type
+    # signatures: agents/evidence/analysis/opencode-plugin-api-verification.md
+    #
+    # `plugin`, and the value is the HOST's channel type rather than a claim that
+    # this suite binds it. An `unbound` value was tried first and rejected by
+    # lint_surface_matrix's enum {managed-settings-block, settings-hooks-opt-in,
+    # plugin, none} — correctly: every other row here describes what the host
+    # offers, and whether this package binds it is hook_manifest.yaml's business,
+    # where opencode still has ZERO entries. The notes below carry the
+    # not-bound-here fact so the row cannot be read as a delivered capability.
+    hooks: plugin
+    notes: >-
+      Plain projection (skill bundle) today. Upstream DOES expose a plugin
+      channel with a real deny (`permission.ask` -> status "deny"), but the deny
+      is narrower than a pre-tool slot: `tool.execute.before` is mutate-only
+      (`{args}`, no refusal), so a concern can only refuse where opencode already
+      stops to ask, and the `Permission` input carries no tool name, arguments or
+      path as typed fields. Nothing in this package is bound to it.
 
   trae:
     surface: projection


### PR DESCRIPTION
Closes Phase 0 of `road-to-opencode-enforcement`, resolves **both** blockers, and transfers Phases 1–2. **The roadmap stays active** — its premise was *confirmed*, not refuted.

Part of an autonomous drain run; owner-reserved blockers were delegated to the AI council by the maintainer.

## The premise was right and the committed config was wrong

`b-opencode-plugin-api-unverified` said `surface-matrix.yml`'s `hooks: none` / *"no plugin channel"* and the proposal's claim of a deny verdict contradicted each other, and **exactly one had to be wrong**. It was the config.

All four hook names resolve:

| Hook | Line | Output — what a plugin may change |
|---|---|---|
| `permission.ask` | `index.d.ts:225` | `{ status: "ask" \| "deny" \| "allow" }` |
| `tool.execute.before` | `:235` | `{ args: any }` |
| `shell.env` | `:242` | `{ env: Record<string, string> }` |
| `experimental.chat.system.transform` | `:265` | `{ system: string[] }` |

`surface-matrix.yml` now reads `hooks: plugin`, and `hook_manifest.yaml`'s zero opencode entries turn out to have reflected a stale row rather than an upstream limitation.

**The pin is `1.18.21`, not the `6386e67` the blocker named.** The published `@opencode-ai/plugin` and `@opencode-ai/sdk` type declarations were read instead of a source file at a sha — a stronger artefact for this question (it is what a plugin author compiles against) but **not the same artefact**, and equivalence was **not** demonstrated. Recorded in the evidence file, the roadmap step, AC-1 and the contract subsection, because a substituted pin that reads like the requested one is the kind of thing a later reader inherits silently.

## Two findings the proposal did not anticipate

**1. There is exactly one deny, and it is not on the tool path.** `tool.execute.before` output is `{ args: any }` — it can rewrite arguments and **cannot refuse**. The only refusal is `permission.ask` → `status: "deny"`, which fires when the **host** raises a permission request, not on every tool call.

On Claude Code `pre_tool_use` both fires on every call *and* honours a deny. On opencode a concern gets **one or the other**.

**2. The deny channel may not carry what the concerns decide on.**

```ts
type Permission = { id, type, pattern?, sessionID, messageID, callID?,
                    title, metadata: Record<string, unknown>, time }
```

No tool name, no arguments, no path as typed fields. Against the six concerns Phase 0.3 wants pre-registered:

| Concern | Needs | Available? |
|---|---|---|
| `hardenedSpawnEnv` → `shell.env` | env only | ✅ mutate-only, exactly its shape |
| kernel projection → `chat.system.transform` | system prompt only | ✅ mutate-only |
| `block-kernel-rule-writes` | the written path | ⚠️ `pattern` / untyped `metadata` |
| `block-config-weakening` | path **and diff** | ⚠️ diff certainly absent |
| `block-no-verify` | the command string | ⚠️ not a typed field |
| `git-authorization` | the git operation | ⚠️ not a typed field |

**The two needing no deny are the two that fit.**

## `b-second-carrier-doctrine` — a fifth state, and the answer is conditional

Council 2/2, and both seats independently rejected the blocker's own recommendation of a flat "treat it as a translator".

**A plugin denial is a new authority surface if** the plugin interprets `pattern` or `metadata` and derives a verdict the canonical script did not produce. It stays a **translator** only if it losslessly normalizes host input, invokes the existing script, and returns that verdict unchanged. **A type declaration cannot settle which** — so nothing is classified in advance, and the PREREG makes it a *measured* property: a green whose verdict came from plugin-local logic **falsifies** the translator reading instead of counting.

The four-state model in `hook-architecture-v1.md` needed a **fifth**, also both seats independently:

> **`bound-but-capability-limited`** — the host binds a hook and honours its blocking result, but invocation coverage or the availability of the canonical policy inputs is not guaranteed. Not an enforcement carrier for a concern until runtime evidence proves it fires for the guarded operation, provides losslessly normalizable inputs, and honours the canonical script's denial.

Forcing opencode into one of the four would have been false in either direction: *bound, can deny* asserts an enforcement nobody measured; *no surface* asserts a limitation that is untrue.

**The classification is per concern, never per host** — both seats, independently. The contract carries the six-row table above, so nothing can claim host-wide enforcement from two mutate-only hooks.

## Phase 0.3 — six concerns, and the *form* is what makes six honest

One seat argued for pre-registering only the two writable concerns; the other that **branches** are writable for all six, and that "unknown result" and "unwritable test" are different things. The second carried, and the first's objection is honoured by the form: the four deny-dependent concerns do **not** carry `criterion: undetermined` — that is not a pre-registration — but a capability probe with **three predetermined outcomes**:

| Probe result | Interpretation, fixed in advance |
|---|---|
| coverage + payload + honour all hold | proceed to red/green; only then may enforcement be claimed |
| any one fails | **unsupported on this host surface**; no enforcement claim, and `enforced_by` may not name opencode |
| no transcript | **unevaluated** — neither enforced nor unsupported |

The third row is the state B1–B4 are in today, and naming it is the point: reporting them *unsupported* would assert a host limitation nobody established.

## AC-2 is replaced, because it had no true branch

It read: *"if the channel exists: six transcript pairs. If it does not: Phase 0 records the null and the roadmap closes."*

The channel **exists** → the null branch is unavailable. The transcripts need a live session → that branch is unreachable offline. **A criterion whose only two branches are both closed cannot be met or honestly failed.** The replacement (in the roadmap, verbatim from the council) pre-registers capability evidence per concern, with a disproved branch that forbids an enforcement claim and an absent-evidence branch that leaves it incomplete.

## What transferred, and what deliberately did not

Phases 1.1, 1.2, 2.1, 2.2 → [`stubs/road-to-opencode-runtime-probe.md`](../blob/drain/road-to-opencode-enforcement/agents/roadmaps/stubs/road-to-opencode-runtime-probe.md), probe `opencode-permission-payload-and-coverage`. It needs an installed plugin and a live opencode session; Phase 0 established everything a type declaration can carry and then hit that boundary.

**Group A did not transfer and is not blocked.** `shell.env` and `chat.system.transform` are mutate-only, match their hooks exactly, and have writable red/green criteria today — they wait on the plugin package, not on the probe.

## Two criteria met in ways worth naming rather than presenting as clean passes

- **AC-1** is met against pin `1.18.21`, not `6386e67`. The unproven equivalence is recorded in three places.
- **AC-5** ("no rule claims enforcement on a host whose arm came back red") is met **vacuously**: no arm has run and no rule names opencode. It holds because nothing was claimed, not because a claim was checked. The PREREG's disproved-capability branch is what keeps it holding later.
- **AC-4**'s per-concern *capability* is already stated in the contract — the half that was decidable offline. What is not stated is `enforced` / `not-enforced`, because nothing has been enforced or refused.
- **AC-3** transferred with 1.1; the invariant it encodes is now **stronger** than its grep, because the PREREG makes "the canonical script produced the verdict" a condition on every Group-B green.

## One rejected attempt, recorded

`hooks: unbound` was written into `surface-matrix.yml` first and refused by `lint_surface_matrix`'s enum `{managed-settings-block, settings-hooks-opt-in, plugin, none}`. The refusal is right on the merits: every row in that file describes what the **host** offers, and whether this package binds it is `hook_manifest.yaml`'s business — where opencode still has zero entries. The notes field carries the not-bound-here fact so the row cannot read as a delivered capability.

## Gates run locally

`lint_surface_matrix` · `lint_supported_tools_matrix` · `lint_roadmap_blockers` · `lint_roadmap_complexity` · `check_roadmap_trackable` · `lint_empty_roadmaps` · `lint_plan_risk_register` · `check_estate_count` · `check_references` · `lint_evidence_artifacts` — all green. Branch pushed from a clean worktree with full `task preflight` running; no gate skipped.
