### PR TITLE
roadmap: command-surface Phase 0 — the path-leak ratchet, and the drain-run summary

### DIFF
--- a/.path-leak-allow
+++ b/.path-leak-allow
@@ -1,0 +1,62 @@
+# Audited published-`.md` exceptions for check_bundle_path_leakage.
+# Format: <path>:<line>.  A `#` comment is stripped, so every entry carries its
+# reason above it.
+#
+# THE FLOOR IS ZERO UNAPPROVED, NEVER A COUNT. A numeric baseline of twelve was
+# rejected by both council seats on 2026-08-24 for one reason: it lets an approved
+# hit disappear while a real leak takes its slot, and the count stays twelve. So
+# every match is either pinned here with a reason or it reds the build.
+#
+# Line-pinned on purpose, same trade-off `.secret-allow` documents for itself: an
+# entry that drifts off its line stops matching and the gate REDS. That is the
+# safe direction — someone re-audits and moves the pin. A path-only entry would
+# silently allow a real leak anywhere in the file.
+#
+# These paths are all under `dist/agent-src/`, a GENERATED projection, so a pin
+# here drifts whenever the source above it gains or loses a line. That is
+# expected and is the mechanism working; re-audit and move the pin rather than
+# widening the entry.
+#
+# WHAT DOES NOT BELONG HERE: a real machine path. The three classes below are the
+# pattern being DOCUMENTED, not committed. If a new entry is not one of those
+# three, the fix is to anonymise the path, not to pin it.
+
+# ── Class 1: anonymised documentation examples ────────────────────────────────
+# Already placeholders (`maintainer`, `me`), and deliberately path-SHAPED so a
+# reader recognises what they stand for. No regex can tell them from a real path,
+# which is why they are pinned rather than pattern-exempted.
+dist/agent-src/commands/knowledge/forget.md:63
+dist/agent-src/commands/knowledge/list.md:58
+dist/agent-src/commands/package/test.md:69
+
+# `/node_modules/` inside a prose explanation of what an ignore file should
+# cover. Matched by `absolute-node-modules`, which was written for baked-in
+# bundle strings; in a command body it is the subject of the sentence.
+dist/agent-src/commands/optimize/augmentignore.md:99
+
+# ── Class 2: the rules that FORBID the pattern, quoting it ────────────────────
+# The sharp class, and the reason a mechanical exemption was refused. These
+# artefacts exist to stop `/Users/<realname>/…` reaching a shipped file; a gate
+# that reds on them makes the rule unwritable. Same shape as
+# lint_deterministic_time, whose own docstring names the construct it bans and
+# which therefore had to exempt its own matcher.
+dist/agent-src/rules/doc-screenshot-hygiene.md:62
+dist/agent-src/skills/screenshot-hygiene/SKILL.md:71
+dist/agent-src/skills/screenshot-hygiene/SKILL.md:72
+# `:78` is the ALLOWED variant (`/Users/<handle>/…` — a public handle), quoted in
+# contrast with the forbidden one on the two lines above. Both halves of that
+# contrast have to be printable or the distinction cannot be taught.
+dist/agent-src/skills/screenshot-hygiene/SKILL.md:78
+
+# The privacy floor enumerating the patterns it detects, backticked, on one line.
+dist/agent-src/rules/low-impact-corpus-privacy-floor.md:46
+
+# ── Class 3: legitimately absolute ───────────────────────────────────────────
+# Where the file actually is on a Homebrew install — a consumer edits this exact
+# path, so anonymising it would make the instruction wrong.
+dist/agent-src/skills/traefik/SKILL.md:60
+
+# This package's own worktree convention, documented by the skill that owns it.
+# `worktree-path` exists to catch a build run from inside `.claude/worktrees/`;
+# the skill defining the convention is the one place the string is the subject.
+dist/agent-src/skills/worktree-lifecycle/SKILL.md:141

--- a/agents/evidence/analysis/published-md-path-leakage-baseline.md
+++ b/agents/evidence/analysis/published-md-path-leakage-baseline.md
@@ -1,0 +1,123 @@
+<!-- evidence-type: analysis -->
+
+# Absolute paths in published `.md` — the population is 12, and none of them is a leak
+
+Measured 2026-08-24. Discharges Phase 0.1 of
+`road-to-inbox-harvest-2026-08-e-command-surface-legibility`, and **falsifies
+Phase 0.3's target of 0**.
+
+## Method, reproducible
+
+"Published `.md`" is derived from `package.json` `files[]` rather than guessed, so
+the population is the one the tarball actually ships: every tracked `.md` under
+`dist/agent-src/`, `docs/guidelines/`, `src/scripts/`, `src/agent-src/`,
+`agents/templates/`, `src/templates/`, `src/config/`, plus the nine named
+root/contract files.
+
+The four patterns are `check_bundle_path_leakage.ts`'s own — `macos-linux-home`,
+`private-or-opt-root`, `windows-drive`, `worktree-path` — copied verbatim from
+`LEAK_PATTERNS` so the baseline is measured with the same regexes the extension
+would apply. (`parent-relative-node-modules` and `absolute-node-modules` are
+bundle-shaped and cannot occur in prose; they were not run.)
+
+```bash
+git ls-files | grep '\.md$'   # then filter to the files[] roots above
+# and apply LEAK_PATTERNS from src/scripts/check_bundle_path_leakage.ts
+```
+
+## The population
+
+**947 published `.md` scanned · 12 hits · 9 distinct files.**
+
+| Pattern | Hits |
+|---|---|
+| `macos-linux-home` | 7 |
+| `private-or-opt-root` | 3 |
+| `worktree-path` | 1 |
+| `absolute-node-modules` | 1 |
+| `windows-drive` | 0 |
+
+### Two corrections to this file's own first numbers, recorded rather than overwritten
+
+**It is 12, not 11, and the miss was a stated assumption that turned out false.**
+The first pass ran four of the gate's six patterns and said so —
+`parent-relative-node-modules` and `absolute-node-modules` were skipped as
+*"bundle-shaped and cannot occur in prose"*. Running the real gate found
+`commands/optimize/augmentignore.md:99` carrying `/node_modules/` inside a
+sentence about what an ignore file should cover. The assumption was wrong in the
+direction that under-reports, which is the worse direction, and the lesson is the
+narrow one: run the gate rather than re-implementing its patterns.
+
+**The population is 947, not 1,079.** The first pass scanned `src/agent-src/`
+wholesale; `package.json` `files[]` ships only `src/agent-src/scripts/` and
+`src/agent-src/templates/scripts/`. Caught by the gate's own new test, which
+asserts every declared root is inside `files[]` — 132 files were being counted
+that no consumer receives.
+
+| File:line | Match | What it actually is |
+|---|---|---|
+| `commands/knowledge/forget.md:63` | `/Users/maintainer/clients/acme` | a documentation **example** path |
+| `commands/knowledge/list.md:58` | `/Users/maintainer/clients/acme` | same example |
+| `commands/package/test.md:69` | `/Users/me/projects/my-package` | a documentation example |
+| `rules/doc-screenshot-hygiene.md:62` | `/Users/<realname>/…` | the rule **forbidding** real-name paths, quoting the shape it forbids |
+| `skills/screenshot-hygiene/SKILL.md:71` | `/Users/<realname>/…` | same, in the skill that implements it |
+| `skills/screenshot-hygiene/SKILL.md:72` | `/home/<realname>/…` | same |
+| `skills/screenshot-hygiene/SKILL.md:78` | `/Users/<handle>/…` | same — the *allowed* variant, contrasted with the forbidden one |
+| `rules/low-impact-corpus-privacy-floor.md:46` | `` `/opt/ `` | the rule **listing the patterns it detects**, in a backticked enumeration |
+| `rules/low-impact-corpus-privacy-floor.md:46` | `` `/private/ `` | same line, same enumeration |
+| `skills/traefik/SKILL.md:60` | `/opt/homebrew/etc/dnsmasq.conf` | a **real and correct** Homebrew path a consumer edits |
+| `skills/worktree-lifecycle/SKILL.md:141` | `.claude/worktrees/` | the skill documenting **this package's own** worktree convention |
+| `commands/optimize/augmentignore.md:99` | `/node_modules/` | prose about what an ignore file should cover — found by the gate, missed by this file's first pass |
+
+## The finding — zero leaks, and the target of 0 is wrong
+
+**Not one of the eleven is a build-machine path leak.** They are three classes,
+and each has a different reason to stay:
+
+1. **Documentation examples** (3) — `/Users/maintainer/…`, `/Users/me/…`. Already
+   anonymised placeholders. A gate cannot tell them from a real path by regex,
+   because they are *shaped* like one on purpose.
+2. **The rules that forbid the pattern, quoting it** (6). This is the sharp case:
+   `doc-screenshot-hygiene` exists to stop `/Users/<realname>/…` reaching a
+   shipped artefact, and `low-impact-corpus-privacy-floor` lists `/opt/` and
+   `/private/` as the patterns it detects. **A gate that reds on these makes the
+   rule unwritable.** Same shape as `lint_deterministic_time`, whose own docstring
+   names the construct it bans and which therefore had to exempt comments and
+   string literals from its own matcher.
+3. **Legitimately absolute paths** (2) — `/opt/homebrew/etc/dnsmasq.conf` is where
+   the file is, and `.claude/worktrees/` is this package's own convention being
+   documented by the skill that owns it.
+
+So Phase 0.3's *"the existing population melts down, target 0"* describes a target
+that **cannot be reached without deleting correct content**. Class 3 is
+permanently legitimate; class 2 is permanently legitimate *and* is the rule layer
+this repository's own privacy discipline rests on.
+
+## What an extension would need instead
+
+A forward-only ratchet is still the right shape — a **real** leak in a new file
+should red. What the baseline shows is that the ratchet's floor is not 0 and the
+gate needs a way to say *"this occurrence is the pattern being documented, not
+committed"*. Three mechanisms already exist in this tree for exactly that shape:
+
+- an inline marker (`# secret-allow`'s form, or `<!-- ref-ignore -->`),
+- a repo-root allow file (`.secret-allow`'s form, line-pinned so drift reds),
+- or the `lint_deterministic_time` approach: exempt matches inside backticks and
+  fenced blocks, which covers class 2 mechanically and needs no per-site marker.
+
+Choosing among them is a design decision, not a measurement, and is put to the
+council rather than decided here.
+
+## What this measurement does NOT establish
+
+- **Nothing about untracked or generated output.** Only tracked `.md` inside
+  `files[]` was scanned. `dist/install/`'s bundle roots — the gate's current
+  scope — are untouched by this and were not re-measured.
+- ~~**Nothing about `parent-relative-node-modules` / `absolute-node-modules`.**~~
+  **Withdrawn.** That exemption was this file's own assumption and it was wrong:
+  `absolute-node-modules` has one prose hit. `parent-relative-node-modules` has
+  none, which is now a measurement rather than a prediction.
+- **Nothing about whether the three example paths SHOULD be anonymised further.**
+  `/Users/maintainer/` and `/Users/me/` are already placeholders; whether a
+  convention should force a non-path-shaped form instead is a separate question
+  this file does not answer.

--- a/agents/evidence/drain-run-summary.md
+++ b/agents/evidence/drain-run-summary.md
@@ -597,3 +597,122 @@ Recorded because they cost real time and recurred:
   folded into the convergent set.
 - `#1594` and `#1604` are deliberately **not** archived and their open items are
   owner-facing, so the active estate is not empty by design.
+
+---
+
+# Run C — 2026-08-24
+
+Second autonomous drain run of 2026-08-24. Every decision below was taken by the
+**AI council** under maintainer-delegated authority; none was taken by the agent
+alone, and none reached the user. Council spend: **$0.45** across 7 sessions.
+
+**This run did not empty the roadmap directory, and the reason is capacity rather
+than a blocker.** That is stated first because it is the fact the mandate's
+success condition turns on.
+
+## The seven pull requests
+
+| PR | Roadmap | Outcome |
+|---|---|---|
+| [#1614](https://github.com/event4u-app/agent-config/pull/1614) | `component-library-lifecycle` | **complete + archived.** 2 steps, 8 ACs · **merged** |
+| [#1615](https://github.com/event4u-app/agent-config/pull/1615) | `release-placeholder-guard` | **reverted to `stubs/`** by council verdict · **merged** |
+| [#1616](https://github.com/event4u-app/agent-config/pull/1616) | `score-contract` | **complete + archived.** New gate + 23-row scorecard · **merged** |
+| [#1617](https://github.com/event4u-app/agent-config/pull/1617) | `npm-payload-reduction` | **complete + archived.** Cap 9.2 → 9.1 |
+| [#1618](https://github.com/event4u-app/agent-config/pull/1618) | `suggestion-block-capture` | 11/13; soak transferred; **stays active** |
+| [#1619](https://github.com/event4u-app/agent-config/pull/1619) | `opencode-enforcement` | Phase 0 complete; Phases 1–2 transferred; **stays active** |
+| (this PR) | `command-surface-legibility` | Phase 0 complete; Phases 1 + 4 transferred; 6 steps open |
+
+## Council decisions — every one, with its verdict
+
+| Question | Verdict | Convergence |
+|---|---|---|
+| May an autonomous run self-issue an estate offset over a deferred decision? | **Never.** Five conditions stated; revert `release-placeholder-guard` | 2/2 |
+| Is the AC scorecard a fourth register or a `CLAIMS.md` projection? | **Register** — but in a **new `agents/evidence/README.md`**, not `provenance/README.md`, which the blocker named wrongly | 2/2 |
+| Seed 32 rubric rows, or the 23 recoverable? | **23**, incompleteness machine-enforced. Both seats corrected the arithmetic to **9** missing, not 7 | 2/2 |
+| Lower `packed_size_mb` to 9.1 on a 92.9 KB reduction? | **Yes**, and state the headroom as **7.4 %**, not "~8 %" | 2/2 |
+| Repoint 9 shipped importers at `dist/agent-src/` for ~102 KB? | **No** — it inverts source-of-truth; needs an ADR | 2/2 |
+| Disposition of a 14-day soak needing a human's log? | **Transfer to `stubs/`; roadmap stays active; AC-2 is `open`, not "partially met"** | 2/2 (after a 1/2 `ENOBUFS` degradation was **re-run rather than banked**) |
+| opencode: translator or new authority? | **Conditional and behavioural**; a **fifth** hook state, classified **per concern** | 2/2 |
+| Six-concern PREREG, or two? | **Six**, as branch pre-registrations with three predetermined outcomes | 2/2 |
+| Path-leak floor: 12, or backtick exemption? | **Neither** — 0 unapproved with line-pinned exceptions | 2/2 |
+| `## Examples` for `visible` only or `visible`+`advanced`? | **Both** = 23 governed, 18 to write | 2/2 |
+
+## Premises the run measured and falsified
+
+Nine, each in a roadmap that asserted the opposite:
+
+1. **`src/scripts/ai_council/` can be dropped for 270 KB** — the candidate carried across four cap raises. Removing it breaks `council:status` **and** `hooks:status` with `ERR_MODULE_NOT_FOUND`. **Settled; should not be proposed a fifth time.**
+2. **Every named payload subtree ships.** All six. The removable set is three *file patterns* nobody had looked for.
+3. **`src/agent-src/` "partly duplicates" `dist/agent-src/`** — it is **94.2 %** byte-identical (284/297 files), and still not removable.
+4. **The 32-category rubric is reconstructible** — it is not in the tracked tree. 23 recoverable; **9 identities unknown**.
+5. **opencode has no plugin channel** (`surface-matrix.yml`) — it has four hooks and a real deny.
+6. **`permission.ask` gives a pre-tool deny** — it gives a deny only where the host already asks; `tool.execute.before` is mutate-only.
+7. **"tier 0/1" classifies commands** — the integer alias was removed; 201 of 202 files have no `tier:` key.
+8. **8 invoking / 14 mentioning** — measured 8/**6**.
+9. **Published `.md` can melt to zero absolute paths** — six of twelve are the rules that *forbid* the pattern, quoting it.
+
+## Errors this run made, caught, and recorded
+
+Kept because a summary that lists only findings reads as a run that made none:
+
+1. **Lowered a ratchet on a local reading.** `ci-parity:local-only` reported itself loose at 164; CI measured 165 and red the gate. Reverted, and the entry now records that this baseline moves on the **enforcing** environment only.
+2. **Skipped two of six patterns on an assumption.** Called the `node_modules` patterns "bundle-shaped, cannot occur in prose". One prose hit exists. Under-reported 11 for 12.
+3. **Scanned a root outside `files[]`.** Counted 132 files no consumer receives. Caught by a test written for the gate.
+4. **Wrote a settings disposition as `derivable`** when the key authorises observing an operator's turns — `consent`. The shrink-only ratchet refused it immediately.
+5. **Appended a stop-slot concern after `run-continuation`**, which must be last. CI named the constraint exactly.
+6. **Four downstream surfaces missed for one settings key** — schema path, class contract, proof page, install bundle. Each caught by CI, none by me.
+7. **Substituted a pin** — read npm `1.18.21` where a blocker asked for git `6386e67`. Disclosed in four places rather than glossed.
+
+## Transferred to `stubs/` — five, each with a named probe
+
+| Stub | Probe | Gated on |
+|---|---|---|
+| `road-to-release-placeholder-guard` | (re-promotion conditions) | a named estate offset, or an authorised capped exemption |
+| `road-to-suggestion-capture-soak` | `probe:suggestion-capture-soak-evidence-ready` | a human's 14-day independent emission log |
+| `road-to-opencode-runtime-probe` | `opencode-permission-payload-and-coverage` | an installed plugin + a live opencode session |
+| `road-to-command-runtime-requirements` | `probe-command-schema-runtime-requires` | a maintainer schema-ownership decision |
+| `road-to-make-it-stick-telemetry` | `probe-make-it-stick-telemetry` | per-invocation telemetry that does not exist |
+
+## What remains, and why — the honest accounting
+
+**The directory is not empty.** Nine roadmaps carry open work this run did not
+reach, and **not one of them is blocked**:
+
+| Roadmap | Open | Why not reached |
+|---|---|---|
+| `command-surface-legibility` | 6 | Phases 2–3 executable; Phase 0 shipped instead |
+| `merge-surface-zero` | 15 | not started |
+| `standing-payload-truth` | 15 | not started (4 blockers) |
+| `skill-estate-drawdown` | 16 | not started (3 blockers) |
+| `web-launch-readiness` | 19 | not started |
+| `episode-finalizer-and-outcome-attribution-v2` | 21 | not started (3 blockers) |
+| `ten-across-the-board` | 20 | index roadmap; owns no state of its own |
+| `routing-assurance` | 33 | not started |
+| `capability-native-execution` | 54 | not started (5 blockers) |
+| `inbox-harvest-2026-08-e-council-topology-evidence` | 77 | not started (6 blockers) |
+
+```
+THIS IS A CAPACITY LIMIT, NOT A BLOCKER. THE MANDATE'S TERMINAL FALLBACK COVERS
+WORK THAT SURVIVES EXECUTION, COUNCIL, RE-SCOPING AND DESCOPING. NONE OF THE
+ABOVE WAS PUT TO ANY OF THE FOUR — THE RUN STOPPED BEFORE REACHING THEM.
+```
+
+Descoping them into stubs would assert a capability gap that does not exist, which
+is the same false-blocker the `command-surface-legibility` ledger refuses for its
+own six open steps. So they are left **active and open**, which is what they are.
+
+## Honest limits of this record
+
+- **PR-reported state.** #1617, #1618, #1619 and this PR were still settling
+  checks when this was written; #1614–#1616 are merged.
+- **Every "complete" is complete against its own ACs**, several of which this run
+  **rewrote** — most sharply `opencode-enforcement`'s AC-2, which had no true
+  branch, and `command-surface-legibility`'s "target 0", which was unreachable. A
+  reader auditing completion should read the AC as amended, and the amendment's
+  reason is recorded at each one.
+- **Three ACs are met vacuously or partially and say so** in their own text:
+  `opencode` AC-5 (nothing claimed, so nothing violated), `suggestion-block` AC-2
+  (unit-verified, live-unverified, N=3 budget spent), `npm-payload` AC-1 (six named
+  boundaries, not "every subtree").
+- **One council reached 1 of 2** on the first attempt (`ENOBUFS`) and was re-run;
+  the degraded reading was not banked. Every other session was 2/2.

--- a/agents/roadmaps/road-to-inbox-harvest-2026-08-e-command-surface-legibility.md
+++ b/agents/roadmaps/road-to-inbox-harvest-2026-08-e-command-surface-legibility.md
@@ -187,27 +187,95 @@ What **this** roadmap keeps is only the ratchet that prevents recurrence
 
 ## Phase 0 — The path-leakage ratchet
 
-- [ ] 0.1 Measure the current absolute-path population across published `.md`
+- [x] 0.1 Measure the current absolute-path population across published `.md`
   and record it as the pre-registered baseline before changing any scan scope.
-      verify: the count and the file list land in
-      `agents/evidence/analysis/` and are reproducible from the recorded
-      command
-- [ ] 0.2 **Extend** `src/scripts/check_bundle_path_leakage.ts` to cover
+      verify (discharged 2026-08-24):
+      `agents/evidence/analysis/published-md-path-leakage-baseline.md` — count,
+      per-pattern breakdown, full file:line table, and the derivation of the
+      population from `package.json` `files[]`.
+
+      **947 published `.md` · 12 hits · 9 files · ZERO leaks.** Every hit is one of
+      three classes: an anonymised documentation example (4), an occurrence inside
+      the rules that FORBID the pattern and must quote it (6), or a legitimately
+      absolute path (2).
+
+      **The measurement corrected itself twice, and both are recorded rather than
+      overwritten.** The first pass said 11 of 1,079. It ran four of the gate's six
+      patterns on a stated assumption that the two `node_modules` ones were
+      "bundle-shaped and cannot occur in prose" — false, there is one prose hit, so
+      the real figure is 12. And it scanned `src/agent-src/` wholesale when
+      `files[]` ships only two subtrees of it, counting 132 files no consumer
+      receives. **The second error was caught by the new test asserting every
+      declared root is inside `files[]`** — a test written for the gate, catching
+      the measurement.
+
+      The narrow lesson, worth more than the numbers: run the gate rather than
+      re-implementing its patterns.
+- [x] 0.2 **Extend** `src/scripts/check_bundle_path_leakage.ts` to cover
   published `.md` files, reusing its existing username redaction and the
   `src/scripts/_lib/scan_scope.ts` dead-scope protection. Do **not** add a
   second gate: this one is already in CI at `.github/workflows/tests.yml:141`
   and already carries the patterns a new gate would duplicate.
-      verify: the extended gate reds on a seeded `/Users/<name>/…` path in a
-      published `.md`, greens after removal, and the bundle-root behaviour is
-      byte-unchanged; sabotage the scope extension and watch it stop firing
-- [ ] 0.3 Convert the measured baseline into a forward-only ratchet: new and
+      verify (discharged 2026-08-24), all four halves:
+
+      | Probe | Result |
+      |---|---|
+      | seeded `/Users/realperson/…` in a published `.md` | **red** (exit 1) |
+      | same seed **inside backticks** | **red** (exit 1) |
+      | seed removed | green |
+      | bundle-root behaviour | unchanged — an explicit single-file run reports `1 bundle + 0 published-md`, and the 31 pre-existing tests pass untouched |
+      | **scope extension sabotaged** (`PUBLISHED_MD_ROOTS` emptied) with the seed in place | **exit 0 — it stopped firing**, which is the sensitivity proof |
+
+      **The backtick row is the load-bearing one.** It empirically refutes the
+      other candidate mechanism: both council seats rejected "exempt matches inside
+      backticks and fenced blocks" because *a real leaked path is commonly
+      formatted as code*, and the seeded-in-backticks probe is that argument as a
+      measurement rather than a prediction.
+
+      Extended rather than duplicated, as the step required: this gate already runs
+      in CI, already carries the patterns, the username masking and the
+      `scan_scope` dead-scope protection.
+
+      **One defect the extension exposed and fixed:** the per-pattern hints are
+      bundle-shaped (*"rebuild from a clean checkout"*), which is the wrong
+      instruction for prose — nothing is rebuilt to fix a `.md`. A published-md hit
+      now gets its own line naming the two real options: anonymise, or pin.
+- [x] 0.3 Convert the measured baseline into a forward-only ratchet: new and
   edited files must be clean, the existing population melts down, target 0.
-      verify: the ratchet value equals the 0.1 measurement, and a new dirty
-      file fails while the recorded population does not
+      verify (discharged 2026-08-24 with the mechanism CHANGED, and the change is
+      the finding): a new dirty file fails; the recorded population does not.
+
+      **"Target 0" was unreachable and the numeric ratchet was rejected.** The
+      measured population contains six occurrences inside the rules that exist to
+      FORBID the pattern — `doc-screenshot-hygiene` and `screenshot-hygiene` quote
+      `/Users/<realname>/…` because that is their subject, and
+      `low-impact-corpus-privacy-floor` lists `/opt/` and `/private/` as the
+      patterns it detects. **A gate that reds on those makes the rule unwritable.**
+      Melting the population to 0 would mean deleting correct content.
+
+      AI council 2026-08-24, 2/2: **the floor is 0 UNAPPROVED matches, not a
+      count.** A numeric floor of 12 was rejected for a specific reason — it lets
+      an approved hit disappear while a real leak takes its slot and the count
+      stays 12. So the twelve are **line-pinned exceptions** in `.path-leak-allow`,
+      each carrying its reason and its class, and everything else reds.
+
+      **Line-pinned deliberately, with the cost named:** the pins point into
+      `dist/agent-src/`, a generated tree, so a pin drifts when its source gains a
+      line. That reds the gate, which is the safe direction — someone re-audits and
+      moves it — and a test asserts **every pin still matches something**, because
+      a pin matching nothing suppresses nothing and hides that the exception was
+      never re-audited. This tree has been bitten by the opposite already: a
+      `.secret-allow` pin sat one line off on `main` for a day, covering nothing,
+      invisible because that gate is diff-scoped.
+
+      **No `gate-violation-baselines.json` entry**, and that is a consequence
+      rather than an omission: a zero-unapproved floor has no number to ratchet, so
+      the mechanism costs one of the three ratchets a new numeric baseline would
+      have.
 
 ## Phase 1 — Command prerequisites and probing (from D3)
 
-- [ ] 1.1 Declare command prerequisites using the **existing**
+- [~] 1.1 Declare command prerequisites using the **existing** <!-- deferred: transferred to agents/roadmaps/stubs/road-to-command-runtime-requirements.md — gated on a maintainer schema-ownership decision -->
   `runtime_requires` vocabulary from
   `src/scripts/schemas/skill.schema.json:45-89` (`bins`, `env`, `primary_env`,
   `network`) rather than inventing a second shape. Note two hard constraints
@@ -219,7 +287,7 @@ What **this** roadmap keeps is only the ratchet that prevents recurrence
       regenerations are run in order (`task sync` then `task generate-tools`),
       and the key name is not `requires`; blocked on
       `blocker: command-schema-additionalproperties`
-- [ ] 1.2 Add gate `check_command_needs`: a static body scan (invocation
+- [~] 1.2 Add gate `check_command_needs`: a static body scan (invocation <!-- deferred: transferred with 1.1; the corrected 8/6 baseline travels with it -->
   heuristic on `gh`, `docker`, `kubectl`, `terraform`, extensible) against the
   declaration. Pre-registered baseline: **8 invoking / 14 mentioning, of 202**
   recursive command files. Forward-only ratchet on the `command-verbs.yml`
@@ -228,12 +296,12 @@ What **this** roadmap keeps is only the ratchet that prevents recurrence
       verify: the gate reds on a seeded undeclared invocation, and the 8/14
       distinction is triaged by hand before the gate goes blocking, so a
       documentation-only mention is not counted as an invocation
-- [ ] 1.3 Probe declared prerequisites from an **existing** doctor entry point,
+- [~] 1.3 Probe declared prerequisites from an **existing** doctor entry point, <!-- deferred: transferred with 1.1 -->
   emitting the pinned fix command, reusing the reach probe taxonomy rather than
   building a parallel doctor.
       verify: a missing binary yields the pinned fix command and the correct
       probe state; blocked on `blocker: reach-doctor-generalisation-verdict`
-- [ ] 1.4 Hold the non-goals: no auto-install, and no network access on the
+- [~] 1.4 Hold the non-goals: no auto-install, and no network access on the <!-- deferred: transferred with 1.1 — a non-goal has nothing to hold until the phase runs -->
   default path (`--deep` stays opt-in, per the reach doctrine).
       verify: the probe issues zero network calls without `--deep`
 
@@ -291,7 +359,7 @@ What **this** roadmap keeps is only the ratchet that prevents recurrence
 
 ## Phase 4 — Later and only with evidence
 
-- [ ] 4.1 A "make it stick" suggestion: repeated manual invocations of the same
+- [~] 4.1 A "make it stick" suggestion: repeated manual invocations of the same <!-- deferred: transferred to agents/roadmaps/stubs/road-to-make-it-stick-telemetry.md — the telemetry to test the hypothesis does not exist -->
   command with similar arguments (local-analytics signal) produce a read-only
   suggestion to capture a preset or a learning via `learning-to-rule-or-skill`.
   Default-off. **Pre-registered precondition, carried over from the source
@@ -306,6 +374,13 @@ What **this** roadmap keeps is only the ratchet that prevents recurrence
 ## Blockers
 
 ### blocker: command-schema-additionalproperties
+
+> **TRANSFERRED 2026-08-24 with Phase 1** to
+> [`stubs/road-to-command-runtime-requirements.md`](stubs/road-to-command-runtime-requirements.md),
+> probe `probe-command-schema-runtime-requires`. It stays **open** and moves file
+> rather than closing: the schema-ownership question is unchanged and is the
+> maintainer's. AI council 2/2 — an autonomous run may not widen a contract every
+> consumer's frontmatter validates against.
 - **Status:** open
 - **Owner:** maintainer
 - **Blocks:** 1.1, and by dependency 1.2 and 1.3. Phases 0, 2 and 3 ship
@@ -330,6 +405,9 @@ What **this** roadmap keeps is only the ratchet that prevents recurrence
   green.
 
 ### blocker: reach-doctor-generalisation-verdict
+
+> **TRANSFERRED 2026-08-24 with Phase 1.3** to the same stub. Unchanged and still
+> open; 1.3 is the only step it gates and that step moved.
 - **Status:** open
 - **Owner:** maintainer
 - **Blocks:** 1.3 only. 1.1, 1.2 and 1.4 are unaffected.
@@ -353,6 +431,14 @@ What **this** roadmap keeps is only the ratchet that prevents recurrence
   verdict exists with a `revisit-if` line.
 
 ### blocker: make-it-stick-telemetry
+
+> **TRANSFERRED 2026-08-24 with Phase 4.1** to
+> [`stubs/road-to-make-it-stick-telemetry.md`](stubs/road-to-make-it-stick-telemetry.md),
+> probe `probe-make-it-stick-telemetry`. Still open. It is a separate stub from its
+> sibling deliberately: this one is gated on a **measurement that has to be built**,
+> the other on a **decision that could be taken tomorrow** — different producers,
+> different re-entry conditions, and `stubs/README.md` refuses to merge two probes
+> into one.
 - **Status:** open
 - **Owner:** agent
 - **Blocks:** 4.1 only.
@@ -371,6 +457,59 @@ What **this** roadmap keeps is only the ratchet that prevents recurrence
   unblocked or closed against the published null.
 
 ---
+
+## Step ledger — every step in a defined state
+
+The council that re-scoped this roadmap on 2026-08-24 required this table
+explicitly: *"a 14-step roadmap partially executed needs each step in a defined
+state, and 'the rest later' is not one."*
+
+| Step | State | Where it went / why |
+|---|---|---|
+| 0.1 baseline | **executed** | `agents/evidence/analysis/published-md-path-leakage-baseline.md` — 947 files, 12 hits, 0 leaks |
+| 0.2 extend the gate | **executed** | `check_bundle_path_leakage` scans published `.md`; four sensitivity probes incl. the backtick case |
+| 0.3 the ratchet | **executed, mechanism changed** | `.path-leak-allow`, floor = 0 unapproved. "Target 0" was unreachable |
+| 1.1 `runtime_requires` | **transferred** | [`stubs/road-to-command-runtime-requirements.md`](stubs/road-to-command-runtime-requirements.md) · probe `probe-command-schema-runtime-requires` |
+| 1.2 `check_command_needs` | **transferred** | same stub; the corrected 8/6 baseline travels with it |
+| 1.3 doctor probe | **transferred** | same stub |
+| 1.4 hold the non-goals | **transferred** | same stub — a non-goal has nothing to hold until the phase runs |
+| 2.1 `## Examples` convention | **open, executable, NOT executed** | see below |
+| 2.2 pattern vocabulary | **open, executable, NOT executed** | see below |
+| 2.3 `check_command_examples` | **open, executable, NOT executed** | see below |
+| 2.4 site sync | **open, executable, NOT executed** | see below |
+| 3.1 re-orientation paragraph | **open, executable, NOT executed** | see below |
+| 3.2 `project-analysis-core` improvement mode | **open, executable, NOT executed** | see below |
+| 4.1 "make it stick" | **transferred** | [`stubs/road-to-make-it-stick-telemetry.md`](stubs/road-to-make-it-stick-telemetry.md) · probe `probe-make-it-stick-telemetry` |
+
+### The six open steps are open, not blocked — and the distinction is the point
+
+```
+PHASES 2 AND 3 NEED NO CAPABILITY THIS RUN LACKED. THEY WERE NOT REACHED.
+RECORDING THEM AS TRANSFERRED WOULD CLAIM A BLOCKER THAT DOES NOT EXIST.
+```
+
+The council ruled both **executable in this run**, and it was right — there is no
+schema decision, no missing telemetry, no absent host. The autonomous drain run
+that executed Phase 0 simply did not get to them, and that is a **capacity** fact
+about the run, not a **capability** fact about the work. A `stubs/` transfer
+asserts the second, so using one here would be a false blocker.
+
+What Phase 2 needs, measured so the next run starts from numbers rather than the
+proposal's:
+
+- The axis is **`visibility:`**, not `tier:` — `command.schema.json:20` records
+  that the integer `tier:` alias was **removed**, so the roadmap's "tier 0/1"
+  vocabulary is stale. 201 of 202 command files carry no `tier:` key at all.
+- Over the 222 files `lint_command_tiers` scans: **179 `internal` · 18 `advanced` ·
+  5 `visible` · 20 with NO `visibility:` key**.
+- The convention binds `visible` **+** `advanced` (council 2/2) = **23 governed**,
+  of which **5 already carry `## Examples`** → **18 to write.**
+- **The 20 missing-key files are a Phase 2 CLOSURE PREREQUISITE**, not a separate
+  concern: Phase 2 cannot honestly close while 20 commands silently evade the
+  classification the convention keys on. Establish whether omission has a
+  documented default; if not, classify them, then re-run the census before
+  freezing the gate.
+- `check_command_examples` will cost the same **three ratchets** as any new gate.
 
 ## Risk Register
 <!-- risk-review: v1 | reviewed: 2026-08-24 | reviewer: claude/host -->

--- a/agents/roadmaps/stubs/road-to-command-runtime-requirements.md
+++ b/agents/roadmaps/stubs/road-to-command-runtime-requirements.md
@@ -1,0 +1,89 @@
+---
+complexity: lightweight
+---
+# Stub: command runtime prerequisites
+
+> **Stub — not active work, and a DRAIN-RUN TRANSFER** per [`README.md`](README.md)
+> § The two classes. **Capability-gated:** the scope is decided and the work is
+> wanted; what is missing is a schema-ownership decision no autonomous run may
+> take. Promoted by its own named probe, never by the shared demand criteria.
+
+## What was transferred
+
+Phase 1 of `road-to-inbox-harvest-2026-08-e-command-surface-legibility`, on an AI
+council verdict of 2026-08-24 (2/2 convergent; owner-reserved dispositions were
+delegated to the council for that drain run).
+
+- **1.1** declare command prerequisites using the existing `runtime_requires`
+  vocabulary (`bins`, `env`, `primary_env`, `network`) from
+  `src/scripts/schemas/skill.schema.json:45-89`.
+- **1.2** the `check_command_needs` gate — a static invocation scan against the
+  declaration, forward-only ratchet on the `command-verbs.yml` precedent.
+- **1.3** probe declared prerequisites from an **existing** doctor entry point,
+  reusing the reach probe taxonomy rather than building a parallel doctor.
+- **1.4** hold the non-goals: no auto-install, no network on the default path.
+
+## Why an autonomous run may not take it
+
+`src/scripts/schemas/command.schema.json` is `additionalProperties: false` at
+`:8`. Adding a key is therefore a **schema change plus four regenerations**, and
+`requires` as a bare key is **reserved** for ADR-015 pack-dependency edges and
+must not be used. The parent roadmap knows all of that and gates 1.1 on
+`blocker: command-schema-additionalproperties`, whose owner is the maintainer.
+
+A schema is a contract every consumer's frontmatter validates against. Widening
+one to admit a new key is the kind of change this repository reserves, and the
+blocker exists to say so.
+
+**1.2's cost, measured on this run rather than estimated:** a new gate costs
+**three ratchets** — `gate-coverage.yml` registration with a `scanned:` line and a
+canary, the `gate-self-test:registered-non-adopters` shrink-only ratchet (which
+reds immediately on a new registered gate with no `--self-test`), and the
+`ci-parity:local-only` direction. Every one of those was hit and paid on this
+run's other branches; a later reader should not rediscover them.
+
+## The named producer and its probe
+
+**Producer:** the maintainer, on the schema-ownership decision.
+
+**Probe — `probe-command-schema-runtime-requires`.** Returns true when **all**:
+
+1. the schema-ownership question is resolved and `command.schema.json` accepts a
+   `runtime_requires` key (or an agreed alternative name that is **not**
+   `requires`);
+2. the four regeneration targets are identified and run in order — `task sync`
+   then `task generate-tools`;
+3. the three registration obligations above are enumerated for
+   `check_command_needs` before it is written, not after.
+
+```bash
+# Condition 1, mechanically:
+python3 -c "import json;print(json.load(open('src/scripts/schemas/command.schema.json')).get('additionalProperties'))"
+# false -> still gated.  true or a declared runtime_requires property -> condition 1 holds.
+```
+
+**Baseline on the transfer date:** `additionalProperties: false`; no
+`runtime_requires` property; `check_command_needs` does not exist.
+
+## The corrected 1.2 baseline travels with it
+
+The parent pre-registered *"8 invoking / 14 mentioning, of 202"*. **Measured
+2026-08-24: 8 invoking / 6 mentioning-only, of 202** recursive command files,
+heuristic `(?:^|[`$\s(])<bin>\s+[a-z]` over `gh`, `docker`, `kubectl`,
+`terraform`.
+
+The **invoking** figure — the half the ratchet gates — is confirmed exactly. The
+mentioning figure is not, and the council directed it corrected in place with the
+population, heuristic and date recorded rather than investigated first, on the
+ground that the gated quantity is the confirmed one. Whoever promotes this stub
+starts from 8/6, not 8/14.
+
+## What this stub does NOT cover
+
+- **Phase 0**, complete: the gate now scans published `.md` with a zero-unapproved
+  floor and twelve pinned exceptions.
+- **Phase 2 and Phase 3**, which the council ruled **executable without any
+  transfer** and which this run did not reach. They are open and un-executed in the
+  parent, not blocked — see its § Step ledger.
+- **Phase 4**, transferred separately to
+  [`road-to-make-it-stick-telemetry.md`](road-to-make-it-stick-telemetry.md).

--- a/agents/roadmaps/stubs/road-to-make-it-stick-telemetry.md
+++ b/agents/roadmaps/stubs/road-to-make-it-stick-telemetry.md
@@ -1,0 +1,56 @@
+---
+complexity: lightweight
+---
+# Stub: "make it stick" needs telemetry that does not exist
+
+> **Stub — not active work, and a DRAIN-RUN TRANSFER** per [`README.md`](README.md)
+> § The two classes. **Capability-gated:** the hypothesis is stated and the
+> measurement to test it does not exist.
+
+## What was transferred
+
+Phase 4.1 of `road-to-inbox-harvest-2026-08-e-command-surface-legibility`, on an
+AI council verdict of 2026-08-24 (2/2 convergent): *a "make it stick" suggestion —
+repeated manual invocations of the same shape should suggest the durable form.*
+
+The parent already gated it on `blocker: make-it-stick-telemetry` and titled its
+own phase **"Later and only with evidence"**, so this transfer changes the file it
+lives in rather than its status.
+
+## Why an autonomous run may not take it
+
+The hypothesis is *"a user who repeats an invocation would adopt the durable form
+if suggested"*. Testing it needs a record of **repeated manual invocations per
+shape per user** — telemetry this package does not collect. Building the
+suggestion without it ships a nudge whose value is asserted, which is the shape
+this repository's `orchestration_record` honest-null already measured and rejected
+once (1 of 369 captured, and that figure *"may not be cited for either
+direction"*).
+
+An autonomous run cannot manufacture the observation, and building the feature
+first is exactly the ordering the parent's own phase title forbids.
+
+## The named producer and its probe
+
+**Producer:** whichever change lands per-invocation telemetry with a shape that
+can group by command form.
+
+**Probe — `probe-make-it-stick-telemetry`.** Returns true when a telemetry surface
+exists that can answer: *for a given command shape, how many times did the same
+operator invoke it manually before adopting (or not adopting) the durable form?*
+That requires a per-invocation record with an operator-stable key and a
+shape-normalised command identity — neither exists today.
+
+**Baseline on the transfer date:** no per-invocation command telemetry. The
+closest surface is the suggestion-block capture instrument landed the same day
+(`road-to-suggestion-block-capture`), and it is **not** this: it records whether a
+numbered-options block was answered, not how often a command shape was retyped.
+
+## Why it is a separate stub rather than folded into its sibling
+
+`road-to-command-runtime-requirements` is gated on a **decision** (schema
+ownership) and could be promoted tomorrow. This one is gated on a **measurement
+that has to be built first**, which is a different re-entry condition with a
+different producer. `stubs/README.md` is explicit that merging two stubs with
+distinct probes is refused for exactly this reason — one probe would then stand in
+for two facts.

--- a/src/scripts/check_bundle_path_leakage.ts
+++ b/src/scripts/check_bundle_path_leakage.ts
@@ -1,6 +1,41 @@
 #!/usr/bin/env tsx
 /**
- * Guard against build-machine path leakage in the tracked install bundle.
+ * Guard against build-machine path leakage in the tracked install bundle AND in
+ * published Markdown.
+ *
+ * ## The published-.md scope (road-to-inbox-harvest-2026-08-e-command-surface-legibility Phase 0)
+ *
+ * The bundle roots below were the original scope. A second population ships the
+ * same leak class: every `.md` inside `package.json` `files[]` — 1,079 files —
+ * and a `/Users/<name>/…` in a shipped skill is the same defect as one in
+ * `install.mjs`.
+ *
+ * **It is EXTENDED here rather than given a second gate**, deliberately: this one
+ * already runs in CI, already carries the patterns, the username masking and the
+ * `scan_scope` dead-scope protection, and a sibling gate would duplicate all
+ * four.
+ *
+ * ### Why the floor is ZERO UNAPPROVED and not the measured 11
+ *
+ * The published-.md baseline measured **11 hits in 8 files, none of them a leak**
+ * (`agents/evidence/analysis/published-md-path-leakage-baseline.md`): three
+ * documentation examples, six occurrences inside the rules that FORBID the
+ * pattern and must quote it, two legitimately absolute paths.
+ *
+ * A numeric floor of 11 was rejected by both council seats, 2026-08-24, for one
+ * reason: it lets an approved hit disappear while a real leak takes its slot, and
+ * the count stays 11. So the floor is **0 unapproved matches**, and the eleven are
+ * pinned exceptions in `.path-leak-allow` — line-pinned, so an entry that drifts
+ * off its line stops matching and the gate REDS, which is the safe direction.
+ *
+ * ### And why NOT "exempt matches inside backticks"
+ *
+ * That was the other candidate, and it was rejected on a false-negative argument
+ * both seats found decisive: **a real leaked path is commonly formatted as code**,
+ * so exempting inline code and fenced blocks opens a channel that hides exactly
+ * the defect this gate exists to catch. It would also hide a skill author's
+ * accidental real path inside an example block — the contribution path where this
+ * class is most likely to arrive.
  *
  * road-to-feedback-9.2.0-followups Phase 4.1. Three 9.1 commits
  * (f8752443b, 5933bf1a9, f30adb5a1) each rebuilt `dist/install/install.mjs`
@@ -74,6 +109,40 @@ const BUNDLE_ROOTS: readonly string[] = [
     'dist/mcp',
     'dist/cli-delegate',
 ];
+
+/**
+ * Published `.md` — the second population, derived from `package.json` `files[]`
+ * rather than guessed, so the scope is what the tarball actually ships. Roots
+ * only; the per-file filter below keeps it to `.md`.
+ */
+const PUBLISHED_MD_ROOTS: readonly string[] = [
+    'dist/agent-src',
+    'docs/guidelines',
+    'src/scripts',
+    // NOT `src/agent-src` wholesale: `files[]` ships only these two subtrees, and
+    // scanning the parent would gate content no consumer receives. Caught by this
+    // gate's own test, which asserts every root is inside `files[]`.
+    'src/agent-src/scripts',
+    'src/agent-src/templates/scripts',
+    'agents/templates',
+    'src/templates',
+    'src/config',
+];
+
+/** Named `.md` / text files `files[]` ships individually. */
+const PUBLISHED_MD_FILES: readonly string[] = [
+    'AGENTS.md',
+    'CHANGELOG.md',
+    'CONTRIBUTING.md',
+    'MIGRATION.md',
+    'README.md',
+    'docs/contracts/persona-schema.md',
+    'docs/contracts/provider-lifecycle.md',
+    'docs/contracts/settings-classes.md',
+];
+
+/** Repo-root allow file for audited published-`.md` exceptions. */
+const ALLOW_FILE = '.path-leak-allow';
 
 interface LeakPattern {
     readonly name: string;
@@ -192,6 +261,49 @@ function _splitlines(text: string): string[] {
     return text.split('\n').filter((l) => l.length > 0);
 }
 
+/**
+ * Parse `.path-leak-allow` into `path:line` keys.
+ *
+ * Line-pinned on purpose, and the trade-off is the same one `.secret-allow`
+ * documents for itself: an entry that drifts off its line stops matching and the
+ * gate REDS. That is the safe direction — someone re-audits and moves the pin —
+ * whereas a path-only entry would silently allow a real leak anywhere in the
+ * file. This tree has already been bitten by the opposite: a `.secret-allow` pin
+ * sat one line off on `main` for a day, covering nothing, invisible because that
+ * gate is diff-scoped.
+ */
+export function parse_allow_file(text: string): Set<string> {
+    const out = new Set<string>();
+    for (const raw of text.split('\n')) {
+        const line = raw.replace(/#.*$/, '').trim();
+        if (line === '') continue;
+        out.add(line);
+    }
+    return out;
+}
+
+function allow_set(): Set<string> {
+    try {
+        return parse_allow_file(fs.readFileSync(path.join(REPO, ALLOW_FILE), 'utf-8'));
+    } catch {
+        return new Set();
+    }
+}
+
+/** Every tracked `.md` inside the published roots, plus the named files. */
+function tracked_published_md(): string[] {
+    const seen = new Set<string>();
+    for (const root of PUBLISHED_MD_ROOTS) {
+        for (const rel of _splitlines(_git(['ls-files', root]))) {
+            if (rel.endsWith('.md')) seen.add(rel);
+        }
+    }
+    for (const rel of PUBLISHED_MD_FILES) {
+        for (const got of _splitlines(_git(['ls-files', rel]))) seen.add(got);
+    }
+    return [...seen].sort();
+}
+
 /** Every tracked path under the bundle roots, deduped and sorted. */
 function tracked_bundle_files(): string[] {
     const seen = new Set<string>();
@@ -291,7 +403,12 @@ function parse_args(argv: readonly string[]): Options {
 
 function main(argv: readonly string[] = process.argv.slice(2)): number {
     const opts = parse_args(argv);
-    const targets = opts.files.length > 0 ? opts.files : tracked_bundle_files();
+    const bundle = opts.files.length > 0 ? opts.files : tracked_bundle_files();
+    // Published `.md` joins the default target list. With explicit `--file`
+    // arguments it does NOT — an ad-hoc single-file run stays a single-file run,
+    // which is what the existing tests and the pre-push path rely on.
+    const published = opts.files.length > 0 ? [] : tracked_published_md();
+    const targets = [...bundle, ...published];
 
     // `git ls-files <untracked-root>` returns nothing, by design (BUNDLE_ROOTS
     // lists roots that may not be tracked yet). That tolerance is also the
@@ -305,8 +422,11 @@ function main(argv: readonly string[] = process.argv.slice(2)): number {
         assertScanned({
             gate: 'check_bundle_path_leakage',
             scanned: targets.length,
-            units: 'bundle file(s)',
-            roots: opts.files.length > 0 ? ['<explicit file arguments>'] : BUNDLE_ROOTS,
+            units: 'bundle + published-md file(s)',
+            roots:
+                opts.files.length > 0
+                    ? ['<explicit file arguments>']
+                    : [...BUNDLE_ROOTS, ...PUBLISHED_MD_ROOTS],
         });
     } catch (exc) {
         if (exc instanceof DeadScopeError) {
@@ -316,17 +436,48 @@ function main(argv: readonly string[] = process.argv.slice(2)): number {
         throw exc;
     }
 
-    const hits = scan_files(targets);
+    const allowed = allow_set();
+    const all = scan_files(targets);
+    // The floor is ZERO UNAPPROVED, never a count. A pinned exception that has
+    // drifted off its line simply stops matching, so the hit resurfaces and the
+    // gate reds — deliberately, per the header.
+    const hits = all.filter((h) => !allowed.has(`${h.file}:${String(h.line)}`));
+    const suppressed = all.length - hits.length;
 
     if (hits.length > 0) {
         process.stderr.write(`${format_report(hits)}\n`);
+        // The per-pattern hints are bundle-shaped ("rebuild from a clean
+        // checkout"), which is the wrong instruction for a `.md` hit — nothing is
+        // rebuilt to fix prose. Published-md hits get their own line rather than
+        // a misleading one.
+        if (hits.some((h) => h.file.endsWith('.md'))) {
+            process.stderr.write(
+                `   NOTE: a \`.md\` hit is not fixed by rebuilding. Either anonymise the path,\n` +
+                    `   or — if it IS the pattern being documented — pin it in ${ALLOW_FILE}.\n`,
+            );
+        }
+        if (suppressed > 0) {
+            process.stderr.write(
+                `   (${suppressed} further match(es) are pinned exceptions in ${ALLOW_FILE})\n`,
+            );
+        }
+        process.stderr.write(
+            `   A published-.md match that is the PATTERN BEING DOCUMENTED — a rule quoting\n` +
+                `   the shape it forbids, or an anonymised example — belongs in ${ALLOW_FILE}\n` +
+                `   as \`<path>:<line>\` with its reason above it. A real path does not.\n`,
+        );
         return 1;
     }
 
     if (!opts.quiet) {
+        // A gate that scans nothing and exits green is indistinguishable from a
+        // broken one, so the green path names both populations and the
+        // suppression count — an exception set that quietly grows is the failure
+        // mode a bare "no leakage" line would hide.
         process.stdout.write(
-            `✅  check_bundle_path_leakage: no build-machine path leakage ` +
-                `(${targets.length} tracked bundle file(s) scanned).\n`,
+            `✅  check_bundle_path_leakage: no unapproved path leakage ` +
+                `(${String(bundle.length)} bundle + ${String(published.length)} published-md ` +
+                `file(s) scanned, ${String(suppressed)} pinned exception(s)).\n`,
         );
     }
     return 0;
@@ -359,6 +510,10 @@ if (_isCliEntry() || process.argv[1] === _HERE) {
 export {
     REPO,
     BUNDLE_ROOTS,
+    PUBLISHED_MD_ROOTS,
+    PUBLISHED_MD_FILES,
+    ALLOW_FILE,
+    tracked_published_md,
     LEAK_PATTERNS,
     MAX_SNIPPET,
     MAX_HITS_SHOWN_PER_GROUP,

--- a/tests/scripts/check_bundle_path_leakage.test.ts
+++ b/tests/scripts/check_bundle_path_leakage.test.ts
@@ -24,6 +24,11 @@ import {
     mask_snippet,
     parse_args,
     scan_content,
+    ALLOW_FILE,
+    PUBLISHED_MD_ROOTS,
+    parse_allow_file,
+    scan_files,
+    tracked_published_md,
 } from '../../src/scripts/check_bundle_path_leakage.js';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
@@ -295,5 +300,62 @@ describe('check_bundle_path_leakage — CLI contract on the real repo', () => {
     it('an unrecognized flag exits 2', () => {
         const result = spawnSync(TSX_BIN, [TS_SCRIPT, '--nope'], { cwd: REPO_ROOT, encoding: 'utf-8' });
         expect(result.status).toBe(2);
+    });
+});
+
+/**
+ * Phase 0 of `road-to-inbox-harvest-2026-08-e-command-surface-legibility`: the
+ * published-`.md` scope, and the pinned-exception mechanism the council chose
+ * over a backtick exemption.
+ */
+describe('published-.md scope and the zero-unapproved floor', () => {
+    it('the published roots are declared and include the projection tree', () => {
+        expect(PUBLISHED_MD_ROOTS).toContain('dist/agent-src');
+        expect(PUBLISHED_MD_ROOTS).toContain('docs/guidelines');
+        // Every root must be a `files[]` root — a root outside the tarball would
+        // scan content no consumer receives, which is scope creep dressed as rigour.
+        const manifest = JSON.parse(fs.readFileSync('package.json', 'utf8')) as { files: string[] };
+        const shipped = manifest.files.filter((f) => !f.startsWith('!'));
+        for (const root of PUBLISHED_MD_ROOTS) {
+            expect(
+                shipped.some((f) => f.replace(/\/$/, '') === root || root.startsWith(f.replace(/\/$/, ''))),
+                `${root} must be inside package.json files[]`,
+            ).toBe(true);
+        }
+    });
+
+    it('scans a four-figure published-md population, not a handful', () => {
+        // The floor a dead-scope would collapse through. Measured 947 on
+        // 2026-08-24 (after narrowing `src/agent-src` to its two shipped
+        // subtrees); 700 is comfortably below and far above a collapse.
+        expect(tracked_published_md().length).toBeGreaterThan(700);
+    });
+
+    it('the allow file parses, strips comments, and holds only path:line keys', () => {
+        const raw = fs.readFileSync(ALLOW_FILE, 'utf8');
+        const set = parse_allow_file(raw);
+        expect(set.size).toBeGreaterThan(0);
+        for (const entry of set) {
+            expect(entry, `${entry} must be <path>:<line>`).toMatch(/^[^\s:]+:\d+$/);
+        }
+        // Every entry carries a reason above it — the file's own contract. A bare
+        // pin with no comment anywhere above it is an unaudited suppression.
+        expect(raw).toMatch(/^#/m);
+    });
+
+    it('every pinned exception still matches something — a drifted pin is a defect', () => {
+        // This is the mechanism's whole cost: pins are line-numbers into a
+        // GENERATED tree. A pin that matches nothing suppresses nothing and hides
+        // that the exception was never re-audited after the source moved.
+        const pinned = parse_allow_file(fs.readFileSync(ALLOW_FILE, 'utf8'));
+        const live = new Set(
+            scan_files(tracked_published_md()).map((h) => `${h.file}:${String(h.line)}`),
+        );
+        const dead = [...pinned].filter((p) => !live.has(p));
+        expect(dead, 'these pins match nothing — re-audit and move them').toEqual([]);
+    });
+
+    it('the whole gate is green on the committed tree', () => {
+        expect(main(['--quiet'])).toBe(0);
     });
 });


### PR DESCRIPTION
Phase 0 of `road-to-inbox-harvest-2026-08-e-command-surface-legibility` — the path-leakage ratchet — plus the run summary for the whole drain. **The roadmap stays active with six open steps**, and it carries a per-step ledger so all 14 are in a defined state.

Part of an autonomous drain run; owner-reserved and capability-gated dispositions were delegated to the AI council by the maintainer.

## Measuring the tree falsified four of the roadmap's premises

The roadmap itself says *"do not quote a figure from a proposal"* for one of these. Doing it for all four found:

| Premise | Measured |
|---|---|
| 0.3: "the population melts down, **target 0**" | **unreachable** — 6 of 12 hits are the rules that *forbid* the pattern, quoting it |
| 2.1: "every visible command (**tier 0/1**)" | `tier:` **no longer exists**. 201 of 202 files carry no such key; `command.schema.json:20` records the integer alias as removed |
| 1.2: pre-registered "**8 invoking / 14 mentioning**" | **8 / 6.** The invoking half — the half the ratchet gates — is exact |
| — | **20 command files carry no `visibility:` key at all.** Not in the roadmap; the council ruled it a Phase 2 *closure prerequisite* |

## Phase 0 — extended, not duplicated

`check_bundle_path_leakage` now scans published `.md` (**947 files**, derived from `package.json` `files[]`) alongside its four bundle roots. Extended rather than given a sibling gate because it already runs in CI and already carries the patterns, the username masking and the `scan_scope` dead-scope protection a second gate would copy.

**Baseline: 12 hits, 9 files, zero leaks.** Three anonymised examples, six occurrences inside `doc-screenshot-hygiene` / `screenshot-hygiene` / `low-impact-corpus-privacy-floor` quoting the shapes they forbid, two legitimately absolute (`/opt/homebrew/etc/dnsmasq.conf`; this package's own `.claude/worktrees/`).

### The floor is zero *unapproved*, not twelve

Council 2/2. A numeric floor of 12 was rejected for a specific reason: **it lets an approved hit disappear while a real leak takes its slot and the count stays 12.** So the twelve are line-pinned in `.path-leak-allow` with a reason and a class each, and everything else reds.

Line-pinned deliberately, cost named: the pins point into `dist/agent-src/`, a generated tree, so a pin drifts when its source gains a line. That reds the gate — the safe direction — and **a test asserts every pin still matches something**, because a pin matching nothing suppresses nothing and hides that the exception was never re-audited. This tree has been bitten by the opposite: a `.secret-allow` pin sat one line off on `main` for a day, covering nothing.

### The rejected mechanism, and its rejection is now measured

The other candidate was *exempt matches inside inline code and fenced blocks* — mechanical, no per-site markers, and it covers the rule-quoting class exactly. Both seats refused it: **a real leaked path is commonly formatted as code**, so the exemption opens a channel that hides the defect the gate exists to catch, and hides it hardest on the skill-contribution path where an accidental real path is most likely to arrive.

That is now an observation, not a prediction:

| Probe | Result |
|---|---|
| seeded `/Users/realperson/…` in a published `.md` | **red** |
| the same seed **inside backticks** | **red** |
| seed removed | green |
| explicit single-file run | `1 bundle + 0 published-md` — bundle behaviour unchanged; 31 pre-existing tests untouched |
| **`PUBLISHED_MD_ROOTS` emptied, seed in place** | **exit 0 — it stopped firing.** The scope-extension proof the step asked for |

**No `gate-violation-baselines.json` entry**, and that is a consequence not an omission: a zero-unapproved floor has no number to ratchet, so this mechanism costs one of the three ratchets a numeric baseline would have.

## Two errors in my own measurement, caught and recorded

Both are in the evidence file with the correction visible rather than overwritten:

1. **It said 11, it is 12.** The first pass ran four of the gate's six patterns on a *stated* assumption that the `node_modules` ones were "bundle-shaped and cannot occur in prose". One prose hit exists (`commands/optimize/augmentignore.md:99`). The assumption erred in the under-reporting direction, which is the worse one.
2. **It said 1,079 files, it is 947.** It scanned `src/agent-src/` wholesale; `files[]` ships only two subtrees. **Caught by the new test asserting every declared root is inside `files[]`** — a test written for the gate catching the measurement, which is the argument for writing it.

Narrow lesson: run the gate rather than re-implementing its patterns.

## The step ledger — the council required it explicitly

> *"A 14-step roadmap partially executed needs each step in a defined state, and 'the rest later' is not one."*

3 executed · 5 transferred · **6 open, executable, not executed**.

### The six open steps are open, not blocked, and that distinction is deliberate

The council ruled Phases 2 and 3 **executable in this run** and was right — no schema decision, no missing telemetry, no absent host. This run executed Phase 0 and did not reach them. That is a **capacity** fact about the run, not a **capability** fact about the work, and `stubs/` asserts the second. Filing them as transferred would manufacture a blocker that does not exist.

The ledger carries the measured numbers Phase 2 needs, so the next run starts from them: **23 governed** (`visible` 5 + `advanced` 18), **5 already compliant → 18 to write**, and the 20 unclassified files as a closure prerequisite.

## Transferred — two stubs, deliberately not one

| Stub | Probe | Gated on |
|---|---|---|
| `road-to-command-runtime-requirements` | `probe-command-schema-runtime-requires` | a maintainer schema-ownership decision (`command.schema.json` is `additionalProperties: false`; `requires` is reserved for ADR-015) |
| `road-to-make-it-stick-telemetry` | `probe-make-it-stick-telemetry` | per-invocation telemetry that does not exist |

Separate because the re-entry conditions differ in kind: one is a **decision** that could be taken tomorrow, the other a **measurement that has to be built first**. `stubs/README.md` refuses to merge two probes into one, for exactly this reason.

The first stub also carries the corrected **8/6** baseline and the **three-ratchet** cost of a new gate, both measured on this run, so a later reader does not rediscover either.

## The run summary — and it says the directory is not empty

`agents/evidence/drain-run-summary.md` gains **Run C**: seven PRs, ten council decisions, nine falsified premises, five stubs, and **seven errors this run made and caught** — because a record carrying only findings reads as a run that made none.

It states plainly what the mandate's success condition turns on: **nine roadmaps carry open work this run did not reach, and none of them is blocked.** That is a capacity limit. The terminal fallback covers work that survives execution, council, re-scoping *and* descoping; none of these nine was put to any of the four. Descoping them would assert a capability gap that does not exist — the same false-blocker this roadmap's own ledger refuses.

It also flags that several "complete" verdicts are complete against acceptance criteria **this run rewrote** (`opencode` AC-2 had no true branch; this roadmap's "target 0" was unreachable), so a reader auditing completion reads the amended AC, with the reason recorded at each one.

## Gates run locally

`check_bundle_path_leakage` (+ 36 tests, 5 new) · `lint_roadmap_blockers` · `lint_roadmap_complexity` · `check_roadmap_trackable` · `lint_empty_roadmaps` · `lint_plan_risk_register` · `check_estate_count` · `check_references` · `lint_evidence_artifacts` — all green. Pushed from a clean worktree with full `task preflight` running; no gate skipped.
