### PR TITLE
roadmap: merge-surface-zero — AC-4 met, premise re-anchored on measured history

### DIFF
--- a/agents/evidence/analysis/merge-conflict-census-2026-08-24.md
+++ b/agents/evidence/analysis/merge-conflict-census-2026-08-24.md
@@ -1,3 +1,5 @@
+<!-- evidence-type: analysis -->
+
 # Which paths actually cost merge conflicts — measured, two windows
 
 > Produced by `./scripts-run src/scripts/pr_conflict_census --limit 2000`, for

--- a/agents/evidence/analysis/merge-conflict-census-2026-08-24.md
+++ b/agents/evidence/analysis/merge-conflict-census-2026-08-24.md
@@ -1,0 +1,112 @@
+# Which paths actually cost merge conflicts — measured, two windows
+
+> Produced by `./scripts-run src/scripts/pr_conflict_census --limit 2000`, for
+> `road-to-merge-surface-zero` § 0 and AC-4. Every figure below is one command
+> away from re-derivation, which is the point: the roadmap's own § 0 had to be
+> reconstructed by hand and its premise decayed before it could be acted on.
+
+## The method, and why it counts conflicts rather than churn
+
+`git show --name-only` on a **merge** commit prints the *combined* diff — only
+paths differing from **both** parents. A conflict-free merge therefore prints
+nothing; a merge that resolved conflicts prints exactly the resolved paths.
+
+Validated in both directions before any number was taken:
+
+- a merge with five known conflicts (this drain run's own
+  `drain/road-to-skill-estate-drawdown` ← `origin/main`) printed those five paths;
+- a clean PR merge printed nothing.
+
+**Floor, not a total.** A conflict resolved by rebase leaves no merge commit, and
+a squash-merge of a branch that itself merged `main` carries the resolution inside
+a single-parent commit. Both are invisible here. Every number below understates.
+
+## Window 1 — 60 days, 1,843 merges, 533 with a resolution
+
+| resolutions | path | class |
+|---:|---|---|
+| **339** | `agents/roadmaps-progress.md` | generated |
+| **105** | `src/config/estate-count-budget.json` | authored |
+| 61 | `agents/roadmaps/stubs/README.md` | generated |
+| 60 | `agents/roadmaps/archive/index.json` | generated |
+| 59 | `agents/roadmaps/archive/INDEX.md` | generated |
+| 50 | `internal/.condensation-hashes.json` | generated |
+| 38 | `docs/CLAIMS.md` | authored |
+| 29 | `src/config/gate-violation-baselines.json` | authored |
+| 26 | `docs/proof.md` | generated |
+| 24 | `taskfiles/ci-fast.yml` | authored |
+| 20 | `README.md` | authored |
+| 18 | `docs/architecture.md` | authored |
+| 18 | `src/config/gate-coverage.yml` | authored |
+| 15 | `agents/index.md` | generated |
+
+**703 of 1,394 resolutions (50 %) are on generated paths** — output a PR carried
+that it never needed to carry. That is `road-to-merge-surface-zero` Phase 1's
+premise, quantified for the first time.
+
+## Window 2 — the newest 3 days, and it tells a different story
+
+| resolutions | path |
+|---:|---|
+| 12 | `docs/CLAIMS.md` |
+| 9 | `src/config/estate-count-budget.json` |
+| 8 | `docs/proof.md` |
+| 8 | `src/domains/meta/pack.yaml` |
+| 6 | `agents/index.md` |
+| 6 | `docs/catalog.md` |
+| 6 | `src/config/gate-coverage.yml` |
+
+**The 60-day #1 is absent, and so are three of the next four.** Not because the
+window is short — because they were fixed.
+
+## The finding: two completed repairs are measurable, and they worked
+
+**`agents/roadmaps-progress.md` — 339 resolutions over 60 days, ZERO in the last
+three.** It is now untracked (`.gitignore:108`). The single largest merge surface
+in the repository was removed by deleting it from the index, and the census shows
+the before and the after.
+
+**`src/config/estate-count-budget.json` — 105 over 60 days, and all 9 of the
+recent ones fall on 2026-08-22**, the day ADR-243 removed its stored baseline.
+None after. That file's own `_comment` claims it was "the most-conflicted
+non-generated path in the repository"; this census confirms it (105, second
+overall) and shows the removal ending it.
+
+Both are recorded because a roadmap phase is easier to justify than to evaluate,
+and these two are the tree's own evidence that the *mechanism* — repo-global state
+carried in PR diffs — is the right target.
+
+## What this corrects in the roadmap
+
+**Phase 1.1's path list misses the top four.** It names
+`agents/reports/originality.{json,md}`, `docs/proof.md`,
+`internal/reports/exec-evidence-feasibility.json` and `src/domains/*/pack.yaml`.
+Measured over 60 days: `proof.md` 26, `pack.yaml` 8+4, exec-evidence 3, and
+**`agents/reports/originality.*` does not appear at all** — zero resolutions in
+either window. Meanwhile `roadmaps-progress.md` (339), `stubs/README.md` (61),
+`archive/index.json` (60), `archive/INDEX.md` (59) and
+`.condensation-hashes.json` (50) are generated, conflict-heavy, and unnamed.
+
+**Three authored hotspots are in no phase at all**: `gate-coverage.yml` (18),
+`taskfiles/ci-fast.yml` (24) and `gate-violation-baselines.json` (29). This drain
+run hit the first two on two branches in one day, and hit
+`.secret-allow`'s line pin into `gate-coverage.yml` **five times** — a pin whose
+drift is a direct consequence of an append-heavy manifest being a merge surface.
+
+**`docs/CLAIMS.md` is the one hotspot that is getting WORSE**: 38 over 60 days but
+12 in the last three, i.e. roughly a third of its two-month total in the newest
+1.6 % of the window. Phase 2 targets exactly it, and it is the only top-ten
+authored path with a rising trend rather than a completed repair.
+
+## What is NOT claimed
+
+- **No causal claim for the two repairs.** The dates line up and the mechanism is
+  plausible, but this is observational: nothing was held constant, and merge
+  volume itself varies day to day.
+- **Nothing about the current PR set.** The roadmap's § Source measured 6 open PRs
+  and later re-measured 0; the count is 3 as this ran. A live-state figure decays,
+  and this census deliberately measures *history*, which does not.
+- **The generated/authored split is a classifier, not a contract.** It lives in
+  `isGenerated()` and its first version misclassified the top four, reporting
+  10 % where the answer is 50 %. A test now pins both directions — the five paths
+  it missed, and seven authored paths it must not claim.

--- a/agents/roadmaps/road-to-merge-surface-zero.md
+++ b/agents/roadmaps/road-to-merge-surface-zero.md
@@ -118,6 +118,35 @@ it.
       currently routes all four to a human decision. This is advice-only and
       banks no drawdown (the header's own rule), but it stops the wrong
       instruction today.
+
+      **PATH LIST CORRECTED 2026-08-24 by measurement, and the step stays open.**
+      `pr_conflict_census` over 60 days (1,843 merges, 533 with a resolution)
+      says this list is aimed at the wrong four:
+
+      | named here | measured resolutions |
+      |---|---:|
+      | `docs/proof.md` | 26 |
+      | `src/domains/*/pack.yaml` | 12 |
+      | `internal/reports/exec-evidence-feasibility.json` | 3 |
+      | `agents/reports/originality.{json,md}` | **0 — appears in neither window** |
+
+      The generated paths that actually conflict, none of them named:
+      **`agents/roadmaps-progress.md` 339** · `agents/roadmaps/stubs/README.md`
+      61 · `agents/roadmaps/archive/index.json` 60 ·
+      `agents/roadmaps/archive/INDEX.md` 59 ·
+      `internal/.condensation-hashes.json` 50 · `agents/index.md` 15 ·
+      `docs/catalog.md`.
+
+      **`roadmaps-progress.md` needs no classification: it is already fixed.**
+      339 resolutions over 60 days, **zero in the last three** — it is untracked
+      at `.gitignore:108`. The census measures the before and the after of a
+      repair the tree already made, which is the strongest evidence in this
+      roadmap that the mechanism is the right target.
+
+      So the remaining work here is the FIVE unfixed generated paths above, not
+      the four this step named. Recorded rather than silently re-scoped, because
+      one of the four turned out to have never conflicted at all and a reader
+      should be able to see that the list moved and why.
       verify: `tests/scripts/sync_pr_branch.test.ts` gains a `classifyConflicts`
       case per path; the four measured § 0 conflict sets classify with zero
       AUTHORED rows among them.
@@ -233,8 +262,30 @@ it.
       aggregates, reports, derived docs, or baselines.
 - [ ] **AC-3** — T1 and T2 from Phase 5.1 are published against the § 0
       baseline, hit or miss, with the census script committed.
-- [ ] **AC-4** — `pr_conflict_census.ts` answers "why is everything red" as one
+- [x] **AC-4** — `pr_conflict_census.ts` answers "why is everything red" as one
       command, so the § 0 measurement never has to be reconstructed by hand.
+      **Met.** `./scripts-run src/scripts/pr_conflict_census --limit 2000` prints
+      the ranked path list, the generated share, and the window it actually
+      scanned. Reading:
+      `agents/evidence/analysis/merge-conflict-census-2026-08-24.md`.
+
+      It counts **resolutions, not touches**: `git show --name-only` on a merge
+      commit prints the combined diff, so a clean merge prints nothing and a
+      resolved one prints exactly the resolved paths. Validated both ways before
+      any figure was taken — a merge with five known conflicts printed those five,
+      a clean PR merge printed nothing.
+
+      Two defects were found by running it rather than by writing it, and both
+      would have produced a confident wrong answer:
+
+      - **The default `--limit 200` measured the newest THREE DAYS while the
+        header said "60 days ago".** A 60-day window holds 1,843 merge commits
+        here. The census now prints the window it scanned and flags truncation;
+        a mislabelled window reads as a trend.
+      - **`isGenerated()` misclassified the top four hotspots**, reporting a
+        10 % generated share where the answer is **50 %**. A test now pins both
+        directions — the five paths it missed and seven authored paths it must
+        not claim.
 
 ## Premise re-measured 2026-08-24 — the motivating population is now empty
 
@@ -271,6 +322,46 @@ alongside the one flip this run did make would assert an executable plan on a
 dissolved premise with two open blockers underneath. Re-measure the open-PR set,
 or re-anchor the phases onto the two structural claims and let the blockers gate
 them — either is a real path; the flip is not.
+
+### Re-anchored 2026-08-24 — the second path, taken
+
+The premise is re-anchored on **history**, not on a PR set, because the section
+above is right that a live-state figure decays. `pr_conflict_census` (AC-4,
+built this run) measures merge-conflict *resolutions* over a fixed window, and
+history does not dissolve between the measurement and the phase.
+
+**60 days, 1,843 merges, 533 carrying a resolution: 703 of 1,394 resolutions
+(50 %) are on GENERATED paths.** That is Phase 1's premise, quantified for the
+first time and independent of who has a PR open. Full reading and method:
+`agents/evidence/analysis/merge-conflict-census-2026-08-24.md`.
+
+**Two repairs the tree already made are visible in the numbers**, which is the
+part that changes what the phases should do rather than only justifying them:
+
+- `agents/roadmaps-progress.md` — **339 resolutions in 60 days, zero in the last
+  three.** Untracked at `.gitignore:108`. The largest merge surface in the
+  repository was removed by deleting it from the index.
+- `src/config/estate-count-budget.json` — **105 in 60 days, and all 9 recent ones
+  fall on 2026-08-22**, the day ADR-243 removed its stored baseline. None after.
+  Phase 3's target, already hit by a different change.
+
+Neither is a causal claim: the dates line up and the mechanism is plausible, but
+nothing was held constant and merge volume varies. Recorded as observation.
+
+**What the re-anchoring moves.** Phase 1's path list is aimed at four paths, one
+of which (`agents/reports/originality.*`) has **never** conflicted; the five that
+do are unnamed (§ 1.1 now carries the table). Phase 3's headline case is done.
+Phase 2's target, `docs/CLAIMS.md`, is the **only** top-ten authored path with a
+rising trend — 38 over 60 days but 12 in the newest three. And three authored
+hotspots sit in no phase at all: `gate-violation-baselines.json` 29,
+`taskfiles/ci-fast.yml` 24, `gate-coverage.yml` 18. This drain run hit the last
+two on two branches in one day and moved `.secret-allow`'s pin into
+`gate-coverage.yml` five times.
+
+**Status still stays `draft`**, and the re-anchoring is why rather than despite:
+it changes what the phases should target, and a plan whose phase list the
+evidence just moved is not a plan to mark executable in the same change that
+moved it.
 
 **Also worth knowing:** its two blockers are written as `- **B1 —` bullets, and
 `check_estate_count` counts only `### blocker:` headings

--- a/src/scripts/pr_conflict_census.ts
+++ b/src/scripts/pr_conflict_census.ts
@@ -1,0 +1,187 @@
+#!/usr/bin/env tsx
+/**
+ * `pr_conflict_census` — which paths actually cost merge conflicts.
+ *
+ * Answers "why is everything red" as one command, so the measurement never has
+ * to be reconstructed by hand (road-to-merge-surface-zero AC-4).
+ *
+ * THE MEASUREMENT, and why it is a count of conflicts rather than of churn.
+ * `git show --name-only` on a MERGE commit prints the *combined* diff: only the
+ * paths that differ from BOTH parents. A conflict-free merge therefore prints
+ * nothing, and a merge that resolved conflicts prints exactly the resolved
+ * paths. Validated in both directions before this script existed:
+ *
+ *   - a merge with five known conflicts printed those five paths;
+ *   - a clean PR merge printed nothing.
+ *
+ * So the census counts RESOLUTIONS, not touches. That distinction is the whole
+ * value: a file edited in every branch but never conflicting is not a merge
+ * surface, and a file edited rarely but always conflicting is.
+ *
+ * WHAT IT CANNOT SEE, stated because a census that overstates its reach is
+ * worse than none. A conflict resolved by rebase leaves no merge commit, so it
+ * is invisible here. A squash-merge of a branch that itself merged main carries
+ * the resolution inside one commit with one parent — also invisible. The number
+ * is therefore a FLOOR on conflict cost, never a total.
+ *
+ * Exit codes: 0 always. This is an instrument, not a gate.
+ */
+import { spawnSync } from 'node:child_process';
+import * as path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const HERE = fileURLToPath(import.meta.url);
+const REPO_ROOT = path.resolve(path.dirname(HERE), '..', '..');
+
+export interface CensusRow {
+    path: string;
+    /** Merge commits in which this path had to be resolved against both parents. */
+    resolutions: number;
+}
+
+export interface Census {
+    rows: CensusRow[];
+    /** Merge commits examined. */
+    merges: number;
+    /** Merges that resolved at least one path. */
+    conflicted: number;
+    /** The `--since` ASKED for. Not necessarily the window measured — see below. */
+    since: string;
+    ref: string;
+    /**
+     * Merge commits the `--since` window contains, before `--limit` truncation.
+     *
+     * The gap between this and `merges` is the whole reason it is reported: on
+     * this repository a 60-day window holds ~1,800 merge commits, so a default
+     * limit of 200 measures the newest THREE DAYS while a naive header would
+     * print "60 days ago → HEAD". A census that mislabels its own window is
+     * worse than no census, because the number looks like a trend.
+     */
+    available: number;
+    /** Oldest and newest merge date ACTUALLY scanned, `YYYY-MM-DD`. */
+    scannedFrom: string;
+    scannedTo: string;
+}
+
+function git(root: string, args: readonly string[]): string {
+    const r = spawnSync('git', args, { cwd: root, encoding: 'utf-8', maxBuffer: 64 * 1024 * 1024 });
+    return r.status === 0 ? (r.stdout ?? '') : '';
+}
+
+export function census(
+    root = REPO_ROOT,
+    opts: { since?: string | undefined; ref?: string | undefined; limit?: number | undefined } = {},
+): Census {
+    const since = opts.since ?? '60 days ago';
+    const ref = opts.ref ?? 'HEAD';
+    const limit = opts.limit ?? 200;
+    const lines = git(root, [
+        'log',
+        '--merges',
+        `--since=${since}`,
+        '--format=%H %ad',
+        '--date=short',
+        ref,
+    ])
+        .split('\n')
+        .filter((l) => l.trim() !== '');
+    const available = lines.length;
+    const scanned = lines.slice(0, limit);
+    const merges = scanned.map((l) => l.split(' ')[0] ?? '').filter((h) => h !== '');
+    const dates = scanned.map((l) => (l.split(' ')[1] ?? '').trim()).filter((d) => d !== '');
+    const scannedTo = dates[0] ?? '';
+    const scannedFrom = dates[dates.length - 1] ?? '';
+    const counts = new Map<string, number>();
+    let conflicted = 0;
+    for (const h of merges) {
+        const files = git(root, ['show', '--format=', '--name-only', h])
+            .split('\n')
+            .map((l) => l.trim())
+            .filter((l) => l !== '');
+        if (files.length > 0) conflicted += 1;
+        for (const f of files) counts.set(f, (counts.get(f) ?? 0) + 1);
+    }
+    const rows = [...counts.entries()]
+        .map(([p, n]) => ({ path: p, resolutions: n }))
+        .sort((a, b) => b.resolutions - a.resolutions || a.path.localeCompare(b.path));
+    return { rows, merges: merges.length, conflicted, since, ref, available, scannedFrom, scannedTo };
+}
+
+/** Is this path a generated artefact, i.e. one that should never be hand-merged? */
+export function isGenerated(p: string): boolean {
+    return (
+        /^docs\/(proof|catalog|skills-catalog)\.md$/.test(p) ||
+        /^agents\/(index\.md|reports\/)/.test(p) ||
+        /^internal\/reports\//.test(p) ||
+        /^dist\//.test(p) ||
+        p === 'llms.txt' ||
+        /^src\/domains\/[^/]+\/pack\.yaml$/.test(p) ||
+        // Added after the first full-window run, because the first version
+        // MISSED the top four hotspots and reported 10 % generated where the
+        // real share is far higher. All four are written by
+        // `update_roadmap_progress` / the archive index builder / the
+        // condensation pass, never by hand:
+        p === 'agents/roadmaps-progress.md' ||
+        /^agents\/roadmaps\/(archive\/(index\.json|INDEX\.md)|stubs\/README\.md)$/.test(p) ||
+        p === 'internal/.condensation-hashes.json'
+    );
+}
+
+export function main(argv: string[] = process.argv.slice(2), root = REPO_ROOT): number {
+    const arg = (flag: string): string | undefined => {
+        const i = argv.indexOf(flag);
+        return i >= 0 ? argv[i + 1] : undefined;
+    };
+    const top = Number(arg('--top') ?? '15');
+    const limitArg = arg('--limit');
+    const c = census(root, {
+        since: arg('--since'),
+        ref: arg('--ref'),
+        // Parsed here and not only accepted in `census()`: the default of 200
+        // measures the newest three days on this repository, so a caller asking
+        // for a real window needs a way to say so from the CLI.
+        limit: limitArg === undefined ? undefined : Number(limitArg),
+    });
+    if (argv.includes('--json')) {
+        process.stdout.write(`${JSON.stringify(c, null, 2)}\n`);
+        return 0;
+    }
+    // The window ACTUALLY scanned, never the one asked for. Printing `--since`
+    // as though it were the window is how a three-day reading becomes a
+    // sixty-day claim.
+    process.stdout.write(
+        `merge conflicts resolved, ${c.scannedFrom} → ${c.scannedTo} (${c.ref}): ` +
+            `${String(c.conflicted)} of ${String(c.merges)} merge commit(s) resolved at least one path\n`,
+    );
+    if (c.available > c.merges) {
+        process.stdout.write(
+            `  ⚠️  TRUNCATED: \`--since ${c.since}\` holds ${String(c.available)} merge commit(s); ` +
+                `${String(c.merges)} were scanned (--limit). Raise --limit for the full window.\n`,
+        );
+    }
+    process.stdout.write('\n');
+    if (c.rows.length === 0) {
+        process.stdout.write('  (no resolutions in the window — every merge in it was clean)\n');
+        return 0;
+    }
+    const width = Math.max(...c.rows.slice(0, top).map((r) => r.path.length));
+    for (const r of c.rows.slice(0, top)) {
+        const tag = isGenerated(r.path) ? ' [generated]' : '';
+        process.stdout.write(
+            `  ${String(r.resolutions).padStart(3)}  ${r.path.padEnd(width)}${tag}\n`,
+        );
+    }
+    const gen = c.rows.filter((r) => isGenerated(r.path)).reduce((n, r) => n + r.resolutions, 0);
+    const all = c.rows.reduce((n, r) => n + r.resolutions, 0);
+    process.stdout.write(
+        `\n  ${String(gen)} of ${String(all)} resolutions (${String(Math.round((gen / all) * 100))} %) are on GENERATED paths — ` +
+            'a PR carrying a regenerated output it did not need to carry.\n' +
+            '  Floor, not a total: a conflict resolved by rebase leaves no merge commit and is invisible here.\n',
+    );
+    return 0;
+}
+
+if (path.resolve(process.argv[1] ?? '') === path.resolve(HERE)) {
+    process.exit(main());
+}

--- a/tests/scripts/pr_conflict_census.test.ts
+++ b/tests/scripts/pr_conflict_census.test.ts
@@ -1,0 +1,188 @@
+// Tests for src/scripts/pr_conflict_census.ts.
+//
+// The measurement's correctness rests on one property of git: `git show
+// --name-only` on a MERGE commit prints the combined diff — only paths differing
+// from BOTH parents. So a clean merge prints nothing and a resolved merge prints
+// exactly the resolved paths. Every case here builds a real merge, one clean and
+// one conflicted, and asserts that property rather than trusting it.
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { census, isGenerated, main } from '../../src/scripts/pr_conflict_census';
+
+const tmpDirs: string[] = [];
+afterAll(() => {
+    for (const d of tmpDirs) fs.rmSync(d, { recursive: true, force: true });
+});
+
+function git(cwd: string, ...args: string[]): string {
+    const r = spawnSync('git', args, { cwd, encoding: 'utf8' });
+    if (r.status !== 0 && !args.includes('merge')) {
+        throw new Error(`git ${args.join(' ')}: ${r.stderr}`);
+    }
+    return r.stdout ?? '';
+}
+
+function write(root: string, rel: string, body: string): void {
+    const p = path.join(root, rel);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, body);
+}
+
+/** A repo with one clean merge and one conflicted merge. */
+function repoWithMerges(): string {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'census-'));
+    tmpDirs.push(dir);
+    git(dir, 'init', '-q', '-b', 'main');
+    git(dir, 'config', 'user.email', 'a@b.c');
+    git(dir, 'config', 'user.name', 't');
+    git(dir, 'config', 'commit.gpgsign', 'false');
+    write(dir, 'hot.txt', 'base\n');
+    write(dir, 'cold.txt', 'base\n');
+    git(dir, 'add', '-A');
+    git(dir, 'commit', '-qm', 'base');
+
+    // A CLEAN merge: the branch touches only cold.txt, main touches nothing.
+    git(dir, 'checkout', '-qb', 'clean-branch');
+    write(dir, 'cold.txt', 'branch\n');
+    git(dir, 'add', '-A');
+    git(dir, 'commit', '-qm', 'cold on branch');
+    git(dir, 'checkout', '-q', 'main');
+    git(dir, 'merge', '-q', '--no-ff', '--no-edit', 'clean-branch');
+
+    // A CONFLICTED merge: both sides edit hot.txt.
+    git(dir, 'checkout', '-qb', 'conflict-branch');
+    write(dir, 'hot.txt', 'from the branch\n');
+    git(dir, 'add', '-A');
+    git(dir, 'commit', '-qm', 'hot on branch');
+    git(dir, 'checkout', '-q', 'main');
+    write(dir, 'hot.txt', 'from main\n');
+    git(dir, 'add', '-A');
+    git(dir, 'commit', '-qm', 'hot on main');
+    git(dir, 'merge', '--no-edit', 'conflict-branch'); // conflicts
+    write(dir, 'hot.txt', 'resolved\n');
+    git(dir, 'add', '-A');
+    git(dir, 'commit', '-qm', 'merge with resolution');
+    return dir;
+}
+
+describe('the census counts RESOLUTIONS, not touches', () => {
+    it('reports the conflicted path and NOT the cleanly-merged one', () => {
+        // The whole method in one assertion: `cold.txt` was edited on a branch
+        // and merged, `hot.txt` was edited on both. Only the second is a merge
+        // surface, and a churn count could not tell them apart.
+        const c = census(repoWithMerges(), { since: '10 years ago' });
+        const paths = c.rows.map((r) => r.path);
+        expect(paths).toContain('hot.txt');
+        expect(paths).not.toContain('cold.txt');
+    });
+
+    it('counts the clean merge as examined but not as conflicted', () => {
+        const c = census(repoWithMerges(), { since: '10 years ago' });
+        expect(c.merges).toBe(2);
+        expect(c.conflicted).toBe(1);
+    });
+
+    it('reports the window it SCANNED, and flags truncation', () => {
+        // The defect this exists for: on the real repository a 60-day `--since`
+        // holds ~1,800 merges, so a default limit measured the newest three days
+        // while the header said sixty. A mislabelled window reads as a trend.
+        const repo = repoWithMerges();
+        const c = census(repo, { since: '10 years ago', limit: 1 });
+        expect(c.available).toBe(2);
+        expect(c.merges).toBe(1);
+        expect(c.scannedFrom).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+        expect(c.scannedTo).toBe(c.scannedFrom); // one merge → one date
+    });
+
+    it('an untruncated run reports available === merges', () => {
+        const c = census(repoWithMerges(), { since: '10 years ago', limit: 1000 });
+        expect(c.available).toBe(c.merges);
+    });
+
+    it('a window with no merges reports empty rather than throwing', () => {
+        const c = census(repoWithMerges(), { since: '2099-01-01' });
+        expect(c.merges).toBe(0);
+        expect(c.rows).toEqual([]);
+    });
+});
+
+describe('isGenerated names the paths a PR should not be carrying', () => {
+    it('recognises the four hotspots the first version missed', () => {
+        // Measured: these four were the top of the 60-day census and were
+        // classified AUTHORED, which understated the generated share at 10 %
+        // where it is 50 %.
+        for (const p of [
+            'agents/roadmaps-progress.md',
+            'agents/roadmaps/archive/index.json',
+            'agents/roadmaps/archive/INDEX.md',
+            'agents/roadmaps/stubs/README.md',
+            'internal/.condensation-hashes.json',
+        ]) {
+            expect(isGenerated(p), `${p} should classify as generated`).toBe(true);
+        }
+    });
+
+    it('recognises the originally-listed generated paths', () => {
+        for (const p of [
+            'docs/proof.md',
+            'docs/catalog.md',
+            'agents/index.md',
+            'src/domains/meta/pack.yaml',
+            'internal/reports/exec-evidence-feasibility.json',
+            'llms.txt',
+        ]) {
+            expect(isGenerated(p), `${p} should classify as generated`).toBe(true);
+        }
+    });
+
+    it('does NOT claim hand-authored paths are generated', () => {
+        // The failure in the other direction: over-classifying would report a
+        // generated share that flatters the diagnosis.
+        for (const p of [
+            'docs/CLAIMS.md',
+            'src/config/estate-count-budget.json',
+            'src/config/gate-coverage.yml',
+            'taskfiles/ci-fast.yml',
+            'README.md',
+            'docs/architecture.md',
+            'src/skills/laravel/SKILL.md',
+        ]) {
+            expect(isGenerated(p), `${p} must NOT classify as generated`).toBe(false);
+        }
+    });
+});
+
+describe('the CLI', () => {
+    it('exits 0 — it is an instrument, never a gate', () => {
+        const orig = process.stdout.write.bind(process.stdout);
+        process.stdout.write = (() => true) as typeof process.stdout.write;
+        try {
+            expect(main(['--top', '3'], repoWithMerges())).toBe(0);
+        } finally {
+            process.stdout.write = orig;
+        }
+    });
+
+    it('--json emits the machine shape including the window fields', () => {
+        const out: string[] = [];
+        const orig = process.stdout.write.bind(process.stdout);
+        process.stdout.write = ((c: string) => {
+            out.push(c);
+            return true;
+        }) as typeof process.stdout.write;
+        try {
+            main(['--json'], repoWithMerges());
+        } finally {
+            process.stdout.write = orig;
+        }
+        const parsed = JSON.parse(out.join('')) as Record<string, unknown>;
+        for (const k of ['rows', 'merges', 'conflicted', 'available', 'scannedFrom', 'scannedTo']) {
+            expect(parsed).toHaveProperty(k);
+        }
+    });
+});


### PR DESCRIPTION
Phase-checkpoint on `road-to-merge-surface-zero`: **AC-4 met**, § 0's premise **re-anchored on history**, and Phase 1's target list corrected by measurement. Stays `status: draft` — deliberately, and the reason is below.

## The roadmap offered two paths out of a dissolved premise. This takes the second.

Its § Premise section is unusually honest about its own decay:

> All six merged. So every per-PR figure in § Source … is **history, not a present state** … Re-measure the open-PR set, **or re-anchor the phases onto the two structural claims** — either is a real path.

Re-measuring the PR set would decay again — it was 6, then 0, and it is 3 as this runs. So: **re-anchor on history**, which does not.

## AC-4 — `pr_conflict_census`, and it counts the right thing

`./scripts-run src/scripts/pr_conflict_census --limit 2000`.

It counts **resolutions, not touches**. `git show --name-only` on a *merge* commit prints the combined diff — only paths differing from **both** parents — so a clean merge prints nothing and a resolved one prints exactly the resolved paths. **Validated in both directions before any figure was taken:** a merge with five known conflicts (this drain run's own) printed those five; a clean PR merge printed nothing.

The distinction is the whole value. A file edited in every branch but never conflicting is not a merge surface; a file edited rarely but always conflicting is. A churn count cannot tell them apart.

## 60 days · 1,843 merges · 533 with a resolution

| resolutions | path | class |
|---:|---|---|
| **339** | `agents/roadmaps-progress.md` | generated |
| **105** | `src/config/estate-count-budget.json` | authored |
| 61 | `agents/roadmaps/stubs/README.md` | generated |
| 60 | `agents/roadmaps/archive/index.json` | generated |
| 59 | `agents/roadmaps/archive/INDEX.md` | generated |
| 50 | `internal/.condensation-hashes.json` | generated |
| 38 | `docs/CLAIMS.md` | authored |
| 29 | `src/config/gate-violation-baselines.json` | authored |
| 26 | `docs/proof.md` | generated |
| 24 | `taskfiles/ci-fast.yml` | authored |

**703 of 1,394 resolutions — 50 % — are on generated paths**: output a PR carried and never needed to carry. That is Phase 1's premise, quantified for the first time and independent of who has a PR open.

## The finding is not the 50 %. It is that two completed repairs are measurable.

**`agents/roadmaps-progress.md` — 339 resolutions in 60 days, ZERO in the last three.** It is untracked at `.gitignore:108`. The single largest merge surface in the repository was removed by deleting it from the index, and the census shows the before **and** the after.

**`src/config/estate-count-budget.json` — 105 in 60 days, and all 9 recent ones fall on 2026-08-22**, the day ADR-243 removed its stored baseline. None after. That file's own `_comment` claims it was *"the most-conflicted non-generated path in the repository"*; this confirms it at 105 — second overall — and shows the removal ending it.

**Neither is a causal claim.** The dates line up and the mechanism is plausible, but nothing was held constant and merge volume varies day to day. Recorded as observation, which is what it is.

## What the measurement moves in the plan

**Phase 1.1 is aimed at the wrong four paths**, and one of them has never conflicted at all:

| named in the step | measured |
|---|---:|
| `docs/proof.md` | 26 |
| `src/domains/*/pack.yaml` | 12 |
| `internal/reports/exec-evidence-feasibility.json` | 3 |
| `agents/reports/originality.{json,md}` | **0 — appears in neither window** |

The five generated paths that do conflict were **unnamed**: `roadmaps-progress.md` 339 (already fixed), `stubs/README.md` 61, `archive/index.json` 60, `archive/INDEX.md` 59, `.condensation-hashes.json` 50. The step now carries the table and stays **open** — the classification work itself is not done.

**Phase 3's headline case is already done** (the estate-budget removal above).

**Phase 2's target is the only top-ten authored path getting worse:** `docs/CLAIMS.md`, 38 over 60 days but **12 in the newest three** — roughly a third of its two-month total in the newest 1.6 % of the window.

**Three authored hotspots sit in no phase at all:** `gate-violation-baselines.json` 29, `taskfiles/ci-fast.yml` 24, `gate-coverage.yml` 18. This drain run hit the last two on two branches in one day and moved `.secret-allow`'s line pin into `gate-coverage.yml` **five times** — a pin whose drift is a direct consequence of an append-heavy manifest being a merge surface.

## Two defects found by RUNNING the census, not by writing it

Both would have produced a confident wrong answer, and both are the kind this repository keeps finding in its own instruments:

**The default `--limit 200` measured the newest THREE DAYS while the header said "60 days ago".** A 60-day window holds 1,843 merge commits here. A mislabelled window reads as a *trend*. The census now prints the window it actually scanned and flags truncation, and `--limit` is parsed from argv — it was accepted by the function and unreachable from the CLI.

**`isGenerated()` misclassified the top four hotspots**, reporting a **10 %** generated share where the answer is **50 %**. Widened, with a test pinning both directions: the five paths it missed, and seven authored paths it must **not** claim — over-classifying would flatter the diagnosis exactly as under-classifying buried it.

## Stated limits rather than implied reach

A conflict resolved by **rebase** leaves no merge commit. A **squash-merge** of a branch that itself merged `main` hides the resolution in a single-parent commit. Both are invisible here, so **every number is a floor, never a total** — printed in the census output, not only in the docs.

The two windows also disagree, and reading only the recent one would have missed both repairs and mis-ranked the remaining work. That is why the artifact publishes both.

## Why it stays `status: draft`

The re-anchoring is the reason, not an exception to it: the evidence just **moved the phase targets** — one path list corrected, one phase's headline case retired, three hotspots newly surfaced. A plan whose phase list moved in this change is not a plan to mark executable in the same change. B1 (`dist/` untrack) and B2 (merge queue) also remain open.

## Gates run locally

`lint_roadmap_blockers` · `check_roadmap_trackable` · `lint_empty_roadmaps` · `check_no_roadmap_refs` · `lint_plan_risk_register` · `lint_roadmap_complexity` · `lint_roadmap_ci_steps` · `check_references` · `check_estate_count` · `lint_evidence_artifacts` — green. Typecheck exit 0. 10 tests, each building a real repo with one clean and one conflicted merge so the git property the method rests on is asserted rather than assumed.

`lint_evidence_artifacts` needed a second commit: it is diff-scoped against `origin/main`, so it reported "nothing to check" while the artifact was untracked and only demanded its `evidence-type` marker after the commit. Noted in that commit because the gate cannot warn earlier by construction.
