### PR TITLE
roadmap: complete road-to-skill-estate-drawdown

### DIFF
--- a/agents/roadmaps/archive/road-to-skill-estate-drawdown.md
+++ b/agents/roadmaps/archive/road-to-skill-estate-drawdown.md
@@ -264,11 +264,37 @@ does not fire, and saying so is cheaper than leaving a reader to wonder.
 
 ## Phase 4 — the first tranche, gated on Phase 1
 
-- [ ] **4.1 Retire the candidates Phase 1 ranked, in one reviewable batch.**
+- [~] **4.1 Retire the candidates Phase 1 ranked, in one reviewable batch.**
       Not "retire aggressively": retire the set whose evidence Phase 1 produced,
       and leave the rest.
-      verify: `skill_count` falls, `check_estate_count` reports the fall, and every
-      retirement cites its 1.3 row.
+      verify: **TRANSFERRED — the input does not exist, and the mechanism does.**
+      AI council 2/2 (2026-08-25) for option (a) over three alternatives, moved to
+      [`stubs/road-to-skill-retirement-signal.md`](stubs/road-to-skill-retirement-signal.md).
+
+      This step says *"retire the set whose evidence Phase 1 produced"*, and
+      Phase 1.3 produced a published null. Re-measured 2026-08-25 rather than
+      recalled from that record: `audit_skill_overlap` **0 pairs ≥ 70 %** over 299
+      skills · `lint_handoffs` 18 findings, **all `handoff_tier_mismatch`**, a
+      `tier` backfill backlog on the linked-TO skills and **0** retirement
+      candidates · `skill_eval_coverage` 42/299 · `skillRanking.ts` a per-query
+      ranker with no dead-skill threshold · **never triggered → `none`**, with
+      `grep -cE 'appendFileSync|writeFileSync' src/scripts/hooks/skill_route_hook.ts`
+      returning **0**. Estate unchanged at 299 / 11,461 / 0 deprecated.
+
+      **Three alternatives were refused, each for its own reason.** Building the
+      missing instrument here (b) is work this roadmap never scoped plus a
+      wall-clock window a run does not have. Re-scoping to "retire what the
+      existing signals nominate" (c) closes 4.1 on the empty set — vacuous
+      completion. Retiring the 257 skills with no eval (d) was refused by both
+      seats independently and on the same ground: **"no eval coverage" means
+      UNMEASURED, not unnecessary**, so those 257 are the un-instrumented
+      majority rather than candidates.
+
+      **The stub gates on BOTH** the instrument and a maintainer-approved tranche.
+      Neither substitutes for the other: the instrument supplies evidence, the
+      maintainer supplies authority, and a prior council call SPLIT on whether an
+      autonomous run may retire consumer-visible capabilities at all. That split
+      stands and is why the authority half is gated separately.
 - [x] **4.2 Record the net direction per release from here.** The reviewer's ask is
       *"netto sinkender Skill Count"* — a falling net, not a single tranche.
       verify: **`agents/evidence/metrics/skill-estate-per-release.jsonl`, with
@@ -488,7 +514,27 @@ does not fire, and saying so is cheaper than leaving a reader to wonder.
       written into the ledger's `_absence_of_refusals` line with the grep that
       establishes it, rather than left as an empty file a later reader would read
       as an unfinished backfill.
-- [ ] **AC-6** — `skill_count` is lower than 299 and every retirement cites its ranking row.
+- [-] **AC-6** — `skill_count` is lower than 299 and every retirement cites its ranking row.
+      **UNMET in this roadmap; objective carried forward.** Measured
+      `skill_count`: **299**. Phase 1 produced no evidence-backed retirement
+      candidates, so Phase 4 never ran.
+
+      **The council split on how to say this, and the split is the record.** Both
+      seats rejected the bare word *failed* — it reads as *the mechanism did not
+      work*, and the mechanism was never exercised. One argued **TRANSFERRED
+      (blocked on 4.1)**: a criterion that could not be *attempted* is blocked
+      rather than failed, and calling it failed inverts a positive finding — the
+      estate was checked and no slimming was indicated. The other argued that a
+      work item may transfer while an **acceptance criterion records an
+      outcome**: AC-6 says below 299, the measurement is 299, so it is unmet here
+      whatever blocked it.
+
+      **The stricter accounting is adopted**, because it also contains the first
+      seat's objection: *"UNMET in this roadmap; objective carried forward"*
+      states the outcome without implying the mechanism failed. The objective
+      lives in
+      [`stubs/road-to-skill-retirement-signal.md`](stubs/road-to-skill-retirement-signal.md);
+      the unmet criterion stays here, where it was declared.
 - [x] **AC-7** — two consecutive per-release readings of the net direction are committed.
       **Met with four readings, not two.** Backfilled from release tags
       (`git archive <tag> src/skills | tar -x`, then `measureSkillEstate`) rather

--- a/agents/roadmaps/stubs/road-to-skill-retirement-signal.md
+++ b/agents/roadmaps/stubs/road-to-skill-retirement-signal.md
@@ -1,0 +1,128 @@
+---
+complexity: bounded
+---
+# Stub: the skill-retirement signal
+
+> **Stub — not active work, and a DRAIN-RUN TRANSFER** in the sense
+> [`README.md`](README.md) § The two classes defines. **Capability-gated:** the
+> retirement mechanism is decided, wired and tested; what is missing is the
+> **input** — a signal that nominates a candidate. Promoted by its own named
+> probe returning true, never by the shared demand-gate criteria.
+
+## What was transferred
+
+From [`archive/road-to-skill-estate-drawdown.md`](../archive/road-to-skill-estate-drawdown.md)
+Phase 4, on an AI council verdict of 2026-08-25 (2/2 for option (a); the
+maintainer delegated owner-reserved dispositions to the council for that drain
+run).
+
+- **4.1** "Retire the candidates Phase 1 ranked, in one reviewable batch."
+- **AC-6's objective** — `skill_count` below 299 with every retirement citing its
+  ranking row. The criterion itself is recorded **UNMET in the parent**, which is
+  not the same as transferred; see § How AC-6 is recorded.
+
+## Why no automation can supply it
+
+**Phase 1.3 published a null, and it is still true.** Re-measured 2026-08-25, on
+the tree rather than from the parent's record:
+
+| signal | instrument | reading |
+|---|---|---|
+| duplicate responsibility | `audit_skill_overlap` | **0 pairs ≥ 70 %** over 299 skills |
+| dead cross-skill links | `lint_handoffs` | 18 findings, **all `handoff_tier_mismatch`** — a `tier` backfill backlog on the linked-TO skills. **0 retirement candidates.** |
+| no unique outcome | `skill_eval_coverage` | 42/299 = 14 % — silent on the other 257 |
+| low relevance score | `src/shared/skillRanking.ts` | a per-query ranker with **no dead-skill threshold** |
+| **never triggered** | **`none`** | `grep -cE 'appendFileSync\|writeFileSync' src/scripts/hooks/skill_route_hook.ts` → **0**. No persistence path exists. |
+
+Estate at transfer: **299 skills, 11,461 description tokens, 0 deprecated**.
+
+So a run cannot retire "the ranked set" because there is no ranked set, and it
+cannot manufacture one without inventing a criterion nobody pre-registered. Both
+council seats refused that route independently: **"no eval coverage" means
+UNMEASURED, not unnecessary**, so the 257 skills without an eval are not
+candidates — they are the un-instrumented majority.
+
+## The named producer and its probe
+
+**Producer:** whoever builds the never-triggered instrument, plus the maintainer
+who approves the tranche. Both seats required **BOTH** gates, and the pairing is
+the point: the instrument supplies evidence, the maintainer supplies authority,
+and neither substitutes for the other. A prior council call **SPLIT** on whether
+an autonomous run may retire consumer-visible capabilities at all; that split
+stands and is why the authority half is named separately here.
+
+**Probe — `skill-retirement-candidates-available`.** Returns true only when
+**all** of:
+
+1. `skill_route_hook.ts` persists a per-skill route decision to a sink, and the
+   sink exists;
+2. an observation window has run whose **length, minimum route volume and
+   candidate threshold were declared BEFORE the data was collected** — both seats
+   insisted on this ordering, so that "no signal" cannot be re-derived after the
+   fact from a window chosen to produce it;
+3. the window nominates ≥ 1 skill under that threshold;
+4. a maintainer-approved tranche exists, or a standing retirement policy the
+   tranche falls under.
+
+Conditions 1 and 3 are mechanically checkable. Conditions 2 and 4 are not, and
+that is the point rather than a gap: a repository gate cannot see whether a
+threshold was chosen before or after the numbers, nor whether a human approved a
+removal.
+
+**Entry conditions to declare before any collection** (both seats, and the list
+is theirs rather than this file's):
+
+- the persistence format for a route decision;
+- the observation window — length AND minimum route volume, because a window
+  with too little traffic distinguishes nothing;
+- the candidate threshold (e.g. zero triggers over N sessions);
+- how a false negative is treated — a skill that never triggered because its
+  trigger is broken is a **repair** candidate, not a retirement one;
+- the approving authority for the tranche.
+
+**Baseline on the transfer date, so a later reader can tell movement from noise:**
+the sink does not exist, the window has never run, and no skill carries
+`lifecycle: deprecated`.
+
+## How AC-6 is recorded — the one thing the council split on
+
+Both seats rejected the bare word **failed**: it reads as *the mechanism did not
+work*, and the mechanism was never exercised.
+
+They differed on what to say instead. One argued **TRANSFERRED (blocked on 4.1)**,
+on the ground that a criterion which could not be *attempted* is blocked rather
+than failed, and that calling it failed inverts a positive finding — the estate
+was checked and no slimming was indicated. The other argued that a work item may
+transfer while an **acceptance criterion records an outcome**: AC-6 says below
+299, the measured value is 299, so it is **UNMET in this roadmap** with the
+objective carried forward.
+
+**The stricter accounting was adopted**, and it is recorded here because it is
+also the one that contains the other's objection: *"UNMET in this roadmap;
+objective carried forward"* states the outcome without implying the mechanism
+failed. The parent's AC-6 carries that wording; this stub carries the objective.
+
+## What this stub does NOT cover
+
+- **The retirement mechanism**, which shipped and is tested:
+  `lifecycle: deprecated` for one release then delete, with `_lib/skill_estate.ts`
+  EXCLUDING deprecated skills from both metrics so deprecating one **lowers** the
+  count. Without that exclusion the mechanism would be unusable against its own
+  gate.
+- **The ratchet**, which shipped: `skill_count` and `skill_description_tokens` on
+  `check_estate_count`, floors measured on the base ref, both proven red by
+  sabotage.
+- **The admission and refusal ledger**, which shipped:
+  `agents/decisions/skill-admissions.jsonl` + `check_skill_admissions`.
+- **Repairing the 18 `handoff_tier_mismatch` findings.** They are a `tier`
+  metadata backlog on the linked-TO skills and have nothing to do with
+  retirement; treating them as retirement candidates is the exact false-negative
+  trap the entry conditions above name.
+
+## The finding this stub preserves
+
+**299 skills, and not one nominated for retirement by any working signal.** One
+seat put the consequence plainly: recording that as a failure inverts it — what
+happened is *checked, found slimming not indicated by the instruments that
+exist*, not *tried to slim and could not*. The gap is instrumentation, not bloat,
+and the successor should start from that rather than re-derive it.


### PR DESCRIPTION
Closes `road-to-skill-estate-drawdown` — **archived at 14/16 items and 6/7 acceptance criteria**, with 4.1 transferred and AC-6 recorded UNMET. Not "all met".

AI council **2/2 for option (a)** over three alternatives, split on one point of wording which is recorded rather than resolved away.

## The state: the mechanism shipped, the input never existed

Everything Phase 4 needs is built and tested — `lifecycle: deprecated` for one release then delete, with `_lib/skill_estate.ts` **excluding** deprecated skills so deprecating one actually *lowers* the count; the `skill_count` / `skill_description_tokens` ratchet with base-ref floors, both proven red by sabotage; the admission and refusal ledger.

What is missing is the **input**. Phase 1.3 published a null, and it was **re-measured today rather than recalled from that record**:

| signal | instrument | reading 2026-08-25 |
|---|---|---|
| duplicate responsibility | `audit_skill_overlap` | **0 pairs ≥ 70 %** over 299 skills |
| dead cross-skill links | `lint_handoffs` | 18 findings, **all `handoff_tier_mismatch`** — a `tier` backfill backlog on the linked-**to** skills. **0 retirement candidates.** |
| no unique outcome | `skill_eval_coverage` | 42/299 = 14 %, silent on the other 257 |
| low relevance score | `src/shared/skillRanking.ts` | per-query ranker, **no dead-skill threshold** |
| **never triggered** | **`none`** | `grep -cE 'appendFileSync\|writeFileSync' src/scripts/hooks/skill_route_hook.ts` → **0** |

Estate unchanged: **299 skills, 11,461 description tokens, 0 deprecated.**

## Three alternatives refused, each on its own ground

**(b) Build the instrument here** — work this roadmap never scoped, plus an observation window that is wall-clock a run does not have.

**(c) Re-scope 4.1 to "retire what the existing signals nominate"** — that is the empty set. Vacuous completion, and AC-6 would still fail by construction.

**(d) Retire the 257 skills with no eval** — refused by **both seats independently and on the same ground**: *"no eval coverage" means **UNMEASURED**, not unnecessary.* Those 257 are the un-instrumented majority, not candidates. This is the option that would have produced a falling count today, which is exactly why it needed refusing rather than adopting.

## The stub gates on BOTH evidence and authority

`stubs/road-to-skill-retirement-signal.md`, probe `skill-retirement-candidates-available`. The instrument supplies evidence; the maintainer supplies authority; **neither substitutes for the other**. A prior council call **split** on whether an autonomous run may retire consumer-visible capabilities at all — that split stands, which is why the authority half is gated separately instead of folded into the evidence half.

Both seats required the **entry conditions be declared before any data is collected** — window length *and* minimum route volume, candidate threshold, false-negative handling, approving authority. The ordering is the point: otherwise "no signal" can be re-derived after the fact from a window chosen to produce it. Two of the four probe conditions are mechanically checkable and two are not, and the stub says which is which.

One entry condition is worth naming here because it is the trap this roadmap's own data sets: **a skill that never triggered because its trigger is broken is a repair candidate, not a retirement one.** The 18 `handoff_tier_mismatch` findings are the same shape — metadata debt that looks like deadness.

## AC-6 — where the council split, and why the stricter reading won

Both seats rejected the bare word **failed**: it reads as *the mechanism did not work*, and the mechanism was never exercised.

- **Seat 1 — TRANSFERRED (blocked on 4.1).** A criterion that could not be *attempted* is blocked, not failed. And calling it failed **inverts a positive finding**: 299 skills with zero nominated means the estate is healthier than assumed — *checked, found slimming not indicated*, not *tried to slim and could not*.
- **Seat 2 — UNMET in this roadmap; objective carried forward.** A work item may transfer; an acceptance criterion records an **outcome**. AC-6 says below 299, the measurement is 299.

**Adopted: seat 2's wording**, because it is the stricter accounting *and* it contains seat 1's objection — "UNMET in this roadmap; objective carried forward" states the outcome without implying a mechanism failure. The unmet criterion stays in the roadmap where it was declared; the objective moves to the stub.

## The finding this preserves

**299 skills, and not one nominated for retirement by any working signal.** The gap is **instrumentation, not bloat**. Recording that as a failure would bury it; the stub carries it forward so the successor starts from the finding instead of re-deriving it.

## Gates run locally

`lint_roadmap_blockers` · `check_roadmap_trackable` · `lint_empty_roadmaps` · `check_no_roadmap_refs` · `lint_plan_risk_register` · `lint_roadmap_complexity` · `lint_roadmap_later_disposition` · `lint_roadmap_ci_steps` · `check_estate_count` · `check_references` — all green.

`check_estate_count` moves **+0 active**: the archive is offset by the stub, which does not register as an active roadmap.
