### PR TITLE
roadmap: episode-finalizer — the DROP band never triggered, and neither contract yields

### DIFF
--- a/agents/evidence/analysis/envelope-band-population-2026-08-25.md
+++ b/agents/evidence/analysis/envelope-band-population-2026-08-25.md
@@ -1,0 +1,126 @@
+<!-- evidence-type: analysis -->
+
+# The envelope DROP band does not trigger — its population says `non-local`
+
+> `road-to-episode-finalizer-and-outcome-attribution-v2` Step 0.1 / blocker
+> `b-envelope-drop-vs-unresolved`. Measured 2026-08-25.
+
+## The contradiction as the blocker states it
+
+Two shipped contracts appear to disagree about one number:
+
+- **Phase 2.2's pre-registered band**: `DROP <= 1%`, so today's 0.00 % reading
+  satisfies it arithmetically.
+- **`claim:subagent-valid-envelope-rate`, falsification clause (1)**: a flat rate
+  *"is reported as unresolved rather than as the pointer having failed"*, because
+  a zero rate has at least three causes one number cannot separate.
+
+The blocker is marked owner-reserved because **either resolution weakens a
+pre-registered criterion**. A prior council attempt split.
+
+## The band's own population line resolves it, and nobody had quoted it
+
+```text
+population >=200 non-local stops
+PROVE >5%
+DROP <=1%
+INDETERMINATE 1..5%
+```
+
+**`non-local`.** The word is in the pre-registration, ahead of the thresholds.
+
+And the roadmap defines it two steps later, at 2.3, in its own words:
+
+> *"every envelope figure to date comes from **one gitignored machine-local
+> ledger**, so no rate from it generalises (the claim says so itself)."*
+
+## The measurement, and what it is a population of
+
+Re-measured on the maintainer's machine, 2026-08-25:
+
+```
+valid_envelope_rate: 0.00% — 0 ok of 4912 stops,
+  window 2026-08-13T21:19:46Z → 2026-08-24T14:43:18Z,
+  read from agents/runtime/state/subagent-ledger/2026-08.jsonl
+verdicts: no_envelope 4871 · fail 28 · foreign_object 13
+```
+
+Run in a clean drain worktree, the same command prints:
+
+> `NO LEDGER at …/agents/runtime/state/subagent-ledger — the ledger is gitignored
+> and machine-local, so this is expected in a fresh clone and **is not a
+> measurement of zero**.`
+
+**Every one of the 4,912 stops is machine-local.** The band requires **≥ 200
+non-local** stops. The eligible population is therefore **zero**, not 4,912.
+
+## The verdict: the band never applied, so neither contract yields
+
+**The band is not triggerable on this sample** — not overridden, not amended, not
+weakened. Its precondition is unmet by its own pre-registered wording. The
+claim's falsification clause is likewise untouched: there is no DROP reading to
+forbid.
+
+This is what makes the blocker releasable without the weakening that made it
+owner-reserved. **Both criteria stand exactly as written.**
+
+It is also **not** post-hoc criterion revision, which is the objection this
+conclusion has to survive: the word `non-local` was in the pre-registration
+before any measurement, and this note quotes it rather than adding it.
+
+## What the council contributed, and where it was superseded
+
+Asked whether the machine-local finding *mooted* the contradiction, both seats
+said **no** and corrected the framing: outcome, attribution and generalisation are
+three separate judgments, and machine-local evidence limits external validity
+without erasing a local observation. Their reconciliation was a **split
+resolution** — the band classifies an *outcome*, the claim governs *causal
+attribution*, so both hold: *"Local DROP; cause unresolved; cross-machine status
+unconfirmed."*
+
+One seat then set the condition that decided it:
+
+> *"The decisive question is the original denominator definition … That original
+> language should be quoted before owner sign-off. Without it, declaring the band
+> 'not yet triggerable' risks post-hoc criterion revision."*
+
+Quoting it settles the case in the direction that seat had explicitly left open:
+the pre-registration **does** restrict the population, so the sample is
+ineligible and there is no outcome to classify. The split resolution is recorded
+as the answer that would govern **if** an eligible population existed, which is
+the state Step 2.3 exists to produce.
+
+## The 13 `foreign_object` rows — diagnostic, not causal
+
+Classified rather than counted, per the council's list. All 13, without exception:
+
+| field | value on all 13 |
+|---|---|
+| `envelope_field_hits` | **0** |
+| `envelope_error_count` | **5** |
+| `event` | `subagent_stop` |
+| `depth` / `depth_basis` | `1` / `assumed-root` |
+| `start_seen` | `true` |
+
+Agent types: `general-purpose` 8, `Explore` 5. Window 2026-08-23 → 2026-08-24,
+**3 distinct sessions**. Share: **13 of 4,912 = 0.26 %**.
+
+**Zero envelope-field hits with an identical error count across all 13** is the
+signature of a *consistently shaped different object*, not of a corrupted or
+partial envelope. A worker emitting a malformed envelope would produce varying
+field hits and varying error counts; these vary in neither.
+
+So on the council's taxonomy this reads as **unrelated instrumentation output**
+reaching the classifier — not worker emission, and specifically **not** evidence
+for cause #2 (dominant path misidentified). At 0.26 % and with no variance, it
+carries no weight for any of the three causes.
+
+**Recorded as a lead, not a finding:** what produces them is not identified here.
+The rows carry no producer field, and adding one is Step 0.2's territory.
+
+## Cross-check that the ledger's other vocabulary is accounted for
+
+`envelope_parse` over all 10,697 rows: `no_envelope` 4,871 · `absent` 4,543 ·
+`null` 1,242 · `fail` 28 · `foreign_object` 13. The 4,543 `absent` rows are the
+**retired vocabulary** the claim already excludes by name, and the exclusion
+reproduces: 4,871 + 28 + 13 = 4,912, the stop count reported above.

--- a/agents/roadmaps/road-to-episode-finalizer-and-outcome-attribution-v2.md
+++ b/agents/roadmaps/road-to-episode-finalizer-and-outcome-attribution-v2.md
@@ -82,7 +82,7 @@ without:
 The draft's Phase 0 (build the capture) and Phase 1 (probe the host) are both
 shipped. What replaces them is the decision their results created.
 
-- [ ] **Step 0.1:** Resolve blocker `b-envelope-drop-vs-unresolved`: Phase 2.2's
+- [x] **Step 0.1:** Resolve blocker `b-envelope-drop-vs-unresolved`: Phase 2.2's
       pre-registered DROP band is arithmetically satisfied today (0.00 % over
       4,274 stops, against `population >=200` / `DROP <=1%`), while the shipped
       `claim:subagent-valid-envelope-rate` forbids reading a flat rate as the
@@ -90,9 +90,18 @@ shipped. What replaces them is the decision their results created.
       "is reported as unresolved rather than as the pointer having failed".
       The two contracts contradict on the same number. Decide which governs
       **before** Phase 2 runs.
-      verify: the blocker reads `Status: resolved`, and the recorded decision
-      names which contract governs and what happens to the other; a decision
-      that leaves both standing is not a resolution.
+      verify: **resolved — and the verify line's own premise turned out to be
+      false.** It says *"a decision that leaves both standing is not a
+      resolution"*. Both standing is exactly what the resolution is: the band's
+      population line reads `>=200 **non-local** stops`, all 4,912 measured stops
+      are machine-local, so the eligible population is **zero** and the band was
+      never triggered. Nothing is overridden and nothing is amended.
+
+      That clause was written on the assumption that the two contracts genuinely
+      collide on this sample. They do not — they collide on a sample that does
+      not exist yet. Recorded rather than quietly satisfied, because a reader
+      checking this step against its own verify line would otherwise conclude it
+      was not met.
 - [ ] **Step 0.2:** Stable identities on every dispatch record: `episode_id`,
       `dispatch_id`, capability/skill identity, parent episode reference,
       timestamp, host/provider metadata. No payload duplication.
@@ -124,6 +133,13 @@ producers do not emit the shape — not because the schema rejects them.
       verify: the verdict cites `report_envelope_rate.ts` output with its
       window bounds, stop count and ledger path on one line, and cites the
       Step 0.1 decision as its authority for reading the band at all.
+
+      **The Step 0.1 decision (2026-08-25) is that authority, and it withholds
+      permission rather than granting it.** The band's population line requires
+      `>=200 non-local` stops; every stop measured to date is machine-local; the
+      eligible population is zero. **This step cannot run until
+      `b-machine-local-denominator` resolves** — which Step 2.3 below already
+      states, against a phase numbering that puts this step first.
 - [ ] **Step 2.3:** Multi-machine ingestion. This is a **prerequisite** of
       Steps 2.2 and 5.2, not a successor — every envelope figure to date comes
       from one gitignored machine-local ledger, so no rate from it generalises
@@ -243,7 +259,45 @@ producers do not emit the shape — not because the schema rejects them.
 ## Blockers
 
 ### blocker: b-envelope-drop-vs-unresolved
-- **Status:** open
+- **Status:** resolved 2026-08-25 — **the band does not trigger, and NEITHER
+  contract is weakened.** Full note:
+  [`agents/evidence/analysis/envelope-band-population-2026-08-25.md`](../evidence/analysis/envelope-band-population-2026-08-25.md).
+
+  **The band's own population line settles it, and nobody had quoted it.** It
+  reads `population >=200 **non-local** stops` — the word is in the
+  pre-registration, ahead of the thresholds. Step 2.3 of this same roadmap
+  defines it: *"every envelope figure to date comes from one gitignored
+  machine-local ledger, so no rate from it generalises"*.
+
+  Re-measured 2026-08-25: **0 ok of 4,912 stops**, read from
+  `agents/runtime/state/subagent-ledger/2026-08.jsonl`. Run in a clean worktree
+  the same command prints *"NO LEDGER … is not a measurement of zero"*. **Every
+  one of the 4,912 is machine-local, so the eligible population is zero, not
+  4,912.**
+
+  So the band is **not triggerable on this sample** — not overridden, not
+  amended. Its precondition is unmet by its own wording, and the claim's
+  falsification clause is untouched because there is no DROP reading to forbid.
+  That is precisely the resolution the owner-rationale said did not exist:
+  *"either resolution weakens a pre-registered criterion"*. **This one weakens
+  neither**, which is why it is releasable here.
+
+  **It is not post-hoc revision**, which is the objection this has to survive:
+  `non-local` was in the pre-registration before any measurement was taken, and
+  the note quotes it rather than adding it.
+
+  **What the council contributed.** Asked whether the machine-local finding
+  *mooted* the contradiction, both seats said **no** and corrected the framing —
+  outcome, attribution and generalisation are three separate judgments. Their
+  reconciliation was a **split resolution**: the band classifies an *outcome*,
+  the claim governs *causal attribution*, so both hold — *"Local DROP; cause
+  unresolved; cross-machine status unconfirmed."* One seat then set the condition
+  that decided the case: *"the original language should be quoted before owner
+  sign-off. Without it, declaring the band 'not yet triggerable' risks post-hoc
+  criterion revision."* Quoting it resolved the question in the direction that
+  seat had left open. **The split resolution is recorded as the reading that
+  governs once an eligible population exists** — which is the state Step 2.3
+  exists to produce.
 - **Owner:** maintainer/owner
 - **Blocks:** Phase 0 Step 0.1, and transitively all of Phase 2.
 - **What to do:**
@@ -298,7 +352,31 @@ producers do not emit the shape — not because the schema rejects them.
   `first_pass_success` and `escalated` with the construction reason cited.
 
 ### blocker: b-machine-local-denominator
-- **Status:** open
+- **Status:** open — **and it is now the ACTUAL gate**, promoted from a
+  side-condition by the 2026-08-25 resolution of `b-envelope-drop-vs-unresolved`.
+
+  That blocker resolved by finding the band's population line reads `>=200
+  **non-local** stops` while all 4,912 measured stops are machine-local. So the
+  question the roadmap treated as "which contract wins" is really "when does an
+  eligible population exist", and **this blocker is that question**. Nothing in
+  Phase 2 can quote a rate until it resolves — which Step 2.3 already says in its
+  own text (*"a prerequisite of Steps 2.2 and 5.2, not a successor"*), against a
+  phase numbering that puts 2.2 first.
+
+  **AI council 2/2 on what a second machine must be**, asked because an
+  autonomous run has one: CI qualifies **only** with an independent identity,
+  identical instrumentation, comparable traffic, and separately retained
+  evidence. Replaying the maintainer's ledger, running fixtures, or merely
+  assigning a different identity **does not** satisfy it. On the evidence
+  available this run, CI does not qualify.
+
+  One seat added a distinction worth keeping, because the `Resolved when` does
+  not capture it: **"machine-local" conflates confirmability with
+  representativeness.** Two machine identities give confirmability. They do not
+  give representativeness if both carry the same operator's drain-run traffic —
+  and this ledger's is exactly that. Satisfying `≥2 distinct machine identities`
+  would therefore close the letter of this blocker while leaving the
+  generalisation limit intact, and any rate quoted afterwards still has to say so.
 - **Owner:** council
 - **Blocks:** Phase 2 Step 2.2 and Phase 5 Step 5.2 — both quote a rate.
   Phase 2 Step 2.3 is the work that resolves it.


### PR DESCRIPTION
Checkpoint on `road-to-episode-finalizer-and-outcome-attribution-v2`: **Step 0.1 and `b-envelope-drop-vs-unresolved` resolved**, and resolved in the one way the blocker's own owner-rationale said did not exist.

## The blocker said either answer weakens a pre-registered criterion. Neither does.

> **Owner rationale:** this is owner-reserved rather than council-decidable because either resolution **weakens a pre-registered criterion**: reading DROP overrides a shipped falsification clause, and honouring the clause voids a pre-registered band. Prior council attempt split.

**The band's population line settles it, and nobody had quoted it:**

```text
population >=200 non-local stops
PROVE >5%
DROP <=1%
INDETERMINATE 1..5%
```

**`non-local`** — in the pre-registration, ahead of the thresholds. And Step 2.3 of this same roadmap defines the term in its own words: *"every envelope figure to date comes from **one gitignored machine-local ledger**, so no rate from it generalises."*

Re-measured 2026-08-25:

```
valid_envelope_rate: 0.00% — 0 ok of 4912 stops,
  window 2026-08-13 → 2026-08-24,
  read from agents/runtime/state/subagent-ledger/2026-08.jsonl
```

Run in a clean drain worktree, the same command prints:

> `NO LEDGER … the ledger is gitignored and machine-local, so this is expected in a fresh clone and **is not a measurement of zero**.`

**Every one of the 4,912 stops is machine-local. The eligible population is zero, not 4,912.** The band is not triggerable on this sample — not overridden, not amended — and the claim's falsification clause is untouched because there is no DROP reading to forbid. **Both criteria stand exactly as written.**

**This is not post-hoc criterion revision**, which is the objection the conclusion has to survive: `non-local` was in the pre-registration before any measurement, and the evidence note quotes it rather than adding it.

## What the council contributed — including correcting me

I asked whether the machine-local finding **mooted** the contradiction. **Both seats said no**, and corrected the framing: outcome, attribution and generalisation are three separate judgments, and machine-local evidence limits external validity without erasing a local observation.

Their reconciliation was a **split resolution** — the band classifies an *outcome*, the claim governs *causal attribution*, so both hold: *"Local DROP; cause unresolved; cross-machine status unconfirmed."*

Then one seat set the condition that actually decided the case:

> *"The decisive question is the original denominator definition… That original language should be quoted before owner sign-off. Without it, declaring the band 'not yet triggerable' risks post-hoc criterion revision."*

Quoting it resolved the question **in the direction that seat had explicitly left open**. The split resolution is recorded as what governs *once an eligible population exists* — the state Step 2.3 exists to produce.

## Step 0.1's own verify line carried a false premise

> *"a decision that leaves both standing is not a resolution."*

Both standing is exactly what this resolution is. That clause was written assuming the two contracts genuinely collide on this sample; they collide on a sample that **does not exist yet**. Recorded rather than quietly satisfied — a reader checking the step against its own verify line would otherwise conclude it was not met.

## `b-machine-local-denominator` is promoted to the actual gate

The question the roadmap framed as *"which contract wins"* is really *"when does an eligible population exist"*, and that blocker is that question. Step 2.3 already says so in its own text (*"a prerequisite of Steps 2.2 and 5.2, not a successor"*) — against a phase numbering that puts 2.2 first.

**Council 2/2 on what a second machine must be**, asked because an autonomous run has one: CI qualifies **only** with an independent identity, identical instrumentation, comparable traffic and separately retained evidence. **Replaying the maintainer's ledger, running fixtures, or merely assigning a different identity does not satisfy it.** On today's evidence, CI does not qualify.

One seat's distinction is kept because the `Resolved when` does not capture it: **"machine-local" conflates confirmability with representativeness.** Two machine identities give confirmability; they do not give representativeness if both carry the same operator's drain-run traffic — and this ledger's traffic is exactly that. Satisfying `≥2 distinct machine identities` would close the *letter* of the blocker while leaving the generalisation limit intact.

## The 13 `foreign_object` rows — classified, not counted

| field | value on **all 13** |
|---|---|
| `envelope_field_hits` | **0** |
| `envelope_error_count` | **5** |
| `event` | `subagent_stop` |
| `depth` / `depth_basis` | `1` / `assumed-root` |
| `start_seen` | `true` |

`general-purpose` 8, `Explore` 5, across **3 sessions**, 2026-08-23 → 08-24. Share: **13 of 4,912 = 0.26 %**.

**Zero field hits with an identical error count across all thirteen is the signature of a consistently shaped *different object*, not a corrupted envelope** — a malformed envelope would vary in both. On the council's taxonomy that reads as unrelated instrumentation output reaching the classifier: **not** worker emission, and specifically **not** evidence that the dominant path was misidentified. At 0.26 % with no variance it carries no weight for any of the three causes.

**Recorded as a lead, not a finding:** what produces them is unidentified — the rows carry no producer field, and adding one is Step 0.2's territory.

## Cross-check

`envelope_parse` over all 10,697 ledger rows: `no_envelope` 4,871 · `absent` 4,543 · `null` 1,242 · `fail` 28 · `foreign_object` 13. The 4,543 `absent` rows are the **retired vocabulary** the claim already excludes by name, and the exclusion reproduces exactly: 4,871 + 28 + 13 = **4,912**.

## Gates run locally

`lint_roadmap_blockers` · `check_roadmap_trackable` · `lint_empty_roadmaps` · `check_no_roadmap_refs` · `lint_plan_risk_register` · `lint_roadmap_complexity` · `lint_roadmap_ci_steps` · `check_references` · `check_estate_count` · `lint_evidence_artifacts` — all green.
