### PR TITLE
roadmap: web-launch-readiness — the indexability check ships, default-off

### DIFF
--- a/agents/roadmaps/road-to-web-launch-readiness.md
+++ b/agents/roadmaps/road-to-web-launch-readiness.md
@@ -232,14 +232,35 @@ disposition as the reason, which is a publishable outcome and not a failure.
 > eleven verify lines to change one noun would bury the decision in a diff; it is
 > recorded once, here, where a reader meets it before the steps.
 
-- [ ] **2.1 Ship the indexability check alone.** `src/skills/web-launch-readiness/`
+- [x] **2.1 Ship the indexability check alone.** `src/skills/web-launch-readiness/`
       with site-type classification as step 1 and exactly one check: no
       `noindex` and no blocking `robots.txt` on the production build.
       Verification method: static grep over the build output plus a fetch of
       `/robots.txt`. Tier `critical`, `applies_to` all site types.
-      verify: on a fixture carrying a staging `noindex`, the skill reports a
-      critical finding with the offending `file:line`; on a clean fixture it
-      reports none. Both states demonstrated.
+      verify: **both states demonstrated**, as
+      `src/scripts/check_web_launch_readiness.ts` — a COMMAND, per the Phase 2
+      re-scope, not `src/skills/`.
+
+      Staging fixture → **2 critical findings, each with a location**:
+      `index.html:7` (the `noindex` meta) and `robots.txt:2` (the blanket
+      `Disallow: /`), exit **1**. Clean fixture → **none**, exit **0**.
+
+      **The clean fixture deliberately keeps `Disallow: /admin/`.** A check
+      matching any `Disallow` would pass a naive clean fixture and still be
+      wrong, so the discrimination is asserted rather than the absence: blanket
+      block versus path rule.
+
+      The `applies_to` axis is exercised on the same tree: audited as `saas-app`
+      it skips `per-route-metadata` and `canonical-and-sitemap-coherence` with
+      *"site type is saas-app"*; audited as `marketing-site` the same directory
+      skips nothing. Same files, different answer — which is what makes the axis
+      conditional rather than incidental.
+
+      **The honesty property this needed and the step did not name:** the six
+      unimplemented checks are reported as `NOT YET IMPLEMENTED (applicable, not
+      audited)` and are **never** counted as PASSED. An unimplemented check
+      reporting clean is the silent-green defect this repository already names,
+      and a one-check command is exactly where it would first appear.
 - [ ] **2.2 Add the remaining critical and high tiers** — HTTPS enforcement,
       custom 404, per-route title and description, alternative text on content
       images, `lang`/charset/viewport. Each with explanation, remediation and
@@ -252,12 +273,26 @@ disposition as the reason, which is a publishable outcome and not a failure.
       verify: a SaaS-app fixture reports the local-business items as
       `situational-skipped` **with the site type as the stated skip reason**,
       never as findings.
-- [ ] **2.4 Tiered output shape.** Report order: critical, high, medium,
+- [x] **2.4 Tiered output shape.** Report order: critical, high, medium,
       situational-applicable, situational-skipped-with-reason.
-      verify: a snapshot test pins the section order and the skip-reason text.
-- [ ] **2.5 Default-off** until the Phase 3 benchmark returns positive.
-      verify: with the flag absent, the skill does not activate on a
-      would-fire prompt.
+      verify: **order asserted by index comparison rather than by a snapshot**,
+      and the difference is deliberate: a snapshot pins the whole string, so any
+      wording edit reds it and the ORDER — the thing the step actually
+      specifies — is not what fails. The test asserts
+      `CRITICAL < NOT YET IMPLEMENTED < SKIPPED` positionally, and separately
+      that the report opens with `site type: <type>` so a reader knows which
+      axis produced it. Skip-reason text is pinned exactly
+      (`site type is saas-app`) because 2.3 requires the type verbatim.
+- [x] **2.5 Default-off** until the Phase 3 benchmark returns positive.
+      verify: **with no settings file at all, a run pointed at the FAILING
+      fixture exits 0, prints `DEFAULT-OFF` with the reason, and does not print
+      `CRITICAL`.** Pointing the disabled run at the fixture that would fire is
+      the load-bearing part: a test that disabled a clean tree would pass
+      whether or not the flag worked.
+
+      Enabled only by the exact key `web_launch_readiness.enabled: true`;
+      `enabled: false` and the near-miss `web_launch:` both leave it off.
+      `--force` is the explicit override the fixtures use.
 
 **Exit:** skill ships, flag off, under 50 checks, every check verifiable.
 **Rollback:** delete the skill directory; the config and claim survive as a
@@ -368,20 +403,43 @@ recorded null.
 
 ## Acceptance Criteria
 
-- [ ] AC-1 — The G0 evidence note, the site-type config, the no-import decision
+- [x] AC-1 — The G0 evidence note, the site-type config, the no-import decision
       and the benchmark claim all exist and predate the first skill commit in
       history.
-- [ ] AC-2 — `b-estate-decision-web-launch` carries a recorded disposition with
+      **Met.** All four landed in the Phase-0 change (merged as #1630) with zero
+      implementation code, and the first implementation commit is in THIS change.
+      The ordering is the pre-registration, and it is checkable in `git log`.
+- [x] AC-2 — `b-estate-decision-web-launch` carries a recorded disposition with
       a date and a named decider.
-- [ ] AC-3 — The indexability check reports a critical finding with a
+      **Met.** `Status: resolved 2026-08-25 — NO to a standalone skill slot; the
+      domain ships as a COMMAND`, decided by AI council 2/2, with the reasoning
+      and the reopening condition recorded at the blocker.
+- [x] AC-3 — The indexability check reports a critical finding with a
       `file:line` on a staging-`noindex` fixture and reports none on a clean
       one — both states demonstrated in the PR.
-- [ ] AC-4 — Every shipped check carries an explanation, a remediation, a
+      **Met.** `index.html:7` and `robots.txt:2`, exit 1; clean fixture exit 0
+      with no findings. Both runs are quoted in the PR body.
+- [x] AC-4 — Every shipped check carries an explanation, a remediation, a
       verification step and a non-empty `applies_to`, asserted by a schema test
       rather than by review.
-- [ ] AC-5 — A SaaS-app fixture reports local-business items as
+      **Met** by the 18-case schema test that landed with the config, which also
+      rejects any field under 20 characters — a one-word remediation is the
+      boilerplate the assertion exists to catch. The command's own tests
+      re-assert `remediation` and `verification` length on every emitted finding,
+      so the contract holds at the output as well as in the config.
+- [~] AC-5 — A SaaS-app fixture reports local-business items as
       situational-skipped with the site type as the skip reason, and the
       benchmark decoy is not flagged.
+      **First half MET, second half NOT REACHABLE YET.** The SaaS-app fixture
+      skips `per-route-metadata` and `canonical-and-sitemap-coherence` with
+      `site type is saas-app` verbatim, asserted per-item.
+
+      The decoy half belongs to Phase 3: the decoy is *a missing team photo on
+      the SaaS app*, and nothing can flag or not-flag it until the checks that
+      could see it exist (`image-alternative-text` is unimplemented) and the
+      benchmark runs. Recorded as partially met rather than checked off, because
+      an AC that folds two phases into one line would otherwise read as green on
+      half its evidence.
 - [ ] AC-6 — The benchmark claim carries a resolved verdict; on DROP the skill
       remains default-off and the null is recorded.
 

--- a/src/scripts/check_web_launch_readiness.ts
+++ b/src/scripts/check_web_launch_readiness.ts
@@ -1,0 +1,326 @@
+#!/usr/bin/env tsx
+/**
+ * `check_web_launch_readiness` — the web-surface pre-ship audit, as a COMMAND.
+ *
+ * NOT a skill, and the container is a recorded decision rather than a default.
+ * AI council 2/2 on 2026-08-25 (`road-to-web-launch-readiness`
+ * § `b-estate-decision-web-launch`): the G0 evidence establishes a COVERAGE gap,
+ * not a SKILL-SHAPED one. A site-type-conditional config, deterministic checks,
+ * tiers and a hard pass/fail gate are *"the signature of a linter, not a skill"*,
+ * and `production-validator` carries unscoped `Bash`, so it can invoke this
+ * directly instead of depending on skill activation — which demonstrably is NOT
+ * firing for web-facing deploys, since `launch-readiness` already exists and
+ * scores 0 of 8 on these axes.
+ *
+ * CONDITIONAL, NOT FLAT. Every check declares `applies_to`, and a check that does
+ * not apply is reported as **skipped with the site type as the reason** — never
+ * silently dropped and never as a finding. A reader must be able to tell "this
+ * does not apply to you" from "this passed", which a flat audit cannot express.
+ *
+ * DEFAULT-OFF until the pre-registered benchmark returns positive
+ * (`claim:web-launch-readiness-finds-more`, status `unbacked`). Absent the
+ * opt-in, this exits 0 and says why rather than auditing.
+ *
+ * Exit codes: 0 = no critical/high finding (or not enabled) · 1 = a blocking
+ * finding · 2 = usage or a dead scan scope.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+import { DeadScopeError, reportScanned } from './_lib/scan_scope.js';
+
+const HERE = fileURLToPath(import.meta.url);
+const REPO_ROOT = path.resolve(path.dirname(HERE), '..', '..');
+export const CONFIG_REL = 'src/config/web-launch-readiness.json';
+
+export type SiteType = 'local-business' | 'marketing-site' | 'saas-app' | 'docs' | 'internal-tool';
+export type Tier = 'critical' | 'high' | 'medium' | 'situational';
+
+export interface CheckDef {
+    id: string;
+    title: string;
+    applies_to: SiteType[];
+    tier: Tier;
+    why: string;
+    remediation: string;
+    verification: string;
+}
+
+export interface Finding {
+    check: string;
+    tier: Tier;
+    /** `path:line` — the step's own verify line requires a location, not a name. */
+    location: string;
+    evidence: string;
+    remediation: string;
+    verification: string;
+}
+
+export interface Skipped {
+    check: string;
+    tier: Tier;
+    /** The SITE TYPE, verbatim — 2.3 requires the type to be the stated reason. */
+    reason: string;
+}
+
+export interface Report {
+    site_type: SiteType;
+    enabled: boolean;
+    findings: Finding[];
+    skipped: Skipped[];
+    /** Checks that applied and found nothing. */
+    passed: string[];
+    /** Applicable checks with no implementation yet — never counted as passed. */
+    unimplemented: string[];
+    scanned_files: number;
+}
+
+export function loadConfig(root = REPO_ROOT): { checks: CheckDef[]; siteTypes: SiteType[] } {
+    const abs = path.join(root, CONFIG_REL);
+    let raw: string;
+    try {
+        raw = fs.readFileSync(abs, 'utf-8');
+    } catch {
+        throw new DeadScopeError(
+            'check_web_launch_readiness',
+            `${CONFIG_REL} is missing — the config IS this command's corpus, and an absent ` +
+                'one cannot be read as "no checks to run".',
+        );
+    }
+    const doc = JSON.parse(raw) as {
+        checks?: CheckDef[];
+        site_types?: { values?: SiteType[] };
+    };
+    const checks = doc.checks ?? [];
+    const siteTypes = doc.site_types?.values ?? [];
+    if (checks.length === 0 || siteTypes.length === 0) {
+        throw new DeadScopeError(
+            'check_web_launch_readiness',
+            `${CONFIG_REL} carries no checks or no site types — an empty corpus checks nothing.`,
+        );
+    }
+    return { checks, siteTypes };
+}
+
+/** `web_launch_readiness.enabled: true` in `.agent-settings.yml` — default OFF. */
+export function enabled(root: string): boolean {
+    let raw: string;
+    try {
+        raw = fs.readFileSync(path.join(root, '.agent-settings.yml'), 'utf-8');
+    } catch {
+        return false;
+    }
+    let inSection = false;
+    for (const line of raw.split('\n')) {
+        if (/^web_launch_readiness:\s*$/.test(line)) {
+            inSection = true;
+            continue;
+        }
+        if (/^\S/.test(line)) {
+            inSection = false;
+            continue;
+        }
+        if (inSection && /^\s{2}enabled:\s*true\s*$/.test(line)) return true;
+    }
+    return false;
+}
+
+/* ── the one implemented check: staging indexability ───────────────────────── */
+
+const NOINDEX_RE = /<meta[^>]+name\s*=\s*["']robots["'][^>]*content\s*=\s*["'][^"']*noindex/i;
+const XROBOTS_RE = /x-robots-tag[^\n]*noindex/i;
+/** `Disallow: /` with nothing after it — a blanket block, not a path rule. */
+const BLANKET_DISALLOW_RE = /^\s*Disallow:\s*\/\s*$/im;
+
+export interface Located {
+    file: string;
+    line: number;
+    text: string;
+}
+
+/**
+ * Walk a build directory for indexability leftovers.
+ *
+ * Returns a LOCATION per hit, because the step's verify line asks for a
+ * `file:line` and a finding without one cannot be acted on.
+ */
+export function scanIndexability(buildDir: string): { hits: Located[]; files: number } {
+    const hits: Located[] = [];
+    let files = 0;
+    const walk = (dir: string): void => {
+        let entries: fs.Dirent[];
+        try {
+            entries = fs.readdirSync(dir, { withFileTypes: true });
+        } catch {
+            return;
+        }
+        for (const e of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+            const p = path.join(dir, e.name);
+            if (e.isDirectory()) {
+                if (e.name === 'node_modules' || e.name === '.git') continue;
+                walk(p);
+                continue;
+            }
+            if (!/\.(html?|txt|xml|js|jsx|ts|tsx|vue|svelte|astro)$/i.test(e.name)) continue;
+            files += 1;
+            let text: string;
+            try {
+                text = fs.readFileSync(p, 'utf-8');
+            } catch {
+                continue;
+            }
+            const isRobots = path.basename(p).toLowerCase() === 'robots.txt';
+            text.split('\n').forEach((line, i) => {
+                const rel = path.relative(buildDir, p);
+                if (NOINDEX_RE.test(line) || XROBOTS_RE.test(line)) {
+                    hits.push({ file: rel, line: i + 1, text: line.trim().slice(0, 160) });
+                } else if (isRobots && BLANKET_DISALLOW_RE.test(line)) {
+                    hits.push({ file: rel, line: i + 1, text: line.trim().slice(0, 160) });
+                }
+            });
+        }
+    };
+    walk(buildDir);
+    return { hits, files };
+}
+
+/** Checks with a real implementation. Everything else reports UNIMPLEMENTED. */
+export const IMPLEMENTED: readonly string[] = ['staging-noindex-leftover'];
+
+export function audit(buildDir: string, siteType: SiteType, root = REPO_ROOT): Report {
+    const { checks, siteTypes } = loadConfig(root);
+    if (!siteTypes.includes(siteType)) {
+        throw new DeadScopeError(
+            'check_web_launch_readiness',
+            `unknown site type "${siteType}" — registered: ${siteTypes.join(', ')}`,
+        );
+    }
+    const findings: Finding[] = [];
+    const skipped: Skipped[] = [];
+    const passed: string[] = [];
+    const unimplemented: string[] = [];
+    let scanned = 0;
+
+    for (const c of checks) {
+        if (!c.applies_to.includes(siteType)) {
+            // The site type IS the reason, verbatim. 2.3 requires exactly this.
+            skipped.push({ check: c.id, tier: c.tier, reason: `site type is ${siteType}` });
+            continue;
+        }
+        if (!IMPLEMENTED.includes(c.id)) {
+            // Never counted as passed: an unimplemented check that reported
+            // "clean" would be the silent-green defect this repository names.
+            unimplemented.push(c.id);
+            continue;
+        }
+        const { hits, files } = scanIndexability(buildDir);
+        scanned = files;
+        if (hits.length === 0) {
+            passed.push(c.id);
+            continue;
+        }
+        for (const h of hits) {
+            findings.push({
+                check: c.id,
+                tier: c.tier,
+                location: `${h.file}:${String(h.line)}`,
+                evidence: h.text,
+                remediation: c.remediation,
+                verification: c.verification,
+            });
+        }
+    }
+    return {
+        site_type: siteType,
+        enabled: enabled(root),
+        findings,
+        skipped,
+        passed,
+        unimplemented,
+        scanned_files: scanned,
+    };
+}
+
+const TIER_ORDER: readonly Tier[] = ['critical', 'high', 'medium', 'situational'];
+
+/** Report order: critical → high → medium → situational-applicable → skipped. */
+export function render(r: Report): string {
+    const out: string[] = [];
+    out.push(`site type: ${r.site_type}`);
+    for (const tier of TIER_ORDER) {
+        const f = r.findings.filter((x) => x.tier === tier);
+        if (f.length === 0) continue;
+        out.push('', `${tier.toUpperCase()} (${String(f.length)})`);
+        for (const x of f) {
+            out.push(`  ${x.location}  ${x.check}`);
+            out.push(`    evidence:     ${x.evidence}`);
+            out.push(`    remediation:  ${x.remediation}`);
+            out.push(`    verification: ${x.verification}`);
+        }
+    }
+    if (r.passed.length > 0) out.push('', `PASSED: ${r.passed.join(', ')}`);
+    if (r.unimplemented.length > 0) {
+        out.push('', `NOT YET IMPLEMENTED (applicable, not audited): ${r.unimplemented.join(', ')}`);
+    }
+    if (r.skipped.length > 0) {
+        out.push('', 'SKIPPED — not applicable to this site type');
+        for (const s of r.skipped) out.push(`  ${s.check}: ${s.reason}`);
+    }
+    return out.join('\n');
+}
+
+export function main(argv: string[] = process.argv.slice(2), root = REPO_ROOT): number {
+    const arg = (f: string): string | undefined => {
+        const i = argv.indexOf(f);
+        return i >= 0 ? argv[i + 1] : undefined;
+    };
+    const build = arg('--build');
+    const siteType = arg('--site-type') as SiteType | undefined;
+    if (build === undefined || siteType === undefined) {
+        process.stderr.write(
+            'usage: check_web_launch_readiness --build <dir> --site-type <type> [--json]\n',
+        );
+        return 2;
+    }
+    if (!enabled(root) && !argv.includes('--force')) {
+        process.stdout.write(
+            'web-launch-readiness is DEFAULT-OFF until the pre-registered benchmark returns\n' +
+                'positive (claim:web-launch-readiness-finds-more, status unbacked). Enable with\n' +
+                '`web_launch_readiness.enabled: true` in .agent-settings.yml, or pass --force.\n',
+        );
+        return 0;
+    }
+    let r: Report;
+    try {
+        r = audit(build, siteType, root);
+        reportScanned({
+            gate: 'check_web_launch_readiness',
+            scanned: r.scanned_files,
+            units: 'build file(s)',
+            roots: [build],
+            allowEmpty:
+                'OPTIONAL_INPUT: a build directory may legitimately hold no scannable file ' +
+                'when the caller points at an unbuilt tree; a missing config is a separate ' +
+                'hard error in loadConfig()',
+        });
+    } catch (e) {
+        if (e instanceof DeadScopeError) {
+            process.stderr.write(`❌  ${e.message}\n`);
+            return 2;
+        }
+        throw e;
+    }
+    if (argv.includes('--json')) {
+        process.stdout.write(`${JSON.stringify(r, null, 2)}\n`);
+    } else {
+        process.stdout.write(`${render(r)}\n`);
+    }
+    const blocking = r.findings.filter((f) => f.tier === 'critical' || f.tier === 'high');
+    return blocking.length > 0 ? 1 : 0;
+}
+
+if (path.resolve(process.argv[1] ?? '') === path.resolve(HERE)) {
+    process.exit(main());
+}

--- a/tests/fixtures/web-launch/README.md
+++ b/tests/fixtures/web-launch/README.md
@@ -1,0 +1,16 @@
+# web-launch fixtures
+
+Three build trees for `check_web_launch_readiness`, and the pairing is the point:
+`staging-leftover` and `clean-marketing` differ **only** in the indexability
+signals, so a finding on the first and silence on the second isolates the check
+rather than the fixture.
+
+| fixture | carries | used for |
+|---|---|---|
+| `staging-leftover/` | a `noindex` robots meta **and** a blanket `Disallow: /` | the critical finding, with `file:line` |
+| `clean-marketing/` | the same page minus those two, plus a path-scoped `Disallow: /admin/` and a `Sitemap:` line | the clean state — and it proves the check does not fire on *any* `Disallow` |
+| `saas-app/` | an authenticated-app shell | the `applies_to` axis: local-business items skip with the site type as the reason |
+
+`clean-marketing/robots.txt` deliberately keeps a `Disallow: /admin/`. A check
+that matched any `Disallow` would pass the naive clean fixture and still be
+wrong; this one has to distinguish a **blanket** block from a path rule.

--- a/tests/fixtures/web-launch/clean-marketing/index.html
+++ b/tests/fixtures/web-launch/clean-marketing/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Acme Landscaping — Garden design and maintenance</title>
+  <meta name="description" content="Garden design, planting and maintenance in Freiburg." />
+  <link rel="canonical" href="https://example.com/" />
+</head>
+<body><h1>Acme Landscaping</h1><img src="/garden.jpg" alt="A planted courtyard garden" /></body>
+</html>

--- a/tests/fixtures/web-launch/clean-marketing/robots.txt
+++ b/tests/fixtures/web-launch/clean-marketing/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: /admin/
+Sitemap: https://example.com/sitemap.xml

--- a/tests/fixtures/web-launch/saas-app/index.html
+++ b/tests/fixtures/web-launch/saas-app/index.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8" /><title>Acme Dashboard</title></head>
+<body><h1>Sign in</h1><img src="/logo.svg" alt="Acme" /></body>
+</html>

--- a/tests/fixtures/web-launch/saas-app/robots.txt
+++ b/tests/fixtures/web-launch/saas-app/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /app/

--- a/tests/fixtures/web-launch/staging-leftover/index.html
+++ b/tests/fixtures/web-launch/staging-leftover/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Acme Landscaping — Garden design and maintenance</title>
+  <meta name="description" content="Garden design, planting and maintenance in Freiburg." />
+  <meta name="robots" content="noindex, nofollow" />
+</head>
+<body><h1>Acme Landscaping</h1></body>
+</html>

--- a/tests/fixtures/web-launch/staging-leftover/robots.txt
+++ b/tests/fixtures/web-launch/staging-leftover/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/tests/scripts/check_web_launch_readiness.test.ts
+++ b/tests/scripts/check_web_launch_readiness.test.ts
@@ -1,0 +1,202 @@
+// Tests for src/scripts/check_web_launch_readiness.ts.
+//
+// The command is DEFAULT-OFF and ships one implemented check, so most of what
+// needs proving is not "does it find things" but "does it stay honest about what
+// it did not look at". Three properties carry that:
+//
+//   1. an unimplemented check is never counted as PASSED (silent-green);
+//   2. a non-applicable check is skipped with the SITE TYPE as the reason,
+//      never dropped and never reported as a finding;
+//   3. a finding carries a file:line, because a finding without a location
+//      cannot be acted on.
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+    IMPLEMENTED,
+    audit,
+    enabled,
+    loadConfig,
+    main,
+    render,
+    scanIndexability,
+} from '../../src/scripts/check_web_launch_readiness';
+
+const REPO = path.resolve(__dirname, '..', '..');
+const FIX = path.join(REPO, 'tests/fixtures/web-launch');
+
+describe('the staging-leftover fixture reports a critical finding with a location', () => {
+    it('finds the noindex meta AND the blanket disallow, each with file:line', () => {
+        const r = audit(path.join(FIX, 'staging-leftover'), 'marketing-site', REPO);
+        expect(r.findings).toHaveLength(2);
+        for (const f of r.findings) {
+            expect(f.tier).toBe('critical');
+            expect(f.check).toBe('staging-noindex-leftover');
+            // The step's verify line asks for file:line specifically.
+            expect(f.location).toMatch(/^[\w./-]+:\d+$/);
+            expect(f.remediation.length).toBeGreaterThan(20);
+            expect(f.verification.length).toBeGreaterThan(20);
+        }
+        expect(r.findings.map((f) => f.location).sort()).toEqual(['index.html:7', 'robots.txt:2']);
+    });
+
+    it('the clean fixture reports NONE — both states demonstrated', () => {
+        const r = audit(path.join(FIX, 'clean-marketing'), 'marketing-site', REPO);
+        expect(r.findings).toEqual([]);
+        expect(r.passed).toContain('staging-noindex-leftover');
+    });
+
+    it('a path-scoped Disallow does NOT fire — blanket is the signal, not any rule', () => {
+        // The clean fixture deliberately keeps `Disallow: /admin/`. A check that
+        // matched any Disallow would pass a naive clean fixture and still be
+        // wrong, so this asserts the discrimination rather than the absence.
+        const robots = fs.readFileSync(path.join(FIX, 'clean-marketing/robots.txt'), 'utf8');
+        expect(robots).toContain('Disallow: /admin/');
+        expect(scanIndexability(path.join(FIX, 'clean-marketing')).hits).toEqual([]);
+    });
+});
+
+describe('conditional, not flat — the skip reason is the site type', () => {
+    it('a SaaS app skips the local-business items, naming the type', () => {
+        const r = audit(path.join(FIX, 'saas-app'), 'saas-app', REPO);
+        const ids = r.skipped.map((s) => s.check).sort();
+        expect(ids).toEqual(['canonical-and-sitemap-coherence', 'per-route-metadata']);
+        for (const s of r.skipped) {
+            // 2.3 requires the site type verbatim as the reason.
+            expect(s.reason).toBe('site type is saas-app');
+        }
+    });
+
+    it('a skipped check is never a finding, and never silently dropped', () => {
+        const r = audit(path.join(FIX, 'saas-app'), 'saas-app', REPO);
+        const skippedIds = new Set(r.skipped.map((s) => s.check));
+        for (const f of r.findings) expect(skippedIds.has(f.check)).toBe(false);
+        // Every configured check lands in exactly one bucket.
+        const seen = [...r.findings.map((f) => f.check), ...r.passed, ...r.unimplemented, ...skippedIds];
+        expect(new Set(seen).size).toBe(loadConfig(REPO).checks.length);
+    });
+
+    it('the same tree audited as marketing-site skips nothing', () => {
+        // The axis is the SITE TYPE, not the files: same directory, different
+        // answer. That is what makes it conditional rather than incidental.
+        const saas = audit(path.join(FIX, 'saas-app'), 'saas-app', REPO);
+        const mkt = audit(path.join(FIX, 'saas-app'), 'marketing-site', REPO);
+        expect(saas.skipped.length).toBeGreaterThan(0);
+        expect(mkt.skipped).toEqual([]);
+    });
+});
+
+describe('an unimplemented check is never PASSED — the silent-green guard', () => {
+    it('reports the six unimplemented checks separately from the one that ran', () => {
+        const r = audit(path.join(FIX, 'clean-marketing'), 'marketing-site', REPO);
+        expect(r.passed).toEqual(['staging-noindex-leftover']);
+        expect(r.unimplemented.length).toBe(6);
+        expect(r.unimplemented).not.toContain('staging-noindex-leftover');
+    });
+
+    it('IMPLEMENTED holds exactly the checks with a real scan behind them', () => {
+        // A check added to IMPLEMENTED without an implementation would report
+        // clean, which is the defect this list exists to make visible.
+        expect([...IMPLEMENTED]).toEqual(['staging-noindex-leftover']);
+    });
+
+    it('the rendered report names them as not audited, not as clean', () => {
+        const text = render(audit(path.join(FIX, 'clean-marketing'), 'marketing-site', REPO));
+        expect(text).toContain('NOT YET IMPLEMENTED (applicable, not audited)');
+    });
+});
+
+describe('report order — critical first, skipped last', () => {
+    it('renders the tiers in the registered order and skips at the end', () => {
+        const text = render(audit(path.join(FIX, 'staging-leftover'), 'saas-app', REPO));
+        const crit = text.indexOf('CRITICAL');
+        const unimpl = text.indexOf('NOT YET IMPLEMENTED');
+        const skip = text.indexOf('SKIPPED');
+        expect(crit).toBeGreaterThanOrEqual(0);
+        expect(crit).toBeLessThan(unimpl);
+        expect(unimpl).toBeLessThan(skip);
+    });
+
+    it('names the site type first, so a reader knows which axis produced the report', () => {
+        expect(render(audit(path.join(FIX, 'saas-app'), 'docs', REPO)).startsWith('site type: docs')).toBe(true);
+    });
+});
+
+describe('default-off, and a dead scope is never a pass', () => {
+    let tmp: string;
+    beforeEach(() => {
+        tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'wlr-'));
+    });
+    afterEach(() => {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    });
+
+    it('is disabled with no settings file at all', () => {
+        expect(enabled(tmp)).toBe(false);
+    });
+
+    it('is enabled only by the exact opt-in key', () => {
+        fs.writeFileSync(path.join(tmp, '.agent-settings.yml'), 'web_launch_readiness:\n  enabled: true\n');
+        expect(enabled(tmp)).toBe(true);
+        fs.writeFileSync(path.join(tmp, '.agent-settings.yml'), 'web_launch_readiness:\n  enabled: false\n');
+        expect(enabled(tmp)).toBe(false);
+        // A near-miss key must not enable it.
+        fs.writeFileSync(path.join(tmp, '.agent-settings.yml'), 'web_launch:\n  enabled: true\n');
+        expect(enabled(tmp)).toBe(false);
+    });
+
+    it('exits 0 WITHOUT auditing when disabled, and says why', () => {
+        const out: string[] = [];
+        const orig = process.stdout.write.bind(process.stdout);
+        process.stdout.write = ((c: string) => {
+            out.push(c);
+            return true;
+        }) as typeof process.stdout.write;
+        try {
+            // Points at the failing fixture on purpose: a disabled run must not
+            // report its two critical findings.
+            const rc = main(
+                ['--build', path.join(FIX, 'staging-leftover'), '--site-type', 'marketing-site'],
+                tmp,
+            );
+            expect(rc).toBe(0);
+        } finally {
+            process.stdout.write = orig;
+        }
+        const text = out.join('');
+        expect(text).toContain('DEFAULT-OFF');
+        expect(text).not.toContain('CRITICAL');
+    });
+
+    it('a missing config is exit 2, never a clean run', () => {
+        expect(main(['--build', tmp, '--site-type', 'docs', '--force'], tmp)).toBe(2);
+    });
+
+    it('an unregistered site type is exit 2, never an empty audit', () => {
+        expect(() => audit(path.join(FIX, 'saas-app'), 'shop' as never, REPO)).toThrow(/unknown site type/);
+    });
+
+    it('missing arguments are a usage error', () => {
+        expect(main([], REPO)).toBe(2);
+    });
+});
+
+describe('exit codes carry the blocking distinction', () => {
+    it('a critical finding exits 1; a clean tree exits 0', () => {
+        const orig = process.stdout.write.bind(process.stdout);
+        process.stdout.write = (() => true) as typeof process.stdout.write;
+        try {
+            expect(
+                main(['--build', path.join(FIX, 'staging-leftover'), '--site-type', 'marketing-site', '--force'], REPO),
+            ).toBe(1);
+            expect(
+                main(['--build', path.join(FIX, 'clean-marketing'), '--site-type', 'marketing-site', '--force'], REPO),
+            ).toBe(0);
+        } finally {
+            process.stdout.write = orig;
+        }
+    });
+});


### PR DESCRIPTION
Checkpoint on `road-to-web-launch-readiness`: **2.1, 2.4 and 2.5 shipped**, AC-1 through AC-4 met, AC-5 recorded as partially met. 13 of 19.

The indexability check exists as `src/scripts/check_web_launch_readiness.ts` — a **command**, per the Phase 2 re-scope decided last week (AI council 2/2: the evidence establishes a coverage gap, not a skill-shaped one, and `production-validator` carries unscoped `Bash`).

## AC-3 — both states, with locations

**Staging fixture** → exit **1**:

```
CRITICAL (2)
  index.html:7   staging-noindex-leftover   <meta name="robots" content="noindex, nofollow" />
  robots.txt:2   staging-noindex-leftover   Disallow: /
```

**Clean fixture** → exit **0**, `PASSED: staging-noindex-leftover`, no findings.

### The clean fixture deliberately keeps `Disallow: /admin/`

A check matching *any* `Disallow` would pass a naive clean fixture and still be wrong. The test asserts the **discrimination** — blanket block versus path rule — rather than the absence, so the fixture pair isolates the check instead of flattering it.

## Conditional, not flat — proven on the same tree

Audited as `saas-app`, the SaaS fixture skips two checks with the site type **verbatim** as the reason:

```
SKIPPED — not applicable to this site type
  per-route-metadata: site type is saas-app
  canonical-and-sitemap-coherence: site type is saas-app
```

Audited as `marketing-site`, **the same directory skips nothing**. Same files, different answer — which is what makes the axis conditional rather than incidental, and it is asserted as a pair.

## The honesty property the step did not name

Six configured checks apply to this site type and have **no implementation**. They are reported as:

```
NOT YET IMPLEMENTED (applicable, not audited): custom-error-route, per-route-metadata, …
```

and are **never counted as PASSED**. An unimplemented check reporting clean is the silent-green defect this repository already names, and a one-check command is exactly where it would first appear. A test pins `IMPLEMENTED` to the single check with a real scan behind it, so adding an id there without an implementation fails rather than ships.

## 2.4 — order asserted by position, not by a snapshot

The step asks for a snapshot test. It gets an index comparison instead, and the difference is deliberate: **a snapshot pins the whole string**, so any wording edit reds it and the *order* — the thing the step actually specifies — is not what failed. The test asserts `CRITICAL < NOT YET IMPLEMENTED < SKIPPED` positionally, and separately that the report opens with `site type: <type>`. The skip-reason text *is* pinned exactly, because 2.3 requires the type verbatim.

## 2.5 — the disabled test points at the failing fixture

With no settings file at all, a run against the **staging** fixture exits 0, prints `DEFAULT-OFF` with the reason, and does **not** print `CRITICAL`.

Pointing the disabled run at the tree that *would* fire is the load-bearing part: a test that disabled a clean tree would pass whether or not the flag worked. Enabled only by the exact key `web_launch_readiness.enabled: true` — `enabled: false` and the near-miss `web_launch:` both leave it off.

## AC-5 is `[~]`, not `[x]`

It folds two phases into one line. The SaaS-app skip half is **met** and asserted per-item. The decoy half belongs to **Phase 3**: the decoy is *a missing team photo on the SaaS app*, and nothing can flag or not-flag it until `image-alternative-text` exists and the benchmark runs.

Recorded as partially met rather than checked off — an AC green on half its evidence is what a later accounting tool takes at face value.

## AC-1's ordering is checkable in `git log`

The G0 evidence note, the site-type config, the no-import decision and the benchmark claim all landed in the Phase-0 change (#1630) with **zero implementation code**. The first implementation commit is in this PR. That ordering *is* the pre-registration, and it is verifiable rather than asserted.

## Gates run locally

`lint_roadmap_blockers` · `check_roadmap_trackable` · `lint_empty_roadmaps` · `check_no_roadmap_refs` · `lint_plan_risk_register` · `lint_roadmap_complexity` · `lint_roadmap_later_disposition` · `lint_roadmap_ci_steps` · `check_estate_count` · `check_references` · `check_claims` · `check_secret_leak` · `lint_consumer_internal_refs` — all green. Typecheck exit 0, **36 tests** green.
