### PR TITLE
roadmap: web-launch-readiness — Phase 2 complete, Phase 3.1 built, the verdict stops short

### DIFF
--- a/agents/roadmaps/later/road-to-web-launch-readiness-benchmark.md
+++ b/agents/roadmaps/later/road-to-web-launch-readiness-benchmark.md
@@ -1,0 +1,154 @@
+---
+complexity: structural
+status: later
+execution:
+  mode: phase-checkpoints
+owner: maintainer
+review_by: 2026-12-31
+estate_growth_exempt: "Not new work. This is the BENCHMARK half of road-to-web-launch-readiness, split out on AI-council verdict (2/2, 2026-08-25) because the session that authored the skill, the fixtures AND the ground truth may not also run and adjudicate the experiment that grades them. The parent roadmap stays OPEN -- the council ruled that closing it is owner-reserved -- so this file preserves the protocol rather than replacing a plan."
+estate_offset_exempt: "Split-out, not authored: every step below is moved verbatim from road-to-web-launch-readiness Phase 3, which retains them as open with a blocker naming the owner decision. Nothing was created that did not already exist as committed scope."
+---
+# Road to web-launch-readiness — the benchmark and its verdict
+
+> **Parent:** `road-to-web-launch-readiness`, which **remains open**. This is not
+> a closure device. AI council 2026-08-25, 2/2 convergent, ruled that parking
+> these steps is a process decision the council may take, and that treating the
+> parking as roadmap *completion* is **owner-reserved** — the parent carries no
+> cut line, so removing two required phases redefines what completion means.
+
+## Why the authoring session may not run this
+
+The session that would have executed 3.2 wrote the nine checks, the site-type
+axis, the region axis, the three fixture sites **and** the ground truth those
+fixtures are scored against. Both seats agreed the checked-in ground truth and
+the binary decoy gate genuinely narrow the room to flatter a result — and both
+held that they do not close it. One seat enumerated exactly where the discretion
+still lives:
+
+> Word the comparator prompt to favor structured or unstructured approaches ·
+> include or exclude specific site context that aids one arm · interpret
+> "missing canonical tag" vs "canonical present but wrong" differently · count
+> or not count findings that overlap but aren't exact matches.
+
+## The protocol must be FROZEN before either arm runs
+
+This list is the second seat's, and it is the most useful thing to come out of
+the round: it is why Option C (*"run the arms now, adjudicate later"*) was
+rejected rather than taken as the compromise it looks like. Executing the arms
+is only mechanical **after** these are fixed, and every one of them can be
+chosen with knowledge of the expected defects:
+
+1. the exact bare-prompt text for the comparator arm;
+2. context packaging and ordering;
+3. the model snapshot and sampling settings;
+4. retry policy and number of runs;
+5. whether a finding must identify the correct **page** as well as the defect;
+6. semantic-match and partial-credit rules;
+7. who scores ambiguous outputs.
+
+**Archiving raw output creates auditability. It cannot undo an execution choice
+made with knowledge of the answer.**
+
+## Three statuses this roadmap keeps apart
+
+The council's sharpest framing, kept because conflating them is the failure mode:
+
+| status | current value |
+|---|---|
+| **Implementation complete** | yes — Phase 2 and 3.1 shipped 2026-08-25 |
+| **Validation unresolved** | yes — `claim:web-launch-readiness-finds-more` is `unbacked` |
+| **Roadmap complete** | **no**, and it may not be called complete without the owner |
+
+`unbacked` + default-off is an honest **product** state, and an honest interim
+state. It is not roadmap completion.
+
+## What is already built and must not be rebuilt
+
+- `src/scripts/check_web_launch_readiness.ts` — nine checks, site-type axis,
+  region escalation. 29 unit tests.
+- `tests/fixtures/web-launch-benchmark/` — three fixture sites, `GROUND-TRUTH.md`
+  with 19 numbered defect rows plus one decoy, 18 tests asserting every row is
+  actually in the tree. Two sabotage probes recorded at the parent's step 3.1.
+
+## The two steps, verbatim from the parent
+
+- [ ] **3.2 Run the comparator arm** — identical model, bare audit prompt, same
+      site access.
+      verify: both arms' raw outputs are archived with the run.
+- [ ] **3.3 Resolve the claim** — PROVE, DROP, or UNDERPOWERED. The decoy gate
+      is checked first: a decoy false positive is DROP regardless of the recall
+      delta.
+      verify: the verdict PR flips the claim status; on DROP the skill stays
+      default-off and the null is recorded rather than noted.
+
+**Exit:** a resolved verdict in either direction.
+
+## The claim, the gate and the falsification paths — quoted, not paraphrased
+
+`claim:web-launch-readiness-finds-more`, registered 2026-08-25 **before any
+skill code existed**:
+
+> A site-type-conditional web-launch audit skill finds more real launch defects
+> than a bare "audit this site before launch" prompt on the same model, without
+> flagging a site-type-irrelevant decoy.
+
+**The hard gate**, and it is the reason the claim can fail while scoring well:
+
+> one site-type-IRRELEVANT decoy is seeded — a missing team photo on the SaaS
+> app — and flagging it is a classification failure that DROPS this claim
+> REGARDLESS of recall. A skill that finds everything by flagging everything is
+> the failure mode a recall threshold cannot see, which is why the decoy is a
+> gate and not a metric.
+
+**Falsification:**
+
+> (1) the decoy is flagged; (2) recall does not exceed the comparator arm's;
+> (3) the fixtures cannot be built to a ground truth both arms are scored
+> against, in which case the claim is UNDERPOWERED rather than dropped — an
+> unbuildable fixture says nothing about the skill.
+
+**On DROP:**
+
+> the skill does not ship enabled, and `road-to-web-launch-readiness` records
+> the null as its outcome.
+
+**Scope, which no result may exceed:**
+
+> three fixtures on one model is one measurement, not a general result about
+> audit skills; it establishes whether THIS skill beats a bare prompt on THESE
+> defects and generalises to neither another model nor another defect set.
+
+## Blockers
+
+### b-benchmark-independent-execution
+
+- **Blocks:** 3.2 and 3.3.
+- **Owner:** maintainer.
+- **Resolved when:** a session that did NOT author the checks, the fixtures or
+  the ground truth has frozen all seven protocol items above in writing, before
+  seeing either arm's output.
+- **Status:** open.
+- **Why it is a blocker and not a note:** the discretion is at execution time and
+  is invisible afterwards. A prompt worded to favour one arm produces a number
+  that looks exactly like a measurement.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-08-25 | reviewer: claude/host -->
+
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | The parked claim is read as abandoned rather than pending | product | `later/` is excluded from the dashboard, so an `unbacked` claim with no visible owner drifts into looking like a decision | The parent roadmap stays OPEN with a blocker naming the owner decision, so the obligation is visible in the active estate rather than only here | Why the authoring session may not run this |
+| 2 | A later session freezes the protocol AFTER a pilot run | implementation | The seven items can be fixed retroactively to match a result that has already been seen | The blocker's `Resolved when` requires the freeze to precede any output, and both arms' raw outputs plus prompts and settings are archived | The protocol must be FROZEN before either arm runs |
+| 3 | The decoy stops being a decoy | implementation | A future check that asked for team imagery would make the seeded absence a legitimate finding, and the gate would silently start scoring it | `web_launch_benchmark_fixtures.test.ts` asserts no configured check id matches team/photo/portrait; a sabotage probe adding such a check was recorded reddening it | What is already built and must not be rebuilt |
+
+## Acceptance Criteria
+
+- [ ] AC-1 — All seven protocol items are frozen in writing, in a commit that
+      precedes any arm's execution.
+- [ ] AC-2 — Both arms' prompts, settings, raw outputs and scoring decisions are
+      archived with the run.
+- [ ] AC-3 — The decoy gate is evaluated FIRST, and its result is recorded
+      whether or not the recall comparison is reached.
+- [ ] AC-4 — The claim carries PROVE, DROP or UNDERPOWERED, and on DROP the
+      skill stays default-off with the null recorded as the outcome rather than
+      noted in passing.

--- a/agents/roadmaps/road-to-web-launch-readiness.md
+++ b/agents/roadmaps/road-to-web-launch-readiness.md
@@ -357,22 +357,111 @@ recorded null.
 
 ## Phase 3 — Benchmark and verdict
 
-- [ ] **3.1 Build the three fixture sites** to the Phase 0.4 ground-truth list,
+- [x] **3.1 Build the three fixture sites** to the Phase 0.4 ground-truth list,
       served locally in CI rather than deployed.
-      verify: each fixture's seeded defect list is a checked-in manifest, and
-      the decoy is present in exactly one fixture.
+      verify: **`tests/fixtures/web-launch-benchmark/`** — `local-business/`,
+      `saas-app/`, `docs/`, plus `GROUND-TRUTH.md` with **19 numbered defect rows
+      and one decoy**, and 18 tests asserting every row is actually in the tree.
+      Static directories, served locally; nothing is deployed.
+
+      **The manifest is checked in so neither arm's author can move the target
+      after seeing a score** — and a fixture that quietly stops carrying a defect
+      is a visible diff rather than a weaker benchmark.
+
+      **The decoy is present in exactly one fixture** (`saas-app`, a missing team
+      photo) and the test asserts it from the CONFIG, not from memory: no
+      configured check id may match `team|photo|portrait|about-us`. If a future
+      check ever asked for team imagery the decoy would stop being a decoy, and
+      the benchmark would silently start scoring it.
+
+      **Both load-bearing tests were sabotage-proved rather than assumed
+      sensitive.** Rewriting `docs/sitemap.xml` so the canonical host matches →
+      1 failed. Adding a `team-photo-present` check to the config → 1 failed.
+      Restored → 18 passed. A test never seen red has unknown sensitivity.
+
+      Two rows are seeded because a presence check would miss them: an Impressum
+      **without** a Datenschutz page (the common real-world DE shape), and a
+      canonical that is **present and wrong** — copied from the marketing site,
+      so the page that gets indexed is not the page anyone chose.
 - [ ] **3.2 Run the comparator arm** — identical model, bare audit prompt, same
       site access.
       verify: both arms' raw outputs are archived with the run.
+
+      **OPEN, and deliberately not closed.** Protocol preserved verbatim in
+      `agents/roadmaps/later/road-to-web-launch-readiness-benchmark.md`; see
+      `b-benchmark-owner-rescope` below for the verdict that put it there and
+      for why this roadmap stays open rather than closing around it.
 - [ ] **3.3 Resolve the claim** — PROVE, DROP, or UNDERPOWERED. The decoy gate
       is checked first: a decoy false positive is DROP regardless of the recall
       delta.
       verify: the verdict PR flips the claim status; on DROP the skill stays
       default-off and the null is recorded rather than noted.
 
-**Exit:** a resolved verdict in either direction.
+      **OPEN.** `claim:web-launch-readiness-finds-more` stays `unbacked` and the
+      command stays default-off, which is already its shipped state — an honest
+      **interim** state, and explicitly not completion.
+
+**Exit:** a resolved verdict in either direction. NOT reached.
 
 ## Blockers
+
+### blocker: b-benchmark-owner-rescope
+- **Blocks:** 3.2, 3.3, AC-6, and the closure of this roadmap.
+- **Owner:** user.
+- **Resolved when:** the owner either (a) approves moving 3.2 and 3.3 into
+  `agents/roadmaps/later/road-to-web-launch-readiness-benchmark.md` as satisfying
+  this roadmap's scope, or (b) directs that the benchmark run and the roadmap
+  stay open until it does.
+- **What to do:** put exactly these two options to the owner, in one numbered
+  question — (1) approve moving 3.2 and 3.3 into
+  `agents/roadmaps/later/road-to-web-launch-readiness-benchmark.md` as
+  satisfying this roadmap's scope, so it may be archived; (2) keep this roadmap
+  open until the benchmark actually runs. Do not run 3.2 in the meantime: the
+  council's parking decision stands on its own and forbids the authoring session
+  from executing either arm, whichever way the closure question is answered.
+- **Recommendation:** option (1) — approve the move. The implementation half is
+  done and independently testable; what remains is an experiment whose validity
+  depends on being run by someone else, and holding a completed body of work
+  open to wait for a different session's calendar does not make the experiment
+  any more likely to happen. Option (2) is the right call only if you want the
+  benchmark visible in the ACTIVE estate as pressure to schedule it.
+- **If you do nothing:** the roadmap stays open indefinitely with two steps
+  nobody in this repository is permitted to execute, the dashboard carries a
+  permanently-13-of-19 entry, and `claim:web-launch-readiness-finds-more` sits
+  `unbacked` with no owner — which over time reads as an abandoned claim rather
+  than a pending one. The command itself is unaffected either way: it ships
+  default-off and stays that way until the claim resolves.
+- **Status:** open.
+- **Why it reached the owner and not the council (2026-08-25).** The council was
+  asked and **declined the closure half of the question**, 2/2 convergent. It
+  ruled it may park the two steps for conflict-of-interest reasons — the session
+  that authored the checks, the fixtures AND the ground truth may not also run
+  and adjudicate the experiment that grades them — but that treating the parking
+  as *completion* is **owner-reserved**, because this roadmap carries **no cut
+  line** and removing two required phases redefines what completion means. One
+  seat: *"The council can park for COI. The owner decides whether that satisfies
+  the roadmap."* The other, independently: *"the council may recommend Option A,
+  but only the owner can approve the scope change."*
+
+  The routing-assurance precedent decided earlier the same day does **not**
+  carry: that roadmap's own text declared stopping at its cut line a valid end
+  state, and this one says nothing of the kind.
+
+  **What the council DID settle, and it is acted on here:** Option C — run the
+  arms now, adjudicate later — was rejected rather than taken as the compromise
+  it looks like. Executing the arms is only mechanical once seven protocol items
+  are frozen (comparator prompt text, context packaging, model snapshot and
+  sampling, retry policy, whether a finding must name the correct page,
+  semantic-match and partial-credit rules, who scores ambiguous output), and
+  every one of them can be chosen with knowledge of the expected defects.
+  *Archiving raw output creates auditability; it cannot undo an execution choice
+  made with knowledge of the answer.* The seven are recorded in the parked
+  roadmap as its blocker's resolution condition.
+
+  **Three statuses this roadmap now keeps apart**, per the council's framing —
+  conflating them is the failure mode: **implementation complete** (yes, Phase 2
+  and 3.1), **validation unresolved** (yes, the claim is `unbacked`), **roadmap
+  complete** (no, and not callable so without the owner).
 
 ### blocker: b-estate-decision-web-launch
 - **Status:** resolved 2026-08-25 — **NO to a standalone skill slot; the domain

--- a/agents/roadmaps/road-to-web-launch-readiness.md
+++ b/agents/roadmaps/road-to-web-launch-readiness.md
@@ -261,18 +261,75 @@ disposition as the reason, which is a publishable outcome and not a failure.
       audited)` and are **never** counted as PASSED. An unimplemented check
       reporting clean is the silent-green defect this repository already names,
       and a one-check command is exactly where it would first appear.
-- [ ] **2.2 Add the remaining critical and high tiers** — HTTPS enforcement,
+- [x] **2.2 Add the remaining critical and high tiers** — HTTPS enforcement,
       custom 404, per-route title and description, alternative text on content
       images, `lang`/charset/viewport. Each with explanation, remediation and
       verification per the design directive.
-      verify: each check has a fixture that fires it and a fixture that does
-      not; `applies_to` is exercised by at least one skipped-with-reason case.
-- [ ] **2.3 Add medium and situational tiers**, including the region axis for
+      verify: **both states for all eight**, asserted as a loop over the check
+      ids rather than one assertion per check, so a check added to the config
+      without a fixture fails this test rather than passing unnoticed.
+      `defects-marketing/` fires every one; `clean-marketing/` passes every one;
+      `saas-app/` supplies the skipped-with-reason case
+      (`site type is saas-app`).
+
+      Two checks that a presence test would have got wrong, and each has its own
+      assertion because getting them right is the whole value:
+
+      - **`alt=""` is a PASS.** `clean-marketing/about.html` carries it
+        deliberately. Flagging it would push authors to write filler alt text,
+        which is worse for a screen reader than the empty string that tells it
+        to skip.
+      - **A title present on every page but SHARED is still a per-route
+        finding.** Presence is the easy half; a layout with one hard-coded title
+        passes a presence check and is exactly what *per-route* excludes. Both
+        locations are reported.
+
+      Two checks were added to the config to cover the step's list —
+      `https-enforcement` (critical: mixed content breaks the padlock silently
+      while the page still looks fine) and `document-head-basics`
+      (`lang`/charset/viewport, one line each, invisible on the developer's
+      machine).
+
+      `defects-marketing/SEEDED.md` is a **checked-in manifest**, so a fixture
+      that stops firing a check is a visible diff rather than a quietly weaker
+      test. It also records what is deliberately NOT seeded there:
+      `staging-noindex-leftover` has its own fixture, and seeding it twice would
+      make the two non-independent.
+
+      **One real defect, found by the fixture rather than by review.**
+      `analytics-and-consent-wiring` passed on a tree seeded to fire it, because
+      `SEEDED.md` contains the word *consent* and the consent scan read prose as
+      an implementation. Prose is now excluded from **both** sides — a README
+      naming an analytics vendor must not count as analytics either.
+- [x] **2.3 Add medium and situational tiers**, including the region axis for
       legal pages (DE: Impressum and Datenschutz as `critical` for
       DE-targeted sites).
-      verify: a SaaS-app fixture reports the local-business items as
-      `situational-skipped` **with the site type as the stated skip reason**,
-      never as findings.
+      verify: `saas-app` reports `per-route-metadata` and
+      `canonical-and-sitemap-coherence` as skipped with the reason `site type is
+      saas-app` verbatim, and a companion assertion proves no skipped check ever
+      appears among the findings.
+
+      **The region axis is a tier ESCALATION, not a second `applies_to`**, and
+      the distinction is the design decision here: `applies_to` decides
+      *whether* a check applies, a region decides *how severely*. A legal page
+      is not more or less applicable in Germany — it is more or less optional,
+      because TMG 5 and DSGVO Art. 13 make it owed. Modelling it as an
+      escalation keeps one check with one implementation and puts the
+      jurisdiction on the consequence.
+
+      Demonstrated in both directions: `required-legal-pages` is
+      **situational** at `--region unspecified` and **critical** at `--region
+      de`, with the reason carried into the report header so a reader seeing two
+      different tiers for one check knows which axis moved it.
+
+      **And the escalation changes the EXIT CODE** — a test asserts the blocking
+      count is exactly one higher under `de`. A tier label nothing acts on is
+      decoration; this one is the difference between a launch that stops and one
+      that does not.
+
+      An unregistered region is a hard `DeadScopeError`, never a silent fallback
+      to `unspecified`: a typo'd `--region` must not quietly downgrade a legally
+      owed page.
 - [x] **2.4 Tiered output shape.** Report order: critical, high, medium,
       situational-applicable, situational-skipped-with-reason.
       verify: **order asserted by index comparison rather than by a snapshot**,

--- a/src/config/web-launch-readiness.json
+++ b/src/config/web-launch-readiness.json
@@ -39,6 +39,20 @@
       "verification": "`curl -sI <prod-url> | grep -i x-robots-tag` returns nothing, `curl -s <prod-url>/robots.txt` carries no blanket disallow, and the rendered HTML has no `noindex` meta."
     },
     {
+      "id": "https-enforcement",
+      "title": "HTTP is redirected to HTTPS and no asset is loaded over plain HTTP",
+      "applies_to": [
+        "local-business",
+        "marketing-site",
+        "saas-app",
+        "docs"
+      ],
+      "tier": "critical",
+      "why": "A mixed-content asset silently breaks the padlock and, on a form page, ships a credential over plaintext. Browsers block some of it and load the rest, so the page LOOKS fine while the guarantee is gone -- which is why this is critical rather than high.",
+      "remediation": "Serve every asset over https:// or protocol-relative paths, and redirect http:// at the edge. Never hard-code an http:// origin you control.",
+      "verification": "`curl -sI http://<prod-host>/` returns a 301/308 to https, and the browser console shows no mixed-content warning on the heaviest page."
+    },
+    {
       "id": "custom-error-route",
       "title": "A custom 404 route exists and is reachable",
       "applies_to": [
@@ -79,6 +93,21 @@
       "why": "The one check that applies to every type, including internal tools -- an internal user with a screen reader is still a user. `alt text` matches 7 files, all accessibility prose rather than a launch check.",
       "remediation": "Add `alt` to content images; decorative images take `alt=\"\"` explicitly rather than being left without the attribute.",
       "verification": "Parse the rendered HTML and assert every `<img>` has an `alt` attribute, empty or not."
+    },
+    {
+      "id": "document-head-basics",
+      "title": "Every page declares lang, charset and viewport",
+      "applies_to": [
+        "local-business",
+        "marketing-site",
+        "saas-app",
+        "docs",
+        "internal-tool"
+      ],
+      "tier": "high",
+      "why": "A missing `lang` makes a screen reader guess the pronunciation of the whole page; a missing viewport makes a phone render a desktop layout at 320px. Both are one line, both are invisible on the developer's machine, and both are the kind of default a framework template silently drops when a page is hand-written.",
+      "remediation": "`<html lang=\"..\">`, `<meta charset=\"utf-8\">` and `<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">` in the shared layout, not per page.",
+      "verification": "View source on two unrelated routes and confirm all three are present on both -- one route proves the layout, two prove it is the layout and not a copy."
     },
     {
       "id": "canonical-and-sitemap-coherence",
@@ -137,5 +166,23 @@
     "why": "An imported rule set arrives with its authors' assumptions about site type, jurisdiction and stack, and none of those is checked on arrival. The failure is silent: the skill grows to N checks, each individually plausible, and the conditional axis this file exists to enforce is the first thing a bulk import flattens. One-at-a-time keeps the axis honest because every entry has to answer `applies_to` before it lands.",
     "ceiling": 50,
     "ceiling_enforced_by": "tests/scripts/web_launch_readiness_config.test.ts asserts checks.length < 50. Currently 7."
+  },
+  "regions": {
+    "_comment": "Region axis (road-to-web-launch-readiness 2.3). Separate from site_types because it answers a different question: site_types decides WHETHER a check applies, regions decides HOW SEVERELY. A DE-targeted site owes Impressum and Datenschutz by law (TMG 5 / DSGVO Art. 13), so `required-legal-pages` is critical there and situational elsewhere -- the same check, a different tier. Modelled as a tier ESCALATION rather than as a second applies_to list, because a legal page is not more or less applicable in Germany, it is more or less optional.",
+    "values": [
+      "de",
+      "eu",
+      "us",
+      "unspecified"
+    ],
+    "default": "unspecified",
+    "escalations": [
+      {
+        "check": "required-legal-pages",
+        "region": "de",
+        "to": "critical",
+        "why": "TMG 5 obliges an Impressum and DSGVO Art. 13 a Datenschutzerklaerung for a DE-targeted commercial site. Abmahnung risk is real and immediate, which is what separates critical from situational here."
+      }
+    ]
   }
 }

--- a/src/scripts/check_web_launch_readiness.ts
+++ b/src/scripts/check_web_launch_readiness.ts
@@ -37,6 +37,16 @@ export const CONFIG_REL = 'src/config/web-launch-readiness.json';
 
 export type SiteType = 'local-business' | 'marketing-site' | 'saas-app' | 'docs' | 'internal-tool';
 export type Tier = 'critical' | 'high' | 'medium' | 'situational';
+/**
+ * The region axis (2.3), and it is deliberately NOT a second `applies_to`.
+ *
+ * `applies_to` decides WHETHER a check applies; a region decides HOW SEVERELY.
+ * A legal page is not more or less *applicable* in Germany — it is more or less
+ * *optional*, because TMG 5 and DSGVO Art. 13 make it owed rather than advisable.
+ * Modelling it as a tier escalation keeps one check with one implementation and
+ * puts the jurisdiction where it belongs: on the consequence.
+ */
+export type Region = 'de' | 'eu' | 'us' | 'unspecified';
 
 export interface CheckDef {
     id: string;
@@ -65,8 +75,17 @@ export interface Skipped {
     reason: string;
 }
 
+/** A tier the region axis moved, and why. Reported so the axis is visible. */
+export interface Escalated {
+    check: string;
+    from: Tier;
+    to: Tier;
+    why: string;
+}
+
 export interface Report {
     site_type: SiteType;
+    region: Region;
     enabled: boolean;
     findings: Finding[];
     skipped: Skipped[];
@@ -74,10 +93,24 @@ export interface Report {
     passed: string[];
     /** Applicable checks with no implementation yet — never counted as passed. */
     unimplemented: string[];
+    /** Tiers the region axis raised. Empty on `unspecified`, by construction. */
+    escalated: Escalated[];
     scanned_files: number;
 }
 
-export function loadConfig(root = REPO_ROOT): { checks: CheckDef[]; siteTypes: SiteType[] } {
+export interface Escalation {
+    check: string;
+    region: Region;
+    to: Tier;
+    why: string;
+}
+
+export function loadConfig(root = REPO_ROOT): {
+    checks: CheckDef[];
+    siteTypes: SiteType[];
+    regions: Region[];
+    escalations: Escalation[];
+} {
     const abs = path.join(root, CONFIG_REL);
     let raw: string;
     try {
@@ -92,6 +125,7 @@ export function loadConfig(root = REPO_ROOT): { checks: CheckDef[]; siteTypes: S
     const doc = JSON.parse(raw) as {
         checks?: CheckDef[];
         site_types?: { values?: SiteType[] };
+        regions?: { values?: Region[]; escalations?: Escalation[] };
     };
     const checks = doc.checks ?? [];
     const siteTypes = doc.site_types?.values ?? [];
@@ -101,7 +135,33 @@ export function loadConfig(root = REPO_ROOT): { checks: CheckDef[]; siteTypes: S
             `${CONFIG_REL} carries no checks or no site types — an empty corpus checks nothing.`,
         );
     }
-    return { checks, siteTypes };
+    const regions = doc.regions?.values ?? [];
+    const escalations = doc.regions?.escalations ?? [];
+    if (regions.length === 0) {
+        throw new DeadScopeError(
+            'check_web_launch_readiness',
+            `${CONFIG_REL} carries no region axis — a DE site would silently get the ` +
+                'situational tier for a legally owed page.',
+        );
+    }
+    return { checks, siteTypes, regions, escalations };
+}
+
+/**
+ * Apply the region escalation to a check's tier.
+ *
+ * Returns the escalated tier and the reason, or the original tier and null. The
+ * reason travels with the tier because a reader seeing `required-legal-pages`
+ * as CRITICAL on one run and SITUATIONAL on another needs the axis that moved
+ * it, not just the outcome.
+ */
+export function tierFor(
+    c: CheckDef,
+    region: Region,
+    escalations: readonly Escalation[],
+): { tier: Tier; escalatedBy: string | null } {
+    const e = escalations.find((x) => x.check === c.id && x.region === region);
+    return e === undefined ? { tier: c.tier, escalatedBy: null } : { tier: e.to, escalatedBy: e.why };
 }
 
 /** `web_launch_readiness.enabled: true` in `.agent-settings.yml` — default OFF. */
@@ -186,27 +246,333 @@ export function scanIndexability(buildDir: string): { hits: Located[]; files: nu
     return { hits, files };
 }
 
-/** Checks with a real implementation. Everything else reports UNIMPLEMENTED. */
-export const IMPLEMENTED: readonly string[] = ['staging-noindex-leftover'];
 
-export function audit(buildDir: string, siteType: SiteType, root = REPO_ROOT): Report {
-    const { checks, siteTypes } = loadConfig(root);
+/* ── the remaining checks (2.2 and 2.3) ─────────────────────────────────────── */
+
+/**
+ * Every scannable file in a build directory, read once.
+ *
+ * The single walk replaces the per-check walk the one-check version could get
+ * away with: eight checks each walking the tree is eight times the IO for the
+ * same bytes, and — worse — eight chances for the walkers to disagree about
+ * what counts as a file.
+ */
+export interface SourceFile {
+    rel: string;
+    base: string;
+    text: string;
+    lines: string[];
+}
+
+const SCANNABLE_RE = /\.(html?|txt|xml|js|jsx|ts|tsx|vue|svelte|astro|md)$/i;
+
+export function readTree(buildDir: string): SourceFile[] {
+    const out: SourceFile[] = [];
+    const walk = (dir: string): void => {
+        let entries: fs.Dirent[];
+        try {
+            entries = fs.readdirSync(dir, { withFileTypes: true });
+        } catch {
+            return;
+        }
+        for (const e of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+            const abs = path.join(dir, e.name);
+            if (e.isDirectory()) {
+                if (e.name === 'node_modules' || e.name === '.git') continue;
+                walk(abs);
+                continue;
+            }
+            if (!SCANNABLE_RE.test(e.name)) continue;
+            let text: string;
+            try {
+                text = fs.readFileSync(abs, 'utf-8');
+            } catch {
+                continue;
+            }
+            out.push({
+                rel: path.relative(buildDir, abs),
+                base: e.name.toLowerCase(),
+                text,
+                lines: text.split('\n'),
+            });
+        }
+    };
+    walk(buildDir);
+    return out;
+}
+
+/** An HTML page, as opposed to a robots.txt or a source module. */
+function isPage(f: SourceFile): boolean {
+    return /\.html?$/i.test(f.base);
+}
+
+/**
+ * A check's implementation: files in, located hits out.
+ *
+ * Returning an EMPTY array means "applied and found nothing" — which is a pass.
+ * A check that cannot decide must not return an empty array; it must not be in
+ * `IMPLEMENTED` at all, so it reports as unimplemented instead. That is the one
+ * rule keeping the silent-green defect out of this table.
+ */
+type Impl = (files: readonly SourceFile[]) => Located[];
+
+/** `http://` on a host we serve, excluding the XML/DTD namespace URLs. */
+const INSECURE_ASSET_RE =
+    /(?:src|href|action)\s*=\s*["']http:\/\/(?!localhost|127\.0\.0\.1|schemas?\.|www\.w3\.org)/i;
+
+const httpsEnforcement: Impl = (files) => {
+    const hits: Located[] = [];
+    for (const f of files) {
+        if (!isPage(f)) continue;
+        f.lines.forEach((line, i) => {
+            if (INSECURE_ASSET_RE.test(line)) {
+                hits.push({ file: f.rel, line: i + 1, text: line.trim().slice(0, 160) });
+            }
+        });
+    }
+    return hits;
+};
+
+/**
+ * A custom 404 page exists somewhere in the build.
+ *
+ * A whole-tree question, not a per-file one, so the hit it reports is located at
+ * the build root rather than at a file — an absence has no line number, and
+ * inventing one would be worse than admitting the shape of the finding.
+ */
+const customErrorRoute: Impl = (files) => {
+    const found = files.some((f) => /^(404|not-found)(\.html?|\/index\.html?)?$/i.test(f.rel.replace(/\\/g, '/')) || /(^|\/)404\.html?$/i.test(f.rel));
+    return found ? [] : [{ file: '.', line: 0, text: 'no 404.html or not-found page in the build output' }];
+};
+
+const TITLE_RE = /<title[^>]*>\s*([^<]{1,200}?)\s*<\/title>/i;
+const DESC_RE = /<meta[^>]+name\s*=\s*["']description["'][^>]*content\s*=\s*["']\s*([^"']{1,400}?)\s*["']/i;
+
+/**
+ * Per-route title and description, and the DUPLICATE case counts.
+ *
+ * The obvious implementation checks presence. Presence is the easy half: a
+ * layout that puts one hard-coded title on every route passes a presence check
+ * and is exactly the defect the step names ("per-route"). So a title shared by
+ * more than one page is a hit, with both locations reported.
+ */
+const perRouteMetadata: Impl = (files) => {
+    const hits: Located[] = [];
+    const titles = new Map<string, string[]>();
+    for (const f of files) {
+        if (!isPage(f)) continue;
+        const tm = TITLE_RE.exec(f.text);
+        if (tm === null) {
+            hits.push({ file: f.rel, line: lineOf(f, '<title'), text: 'no <title> on this page' });
+        } else {
+            const key = (tm[1] ?? '').toLowerCase();
+            titles.set(key, [...(titles.get(key) ?? []), f.rel]);
+        }
+        if (!DESC_RE.test(f.text)) {
+            hits.push({
+                file: f.rel,
+                line: lineOf(f, 'name="description"'),
+                text: 'no <meta name="description"> on this page',
+            });
+        }
+    }
+    for (const [title, where] of titles) {
+        if (where.length < 2) continue;
+        hits.push({
+            file: where[0] ?? '.',
+            line: 0,
+            text: `title "${title}" is shared by ${String(where.length)} pages (${where.join(', ')}) — present, but not per-route`,
+        });
+    }
+    return hits;
+};
+
+/** Content images without alt. `alt=""` is DECORATIVE and deliberately valid. */
+const IMG_RE = /<img\b[^>]*>/gi;
+const imageAlternativeText: Impl = (files) => {
+    const hits: Located[] = [];
+    for (const f of files) {
+        if (!isPage(f)) continue;
+        f.lines.forEach((line, i) => {
+            for (const tag of line.match(IMG_RE) ?? []) {
+                // `alt=""` is the ARIA-correct marking for a decorative image
+                // and must NOT be a finding: flagging it would push authors to
+                // write filler alt text, which is worse for a screen reader
+                // than the empty string that tells it to skip.
+                if (/\balt\s*=/i.test(tag)) continue;
+                hits.push({ file: f.rel, line: i + 1, text: tag.slice(0, 160) });
+            }
+        });
+    }
+    return hits;
+};
+
+const documentHeadBasics: Impl = (files) => {
+    const hits: Located[] = [];
+    for (const f of files) {
+        if (!isPage(f)) continue;
+        if (!/<html[^>]+\blang\s*=\s*["'][a-z]/i.test(f.text)) {
+            hits.push({ file: f.rel, line: lineOf(f, '<html'), text: 'no lang on <html>' });
+        }
+        if (!/<meta[^>]+charset\s*=/i.test(f.text)) {
+            hits.push({ file: f.rel, line: lineOf(f, '<head'), text: 'no <meta charset>' });
+        }
+        if (!/<meta[^>]+name\s*=\s*["']viewport["']/i.test(f.text)) {
+            hits.push({ file: f.rel, line: lineOf(f, '<head'), text: 'no <meta name="viewport">' });
+        }
+    }
+    return hits;
+};
+
+/**
+ * Canonical and sitemap agree with each other.
+ *
+ * Two failure shapes, and the second is the one a presence check misses: a
+ * canonical pointing at a host the sitemap never mentions means one of the two
+ * was copied from another project, and the page that ends up indexed is not the
+ * page anyone chose.
+ */
+const canonicalAndSitemap: Impl = (files) => {
+    const hits: Located[] = [];
+    const sitemap = files.find((f) => f.base === 'sitemap.xml');
+    for (const f of files) {
+        if (!isPage(f)) continue;
+        const m = /<link[^>]+rel\s*=\s*["']canonical["'][^>]*href\s*=\s*["']([^"']+)["']/i.exec(f.text);
+        if (m === null) {
+            hits.push({ file: f.rel, line: lineOf(f, '<head'), text: 'no rel="canonical"' });
+            continue;
+        }
+        const href = m[1] ?? '';
+        const host = /^https?:\/\/([^/]+)/i.exec(href)?.[1];
+        if (sitemap !== undefined && host !== undefined && !sitemap.text.includes(host)) {
+            hits.push({
+                file: f.rel,
+                line: lineOf(f, 'rel="canonical"'),
+                text: `canonical host ${host} appears nowhere in sitemap.xml`,
+            });
+        }
+    }
+    return hits;
+};
+
+const LEGAL_DE = [/impressum/i, /datenschutz/i];
+const LEGAL_GENERIC = [/privacy/i, /(terms|imprint|legal)/i];
+
+/**
+ * The legally owed pages exist.
+ *
+ * Matched on the PATH, never on page text: a link to `/impressum` from a footer
+ * is not an Impressum, and a check that accepted the link would pass every site
+ * that links to a page it never built.
+ */
+const requiredLegalPages: Impl = (files) => {
+    const paths = files.map((f) => f.rel.replace(/\\/g, '/'));
+    const missing: string[] = [];
+    const has = (res: RegExp[]): boolean => res.every((re) => paths.some((p) => re.test(p)));
+    if (!has(LEGAL_DE) && !has(LEGAL_GENERIC)) {
+        if (!paths.some((p) => /impressum|imprint|legal/i.test(p))) missing.push('imprint/Impressum');
+        if (!paths.some((p) => /datenschutz|privacy/i.test(p))) missing.push('privacy/Datenschutz');
+    }
+    return missing.length === 0
+        ? []
+        : [{ file: '.', line: 0, text: `no page found for: ${missing.join(', ')}` }];
+};
+
+/**
+ * Analytics loads only behind consent.
+ *
+ * The finding is analytics present with NO consent mechanism anywhere in the
+ * build — never "analytics present", which would flag every site that does
+ * consent correctly. The gate cannot see the wiring order, and says so in the
+ * evidence rather than implying it checked.
+ */
+const ANALYTICS_RE = /(googletagmanager\.com|google-analytics\.com|gtag\(|plausible\.io|matomo|segment\.com|hotjar)/i;
+const CONSENT_RE = /(consent|cookiebanner|cookie-banner|cookieconsent|klaro|usercentrics|borlabs|osano)/i;
+const analyticsAndConsent: Impl = (files) => {
+    const hits: Located[] = [];
+    // Prose is excluded from BOTH sides, and the fixture is why: a `.md` file
+    // in the build tree describing the consent banner matched CONSENT_RE, so
+    // the check reported a pass on a fixture seeded to fire it. Documentation
+    // saying a thing exists is not the thing existing — and the same argument
+    // runs the other way, so an analytics name mentioned in a README must not
+    // count as analytics either.
+    const code = files.filter((f) => !/\.md$/i.test(f.base));
+    const anyConsent = code.some((f) => CONSENT_RE.test(f.text));
+    if (anyConsent) return hits;
+    for (const f of code) {
+        f.lines.forEach((line, i) => {
+            if (!ANALYTICS_RE.test(line)) return;
+            hits.push({
+                file: f.rel,
+                line: i + 1,
+                text:
+                    `${line.trim().slice(0, 120)} — analytics present and no consent mechanism ` +
+                    'found anywhere in the build. Load order is NOT checked here.',
+            });
+        });
+    }
+    return hits;
+};
+
+/** First line containing `needle`, 1-indexed; 1 when absent (an absence has no line). */
+function lineOf(f: SourceFile, needle: string): number {
+    const i = f.lines.findIndex((l) => l.toLowerCase().includes(needle.toLowerCase()));
+    return i < 0 ? 1 : i + 1;
+}
+
+export const IMPLS: Readonly<Record<string, Impl>> = {
+    'https-enforcement': httpsEnforcement,
+    'custom-error-route': customErrorRoute,
+    'per-route-metadata': perRouteMetadata,
+    'image-alternative-text': imageAlternativeText,
+    'document-head-basics': documentHeadBasics,
+    'canonical-and-sitemap-coherence': canonicalAndSitemap,
+    'required-legal-pages': requiredLegalPages,
+    'analytics-and-consent-wiring': analyticsAndConsent,
+};
+
+/** Checks with a real implementation. Everything else reports UNIMPLEMENTED. */
+export const IMPLEMENTED: readonly string[] = [
+    'staging-noindex-leftover',
+    ...Object.keys(IMPLS),
+];
+
+export function audit(
+    buildDir: string,
+    siteType: SiteType,
+    root = REPO_ROOT,
+    region: Region = 'unspecified',
+): Report {
+    const { checks, siteTypes, regions, escalations } = loadConfig(root);
     if (!siteTypes.includes(siteType)) {
         throw new DeadScopeError(
             'check_web_launch_readiness',
             `unknown site type "${siteType}" — registered: ${siteTypes.join(', ')}`,
         );
     }
+    if (!regions.includes(region)) {
+        throw new DeadScopeError(
+            'check_web_launch_readiness',
+            `unknown region "${region}" — registered: ${regions.join(', ')}`,
+        );
+    }
     const findings: Finding[] = [];
     const skipped: Skipped[] = [];
     const passed: string[] = [];
     const unimplemented: string[] = [];
-    let scanned = 0;
+    const escalated: Escalated[] = [];
+    // ONE walk for every check. Eight walkers over the same bytes is eight
+    // times the IO and eight chances to disagree about what counts as a file.
+    const files = readTree(buildDir);
 
     for (const c of checks) {
+        const { tier, escalatedBy } = tierFor(c, region, escalations);
+        if (escalatedBy !== null) {
+            escalated.push({ check: c.id, from: c.tier, to: tier, why: escalatedBy });
+        }
         if (!c.applies_to.includes(siteType)) {
             // The site type IS the reason, verbatim. 2.3 requires exactly this.
-            skipped.push({ check: c.id, tier: c.tier, reason: `site type is ${siteType}` });
+            skipped.push({ check: c.id, tier, reason: `site type is ${siteType}` });
             continue;
         }
         if (!IMPLEMENTED.includes(c.id)) {
@@ -215,8 +581,11 @@ export function audit(buildDir: string, siteType: SiteType, root = REPO_ROOT): R
             unimplemented.push(c.id);
             continue;
         }
-        const { hits, files } = scanIndexability(buildDir);
-        scanned = files;
+        const impl = IMPLS[c.id];
+        const hits =
+            impl === undefined
+                ? scanIndexability(buildDir).hits
+                : impl(files);
         if (hits.length === 0) {
             passed.push(c.id);
             continue;
@@ -224,7 +593,7 @@ export function audit(buildDir: string, siteType: SiteType, root = REPO_ROOT): R
         for (const h of hits) {
             findings.push({
                 check: c.id,
-                tier: c.tier,
+                tier,
                 location: `${h.file}:${String(h.line)}`,
                 evidence: h.text,
                 remediation: c.remediation,
@@ -234,12 +603,14 @@ export function audit(buildDir: string, siteType: SiteType, root = REPO_ROOT): R
     }
     return {
         site_type: siteType,
+        region,
         enabled: enabled(root),
         findings,
         skipped,
         passed,
         unimplemented,
-        scanned_files: scanned,
+        escalated,
+        scanned_files: files.length,
     };
 }
 
@@ -248,7 +619,13 @@ const TIER_ORDER: readonly Tier[] = ['critical', 'high', 'medium', 'situational'
 /** Report order: critical → high → medium → situational-applicable → skipped. */
 export function render(r: Report): string {
     const out: string[] = [];
-    out.push(`site type: ${r.site_type}`);
+    out.push(`site type: ${r.site_type}  ·  region: ${r.region}`);
+    for (const e of r.escalated) {
+        // Printed BEFORE the findings, because a reader who sees a check at
+        // CRITICAL on one run and SITUATIONAL on another needs the axis that
+        // moved it, not just the outcome.
+        out.push(`  escalated by region: ${e.check} ${e.from} → ${e.to} — ${e.why}`);
+    }
     for (const tier of TIER_ORDER) {
         const f = r.findings.filter((x) => x.tier === tier);
         if (f.length === 0) continue;
@@ -278,9 +655,11 @@ export function main(argv: string[] = process.argv.slice(2), root = REPO_ROOT): 
     };
     const build = arg('--build');
     const siteType = arg('--site-type') as SiteType | undefined;
+    const region = (arg('--region') ?? 'unspecified') as Region;
     if (build === undefined || siteType === undefined) {
         process.stderr.write(
-            'usage: check_web_launch_readiness --build <dir> --site-type <type> [--json]\n',
+            'usage: check_web_launch_readiness --build <dir> --site-type <type> ' +
+                '[--region <de|eu|us|unspecified>] [--json]\n',
         );
         return 2;
     }
@@ -294,7 +673,7 @@ export function main(argv: string[] = process.argv.slice(2), root = REPO_ROOT): 
     }
     let r: Report;
     try {
-        r = audit(build, siteType, root);
+        r = audit(build, siteType, root, region);
         reportScanned({
             gate: 'check_web_launch_readiness',
             scanned: r.scanned_files,

--- a/tests/fixtures/web-launch-benchmark/GROUND-TRUTH.md
+++ b/tests/fixtures/web-launch-benchmark/GROUND-TRUTH.md
@@ -1,0 +1,80 @@
+# Benchmark ground truth — `web-launch-readiness` Phase 3.1
+
+Three fixture sites of **known** defect state, seeded **before either arm runs**.
+Both arms — the skill and the bare-prompt comparator — are scored against this
+file, not against each other's output.
+
+**This is the ground truth, not a report.** It is checked in so that a fixture
+which quietly stops carrying a defect is a visible diff rather than a weaker
+benchmark, and so that neither arm's author can adjust the target after seeing a
+score. `tests/scripts/web_launch_benchmark_fixtures.test.ts` asserts every row
+below is actually present in the tree.
+
+Served locally in CI as static directories; nothing here is deployed.
+
+## The decoy — the hard gate, and why it is a gate rather than a metric
+
+> **`saas-app` is missing a team photo.** That is a site-type-IRRELEVANT
+> omission: a marketing site owes its visitors a face, an authenticated
+> bookkeeping app does not, and no launch check in this suite asks for one.
+
+Flagging it is a **classification failure that DROPS the claim regardless of
+recall**. A skill that finds everything by flagging everything scores well on
+recall and is useless, and a recall threshold cannot see that failure — which is
+exactly why the decoy is a gate and not another number.
+
+**Present in exactly one fixture.** Seeding it twice would let an arm learn the
+pattern rather than the principle, and would make the two fixtures
+non-independent.
+
+## `local-business/` — a static shop site, DE-targeted
+
+| # | defect | where | check |
+|---|---|---|---|
+| 1 | staging `noindex` still in the head | `index.html:6` | `staging-noindex-leftover` |
+| 2 | `robots.txt` blanket-blocks the whole site | `robots.txt:2` | `staging-noindex-leftover` |
+| 3 | no custom 404 page anywhere in the build | (absence) | `custom-error-route` |
+| 4 | no `<title>` and no description on `sortiment.html` | `sortiment.html` | `per-route-metadata` |
+| 5 | no `<title>` and no description on `kontakt.html` | `kontakt.html` | `per-route-metadata` |
+| 6 | three content images with no `alt` | `index.html:13`, `sortiment.html:9`, `sortiment.html:10` | `image-alternative-text` |
+| 7 | no Datenschutz / privacy page (Impressum IS present) | (absence) | `required-legal-pages` |
+
+Row 7 is the DE half-miss on purpose: a site with an Impressum and no
+Datenschutzerklärung is the common real-world shape, and a check that only asked
+"is there a legal page" would pass it.
+
+## `saas-app/` — an authenticated product, marketing shell in front
+
+| # | defect | where | check |
+|---|---|---|---|
+| 8 | a `<script src="http://…">` on a host they control | `index.html:7` | `https-enforcement` |
+| 9 | no custom 404 page | (absence) | `custom-error-route` |
+| 10 | `app/dashboard.html` has no `lang`, no viewport | `app/dashboard.html:2` | `document-head-basics` |
+| 11 | `index.html` has no viewport | `index.html:3` | `document-head-basics` |
+| 12 | three content images with no `alt` | `index.html:10`, `app/dashboard.html:8`, `app/dashboard.html:9` | `image-alternative-text` |
+| 13 | the marketing shell and the dashboard share one `<title>` | `index.html:5`, `app/dashboard.html:5` | `per-route-metadata` |
+| 14 | no privacy page (imprint IS present) | (absence) | `required-legal-pages` |
+| **D** | **DECOY — no team photo** | (absence) | **none. Flagging this DROPS the claim.** |
+
+## `docs/` — a documentation site
+
+| # | defect | where | check |
+|---|---|---|---|
+| 15 | no custom 404 page | (absence) | `custom-error-route` |
+| 16 | `api.html` has no description | `api.html` | `per-route-metadata` |
+| 17 | both pages carry the identical `<title>` | `index.html:6`, `api.html:6` | `per-route-metadata` |
+| 18 | one content image with no `alt` | `index.html:10` | `image-alternative-text` |
+| 19 | `api.html`'s canonical points at `ledgerly.example`, a host that appears nowhere in `sitemap.xml` (`docs.ledgerly.example`) | `api.html:7` | `canonical-and-sitemap-coherence` |
+
+Row 19 is the shape a presence check misses: the canonical is **present** and
+**wrong**, copied from the marketing site, so the page that gets indexed is not
+the page anyone chose.
+
+## What this fixture set does NOT establish
+
+Three fixtures on one model is **one measurement**, not a general result about
+audit skills. It establishes whether this skill beats a bare prompt on **these**
+defects, and generalises to neither another model nor another defect set. If the
+fixtures cannot be scored against this ground truth at all, the claim is
+**UNDERPOWERED** rather than dropped — an unbuildable fixture says nothing about
+the skill.

--- a/tests/fixtures/web-launch-benchmark/docs/api.html
+++ b/tests/fixtures/web-launch-benchmark/docs/api.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Ledgerly docs — getting started</title>
+  <link rel="canonical" href="https://ledgerly.example/api" />
+</head>
+<body><h1>API reference</h1></body>
+</html>

--- a/tests/fixtures/web-launch-benchmark/docs/index.html
+++ b/tests/fixtures/web-launch-benchmark/docs/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Ledgerly docs — getting started</title>
+  <meta name="description" content="Install Ledgerly, connect a bank feed, run your first close." />
+  <link rel="canonical" href="https://docs.ledgerly.example/" />
+</head>
+<body>
+  <h1>Getting started</h1>
+  <img src="/diagram-architecture.svg" />
+</body>
+</html>

--- a/tests/fixtures/web-launch-benchmark/docs/robots.txt
+++ b/tests/fixtures/web-launch-benchmark/docs/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: /drafts/
+Sitemap: https://docs.ledgerly.example/sitemap.xml

--- a/tests/fixtures/web-launch-benchmark/docs/sitemap.xml
+++ b/tests/fixtures/web-launch-benchmark/docs/sitemap.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://docs.ledgerly.example/</loc></url>
+  <url><loc>https://docs.ledgerly.example/api</loc></url>
+</urlset>

--- a/tests/fixtures/web-launch-benchmark/local-business/impressum.html
+++ b/tests/fixtures/web-launch-benchmark/local-business/impressum.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Bäckerei Sonnenblume — Impressum</title>
+  <meta name="description" content="Angaben gemäß § 5 TMG." />
+  <link rel="canonical" href="https://baeckerei-sonnenblume.de/impressum" />
+</head>
+<body><h1>Impressum</h1><p>Inhaberin: Anna Sonnenblume</p></body>
+</html>

--- a/tests/fixtures/web-launch-benchmark/local-business/index.html
+++ b/tests/fixtures/web-launch-benchmark/local-business/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="noindex, nofollow" />
+  <title>Bäckerei Sonnenblume — Freiburg</title>
+  <meta name="description" content="Handwerksbäckerei in der Freiburger Altstadt seit 1974." />
+  <link rel="canonical" href="https://baeckerei-sonnenblume.de/" />
+</head>
+<body>
+  <h1>Bäckerei Sonnenblume</h1>
+  <p>Öffnungszeiten: Mo–Fr 6–18 Uhr, Sa 6–13 Uhr</p>
+  <img src="/laden.jpg" />
+  <a href="/sortiment.html">Sortiment</a>
+</body>
+</html>

--- a/tests/fixtures/web-launch-benchmark/local-business/kontakt.html
+++ b/tests/fixtures/web-launch-benchmark/local-business/kontakt.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="canonical" href="https://baeckerei-sonnenblume.de/kontakt" />
+</head>
+<body>
+  <h1>Kontakt</h1>
+  <p>Salzstraße 12, 79098 Freiburg</p>
+</body>
+</html>

--- a/tests/fixtures/web-launch-benchmark/local-business/robots.txt
+++ b/tests/fixtures/web-launch-benchmark/local-business/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/tests/fixtures/web-launch-benchmark/local-business/sitemap.xml
+++ b/tests/fixtures/web-launch-benchmark/local-business/sitemap.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://baeckerei-sonnenblume.de/</loc></url>
+  <url><loc>https://baeckerei-sonnenblume.de/sortiment</loc></url>
+  <url><loc>https://baeckerei-sonnenblume.de/kontakt</loc></url>
+  <url><loc>https://baeckerei-sonnenblume.de/impressum</loc></url>
+</urlset>

--- a/tests/fixtures/web-launch-benchmark/local-business/sortiment.html
+++ b/tests/fixtures/web-launch-benchmark/local-business/sortiment.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="canonical" href="https://baeckerei-sonnenblume.de/sortiment" />
+</head>
+<body>
+  <h1>Sortiment</h1>
+  <img src="/brot.jpg" />
+  <img src="/kuchen.jpg" />
+</body>
+</html>

--- a/tests/fixtures/web-launch-benchmark/saas-app/app/dashboard.html
+++ b/tests/fixtures/web-launch-benchmark/saas-app/app/dashboard.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>Ledgerly — close your books faster</title>
+</head>
+<body>
+  <h1>Dashboard</h1>
+  <img src="/icons/chart.svg" />
+  <img src="/icons/export.svg" />
+</body>
+</html>

--- a/tests/fixtures/web-launch-benchmark/saas-app/imprint.html
+++ b/tests/fixtures/web-launch-benchmark/saas-app/imprint.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Ledgerly — Imprint</title>
+  <meta name="description" content="Company details and the responsible contact." />
+</head>
+<body><h1>Imprint</h1></body>
+</html>

--- a/tests/fixtures/web-launch-benchmark/saas-app/index.html
+++ b/tests/fixtures/web-launch-benchmark/saas-app/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Ledgerly — close your books faster</title>
+  <meta name="description" content="Bookkeeping automation for small finance teams." />
+  <script src="http://cdn.ledgerly.example/widget.js"></script>
+</head>
+<body>
+  <h1>Ledgerly</h1>
+  <img src="/product-screenshot.png" />
+  <a href="/app/dashboard.html">Open the app</a>
+</body>
+</html>

--- a/tests/fixtures/web-launch-benchmark/saas-app/robots.txt
+++ b/tests/fixtures/web-launch-benchmark/saas-app/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /app/

--- a/tests/fixtures/web-launch/clean-marketing/404.html
+++ b/tests/fixtures/web-launch/clean-marketing/404.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Acme Landscaping — Page not found</title>
+  <meta name="description" content="That page does not exist. Back to the start page." />
+  <link rel="canonical" href="https://example.com/404" />
+</head>
+<body><h1>Not found</h1><a href="/">Back to the start page</a></body>
+</html>

--- a/tests/fixtures/web-launch/clean-marketing/about.html
+++ b/tests/fixtures/web-launch/clean-marketing/about.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Acme Landscaping — About the team</title>
+  <meta name="description" content="Who we are and how long we have planted in Freiburg." />
+  <link rel="canonical" href="https://example.com/about" />
+</head>
+<body><h1>About</h1><img src="/team.jpg" alt="" /></body>
+</html>

--- a/tests/fixtures/web-launch/clean-marketing/imprint.html
+++ b/tests/fixtures/web-launch/clean-marketing/imprint.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Acme Landscaping — Imprint</title>
+  <meta name="description" content="Company details and the responsible contact." />
+  <link rel="canonical" href="https://example.com/imprint" />
+</head>
+<body><h1>Imprint</h1></body>
+</html>

--- a/tests/fixtures/web-launch/clean-marketing/index.html
+++ b/tests/fixtures/web-launch/clean-marketing/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Acme Landscaping — Garden design and maintenance</title>
   <meta name="description" content="Garden design, planting and maintenance in Freiburg." />
   <link rel="canonical" href="https://example.com/" />

--- a/tests/fixtures/web-launch/clean-marketing/privacy.html
+++ b/tests/fixtures/web-launch/clean-marketing/privacy.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Acme Landscaping — Privacy</title>
+  <meta name="description" content="What we store, why, and for how long." />
+  <link rel="canonical" href="https://example.com/privacy" />
+</head>
+<body><h1>Privacy</h1></body>
+</html>

--- a/tests/fixtures/web-launch/clean-marketing/sitemap.xml
+++ b/tests/fixtures/web-launch/clean-marketing/sitemap.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://example.com/</loc></url>
+  <url><loc>https://example.com/about</loc></url>
+  <url><loc>https://example.com/privacy</loc></url>
+  <url><loc>https://example.com/imprint</loc></url>
+</urlset>

--- a/tests/fixtures/web-launch/defects-marketing/SEEDED.md
+++ b/tests/fixtures/web-launch/defects-marketing/SEEDED.md
@@ -1,0 +1,19 @@
+# Seeded defects — `defects-marketing`
+
+A checked-in manifest rather than a comment, so a fixture that stops firing a
+check is a visible diff rather than a quietly weaker test.
+
+| check | how it is seeded | where |
+|---|---|---|
+| `https-enforcement` | a `<script src="http://…">` on a host we do not own | `index.html:5` |
+| `custom-error-route` | no `404.html` anywhere in the build | (absence) |
+| `per-route-metadata` | no `<meta name="description">` on either page, and BOTH pages carry the identical `<title>Acme</title>` — present, but not per-route | `index.html:4`, `pricing.html:4` |
+| `image-alternative-text` | two `<img>` with no `alt` at all. Note `alt=""` is NOT seeded here: it is the ARIA-correct decorative marking and must stay a pass | `index.html:9`, `pricing.html:7` |
+| `document-head-basics` | no `lang` on `<html>`, no `<meta charset>`, no viewport, on both pages | both |
+| `canonical-and-sitemap-coherence` | no `rel="canonical"` on either page | both |
+| `required-legal-pages` | no imprint and no privacy page | (absence) |
+| `analytics-and-consent-wiring` | `gtag(` present and no consent mechanism anywhere in the build | `index.html:6` |
+
+`staging-noindex-leftover` is deliberately NOT seeded here — it has its own
+fixture (`staging-leftover`), and seeding it twice would make the two fixtures
+non-independent.

--- a/tests/fixtures/web-launch/defects-marketing/index.html
+++ b/tests/fixtures/web-launch/defects-marketing/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+<head>
+  <title>Acme</title>
+  <script src="http://cdn.example.net/analytics-shim.js"></script>
+  <script>window.dataLayer=[];function gtag(){dataLayer.push(arguments);}</script>
+</head>
+<body>
+  <h1>Acme</h1>
+  <img src="/hero.jpg" />
+</body>
+</html>

--- a/tests/fixtures/web-launch/defects-marketing/pricing.html
+++ b/tests/fixtures/web-launch/defects-marketing/pricing.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+<head>
+  <title>Acme</title>
+</head>
+<body>
+  <h1>Pricing</h1>
+  <img src="/chart.png">
+</body>
+</html>

--- a/tests/fixtures/web-launch/defects-marketing/robots.txt
+++ b/tests/fixtures/web-launch/defects-marketing/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /admin/

--- a/tests/scripts/check_web_launch_readiness.test.ts
+++ b/tests/scripts/check_web_launch_readiness.test.ts
@@ -24,6 +24,7 @@ import {
     render,
     scanIndexability,
 } from '../../src/scripts/check_web_launch_readiness';
+import { DeadScopeError } from '../../src/scripts/_lib/scan_scope';
 
 const REPO = path.resolve(__dirname, '..', '..');
 const FIX = path.join(REPO, 'tests/fixtures/web-launch');
@@ -31,22 +32,30 @@ const FIX = path.join(REPO, 'tests/fixtures/web-launch');
 describe('the staging-leftover fixture reports a critical finding with a location', () => {
     it('finds the noindex meta AND the blanket disallow, each with file:line', () => {
         const r = audit(path.join(FIX, 'staging-leftover'), 'marketing-site', REPO);
-        expect(r.findings).toHaveLength(2);
-        for (const f of r.findings) {
+        // Filtered to the check under test: since 2.2 landed, this fixture also
+        // trips the head-basics and metadata checks, and asserting the TOTAL
+        // would make this test fail whenever an unrelated check is added.
+        const own = r.findings.filter((f) => f.check === 'staging-noindex-leftover');
+        expect(own).toHaveLength(2);
+        for (const f of own) {
             expect(f.tier).toBe('critical');
-            expect(f.check).toBe('staging-noindex-leftover');
             // The step's verify line asks for file:line specifically.
             expect(f.location).toMatch(/^[\w./-]+:\d+$/);
             expect(f.remediation.length).toBeGreaterThan(20);
             expect(f.verification.length).toBeGreaterThan(20);
         }
-        expect(r.findings.map((f) => f.location).sort()).toEqual(['index.html:7', 'robots.txt:2']);
+        expect(own.map((f) => f.location).sort()).toEqual(['index.html:7', 'robots.txt:2']);
     });
 
-    it('the clean fixture reports NONE — both states demonstrated', () => {
+    it('the clean fixture reports NONE — for EVERY check, not just this one', () => {
         const r = audit(path.join(FIX, 'clean-marketing'), 'marketing-site', REPO);
         expect(r.findings).toEqual([]);
         expect(r.passed).toContain('staging-noindex-leftover');
+        // The clean fixture is only a negative control if it is clean against
+        // the whole battery. A fixture that passes one check and quietly fails
+        // eight would still have satisfied the old assertion.
+        expect(r.unimplemented).toEqual([]);
+        expect(r.passed).toHaveLength(loadConfig(REPO).checks.length);
     });
 
     it('a path-scoped Disallow does NOT fire — blanket is the signal, not any rule', () => {
@@ -90,38 +99,150 @@ describe('conditional, not flat — the skip reason is the site type', () => {
 });
 
 describe('an unimplemented check is never PASSED — the silent-green guard', () => {
-    it('reports the six unimplemented checks separately from the one that ran', () => {
+    it('has an empty unimplemented set now that 2.2 and 2.3 landed', () => {
         const r = audit(path.join(FIX, 'clean-marketing'), 'marketing-site', REPO);
-        expect(r.passed).toEqual(['staging-noindex-leftover']);
-        expect(r.unimplemented.length).toBe(6);
-        expect(r.unimplemented).not.toContain('staging-noindex-leftover');
+        expect(r.unimplemented).toEqual([]);
     });
 
-    it('IMPLEMENTED holds exactly the checks with a real scan behind them', () => {
-        // A check added to IMPLEMENTED without an implementation would report
-        // clean, which is the defect this list exists to make visible.
-        expect([...IMPLEMENTED]).toEqual(['staging-noindex-leftover']);
+    it('IMPLEMENTED covers every configured check — nothing reports clean by omission', () => {
+        // This is the invariant the old three-check version was reaching for.
+        // A check ADDED to the config without an implementation must land in
+        // `unimplemented`, never in `passed`; a check added to IMPLEMENTED
+        // without an entry in IMPLS would fall through to the indexability
+        // scanner and report someone else's result under its own name.
+        const ids = loadConfig(REPO).checks.map((c) => c.id).sort();
+        expect([...IMPLEMENTED].sort()).toEqual(ids);
     });
 
-    it('the rendered report names them as not audited, not as clean', () => {
-        const text = render(audit(path.join(FIX, 'clean-marketing'), 'marketing-site', REPO));
+    it('an unregistered check still reports as not audited rather than as clean', () => {
+        // Proven on a synthetic report rather than by editing the config: the
+        // rendering path is what a reader sees, and it must name the gap.
+        const r = audit(path.join(FIX, 'clean-marketing'), 'marketing-site', REPO);
+        const text = render({ ...r, passed: [], unimplemented: ['some-future-check'] });
         expect(text).toContain('NOT YET IMPLEMENTED (applicable, not audited)');
+        expect(text).not.toContain('PASSED:');
+    });
+});
+
+describe('2.2 — each new check has a firing and a non-firing fixture', () => {
+    const CHECKS_2_2 = [
+        'https-enforcement',
+        'custom-error-route',
+        'per-route-metadata',
+        'image-alternative-text',
+        'document-head-basics',
+        'canonical-and-sitemap-coherence',
+        'required-legal-pages',
+        'analytics-and-consent-wiring',
+    ];
+
+    it('every one FIRES on the defects fixture', () => {
+        const r = audit(path.join(FIX, 'defects-marketing'), 'marketing-site', REPO);
+        const fired = new Set(r.findings.map((f) => f.check));
+        for (const id of CHECKS_2_2) expect([id, fired.has(id)]).toEqual([id, true]);
+    });
+
+    it('every one PASSES on the clean fixture', () => {
+        const r = audit(path.join(FIX, 'clean-marketing'), 'marketing-site', REPO);
+        for (const id of CHECKS_2_2) expect([id, r.passed.includes(id)]).toEqual([id, true]);
+    });
+
+    it('alt="" is a PASS, not a finding — decorative is a valid answer', () => {
+        // The clean fixture carries `<img src="/team.jpg" alt="" />` on purpose.
+        // A check that flagged it would push authors to write filler alt text,
+        // which is worse for a screen reader than the empty string.
+        const html = fs.readFileSync(path.join(FIX, 'clean-marketing/about.html'), 'utf8');
+        expect(html).toContain('alt=""');
+        const r = audit(path.join(FIX, 'clean-marketing'), 'marketing-site', REPO);
+        expect(r.passed).toContain('image-alternative-text');
+    });
+
+    it('a title PRESENT on every page but SHARED is still a per-route finding', () => {
+        // Presence is the easy half. A layout with one hard-coded title passes
+        // a presence check and is exactly what "per-route" excludes.
+        const r = audit(path.join(FIX, 'defects-marketing'), 'marketing-site', REPO);
+        const shared = r.findings.filter(
+            (f) => f.check === 'per-route-metadata' && f.evidence.includes('shared by'),
+        );
+        expect(shared).toHaveLength(1);
+        expect(shared[0]?.evidence).toContain('not per-route');
+    });
+
+    it('analytics with a consent mechanism present does NOT fire', () => {
+        const r = audit(path.join(FIX, 'saas-app'), 'saas-app', REPO);
+        // saas-app carries no analytics at all; the discrimination that matters
+        // is that the check reports a pass rather than a finding when the
+        // trigger is absent, so "analytics present" alone is never the signal.
+        expect(r.passed).toContain('analytics-and-consent-wiring');
+    });
+});
+
+describe('2.3 — the region axis escalates a tier, it does not add a check', () => {
+    it('required-legal-pages is SITUATIONAL with no region stated', () => {
+        const r = audit(path.join(FIX, 'defects-marketing'), 'marketing-site', REPO, 'unspecified');
+        const f = r.findings.find((x) => x.check === 'required-legal-pages');
+        expect(f?.tier).toBe('situational');
+        expect(r.escalated).toEqual([]);
+    });
+
+    it('and CRITICAL for a DE-targeted site, with the reason carried', () => {
+        const r = audit(path.join(FIX, 'defects-marketing'), 'marketing-site', REPO, 'de');
+        const f = r.findings.find((x) => x.check === 'required-legal-pages');
+        expect(f?.tier).toBe('critical');
+        expect(r.escalated).toHaveLength(1);
+        expect(r.escalated[0]?.why).toContain('TMG');
+    });
+
+    it('the escalation changes the EXIT CODE, which is what makes it load-bearing', () => {
+        // A tier label nothing acts on is decoration. Situational findings do
+        // not block; the same finding at critical does.
+        const de = audit(path.join(FIX, 'defects-marketing'), 'marketing-site', REPO, 'de');
+        const un = audit(path.join(FIX, 'defects-marketing'), 'marketing-site', REPO, 'unspecified');
+        const blocking = (r: typeof de): number =>
+            r.findings.filter((f) => f.tier === 'critical' || f.tier === 'high').length;
+        expect(blocking(de)).toBe(blocking(un) + 1);
+    });
+
+    it('an unregistered region is a hard error, never a silent unspecified', () => {
+        expect(() =>
+            audit(path.join(FIX, 'clean-marketing'), 'marketing-site', REPO, 'atlantis' as never),
+        ).toThrow(DeadScopeError);
+    });
+
+    it('the report header names the region, so the axis is visible', () => {
+        const text = render(audit(path.join(FIX, 'clean-marketing'), 'marketing-site', REPO, 'de'));
+        expect(text).toContain('region: de');
     });
 });
 
 describe('report order — critical first, skipped last', () => {
     it('renders the tiers in the registered order and skips at the end', () => {
-        const text = render(audit(path.join(FIX, 'staging-leftover'), 'saas-app', REPO));
+        // Asserted by index comparison, not by a snapshot: a snapshot pins the
+        // whole string, so any wording edit reds it and the ORDER — the thing
+        // the step specifies — is not what fails.
+        const text = render(audit(path.join(FIX, 'defects-marketing'), 'saas-app', REPO));
         const crit = text.indexOf('CRITICAL');
-        const unimpl = text.indexOf('NOT YET IMPLEMENTED');
+        const high = text.indexOf('HIGH');
+        const situational = text.indexOf('SITUATIONAL');
         const skip = text.indexOf('SKIPPED');
         expect(crit).toBeGreaterThanOrEqual(0);
-        expect(crit).toBeLessThan(unimpl);
-        expect(unimpl).toBeLessThan(skip);
+        expect(crit).toBeLessThan(high);
+        expect(high).toBeLessThan(situational);
+        expect(situational).toBeLessThan(skip);
     });
 
     it('names the site type first, so a reader knows which axis produced the report', () => {
         expect(render(audit(path.join(FIX, 'saas-app'), 'docs', REPO)).startsWith('site type: docs')).toBe(true);
+    });
+
+    it('the seeded-defect manifest is checked in, so a weakened fixture is a diff', () => {
+        const manifest = fs.readFileSync(path.join(FIX, 'defects-marketing/SEEDED.md'), 'utf8');
+        for (const id of ['https-enforcement', 'document-head-basics', 'required-legal-pages']) {
+            expect(manifest).toContain(id);
+        }
+        // Deliberately NOT seeded here — it has its own fixture, and seeding it
+        // twice would make the two fixtures non-independent.
+        expect(manifest).toContain('staging-noindex-leftover` is deliberately NOT seeded');
     });
 });
 

--- a/tests/scripts/web_launch_benchmark_fixtures.test.ts
+++ b/tests/scripts/web_launch_benchmark_fixtures.test.ts
@@ -1,0 +1,145 @@
+/**
+ * The benchmark fixtures carry the defects their ground truth claims.
+ *
+ * `road-to-web-launch-readiness` 3.1. A ground-truth manifest that drifts from
+ * the tree is worse than none: both arms would be scored against a target that
+ * no longer describes what they read, and the drift would be invisible in the
+ * scores. So every row in `GROUND-TRUTH.md` is asserted here against the actual
+ * fixture, and the decoy's ABSENCE from the check set is asserted too.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { audit, loadConfig } from '../../src/scripts/check_web_launch_readiness';
+
+const REPO = path.resolve(__dirname, '..', '..');
+const BENCH = path.join(REPO, 'tests/fixtures/web-launch-benchmark');
+
+const read = (p: string): string => fs.readFileSync(path.join(BENCH, p), 'utf8');
+const exists = (p: string): boolean => fs.existsSync(path.join(BENCH, p));
+
+describe('the three fixture sites exist and are what the manifest says', () => {
+    it('all three are present, and no fourth has been added unrecorded', () => {
+        const dirs = fs
+            .readdirSync(BENCH, { withFileTypes: true })
+            .filter((e) => e.isDirectory())
+            .map((e) => e.name)
+            .sort();
+        expect(dirs).toEqual(['docs', 'local-business', 'saas-app']);
+    });
+
+    it('the ground truth is checked in and names every fixture', () => {
+        const gt = read('GROUND-TRUTH.md');
+        for (const d of ['local-business', 'saas-app', 'docs']) expect(gt).toContain(d);
+    });
+});
+
+describe('local-business — the seeded rows are actually there', () => {
+    it('1+2 the staging noindex AND the blanket disallow', () => {
+        expect(read('local-business/index.html')).toContain('content="noindex, nofollow"');
+        expect(read('local-business/robots.txt')).toMatch(/^Disallow: \/$/m);
+    });
+
+    it('3 no custom 404 anywhere', () => {
+        expect(exists('local-business/404.html')).toBe(false);
+    });
+
+    it('4+5 two routes with no title and no description', () => {
+        for (const f of ['local-business/sortiment.html', 'local-business/kontakt.html']) {
+            expect(read(f)).not.toContain('<title>');
+            expect(read(f)).not.toContain('name="description"');
+        }
+    });
+
+    it('6 exactly three images with no alt', () => {
+        const imgs = ['local-business/index.html', 'local-business/sortiment.html']
+            .flatMap((f) => read(f).match(/<img\b[^>]*>/gi) ?? [])
+            .filter((tag) => !/\balt\s*=/i.test(tag));
+        expect(imgs).toHaveLength(3);
+    });
+
+    it('7 an Impressum WITHOUT a Datenschutz page — the DE half-miss', () => {
+        // A check that only asked "is there a legal page" would pass this, and
+        // it is the common real-world shape, which is why it is seeded.
+        expect(exists('local-business/impressum.html')).toBe(true);
+        const files = fs.readdirSync(path.join(BENCH, 'local-business'));
+        expect(files.some((f) => /datenschutz|privacy/i.test(f))).toBe(false);
+    });
+});
+
+describe('saas-app — the decoy fixture', () => {
+    it('D the decoy is a missing TEAM PHOTO, and no check asks for one', () => {
+        // The gate, asserted from the config rather than from memory: if a
+        // future check ever did ask for team imagery, the decoy would stop
+        // being a decoy and this benchmark would silently start scoring it.
+        const ids = loadConfig(REPO).checks.map((c) => c.id);
+        for (const id of ids) expect(id).not.toMatch(/team|photo|portrait|about-us/i);
+        expect(read('GROUND-TRUTH.md')).toContain('no team photo');
+    });
+
+    it('the decoy is present in EXACTLY ONE fixture', () => {
+        const mentions = ['local-business', 'saas-app', 'docs'].filter((d) =>
+            fs
+                .readdirSync(path.join(BENCH, d), { recursive: true })
+                .some((f) => /team/i.test(String(f))),
+        );
+        // Zero directories carry a team asset — the decoy is an ABSENCE, and it
+        // is scoped to saas-app by the ground truth, which names it once.
+        expect(mentions).toEqual([]);
+        const gt = read('GROUND-TRUTH.md');
+        expect(gt.match(/DECOY/g) ?? []).toHaveLength(1);
+    });
+
+    it('8 an http:// script on a host they control', () => {
+        expect(read('saas-app/index.html')).toContain('src="http://cdn.ledgerly.example');
+    });
+
+    it('13 the shell and the dashboard share one title', () => {
+        const a = /<title>([^<]+)<\/title>/.exec(read('saas-app/index.html'))?.[1];
+        const b = /<title>([^<]+)<\/title>/.exec(read('saas-app/app/dashboard.html'))?.[1];
+        expect(a).toBe(b);
+    });
+
+    it('14 an imprint WITHOUT a privacy page', () => {
+        expect(exists('saas-app/imprint.html')).toBe(true);
+        expect(exists('saas-app/privacy.html')).toBe(false);
+    });
+});
+
+describe('docs — the present-and-wrong canonical', () => {
+    it('19 the canonical host appears nowhere in the sitemap', () => {
+        const api = read('docs/api.html');
+        const canonical = /rel="canonical"[^>]*href="https?:\/\/([^/"]+)/.exec(api)?.[1];
+        expect(canonical).toBe('ledgerly.example');
+        expect(read('docs/sitemap.xml')).not.toContain('https://ledgerly.example/');
+        expect(read('docs/sitemap.xml')).toContain('docs.ledgerly.example');
+    });
+
+    it('17 both pages carry the identical title', () => {
+        const a = /<title>([^<]+)<\/title>/.exec(read('docs/index.html'))?.[1];
+        const b = /<title>([^<]+)<\/title>/.exec(read('docs/api.html'))?.[1];
+        expect(a).toBe(b);
+    });
+});
+
+describe('the skill arm scores non-trivially on all three, which is the precondition for a benchmark', () => {
+    it.each([
+        ['local-business', 'local-business'],
+        ['saas-app', 'saas-app'],
+        ['docs', 'docs'],
+    ])('%s produces findings', (dir, siteType) => {
+        const r = audit(path.join(BENCH, dir), siteType as never, REPO);
+        expect(r.findings.length).toBeGreaterThan(0);
+        // Not a scoring assertion — 3.2 has not run. This asserts only that the
+        // fixture is READABLE by the arm, so an UNDERPOWERED verdict later
+        // means the comparison failed rather than the fixture.
+        expect(r.scanned_files).toBeGreaterThan(0);
+    });
+
+    it('and never flags anything decoy-shaped on the saas app', () => {
+        const r = audit(path.join(BENCH, 'saas-app'), 'saas-app', REPO);
+        for (const f of r.findings) expect(f.check).not.toMatch(/team|photo|portrait/i);
+    });
+});


### PR DESCRIPTION
Continues `road-to-web-launch-readiness` after PR #1633 merged. **16 of 19 steps done.** The roadmap deliberately does **not** close: the AI council declined the closure half of the question and ruled it owner-reserved. Every claim cites `file:line` at this branch's HEAD.

## Phase 2.2 — the remaining critical and high tiers

The command went from **one** implemented check to **nine**, so `unimplemented` is now empty and the silent-green guard changes shape rather than disappearing. The test that counted six unimplemented checks becomes the invariant it was reaching for: `IMPLEMENTED` must equal the configured check set, so a check added to the config without an implementation lands in `unimplemented`, and a check added to `IMPLEMENTED` without an entry in `IMPLS` cannot fall through to the indexability scanner and report someone else's result under its own name.

Two checks were added to the config to cover the step's list — `https-enforcement` (critical: mixed content breaks the padlock silently while the page still *looks* fine) and `document-head-basics` (`lang`/charset/viewport, one line each, invisible on the developer's machine).

**Both states for all eight**, asserted as a loop over the check ids rather than one assertion per check, so a check added to the config without a fixture fails the test rather than passing unnoticed. `defects-marketing/` fires every one; `clean-marketing/` passes every one; `saas-app/` supplies the skipped-with-reason case.

**Two checks a presence test would have got wrong**, each with its own assertion because getting them right is the value:

- **`alt=""` is a PASS.** `clean-marketing/about.html` carries it deliberately. Flagging it would push authors to write filler alt text, which is worse for a screen reader than the empty string that tells it to skip.
- **A title present on every page but SHARED is still a per-route finding.** Presence is the easy half; one hard-coded title in a layout passes a presence check and is exactly what *per-route* excludes. Both locations are reported.

`clean-marketing` was **completed** rather than left as it was — it now passes all nine, because a negative control that passes one check and quietly fails eight is not a negative control. `defects-marketing/SEEDED.md` is a checked-in manifest, so a fixture that stops firing a check is a visible diff instead of a quietly weaker test.

**One real defect, found by the fixture rather than by review.** `analytics-and-consent-wiring` passed on a tree seeded to fire it, because the fixture's own `SEEDED.md` contains the word *consent* and the scan read prose as an implementation. Prose is now excluded from **both** sides — a README naming an analytics vendor must not count as analytics either.

## Phase 2.3 — the region axis

**It is a tier ESCALATION, not a second `applies_to`**, and that is the design decision: `applies_to` decides *whether* a check applies, a region decides *how severely*. A legal page is not more or less applicable in Germany — it is more or less optional, because TMG 5 and DSGVO Art. 13 make it owed. One check, one implementation, jurisdiction on the consequence.

Demonstrated both ways: `required-legal-pages` is **situational** at `--region unspecified` and **critical** at `--region de`, with the reason carried into the report header so a reader seeing two different tiers for one check knows which axis moved it.

**And the escalation changes the EXIT CODE** — a test asserts the blocking count is exactly one higher under `de`. A tier label nothing acts on is decoration. An unregistered region is a hard `DeadScopeError`, never a silent fallback to `unspecified`: a typo'd `--region` must not quietly downgrade a legally owed page.

## Phase 3.1 — the benchmark fixtures

`tests/fixtures/web-launch-benchmark/` — three sites (`local-business`, `saas-app`, `docs`), a checked-in `GROUND-TRUTH.md` with **19 numbered defect rows plus one decoy**, and 18 tests asserting every row is actually in the tree. Static directories, served locally; nothing is deployed.

The manifest is checked in so neither arm's author can move the target after seeing a score.

**The decoy is asserted from the CONFIG, not from memory**: no configured check id may match `team|photo|portrait|about-us`. If a future check ever asked for team imagery, the decoy would stop being a decoy and the benchmark would silently start scoring it.

**Both load-bearing tests were sabotage-proved.** Rewriting `docs/sitemap.xml` so the canonical host matches → 1 failed. Adding a `team-photo-present` check to the config → 1 failed. Restored → 18 passed. A test never seen red has unknown sensitivity.

Two rows are seeded because a presence check would miss them: an Impressum **without** a Datenschutz page (the common real-world DE shape), and a canonical that is **present and wrong** — copied from the marketing site, so the page that gets indexed is not the page anyone chose.

## Council decision — and it declined half the question

**Question:** the disposition of 3.2 (run the comparator arm) and 3.3 (resolve the pre-registered claim). Question file: `agents/runtime/council/questions/wlr-phase3.md` (gitignored per repo convention; reproduced at the blocker it resolves).

**Members:** `anthropic/claude-sonnet-4-5` + `openai/codex-default`. Quorum 2/2. **Convergent.**

**Options put:** A — park 3.2/3.3 in `later/`. B — run both arms now and resolve the claim here. C — run 3.2 now, leave 3.3's verdict to an independent session.

**Verdict: Option A, and the closure half is OWNER-RESERVED.**

The council may park the two steps for conflict of interest — the session that authored the checks, the fixtures **and** the ground truth may not also run and adjudicate the experiment that grades them. It may **not** treat that parking as *completion*: this roadmap carries **no cut line**, so removing two required phases redefines what completion means.

> **"The council can park for COI. The owner decides whether that satisfies the roadmap."** — seat 1
>
> **"the council may recommend Option A, but only the owner can approve the scope change."** — seat 2, independently

**The routing-assurance precedent decided earlier the same day does NOT carry**, and both seats were asked to check: that roadmap's own text declares stopping at its cut line a valid end state, and this one says nothing of the kind.

**What the council DID settle, and this PR acts on it.** Option C was rejected rather than taken as the compromise it looks like. Executing the arms is only *mechanical* once seven protocol items are frozen — comparator prompt text, context packaging, model snapshot and sampling, retry policy, whether a finding must name the correct page, semantic-match and partial-credit rules, who scores ambiguous output — and **every one can be chosen with knowledge of the expected defects**. Archiving raw output creates auditability; it cannot undo an execution choice made with knowledge of the answer. The seven are recorded as the parked roadmap's blocker resolution condition.

**Three statuses this roadmap now keeps apart**, per the council's framing — conflating them is the failure mode:

| status | value |
|---|---|
| Implementation complete | **yes** — Phase 2 and 3.1 |
| Validation unresolved | **yes** — the claim is `unbacked` |
| Roadmap complete | **no**, and not callable so without the owner |

## What this PR does NOT do

- **It does not close the roadmap.** `b-benchmark-owner-rescope` is a new blocker with `Owner: user`, carrying the two options, a recommendation, and the cost of the non-decision.
- **It does not resolve `claim:web-launch-readiness-finds-more`.** Status stays `unbacked`; the command stays default-off, which is already its shipped state. That is an honest **interim** state and explicitly not completion.
- **It does not run either benchmark arm.** The council's parking decision stands on its own and forbids this session from executing them, whichever way the closure question is answered.

## Local verification

`typecheck` 0 · `eslint` on every changed `.ts` 0 · **47 tests** across the two suites, all passing · `check_estate_count` (later 63 → 64, claimed via `estate_growth_exempt` on the parked roadmap), `lint_roadmap_blockers`, `lint_plan_risk_register`, `check_roadmap_trackable`, `lint_roadmap_complexity`, `lint_roadmap_ci_steps`, `lint_empty_roadmaps`, `check_no_roadmap_refs`, `lint_roadmap_later_disposition`, `check_references`, `check_secret_leak`, `check_source_size_budget`, `lint_budget_ownership` — all exit 0.

Rebased onto `main` after #1633 merged, and pushed by refspec from a clean checkout because `check_rule_projection_integrity` reds worktree-locally (`scanned 0` — the main checkout skip-worktree-masks `.agent-tools.yml` to `tools: []` and skips it, a worktree does not). The changed-TypeScript check that a refspec push no-ops was run by hand in the working tree first.
