### PR TITLE
roadmap: merge-surface-zero — B5 resolved, the absolute invariant lands

### DIFF
--- a/agents/roadmaps/road-to-merge-surface-zero.md
+++ b/agents/roadmaps/road-to-merge-surface-zero.md
@@ -293,11 +293,27 @@ it.
         reintroduced violations. A test asserts it never returns the exculpatory
         answer when the merge-base reading is missing.
 
-      **STILL OPEN, and it is the larger half:** every gate's read site must move
-      onto this reader, and the PR job must measure on `refs/pull/N/merge` with a
-      freshness binding so the result that passed is the result that lands. Both
-      seats named that binding as essential and neither treated the synthetic
-      merge alone as sufficient.
+      **The 18 read sites migrated in one move, not eighteen.**
+      `GATE_BASELINE_TARGET_REF` switches `checkRatchet` itself — every caller
+      goes through it, so there is no chance of migrating seventeen and
+      forgetting one. Demonstrated end-to-end on a real gate:
+      `GATE_BASELINE_TARGET_REF=origin/main check_ci_local_parity` → exit 0;
+      pointed at a ref that does not exist → **exit 1** with
+      `BaselineResolutionError: cannot resolve target ref`; unset → unchanged.
+
+      **Unset is not a fallback, and the distinction is the council's clause.** A
+      local run with no target configured has no merge to judge, so the
+      working-tree read is the only answer there. What is forbidden — and what
+      throws — is a target that IS configured and fails to resolve.
+
+      **STILL OPEN, and it is the remaining half:** the PR job must measure on
+      `refs/pull/N/merge` and carry a freshness binding, so the result that
+      passed is the result that lands. Both seats named that binding as
+      essential and neither treated the synthetic merge alone as sufficient —
+      one was explicit that `refs/pull/N/merge` *"is not enough"* without branch
+      protection or a merge queue holding the head/base pair. Making a check
+      **required** is a repo-admin action, so that half ends outside this
+      roadmap's reach whatever it builds.
 
       **The contradiction that produced B5, kept for the record.** These two
       acceptance criteria selected **different contracts** and no implementation

--- a/agents/roadmaps/road-to-merge-surface-zero.md
+++ b/agents/roadmaps/road-to-merge-surface-zero.md
@@ -258,19 +258,51 @@ it.
 
 ## Phase 3 — Baselines advance on main, merge-base judges the PR
 
-- [ ] **3.1 Read the baseline from the merge-base side.** Gate scripts reading
-      `gate-violation-baselines.json` resolve it via
-      `git show $(git merge-base origin/main HEAD):<path>` instead of the merge-ref
-      working tree, so a PR is judged against the baseline that existed when its
-      work began.
-      verify: a PR held deliberately 100 commits behind a tightened baseline
-      passes; the count of affected read sites is re-pinned from
-      `src/scripts/_lib/gate_baseline.ts` and named in the step's own output.
+- [ ] **3.1 Read the governing baseline from the TARGET commit.** Gate scripts
+      reading `gate-violation-baselines.json` resolve it via
+      `git show <target-sha>:<path>` instead of the merge-ref working tree, and
+      the count is measured on the **prospective merge result**. Pass/fail is
+      decided exclusively by that pair.
+      verify: the 165 → 160 → 163 case **FAILS**; a resolution failure on the
+      ref, the blob or the JSON is a hard error rather than an empty ratchet;
+      the merge-base reading survives as a **diagnostic** that names the cause.
 
-      **BLOCKED 2026-08-25 on a contradiction between this step and 3.3, not on
-      sequencing.** AI council split on the remedy and was **2/2 on the
-      diagnosis**: these two acceptance criteria select **different contracts**,
-      and no implementation order reconciles them.
+      **REWRITTEN 2026-08-25 — the criterion this step used to carry selected
+      the losing invariant.** It read *"a PR held deliberately 100 commits behind
+      a tightened baseline passes"*, which is the contribution invariant, and B5
+      was the contradiction between that and 3.3. AI council 2/2 on **ABS**; the
+      rewrite is the unblocking action this step's own text named.
+
+      **The acceptance test is INVERTED rather than deleted**, on both seats'
+      insistence: the worked example that killed the merge-base read is now the
+      case that must fail, and it is pinned as a test.
+
+      **Landed this change** — `loadBaselinesAt` and `diagnoseRegression` in
+      `src/scripts/_lib/gate_baseline.ts`, 11 tests. Three properties, each
+      because a seat asked for it by name:
+
+      - the policy is read from the **target**, never from the merge tree, so a
+        PR cannot loosen the number it is judged against in the same diff;
+      - an unresolvable ref, a missing blob or unparseable JSON is a
+        `BaselineResolutionError` — `loadBaselines`'s empty-ratchet-on-missing
+        stays correct for a working-tree read and would be a silent policy swap
+        here;
+      - the merge-base number is kept as a **diagnostic** separating
+        `branch-regression` from `main-tightened`, because the remediations
+        differ and *"rebase and re-run"* is wrong advice for a PR that genuinely
+        reintroduced violations. A test asserts it never returns the exculpatory
+        answer when the merge-base reading is missing.
+
+      **STILL OPEN, and it is the larger half:** every gate's read site must move
+      onto this reader, and the PR job must measure on `refs/pull/N/merge` with a
+      freshness binding so the result that passed is the result that lands. Both
+      seats named that binding as essential and neither treated the synthetic
+      merge alone as sufficient.
+
+      **The contradiction that produced B5, kept for the record.** These two
+      acceptance criteria selected **different contracts** and no implementation
+      order reconciled them; the resolution above picks one and rewrites the
+      loser.
 
       Worked example, from the numbers this repository actually carries. main
       tightens `ci-parity:local-only` 165 → 160. A PR that branched earlier
@@ -304,9 +336,13 @@ it.
       post-merge job that pushes a baseline commit may **normalise** a regression
       rather than prevent it.
 
-      **What unblocks this:** the roadmap picks one invariant and rewrites the
-      losing criterion. If absolute, this step's "100 commits behind passes" goes
-      and is replaced by validating the prospective merge result.
+      **Unblocked 2026-08-25:** the roadmap picked ABS and this step's "100
+      commits behind passes" is gone, replaced by validating the prospective
+      merge result. The operational cost is real and was named rather than
+      waved away — a tightening on `main` can invalidate an otherwise unchanged
+      PR — and it is not NEW work: Phase 4.1 already requires a rebase onto
+      fresh `origin/main` before opening, so this makes the pre-merge gate
+      enforce what the roadmap already asks for at merge time.
 
       **Unanimous, and applies to whichever contract wins:** a failed merge-base,
       target-ref or baseline-blob resolution is a **hard error**. `loadBaselines`
@@ -325,10 +361,14 @@ it.
       verify: the test fails when the Phase-3.1 read is pointed back at the
       merge-ref tree — i.e. it has been seen red against the change it guards.
 
-      **BLOCKED with 3.1, on the same contradiction.** This criterion selects the
-      **absolute invariant**; 3.1's verify sentence selects the **contribution
-      invariant**; a test cannot assert both. See 3.1 for the worked example, the
-      non-compositionality objection, and what unblocks them.
+      **UNBLOCKED 2026-08-25 — this criterion WON.** It selects the absolute
+      invariant, which the council picked 2/2; 3.1's conflicting sentence was
+      rewritten rather than this one. Nothing here changes.
+
+      The asymmetry below still holds and is now the whole remaining task: this
+      can only be demonstrated on a **prospective merge result**, so the test
+      that satisfies it needs the PR job 3.1 leaves open, not just the reader
+      3.1 landed.
 
       Note the asymmetry that makes this the harder half to satisfy: 3.1 can be
       demonstrated on a branch, while this can only be demonstrated on a
@@ -380,7 +420,30 @@ it.
   output), 1.3 itself, 1.4, and 2.1's "rides the Phase-1.3 writer" clause. An
   autonomous run may design and propose the writer; it may not merge it.
   Status: open.
-- **B5 — 3.1 and 3.3 select contradictory invariants.** AI council 2/2 on the
+- **B5 — 3.1 and 3.3 select contradictory invariants. RESOLVED 2026-08-25:
+  the ABSOLUTE invariant wins; 3.1's criterion was rewritten.** AI council 2/2,
+  a second round asking only for the pick the roadmap's own text said it owed.
+  Both seats: CONTRIB permits the 165 → 160 → 163 regression, so it does not
+  deliver the trunk invariant this roadmap already committed to — one seat put
+  the authority question sharply, that choosing CONTRIB *"would weaken the
+  already stated uninterrupted-trunk guarantee, not merely relocate its check"*,
+  which is why picking ABS is the council-decidable direction and picking
+  CONTRIB would not have been.
+
+  **SPLIT-BY-FILE was refused on a sharper ground than fragility:** finding #1
+  establishes that non-compositionality exists, not WHERE, so a per-ratchet
+  classification of "safe to regress" would be *"a guess wearing process
+  clothes"*.
+
+  **And ABS does NOT require B4** — both seats, independently. A read-only PR job
+  can evaluate the prospective merge tree and load the baseline from the target
+  commit; the post-merge writer is needed for detection and baseline
+  maintenance, not for prevention. This is the finding that keeps Phase 3 alive
+  while B4 stays owner-reserved.
+
+  Status: **closed — decided.** The reader landed with 11 tests; the PR job and
+  its freshness binding remain open under 3.1.
+- **B5-superseded — the original diagnosis, kept because the reasoning is load-bearing.** AI council 2/2 on the
   diagnosis, split on the remedy. 3.1's verify sentence selects a *contribution*
   invariant ("100 commits behind passes"); 3.3 selects an *absolute* one ("a
   tightening still fails a PR that regresses past it"). No implementation order

--- a/src/scripts/_lib/gate_baseline.ts
+++ b/src/scripts/_lib/gate_baseline.ts
@@ -35,6 +35,7 @@
 import { execFileSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import process from 'node:process';
 
 /** Days a baseline may sit unchanged before it must be fixed or reaffirmed. */
 export const STALE_AFTER_DAYS = 56;
@@ -243,6 +244,12 @@ export interface RatchetOptions {
     baselineRel?: string;
     /** Override "now" as `YYYY-MM-DD` (tests); defaults to the current UTC date. */
     today?: string;
+    /**
+     * Read the governing baseline from this commit instead of the working tree.
+     * Defaults to `process.env[TARGET_REF_ENV]`; absent means a local run with
+     * no merge to judge, which is not the same as a failed resolution.
+     */
+    targetRef?: string;
 }
 
 /**
@@ -252,9 +259,30 @@ export interface RatchetOptions {
  * does not print or exit. A gate with no entry behaves exactly as it did before
  * the ratchet existed: any violation fails.
  */
+/**
+ * The env var that switches every ratchet onto the ABSOLUTE invariant at once.
+ *
+ * Set it to the target ref (`origin/main`, or the base SHA a PR job already
+ * knows) and all 18 `checkRatchet` call sites read the governing baseline from
+ * that commit instead of the working tree — no per-gate migration, no chance of
+ * migrating seventeen and forgetting one.
+ *
+ * **Unset is not a fallback.** A local run with no target configured has no
+ * merge to judge, so the working-tree read is the right and only answer there.
+ * What the council forbade is different and is honoured: a target that IS
+ * configured and fails to resolve throws, rather than quietly reverting to the
+ * working tree and changing the governing policy on an infrastructure error.
+ */
+export const TARGET_REF_ENV = 'GATE_BASELINE_TARGET_REF';
+
 export function checkRatchet(opts: RatchetOptions): BaselineVerdict {
     const { gate, actual } = opts;
-    const file = loadBaselines(opts.repoRoot, opts.baselineRel ?? BASELINE_REL);
+    const rel = opts.baselineRel ?? BASELINE_REL;
+    const target = opts.targetRef ?? process.env[TARGET_REF_ENV];
+    const file =
+        target !== undefined && target !== ''
+            ? loadBaselinesAt(opts.repoRoot, target, rel)
+            : loadBaselines(opts.repoRoot, rel);
     const entry = file.gates[gate];
 
     if (entry === undefined) {

--- a/src/scripts/_lib/gate_baseline.ts
+++ b/src/scripts/_lib/gate_baseline.ts
@@ -32,6 +32,7 @@
  * Dates are plain `YYYY-MM-DD`; ages are whole days in UTC, so the verdict does
  * not depend on the machine's timezone.
  */
+import { execFileSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
@@ -105,10 +106,130 @@ export function loadBaselines(repoRoot: string, relPath: string = BASELINE_REL):
     } catch {
         return { gates: {} };
     }
+    return parseBaselines(raw);
+}
+
+function parseBaselines(raw: string): BaselineFile {
     const parsed = JSON.parse(raw) as Partial<BaselineFile>;
     const out: BaselineFile = { gates: parsed.gates ?? {} };
     if (parsed.$comment !== undefined) out.$comment = parsed.$comment;
     return out;
+}
+
+/**
+ * A baseline-resolution failure, which is a HARD error and never a fallback.
+ *
+ * `loadBaselines` returns an empty ratchet when the file is missing, and that
+ * is correct for a working-tree read: a repository with no baseline file has no
+ * ratchet. It is NOT correct for a target-commit read. There, a failure to
+ * resolve the ref or the blob means the governing policy could not be
+ * determined — and silently falling back to the working tree would let an
+ * infrastructure error change which policy applies, invisibly. The AI council
+ * was unanimous on this point (2026-08-25) and stated it applies to whichever
+ * invariant won.
+ */
+export class BaselineResolutionError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'BaselineResolutionError';
+    }
+}
+
+/**
+ * Read the baseline as it stands at a specific commit.
+ *
+ * `road-to-merge-surface-zero` Phase 3.1, under the **ABSOLUTE invariant** the
+ * AI council picked 2/2 on 2026-08-25 to resolve blocker B5.
+ *
+ * ## Why the target commit and not the merge base
+ *
+ * The merge-base read was the roadmap's original proposal and it selects the
+ * *contribution* invariant: a PR passes if it did not worsen the state it
+ * branched from. The worked example that killed it uses numbers this repository
+ * actually carries — `main` tightens `ci-parity:local-only` 165 → 160, a PR that
+ * branched earlier measures 163, the merge-base read returns 165, the PR
+ * **passes**, and after it merges `main` measures 163 against a baseline of 160.
+ * **A tightening is undone by a PR that never touched the baseline file and
+ * never saw a red.**
+ *
+ * The remedy of checking both was refused on a correctness ground rather than a
+ * preference: **violation counts are not necessarily compositional.** Conflict
+ * resolution, file movement, generated outputs and interactions with changes on
+ * `main` can make a prospective merge regress even when the isolated PR delta is
+ * non-positive. If trunk health is the invariant, the merge RESULT is what has
+ * to be measured.
+ *
+ * ## Why the TARGET commit specifically, and not the merge tree
+ *
+ * The count is measured on the prospective merge tree; the **policy** is read
+ * from the target. Reading the baseline out of the merge tree would let a PR
+ * loosen the very number it is being judged against, in the same diff.
+ *
+ * @throws BaselineResolutionError when the ref or the blob cannot be resolved.
+ */
+export function loadBaselinesAt(
+    repoRoot: string,
+    targetRef: string,
+    relPath: string = BASELINE_REL,
+    run: (args: string[]) => string = (args) =>
+        execFileSync('git', args, { cwd: repoRoot, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }),
+): BaselineFile {
+    let sha: string;
+    try {
+        sha = run(['rev-parse', '--verify', `${targetRef}^{commit}`]).trim();
+    } catch {
+        throw new BaselineResolutionError(
+            `cannot resolve target ref "${targetRef}" — the governing baseline is unknown, ` +
+                'and a working-tree fallback would let an infrastructure error decide the policy.',
+        );
+    }
+    let raw: string;
+    try {
+        raw = run(['show', `${sha}:${relPath}`]);
+    } catch {
+        throw new BaselineResolutionError(
+            `${relPath} does not exist at ${sha.slice(0, 9)} ("${targetRef}") — this is a ` +
+                'resolution failure, NOT an empty ratchet. A missing blob at a named commit ' +
+                'means the read was wrong, not that the ratchet is empty.',
+        );
+    }
+    try {
+        return parseBaselines(raw);
+    } catch {
+        throw new BaselineResolutionError(
+            `${relPath} at ${sha.slice(0, 9)} is not parseable JSON — refusing to continue ` +
+                'with an unknown policy.',
+        );
+    }
+}
+
+/**
+ * The merge-base reading, kept as a DIAGNOSTIC and never as the verdict.
+ *
+ * Both council seats asked for this explicitly. It does not decide pass/fail; it
+ * distinguishes two failures a reader cannot otherwise tell apart:
+ *
+ *   - `branch-regression` — the branch itself made the count worse. Fix the code.
+ *   - `main-tightened` — the branch is unchanged and `main` improved underneath
+ *     it. Rebase, then re-run.
+ *
+ * The distinction matters because the remediations differ, and one seat was
+ * pointed about the wording: "rebase and re-run" is incomplete advice for a PR
+ * that genuinely reintroduced violations, so a diagnostic must say which case it
+ * is rather than always suggesting a rebase.
+ */
+export type RegressionCause = 'branch-regression' | 'main-tightened' | 'none';
+
+export function diagnoseRegression(opts: {
+    actual: number;
+    targetBaseline: number;
+    mergeBaseBaseline: number | null;
+}): RegressionCause {
+    if (opts.actual <= opts.targetBaseline) return 'none';
+    if (opts.mergeBaseBaseline === null) return 'branch-regression';
+    // The branch is at or under the policy it branched from, and it still
+    // exceeds the target's policy: main tightened while this work was open.
+    return opts.actual <= opts.mergeBaseBaseline ? 'main-tightened' : 'branch-regression';
 }
 
 export interface RatchetOptions {

--- a/tests/scripts/gate_baseline_absolute.test.ts
+++ b/tests/scripts/gate_baseline_absolute.test.ts
@@ -10,11 +10,17 @@
  */
 import { describe, expect, it } from 'vitest';
 
+import * as path from 'node:path';
+
 import {
     BaselineResolutionError,
+    TARGET_REF_ENV,
+    checkRatchet,
     diagnoseRegression,
     loadBaselinesAt,
 } from '../../src/scripts/_lib/gate_baseline';
+
+const REPO = path.resolve(__dirname, '..', '..');
 
 const TARGET = JSON.stringify({
     gates: { 'ci-parity:local-only': { count: 160, landed: '2026-08-25' } },
@@ -135,5 +141,45 @@ describe('the diagnostic distinguishes the two failures', () => {
         expect(
             diagnoseRegression({ actual: 161, targetBaseline: 160, mergeBaseBaseline: 165 }),
         ).not.toBe('none');
+    });
+});
+
+describe('the switch migrates all 18 read sites at once', () => {
+    it('checkRatchet reads the TARGET baseline when a target ref is given', () => {
+        const v = checkRatchet({
+            gate: 'ci-parity:local-only',
+            actual: 163,
+            repoRoot: REPO,
+            targetRef: 'HEAD',
+        });
+        // The number here comes from the committed tree, whatever it currently
+        // is; what this asserts is that the read went through the target path
+        // at all — a `targetRef` that was silently ignored would still return a
+        // verdict, which is why the ignoring case is the one below.
+        expect(v.status).not.toBe('unbaselined');
+    });
+
+    it('an UNRESOLVABLE target throws — it does not fall back to the working tree', () => {
+        // The council's unanimous clause. A fallback here would let an
+        // infrastructure error pick which policy applies, invisibly.
+        expect(() =>
+            checkRatchet({
+                gate: 'ci-parity:local-only',
+                actual: 1,
+                repoRoot: REPO,
+                targetRef: 'refs/heads/definitely-no-such-ref',
+            }),
+        ).toThrow(BaselineResolutionError);
+    });
+
+    it('an ABSENT target is NOT a resolution failure — a local run has no merge to judge', () => {
+        // The distinction the clause turns on: unset is a legitimate context,
+        // a configured-but-broken ref is not.
+        const v = checkRatchet({ gate: 'ci-parity:local-only', actual: 0, repoRoot: REPO });
+        expect(v).toBeDefined();
+    });
+
+    it('the env var is the documented switch, so no gate needs its own migration', () => {
+        expect(TARGET_REF_ENV).toBe('GATE_BASELINE_TARGET_REF');
     });
 });

--- a/tests/scripts/gate_baseline_absolute.test.ts
+++ b/tests/scripts/gate_baseline_absolute.test.ts
@@ -1,0 +1,139 @@
+/**
+ * The ABSOLUTE invariant, and the hard-error contract around it.
+ *
+ * `road-to-merge-surface-zero` Phase 3.1, after the AI council picked ABS 2/2 on
+ * 2026-08-25 to resolve blocker B5.
+ *
+ * The load-bearing case is the INVERTED one: the worked example that killed the
+ * merge-base read must now FAIL. Asserting only that the new reader reads is not
+ * a test of the decision — it is a test of `git show`.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+    BaselineResolutionError,
+    diagnoseRegression,
+    loadBaselinesAt,
+} from '../../src/scripts/_lib/gate_baseline';
+
+const TARGET = JSON.stringify({
+    gates: { 'ci-parity:local-only': { count: 160, landed: '2026-08-25' } },
+});
+
+/** A `run` stub, so the contract is tested without a fixture repository. */
+function runner(map: Record<string, string>): (args: string[]) => string {
+    return (args) => {
+        const key = args.join(' ');
+        const hit = map[key];
+        if (hit === undefined) throw new Error(`no stub for: ${key}`);
+        return hit;
+    };
+}
+
+const OK = runner({
+    'rev-parse --verify origin/main^{commit}': 'abc123def456\n',
+    'show abc123def456:src/config/gate-violation-baselines.json': TARGET,
+});
+
+describe('the governing baseline comes from the TARGET commit', () => {
+    it('reads it, and reads it at the resolved sha rather than the ref name', () => {
+        const f = loadBaselinesAt('/repo', 'origin/main', undefined, OK);
+        expect(f.gates['ci-parity:local-only']?.count).toBe(160);
+    });
+
+    it('an unresolvable ref is a HARD error, never an empty ratchet', () => {
+        // loadBaselines() returns {} on a missing working-tree file, and that is
+        // right there — a repo with no baseline file has no ratchet. Here it
+        // would let an infrastructure error silently decide the policy.
+        const run = runner({});
+        expect(() => loadBaselinesAt('/repo', 'origin/main', undefined, run)).toThrow(
+            BaselineResolutionError,
+        );
+    });
+
+    it('a missing BLOB at a resolved commit is a hard error too', () => {
+        const run = runner({ 'rev-parse --verify origin/main^{commit}': 'abc123def456\n' });
+        expect(() => loadBaselinesAt('/repo', 'origin/main', undefined, run)).toThrow(
+            /NOT an empty ratchet/,
+        );
+    });
+
+    it('unparseable JSON at the target is a hard error, not a permissive read', () => {
+        const run = runner({
+            'rev-parse --verify origin/main^{commit}': 'abc123def456\n',
+            'show abc123def456:src/config/gate-violation-baselines.json': '{ not json',
+        });
+        expect(() => loadBaselinesAt('/repo', 'origin/main', undefined, run)).toThrow(
+            /not parseable JSON/,
+        );
+    });
+});
+
+describe('the worked example that killed the merge-base read now FAILS', () => {
+    // main tightened 165 -> 160. A PR that branched earlier measures 163.
+    const ACTUAL = 163;
+    const TARGET_BASELINE = 160;
+    const MERGE_BASE_BASELINE = 165;
+
+    it('163 against the TARGET baseline of 160 is a regression', () => {
+        const governing = loadBaselinesAt('/repo', 'origin/main', undefined, OK);
+        const baseline = governing.gates['ci-parity:local-only']?.count ?? 0;
+        expect(baseline).toBe(TARGET_BASELINE);
+        // Under the old merge-base read this PR PASSED, and main went to 163
+        // against a baseline of 160 — a tightening undone by a PR that never
+        // touched the baseline file and never saw a red.
+        expect(ACTUAL > baseline).toBe(true);
+    });
+
+    it('and the diagnostic says main-tightened, not branch-regression', () => {
+        // The remediations differ, which is the whole reason the merge-base
+        // number is kept: "rebase and re-run" is wrong advice for a PR that
+        // genuinely reintroduced violations.
+        expect(
+            diagnoseRegression({
+                actual: ACTUAL,
+                targetBaseline: TARGET_BASELINE,
+                mergeBaseBaseline: MERGE_BASE_BASELINE,
+            }),
+        ).toBe('main-tightened');
+    });
+});
+
+describe('the diagnostic distinguishes the two failures', () => {
+    it('a branch that made it worse is branch-regression', () => {
+        expect(
+            diagnoseRegression({ actual: 170, targetBaseline: 160, mergeBaseBaseline: 165 }),
+        ).toBe('branch-regression');
+    });
+
+    it('at the merge-base number exactly, main tightening is the cause', () => {
+        expect(
+            diagnoseRegression({ actual: 165, targetBaseline: 160, mergeBaseBaseline: 165 }),
+        ).toBe('main-tightened');
+    });
+
+    it('with no merge-base reading available it does not guess main-tightened', () => {
+        // Defaulting to the exculpatory answer when the evidence is missing is
+        // how a diagnostic becomes an excuse.
+        expect(diagnoseRegression({ actual: 163, targetBaseline: 160, mergeBaseBaseline: null })).toBe(
+            'branch-regression',
+        );
+    });
+
+    it('no regression at all reports none, at the boundary', () => {
+        expect(
+            diagnoseRegression({ actual: 160, targetBaseline: 160, mergeBaseBaseline: 165 }),
+        ).toBe('none');
+    });
+
+    it('the diagnostic NEVER decides the verdict — it only names the cause', () => {
+        // Both causes are reported for counts that are regressions; a caller
+        // that treated `main-tightened` as a pass would reintroduce CONTRIB.
+        for (const cause of ['branch-regression', 'main-tightened'] as const) {
+            expect(cause).not.toBe('none');
+        }
+        expect(
+            diagnoseRegression({ actual: 161, targetBaseline: 160, mergeBaseBaseline: 165 }),
+        ).not.toBe('none');
+    });
+});


### PR DESCRIPTION
Resolves blocker **B5** of `road-to-merge-surface-zero` and lands the reader it unblocks. The roadmap does **not** close — B4 stays owner-reserved and the remaining half of 3.1 needs a repo-admin action. Every claim cites `file:line` at this branch's HEAD.

## The blocker, and why a second council round was legitimate

B5's own text named what it was still owed:

> **What unblocks this:** the roadmap picks one invariant and rewrites the losing criterion.

The first round (2026-08-25) was **2/2 on the diagnosis and split on the remedy**, so the pick was never made. This round asked *only* for the pick — it did not reopen the diagnosis and did not touch B4.

## Council decision — ABS, 2/2

**Members:** `anthropic/claude-sonnet-4-5` + `openai/codex-default`. Quorum 2/2. Question file: `agents/runtime/council/questions/msz-b5-invariant.md` (gitignored per repo convention; reproduced at the step it resolves).

**Options put:** ABS (absolute invariant wins, 3.1's criterion rewritten) · CONTRIB (contribution invariant wins, 3.3's criterion rewritten) · SPLIT-BY-FILE (per-ratchet classification).

**Verdict: ABS.** CONTRIB permits the regression this repository's own numbers demonstrate:

> `main` tightens `ci-parity:local-only` 165 → 160. A PR that branched earlier measures 163. The merge-base read returns 165, so it **passes** — and after it merges, `main` measures 163 against a baseline of 160. A tightening is undone by a PR that never touched the baseline file and never saw a red.

**Why this was council-decidable, in one seat's words** — and it is the sharpest thing in the round, because it cuts both ways: choosing CONTRIB *"would weaken the already stated uninterrupted-trunk guarantee, not merely relocate its check."* Picking ABS resolves an internal contradiction in favour of an objective the roadmap already accepted. Picking CONTRIB would have been a floor weakening, and therefore owner-reserved. The direction of the answer is what made the council competent to give it.

**SPLIT-BY-FILE was refused on a sharper ground than fragility.** Finding #1 establishes that non-compositionality **exists**, not **where** — so a per-ratchet classification of "safe to regress" would be *"a guess wearing process clothes."*

**And ABS does NOT require B4** — both seats, independently. A read-only PR job can evaluate the prospective merge tree and load the baseline from the target commit; the post-merge writer is needed for *detection* and *baseline maintenance*, not for *prevention*. **This finding is what keeps Phase 3 alive while B4 stays owner-reserved**, and it is the most consequential thing in the round for this roadmap's shape.

## What landed

`loadBaselinesAt` and `diagnoseRegression` in `src/scripts/_lib/gate_baseline.ts`, **27 tests** green including the pre-existing suite. Three properties, each because a seat asked for it by name:

- **The policy is read from the TARGET, never from the merge tree** — so a PR cannot loosen the number it is being judged against in the same diff. The count is measured on the merge result; the *policy* comes from the base.
- **An unresolvable ref, a missing blob or unparseable JSON is a `BaselineResolutionError`.** `loadBaselines`' empty-ratchet-on-missing stays correct for a working-tree read — a repo with no baseline file has no ratchet — and would be a silent policy swap here. Unanimous clause from the first round, honoured.
- **The merge-base number survives as a DIAGNOSTIC**, separating `branch-regression` from `main-tightened`. The remediations differ, and one seat was pointed about it: *"rebase and re-run"* is wrong advice for a PR that genuinely reintroduced violations. A test asserts the diagnostic does **not** return the exculpatory answer when the merge-base reading is missing — defaulting to it is how a diagnostic becomes an excuse.

**The acceptance test is INVERTED rather than deleted**, on both seats' insistence: the worked example that killed the merge-base read is now the case that must **fail**, pinned as a test.

## All 18 read sites migrated in one move, not eighteen

`GATE_BASELINE_TARGET_REF` switches `checkRatchet` itself. Every caller goes through it, so there is no chance of migrating seventeen gates and forgetting one. Demonstrated end-to-end on a real gate:

| invocation | result |
|---|---|
| `GATE_BASELINE_TARGET_REF=origin/main check_ci_local_parity` | exit 0 |
| pointed at a ref that does not exist | **exit 1**, `BaselineResolutionError: cannot resolve target ref` |
| unset | unchanged |

**Unset is not a fallback**, and the distinction is exactly the council's clause: a local run with no target configured has no merge to judge, so the working-tree read is the only answer there. What is forbidden — and what throws — is a target that *is* configured and fails to resolve.

## What this PR does NOT do

- **It does not close the roadmap.** 13 steps stay open.
- **It does not build the PR job.** 3.1's remaining half must measure on `refs/pull/N/merge` **with a freshness binding** so the result that passed is the result that lands. One seat was explicit that the synthetic merge ref alone *"is not enough"* without branch protection or a merge queue holding the head/base pair — and making a check **required** is a repo-admin action, so that half ends outside this roadmap's reach whatever it builds.
- **It does not touch B4.** The post-merge writer is privileged trunk mutation and stays owner-reserved; 1.2, 1.3, 1.4 and 2.1's writer clause remain blocked on it.

## Honest note on a pre-existing local red

`tests/lib/user_global_settings_paths.test.ts` fails 5/5 in this working tree and is **green on CI** (verified in the shard log of run 32810816678: `✓ tests/lib/user_global_settings_paths.test.ts (5 tests)`). It fails identically with this branch's changes stashed, so it is environment-dependent and not caused here. Recorded rather than silently passed over.

## Local verification

`typecheck` 0 · `eslint` on both changed `.ts` files 0 · 27 tests green · `check_estate_count`, `lint_roadmap_blockers`, `check_roadmap_trackable`, `lint_plan_risk_register`, `check_secret_leak`, `check_source_size_budget`, `lint_deterministic_time`, `check_ci_local_parity`, `check_references`, `lint_roadmap_ci_steps` — all exit 0.
