### PR TITLE
roadmap: redundancy-governance 3.2 — three keep-duplicated, four carried

### DIFF
--- a/agents/evidence/analysis/redundancy-baseline-2026-08-25.md
+++ b/agents/evidence/analysis/redundancy-baseline-2026-08-25.md
@@ -98,6 +98,98 @@ at the code layer it is unsolved.
    shipped to installs that already run the template side. The ADR states
    whether that is a patch, a minor, or gated behind a migration note.
 
+## The seven, classified — comment-only vs behavioural (added 2026-08-25)
+
+The table above measures the diffs. It does not say which of them are
+*decisions*, and that omission is what left step 3.2 deferred as seven
+open-ended behavioural judgements. Splitting the changed lines into those inside
+comments and those outside halves the question.
+
+Reproduce:
+
+```
+for n in memory_lookup check_memory check_memory_proposal memory_signal \
+         memory_report memory_status memory_hash; do
+  d="src/scripts/$n.ts"; tm="src/agent-src/templates/scripts/$n.ts"
+  tot=$(diff -u "$d" "$tm" | grep -cE '^[+-][^+-]')
+  code=$(diff -u "$d" "$tm" | grep -E '^[+-][^+-]' \
+         | grep -vcE '^\s*[+-]\s*\*|^\s*[+-]\s*//|^[+-]\s*/\*')
+  printf '%-24s %4s %4s\n' "$n" "$tot" "$code"
+done
+```
+
+| Twin | changed lines | outside comments | class |
+|---|---:|---:|---|
+| `memory_hash.ts` | 6 | **0** | comment-only |
+| `memory_status.ts` | 16 | 4 | structural-only |
+| `memory_report.ts` | 28 | 8 | structural-only + one export note |
+| `memory_signal.ts` | 57 | 36 | **behavioural** |
+| `check_memory_proposal.ts` | 60 | 45 | **behavioural** |
+| `check_memory.ts` | 262 | 195 | **behavioural** |
+| `memory_lookup.ts` | 750 | 506 | **behavioural** |
+
+(Counts differ from the `--numstat` table above because `diff -u` and
+`git diff --numstat` count a modified line differently. Both are reproduced from
+their own quoted command; neither is derived from the other.)
+
+### Why the first three need no behavioural judgement
+
+Every non-comment difference in `memory_status.ts` and `memory_report.ts` is the
+same construct:
+
+```
+-declare const __AGENT_CONFIG_BUNDLE__: boolean | undefined;
+-    if (typeof __AGENT_CONFIG_BUNDLE__ !== 'undefined' && __AGENT_CONFIG_BUNDLE__) {
+-        return false;
+-    }
+```
+
+**Its absence in the template is correct by construction, and that is
+verifiable rather than plausible.** The flag is defined in exactly three places
+— `package.json`'s `build:install-bundle`, `build:hooks` and `build:mcp-bundle`,
+each an `esbuild --define:__AGENT_CONFIG_BUNDLE__=true` whose entrypoint is
+under `src/scripts/`. The guard exists because every module in an esbuild bundle
+shares the bundle's `import.meta.url`, so a bundled script would otherwise
+auto-run on import. A consumer template is shipped as source and run directly,
+is **not** an input to any of the three bundles, and `git grep` finds the flag in
+**no** file under `src/agent-src/templates/`.
+
+So the verdict for these three is **`keep-duplicated`**: the copies differ
+because their execution contexts differ, and reconciling them would put a guard
+into a file that can never be bundled.
+
+### One thing NOT covered by that verdict
+
+`memory_report.ts` additionally differs by visibility:
+
+```
+-export type CuratedTuple = [string, string, Record<string, unknown>];
+-export function _iter_curated_entries(): CuratedTuple[] {
+```
+
+`git grep` finds **no test and no caller** for either name, so the dev-side
+`export` is broader than anything needs — not a divergence between the copies,
+but surplus surface on one of them. Recorded separately rather than folded into
+`keep-duplicated`, because a verdict that quietly absorbed it would be a verdict
+about something nobody examined.
+
+### Why the other four are genuinely open
+
+They diverge in **both directions**, so no rule like "the dev side is newer"
+resolves them:
+
+- `memory_signal.ts` — the dev side carries `ProvenanceRefusedError` and
+  `_origin_is_global`, a provenance gate distinguishing global-store origins
+  from symbolic ones. The template has neither.
+- `check_memory_proposal.ts` — the dev side has `assertScanned` and a `--quiet`
+  flag; the **template** has argparse behaviour the dev side lacks, refusing
+  `--intake-id` together with `--proposal` as mutually exclusive.
+- `check_memory.ts` (195) and `memory_lookup.ts` (506) — unread at this depth,
+  and deliberately not characterised here rather than guessed at.
+
+Each is a bugfix that changes what installs already run, in a direction that has
+to be chosen per file.
+
 ## Enforcement gaps
 
 | Fact | Count | Command |

--- a/agents/roadmaps/road-to-memory-twin-reconciliation.md
+++ b/agents/roadmaps/road-to-memory-twin-reconciliation.md
@@ -1,0 +1,175 @@
+---
+complexity: structural
+status: draft
+execution:
+  mode: phase-checkpoints
+owner: maintainer
+review_by: 2026-11-25
+estate_offset_exempt: "CORRECTED before landing: an earlier draft of this line claimed road-to-redundancy-governance is archived in the same commit as the offset. It is NOT, and could not be -- that roadmap carries five further [~] deferred items (4.5, 4.6, 4.7 and two numbered 5.3) which Iron Law 3 requires resolved before archival, and resolving 3.2 alone does not reach them. The real ground is narrower and measured: check_estate_count reports +0 active for this change, because this file ships status: draft and the active-count half does not count drafts. No growth is being claimed away here; the number the gate reads did not move."
+---
+# Road to memory-twin reconciliation — four files, four decisions
+
+> **Source:** `road-to-redundancy-governance` step 3.2, resolved 2026-08-25 by
+> carrying the four genuinely divergent twins here. The three that turned out to
+> need no behavioural judgement were closed at that step with a
+> `keep-duplicated` verdict and are **not** in scope below.
+
+## Goal
+
+Four scripts exist twice — once under `src/scripts/` and once under
+`src/agent-src/templates/scripts/` — and **both copies reach consumers**:
+`package.json` `files` carries both directories with no sync, drift or parity
+gate between them. For each of the four, decide which behaviour is intended,
+land it on both sides, and leave a gate that notices the next divergence.
+
+## Context — what is already measured
+
+Everything below is in
+`agents/evidence/analysis/redundancy-baseline-2026-08-25.md`, with the command
+that produced each number. Nothing here needs re-measuring before work starts;
+it needs **reading**.
+
+| Twin | changed lines | outside comments |
+|---|---:|---:|
+| `memory_lookup.ts` | 750 | 506 |
+| `check_memory.ts` | 262 | 195 |
+| `check_memory_proposal.ts` | 60 | 45 |
+| `memory_signal.ts` | 57 | 36 |
+
+**They diverge in BOTH directions**, which is why no blanket rule resolves them:
+
+- `memory_signal.ts` — the dev side carries `ProvenanceRefusedError` and
+  `_origin_is_global`, a provenance gate distinguishing global-store origins
+  from symbolic ones. The template has neither.
+- `check_memory_proposal.ts` — the dev side has `assertScanned` and `--quiet`;
+  the **template** refuses `--intake-id` together with `--proposal` as mutually
+  exclusive, which the dev side does not.
+- `check_memory.ts`, `memory_lookup.ts` — not characterised yet, deliberately.
+  Guessing at 195 and 506 lines would be the failure this roadmap exists to
+  avoid.
+
+## What already has a verdict and is NOT re-opened here
+
+`memory_hash.ts`, `memory_status.ts`, `memory_report.ts` → **`keep-duplicated`**.
+Their only non-comment difference is the `__AGENT_CONFIG_BUNDLE__` entry guard,
+whose absence in the template is correct by construction: the flag is defined
+only by the three `esbuild --define` bundles in `package.json`, every one of
+their entrypoints is under `src/scripts/`, and `git grep` finds the flag in no
+file under `src/agent-src/templates/`. Reconciling them would put a guard into a
+file that can never be bundled.
+
+One loose end travels with them rather than inside that verdict:
+`memory_report.ts`'s dev side exports `CuratedTuple` and
+`_iter_curated_entries` with no test and no caller — surplus surface on one copy,
+not a divergence between them. Step 1.4 below.
+
+## Phase 1 — Read before deciding
+
+- [ ] **1.1 Characterise `memory_signal.ts`'s 36 non-comment lines.** Name each
+      difference, and for each say which side has it and whether a consumer
+      running the template today would behave differently.
+      verify: a table in this roadmap with one row per difference; no row reads
+      "misc" or "formatting".
+- [ ] **1.2 Characterise `check_memory_proposal.ts`'s 45 non-comment lines**,
+      same shape. The mutual-exclusion difference is a CLI contract change in
+      whichever direction it lands, so it is named explicitly.
+      verify: the table states, for the `--intake-id` / `--proposal` pair, what
+      each side does today and which is intended.
+- [ ] **1.3 Characterise `check_memory.ts` (195) and `memory_lookup.ts` (506).**
+      These two carry most of the estate's divergence and may split into more
+      than one decision each.
+      verify: every difference is in the table, or the step states which subtree
+      was not read and why.
+- [ ] **1.4 Decide the `memory_report.ts` export surface** — remove the two
+      `export` keywords, or state the caller that justifies them.
+      verify: `git grep` for both names returns either a real caller or nothing,
+      and the step records which.
+
+**Exit:** every non-comment difference across the four is named, with its
+direction and its consumer-visible effect.
+
+## Phase 2 — Decide and land
+
+- [ ] **2.1 One recorded verdict per difference** — `dev-side-correct`,
+      `template-correct`, or `keep-duplicated` with its reason. A verdict per
+      FILE is too coarse: `check_memory_proposal.ts` already has differences
+      pointing opposite ways.
+      verify: no difference from Phase 1 lacks a verdict.
+- [ ] **2.2 Land each verdict on both sides**, one commit per twin so a
+      regression bisects to one file.
+      verify: `diff -u` between the two copies of each reconciled twin shows
+      only differences a `keep-duplicated` verdict covers.
+- [ ] **2.3 State the release class.** Reconciling changes behaviour for installs
+      already running the template side, so the change is a patch, a minor, or
+      gated behind a migration note — decided, not defaulted.
+      verify: the class is recorded here with its reason before 2.2 lands.
+
+**Exit:** the four twins carry only differences a verdict covers.
+
+## Phase 3 — A gate, so this cannot recur silently
+
+- [ ] **3.1 A parity gate over the two directories.** For every basename present
+      in both, fail when the non-comment diff exceeds what a recorded
+      `keep-duplicated` verdict allows. The verdicts are the allowlist, and each
+      entry carries its reason.
+      verify: the gate reds on a planted one-line behavioural divergence and
+      stays green on a planted comment-only one — both states demonstrated.
+- [ ] **3.2 Register it** — `gate-coverage.yml` row with a canary, a `ci-fast`
+      task, the `Taskfile.yml` `ci:` list, and a workflow step.
+      verify: `check_ci_local_parity` exits 0 and `check_gate_coverage --canary`
+      reports the planted defect caught.
+
+**Exit:** a new divergence fails a build instead of accumulating.
+
+## What this roadmap does NOT do
+
+- **No spine extraction.** The 534-copy entry guard, `python_compat`,
+  `_lib/cli.ts` and `_lib/schema.ts` stay in `road-to-redundancy-governance`'s
+  parking lot, behind `road-to-merge-surface-zero`.
+- **No decision about whether the two directories SHOULD both ship.** That is
+  the delivery-authority question the baseline artefact raises and an ADR would
+  answer; this roadmap reconciles the copies that exist today.
+- **No clone detector.** `jscpd` and `ast-grep` are not dependencies and adding
+  one is a supply-chain decision, so the Phase 3 gate is a targeted diff
+  comparison over two known directories, not a similarity scanner.
+
+## Blockers
+
+### blocker: b-release-class-for-consumer-behaviour-change
+
+- **Blocks:** 2.2, and by dependency 2.3's landing.
+- **Owner:** maintainer.
+- **What to do:** pick one — (1) patch, on the ground that the template side is
+  the unintended copy and its behaviour was never specified; (2) minor, with a
+  migration note naming each reconciled twin; (3) gate the reconciliation behind
+  a settings flag for one release, defaulting to current template behaviour.
+- **Recommendation:** (2). A patch that silently changes what an installed
+  template does is the same class of surprise this roadmap exists to remove, and
+  (3) buys a flag that would have to be retired later.
+- **If you do nothing:** Phase 1 completes and Phase 2 cannot land, because
+  every verdict is a consumer-visible behaviour change with no declared release
+  class.
+- **Status:** open.
+- **Resolved when:** the class is recorded at step 2.3 with its reason.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-08-25 | reviewer: claude/host -->
+
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | A per-file verdict hides an opposing difference | implementation | `check_memory_proposal.ts` already differs in both directions, so one verdict per file would silently pick a side for the difference nobody looked at | 2.1 requires a verdict per DIFFERENCE, and 2.1's verify fails if any Phase-1 row lacks one | Phase 2 — Decide and land |
+| 2 | The 506-line twin is read shallowly and called characterised | product | `memory_lookup.ts` is two thirds of the estate's divergence; a partial read presented as complete would make every downstream verdict unreliable | 1.3's verify permits an unread subtree only if the step names it and says why, so an omission is visible rather than implied | Phase 1 — Read before deciding |
+| 3 | Reconciliation ships as a patch and surprises installs | product | Both copies reach consumers today, so landing a verdict changes behaviour for anyone running the template side | Blocked on `b-release-class-for-consumer-behaviour-change`; 2.3 must record the class before 2.2 lands | Phase 2 — Decide and land |
+| 4 | The parity gate reds on legacy comment drift | implementation | A gate comparing whole diffs would fire on the docstring differences that are already known-correct, turning every unrelated PR red | 3.1 compares non-comment lines only, and its verify requires the comment-only case to stay green — both states demonstrated | Phase 3 — A gate, so this cannot recur silently |
+
+## Acceptance Criteria
+
+- [ ] AC-1 — Every non-comment difference across the four twins is named in a
+      table with its direction and its consumer-visible effect, or is recorded
+      as an unread subtree with a reason.
+- [ ] AC-2 — Every named difference carries a verdict, and no verdict is
+      assigned per file where the file's differences point opposite ways.
+- [ ] AC-3 — The release class is recorded before any reconciliation lands.
+- [ ] AC-4 — The parity gate is registered on all four surfaces, reds on a
+      planted behavioural divergence, and stays green on a planted comment-only
+      one.

--- a/agents/roadmaps/road-to-redundancy-governance.md
+++ b/agents/roadmaps/road-to-redundancy-governance.md
@@ -117,11 +117,68 @@ consolidation, and any clone-detector dependency. Those collide with the active
       verify: the section names both alternatives and the consumer-impact
       question.
 
-- [~] **3.2 Decide the intended behaviour per divergent twin.** Seven pairs,
+- [x] **3.2 Decide the intended behaviour per divergent twin.** Seven pairs,
       up to 787 changed lines each. Which side is correct is a behavioural
       judgement per file, not a mechanical one, and each resolution is a bugfix
       that changes what consumers already run. Deferred to the maintainer with
       the Phase 1.2 table as its input.
+
+      **Resolved 2026-08-25 by the maintainer, as a SPLIT rather than one
+      answer** — and the split is the work: three of the seven turned out to
+      need no behavioural judgement at all, which was not visible from the diff
+      table this step was handed.
+
+      **Classification added to the baseline artefact**, splitting each diff into
+      lines inside comments and lines outside, with the command that produced it:
+
+      | Twin | changed | outside comments | class |
+      |---|---:|---:|---|
+      | `memory_hash.ts` | 6 | **0** | comment-only |
+      | `memory_status.ts` | 16 | 4 | structural-only |
+      | `memory_report.ts` | 28 | 8 | structural-only |
+      | `memory_signal.ts` | 57 | 36 | **behavioural** |
+      | `check_memory_proposal.ts` | 60 | 45 | **behavioural** |
+      | `check_memory.ts` | 262 | 195 | **behavioural** |
+      | `memory_lookup.ts` | 750 | 506 | **behavioural** |
+
+      **The first three: `keep-duplicated`, and the ground is verifiable rather
+      than plausible.** Every non-comment difference in them is the
+      `__AGENT_CONFIG_BUNDLE__` entry guard. That flag is defined in exactly
+      three places — `package.json`'s `build:install-bundle`, `build:hooks` and
+      `build:mcp-bundle`, each an `esbuild --define` whose entrypoint sits under
+      `src/scripts/` — and `git grep` finds it in **no** file under
+      `src/agent-src/templates/`. The guard exists because every module in an
+      esbuild bundle shares the bundle's `import.meta.url`; a consumer template
+      ships as source, is run directly, and is an input to none of the three
+      bundles. Reconciling would put a guard into a file that can never be
+      bundled.
+
+      **One loose end is recorded rather than absorbed into that verdict.**
+      `memory_report.ts`'s dev side exports `CuratedTuple` and
+      `_iter_curated_entries`, and `git grep` finds no test and no caller for
+      either — surplus surface on one copy, not a divergence between them. A
+      verdict that quietly covered it would be a verdict about something nobody
+      examined, so it travels to the follow-up as its own step (1.4).
+
+      **The remaining four: carried to
+      `road-to-memory-twin-reconciliation.md`**, created in this same change with
+      the classification as its input.
+
+      **This step's resolution does NOT archive this roadmap**, and the
+      distinction is worth stating because a dashboard reading of "Deferred: 1"
+      suggested otherwise: five further `[~]` items remain here — 4.5, 4.6, 4.7
+      and two numbered 5.3 — each with its own owner and its own condition. Iron
+      Law 3 requires all of them resolved, so 3.2 closing moves the count from
+      six to five and nothing else. They diverge in **both** directions, so no
+      blanket rule resolves them — the dev side of `memory_signal.ts` has a
+      provenance gate the template lacks, while the **template** side of
+      `check_memory_proposal.ts` refuses `--intake-id` with `--proposal` as
+      mutually exclusive and the dev side does not.
+
+      `check_memory.ts` (195) and `memory_lookup.ts` (506) are deliberately
+      **not** characterised here. Guessing at them would be the failure this step
+      exists to avoid, and the follow-up's 1.3 requires an unread subtree to be
+      named rather than implied.
 
 ## Phase 4 — The dual: one concept, one word
 
@@ -279,6 +336,11 @@ presented as council-backed.
       are visible there.
 - [x] AC-4 — The seven divergent shipped twins are recorded with measured diff
       sizes and the decision is in front of the maintainer, not guessed.
+      **Decided 2026-08-25**, and the decision arrived as a split: three closed
+      here with a `keep-duplicated` verdict on verifiable grounds, four carried
+      to `road-to-memory-twin-reconciliation.md` with the classification as
+      input. Nothing was guessed — the two largest twins are explicitly recorded
+      as un-characterised rather than summarised.
 - [x] AC-5 — The taxonomy covers naming as well as duplication, and the same
       three carriers cite it for both without restating either.
 - [x] AC-6 — A closed-set change cannot be called done from an identifier


### PR DESCRIPTION
Resolves step **3.2** of `road-to-redundancy-governance` per the maintainer's option 1: close the twins that need no behavioural judgement, carry the ones that do.

## Correction up front

The dashboard read **"Deferred: 1"** and that was a stale regeneration. `road-to-redundancy-governance` carries **six** `[~]` items, not one. This PR resolves **3.2** and moves the count to **five** — 4.5, 4.6, 4.7 and two numbered 5.3 remain, each with its own owner and condition. **The roadmap therefore does not archive**, and the dashboard is regenerated so it says so rather than implying otherwise.

## The classification is the work 3.2 was blocked on

The step was handed a diff table and asked for seven behavioural judgements. Splitting each diff into lines **inside** comments and lines **outside** halves the question — and that split was not in the artefact:

| Twin | changed | outside comments | class |
|---|---:|---:|---|
| `memory_hash.ts` | 6 | **0** | comment-only |
| `memory_status.ts` | 16 | 4 | structural-only |
| `memory_report.ts` | 28 | 8 | structural-only |
| `memory_signal.ts` | 57 | 36 | **behavioural** |
| `check_memory_proposal.ts` | 60 | 45 | **behavioural** |
| `check_memory.ts` | 262 | 195 | **behavioural** |
| `memory_lookup.ts` | 750 | 506 | **behavioural** |

Added to `agents/evidence/analysis/redundancy-baseline-2026-08-25.md` with the command that produces it, and with a note that these counts differ from the existing `--numstat` table because `diff -u` and `git diff --numstat` count a modified line differently — **both reproduced from their own quoted command, neither derived from the other**.

## The first three: `keep-duplicated`, on verifiable ground

Every non-comment difference in them is the same construct:

```
-declare const __AGENT_CONFIG_BUNDLE__: boolean | undefined;
-    if (typeof __AGENT_CONFIG_BUNDLE__ !== 'undefined' && __AGENT_CONFIG_BUNDLE__) {
```

Its absence in the template is **correct by construction**, and that is checkable rather than plausible:

- the flag is defined in exactly three places — `package.json`'s `build:install-bundle`, `build:hooks`, `build:mcp-bundle`, each an `esbuild --define:__AGENT_CONFIG_BUNDLE__=true`;
- **every one of those entrypoints is under `src/scripts/`**;
- `git grep` finds the flag in **no** file under `src/agent-src/templates/`.

The guard exists because every module in an esbuild bundle shares the bundle's `import.meta.url`, so a bundled script would auto-run on import. A consumer template ships as source, is run directly, and is an input to none of the three bundles. **Reconciling would put a guard into a file that can never be bundled.**

## One loose end, recorded rather than absorbed

`memory_report.ts`'s dev side additionally exports `CuratedTuple` and `_iter_curated_entries`, and `git grep` finds **no test and no caller** for either — surplus surface on one copy, not a divergence between them. A verdict that quietly covered it would be a verdict about something nobody examined, so it travels to the follow-up as its own step (1.4).

## The other four: carried, with the reason they cannot be batch-resolved

`agents/roadmaps/road-to-memory-twin-reconciliation.md`, created in this change with the classification as its input. **They diverge in both directions**, so no blanket rule like "the dev side is newer" resolves them:

- `memory_signal.ts` — the **dev** side carries `ProvenanceRefusedError` and `_origin_is_global`, a provenance gate distinguishing global-store origins from symbolic ones. The template has neither.
- `check_memory_proposal.ts` — the dev side has `assertScanned` and `--quiet`; the **template** refuses `--intake-id` together with `--proposal` as mutually exclusive, and the dev side does not.
- `check_memory.ts` (195) and `memory_lookup.ts` (506) — **deliberately not characterised.** Guessing at them is the failure 3.2 exists to avoid, and the follow-up's step 1.3 permits an unread subtree only if the step names it and says why.

The follow-up asks for **one verdict per difference, not per file** — `check_memory_proposal.ts` already has differences pointing opposite ways, so a per-file verdict would silently pick a side for the one nobody looked at. It carries a maintainer blocker on the release class, because reconciling changes behaviour for installs already running the template side, and a Phase 3 parity gate whose verify requires **both** states demonstrated: red on a planted behavioural divergence, green on a planted comment-only one.

## A second correction, before it landed

The new roadmap's first draft carried an `estate_offset_exempt` claiming `road-to-redundancy-governance` is archived in the same commit. **It is not, and could not be** — the five remaining deferred items block archival. The key now states the narrower, measured ground: `check_estate_count` reports **+0 active** because the file ships `status: draft`. No growth is being claimed away.

## Local verification

`lint_roadmap_blockers` (blocker-contract-clean, decidability 0 violations), `lint_plan_risk_register`, `check_roadmap_trackable`, `lint_roadmap_complexity`, `lint_roadmap_ci_steps`, `lint_empty_roadmaps`, `lint_roadmap_later_disposition`, `check_no_roadmap_refs`, `check_estate_count`, `check_references`, `lint_evidence_artifacts`, `check_secret_leak`, `check_md_language` — all exit 0. Documentation-only; no TypeScript touched.
