### PR TITLE
chore(roadmaps): activate every roadmap whose blocking condition has actually cleared

### DIFF
--- a/agents/roadmaps/road-to-channel-contract-and-profile-drift.md
+++ b/agents/roadmaps/road-to-channel-contract-and-profile-drift.md
@@ -1,6 +1,6 @@
 ---
 complexity: lightweight
-status: draft
+status: ready
 execution:
   mode: phase-checkpoints
 owner: maintainer

--- a/agents/roadmaps/road-to-component-granularity-vocabulary.md
+++ b/agents/roadmaps/road-to-component-granularity-vocabulary.md
@@ -1,6 +1,6 @@
 ---
 complexity: structural
-status: draft
+status: ready
 execution:
   mode: phase-checkpoints
 owner: maintainer

--- a/agents/roadmaps/road-to-contract-review-deadlines.md
+++ b/agents/roadmaps/road-to-contract-review-deadlines.md
@@ -1,6 +1,6 @@
 ---
 complexity: structural
-status: draft
+status: ready
 execution:
   mode: phase-checkpoints
 owner: maintainer
@@ -193,7 +193,7 @@ as D5: a gate exists, and `docs/` is not in its scope.
 | 1 | The lower bound lands before the backlog and 86 reds teach the maintainer to waive | implementation | This repository documents the pattern directly: a gate that floods is a gate that gets bypassed, and 86 simultaneous violations on the next PR is a flood by any reading. | Phase 0 dispositions all 86 before Phase 1 changes any comparison, and 0.2 admits "report, not failure" as a complete outcome; Phase 2 wires the gate only after Phase 1 is green. | Phase 0 — disposition before enforcement |
 | 2 | The 90-day cadence is unsustainable and the fix encodes it harder | product | 71.1 % lapsed is not 86 individual oversights; it is evidence about the cadence. Enforcing the floor without questioning the window would make a real constraint out of a number nobody has met. | 0.2 puts the window itself in scope with the measured rate as its input, and 2.3 applies the same treatment to the ceiling rather than defending it by default. | Phase 0 — disposition before enforcement |
 | 3 | Two roadmaps edit the same contract frontmatter | implementation | `road-to-channel-contract-and-profile-drift` step 1.1 already changes `write-engine.md`; this sweep would change it again, and the two are in the same PR. | 3.1 makes the reconciliation an explicit step with a verify that forbids both files touching the same frontmatter; the sweep treats the earlier filing as its first row rather than as a competing fix. | Phase 3 — close the two one-off filings |
-| 4 | Wiring a previously-unwired gate reds the branch that wires it | implementation | D4's single violation is live at HEAD, so step 2.1 turns an invisible red into a blocking one on its own PR. | 2.3 resolves that violation before or with 2.1, and it is one day on one file; the sequencing is stated rather than discovered. | Phase 2 — put it where a PR can see it |
+| 4 | Wiring a previously-unwired gate reds the branch that wires it | implementation | D4's single violation is live at HEAD, so step 2.1 turns an invisible red into a blocking one on its own PR. | 2.3 resolves that violation before or with 2.1, and it is one day on one file; the sequencing is stated rather than discovered. | Phase 2 — put it where a pull request can see it |
 | 5 | Widening the reference scan floods the next PR with 383 internal findings | implementation | Same failure as rank 1, on a second gate: 4.3's cheapest branch is to widen the constant, and 383 simultaneous reds is a flood. | 4.3 is ordered after 4.2 so the shipped half is already repaired, prices the widening before deciding, and admits "record the exclusion" as a complete outcome. | Phase 4 — the same shape, one surface over |
 | 6 | The disposition pass becomes a promotion pass | product | The cheapest disposition for 86 lapsed contracts is "promote to stable", and promotion by exhaustion turns a review backlog into a stability claim nobody reviewed. | 0.1 requires one of four dispositions per row with a reason, and promotion is not the default; the four counts are reported separately so a 86-way promotion is visible as one number. | Phase 0 — disposition before enforcement |
 

--- a/agents/roadmaps/road-to-decision-conformance.md
+++ b/agents/roadmaps/road-to-decision-conformance.md
@@ -1,6 +1,6 @@
 ---
 complexity: structural
-status: draft
+status: ready
 execution:
   mode: phase-checkpoints
 owner: maintainer

--- a/agents/roadmaps/road-to-episode-finalizer-and-outcome-attribution-v2.md
+++ b/agents/roadmaps/road-to-episode-finalizer-and-outcome-attribution-v2.md
@@ -1,7 +1,7 @@
 ---
 title: "Road to Episode Finalizer and Outcome Attribution v2"
 complexity: structural
-status: draft
+status: ready
 estate_offset_exempt: "Landed by the /analyze:inbox run of 2026-08-24. The one-in-one-out half fires on every added agents/roadmaps/road-to-*.md whatever its status, and this run archived only status: draft roadmaps, which were never counted and so are unavailable as offsets. Its predecessor road-to-episode-finalizer-and-outcome-attribution was never landed in the active estate either, so the supersedes edge offsets nothing countable."
 execution:
   mode: phase-checkpoints

--- a/agents/roadmaps/road-to-inbox-harvest-2026-08-e-council-topology-evidence.md
+++ b/agents/roadmaps/road-to-inbox-harvest-2026-08-e-council-topology-evidence.md
@@ -1,6 +1,6 @@
 ---
 complexity: structural
-status: draft
+status: ready
 execution:
   mode: phase-checkpoints
 research_pin: "agent-config @ f16c7d9df2e1a4a6f480e734be6ed3a0138fc14d · @event4u/agent-config 14.10.0 · citations re-verified against the landing HEAD 2026-08-24"

--- a/agents/roadmaps/road-to-internal-estate-fit.md
+++ b/agents/roadmaps/road-to-internal-estate-fit.md
@@ -1,6 +1,6 @@
 ---
 complexity: structural
-status: draft
+status: ready
 execution:
   mode: phase-checkpoints
 owner: maintainer

--- a/agents/roadmaps/road-to-memory-twin-reconciliation.md
+++ b/agents/roadmaps/road-to-memory-twin-reconciliation.md
@@ -1,6 +1,6 @@
 ---
 complexity: structural
-status: draft
+status: ready
 execution:
   mode: phase-checkpoints
 owner: maintainer

--- a/agents/roadmaps/road-to-published-number-truth.md
+++ b/agents/roadmaps/road-to-published-number-truth.md
@@ -1,6 +1,6 @@
 ---
 complexity: structural
-status: draft
+status: ready
 execution:
   mode: phase-checkpoints
 owner: maintainer

--- a/agents/roadmaps/road-to-skill-ecosystem-eval-integrity.md
+++ b/agents/roadmaps/road-to-skill-ecosystem-eval-integrity.md
@@ -1,18 +1,21 @@
 ---
 complexity: lightweight
-status: later
+status: ready
+estate_offset_exempt: "Un-parking counts as an ADDITION under one-in-one-out (later/X -> X is classified an addition by classifyDiff), and no archive move is available in this change: it closes a slot-cap blocker rather than finishing a roadmap. The offsetting event already happened in an earlier change -- the two predecessors this file queued behind, road-to-skill-ecosystem-gate-integrity and road-to-skill-ecosystem-authoring-discipline, both sit in archive/, which is why lint_roadmap_family_cap measures 0/2 slots used and why this file's own blocker instructs the move."
+estate_growth_exempt: "Measured on this change: active_roadmaps 0 -> 11 and open_blockers 28 -> 36. No roadmap file was created. All sixteen files involved already existed at origin/main; fourteen sat at the active TOP LEVEL carrying status: draft, which excludes them from collect() and made the estate report 0 active while fourteen files of planned work sat in the active tree. The growth is therefore a correction of a bookkeeping state, and the direction it corrects is the one this ratchet exists to make visible: draft-at-top-level was functioning as a second parking lot that no count could see. Every one of the 65 later/ roadmaps was probed against its own stated resume condition on 2026-08-25 and 63 stay parked, each for a named external reason (a real consumer repo, a paid bench arm, host access this tree lacks, an owner-reserved decision, or an empty measurement corpus such as gate-metrics.jsonl at 0 of 10 required events). The two un-parked hold queue positions 3 and 4 of the verification track and had the family slot cap as their only blocker: lint_roadmap_family_cap reports 0/2 slots used with both predecessors in archive/, and eval-integrity own blocker verification-slot instructs the move in as many words. Position 5 stays parked because 3 and 4 fill the cap. Of the fourteen drafts, four stay draft because an owner-reserved blocker gates their Phase 1 (canonical-terms, capability-native-execution, merge-surface-zero, web-launch-readiness) and one stays draft because it carries no canonical Phase heading and check_roadmap_trackable would rightly call it invisible (ten-across-the-board). The +8 open_blockers are pre-existing entries in files that were already in the active tree: this change created no blocker and RESOLVED one, verification-slot, on its stated condition."
 ---
 
 # Road to eval integrity — gate the measurement inputs, and score direction not magnitude
 
-> **Parked at queue position 4 of the verification track.** The 2026-08-05
-> council capped concurrently-open verification roadmaps at two. This roadmap is
-> verification infrastructure and is eligible under the successor constraint, not
-> under the capability arm.
->
-> **Resume when** a verification slot frees — a predecessor roadmap reaches zero
-> open steps and lands in `agents/roadmaps/archive/`. Verify with
-> `./agent-config roadmap:progress`.
+> **RESUMED 2026-08-25 — queue position 4 reached.** This roadmap was parked
+> on one condition only: the 2026-08-05 council capped concurrently-open
+> verification roadmaps at two. Both predecessors it queued behind —
+> `road-to-skill-ecosystem-gate-integrity` and
+> `road-to-skill-ecosystem-authoring-discipline` — now sit in
+> `agents/roadmaps/archive/`, and `lint_roadmap_family_cap` measures **0/2 slots
+> used**. That is the file's own stated resume test, so it is unparked and open.
+> Position 5 (`road-to-skill-ecosystem-security-and-conformance`) stays parked:
+> positions 3 and 4 fill the cap.
 
 > Put a gate on this package's own measurement inputs, and fix a named scoring
 > defect: a magnitude-weighted verdict punishes a decisively-winning artifact,
@@ -22,7 +25,7 @@ status: later
 ## Context
 
 Source + verdicts:
-[`skill-ecosystem-sweep-2026-08`](../../settings/contexts/skill-ecosystem-sweep-2026-08.md).
+[`skill-ecosystem-sweep-2026-08`](../settings/contexts/skill-ecosystem-sweep-2026-08.md).
 
 **Why this is verification infrastructure rather than capability.** Every item
 below hardens the machinery that decides whether a change helped. None adds a
@@ -154,13 +157,14 @@ started.
 ## Blockers
 
 ### blocker: verification-slot
-- **Status:** open
+- **Status:** resolved
 - **Owner:** maintainer
 - **Blocks:** Phase 1 — A gate on the measurement inputs
 - **What to do:**
   1. This roadmap holds queue position 4 of the verification track under the 2026-08-05 successor constraint (maximum two concurrently open).
   2. When a predecessor archives, move this file to `agents/roadmaps/` and drop `status: later`.
 - **Resolved when:** fewer than two `road-to-skill-ecosystem-*` roadmaps sit outside `archive/` and `later/`, checked by `./agent-config roadmap:progress`.
+- **Resolved 2026-08-25:** `lint_roadmap_family_cap` reports `0/2 slot(s) used`; both predecessors (`road-to-skill-ecosystem-gate-integrity`, `road-to-skill-ecosystem-authoring-discipline`) are in `agents/roadmaps/archive/`. This file moved to `agents/roadmaps/` and dropped `status: later`, exactly as step 2 above directs.
 
 ## Risk Register
 

--- a/agents/roadmaps/road-to-skill-ecosystem-runtime-enforcement.md
+++ b/agents/roadmaps/road-to-skill-ecosystem-runtime-enforcement.md
@@ -1,23 +1,22 @@
 ---
 complexity: lightweight
-status: later
+status: ready
 execution:
   mode: phase-checkpoints
+estate_offset_exempt: "Un-parking counts as an ADDITION under one-in-one-out (later/X -> X is classified an addition by classifyDiff), and no archive move is available in this change: it closes a slot-cap blocker rather than finishing a roadmap. The offsetting event already happened in an earlier change -- the two predecessors this file queued behind, road-to-skill-ecosystem-gate-integrity and road-to-skill-ecosystem-authoring-discipline, both sit in archive/, which is why lint_roadmap_family_cap measures 0/2 slots used and why this file's own blocker instructs the move."
 ---
 
 # Road to runtime enforcement — bind the rules that currently only ask
 
-> **Parked at queue position 3 of the verification track.** The 2026-08-05
-> council capped concurrently-open verification roadmaps at two; the two open
-> slots are held by the gate-integrity and authoring-discipline roadmaps, which
-> the council named mandatory-first and mandatory-second. This roadmap is
-> verification infrastructure and is therefore eligible under the successor
-> constraint, not under the capability arm.
->
-> **Resume when** one of the two open verification roadmaps reaches zero open
-> steps and is archived, freeing a slot. Verify with
-> `./agent-config roadmap:progress` and by confirming the predecessor moved to
-> `agents/roadmaps/archive/`.
+> **RESUMED 2026-08-25 — queue position 3 reached.** This roadmap was parked
+> on one condition only: the 2026-08-05 council capped concurrently-open
+> verification roadmaps at two. Both predecessors it queued behind —
+> `road-to-skill-ecosystem-gate-integrity` and
+> `road-to-skill-ecosystem-authoring-discipline` — now sit in
+> `agents/roadmaps/archive/`, and `lint_roadmap_family_cap` measures **0/2 slots
+> used**. That is the file's own stated resume test, so it is unparked and open.
+> Position 5 (`road-to-skill-ecosystem-security-and-conformance`) stays parked:
+> positions 4 and 3 fill the cap.
 
 > Convert the cheapest of this package's honestly-unenforced obligations into
 > deterministic runtime behaviour — a non-zero exit, a machine-checkable state, a
@@ -166,18 +165,24 @@ block on this host constrains every new hook's exit contract.
 - **Status:** open
 - **Owner:** user
 - **Blocks:** Phase 1 — Shims and the hook contract
-- **What to do:**
-  1. Decide which surfaces get a shim beyond the container-only tooling rule. Candidates observed in the sweep: hook-bypass flags (already guarded by a pre-tool hook, so a shim is additive), and package-manager invocations the house rules route elsewhere.
-  2. A shim changes what a developer's shell does inside a session, so the set is a maintainer decision rather than an agent inference.
+- **Recommendation:** (a). It is the only candidate the sweep gives a recorded need for — Phase 1 Step 2 calls the container-only tooling rule "the surface with the clearest recorded need" — while this blocker's own text says a shim over the hook-bypass flags would be *additive* to a guard that already exists, and names no failure behind the package-manager candidate. A shim changes what a developer's shell does, so the narrow set is the reversible one.
+- **If you do nothing:** Phase 1 Steps 2, 3 and 4 cannot name their subject, so Steps 1, 5, 6 and 7 land a shim directory, a performance doctrine and a global kill switch with no shim inside them, and Step 4's false-positive matrix has nothing to cover. Phases 2, 3, 4 and 6 are unaffected.
+- **What to do:** pick exactly one —
+  1. (a) Ship only the container-only tooling shim: `src/scripts/hooks/shims/php`, and record the hook-bypass and package-manager candidates as out of scope in Phase 1 Step 2.
+  2. (b) Add the hook-bypass-flag shim as well, accepting that it duplicates the existing pre-tool guard, and extend the matrix in `tests/scripts/hook_shims.test.ts` to cover both basenames.
+  3. (c) Also shim package-manager invocations, which needs a recorded failure first per this roadmap's own evidence discipline.
 - **Resolved when:** the shim set is named in this roadmap's Phase 1 Step 2 and the remaining candidates are recorded as out of scope.
 
 ### blocker: plan-injection-decision
 - **Status:** open
 - **Owner:** user
 - **Blocks:** Phase 5 — A bounded loop the harness enforces
-- **What to do:**
-  1. Decide whether per-turn re-injection of the active roadmap into context is wanted at all. The sweep's evidence is that it closes context rot; the sweep's own counter-evidence is that it converts a governed file into a standing injection amplifier.
-  2. The attestation mechanism (Phase 5 Steps 6 and 7) ships regardless, because it is the precondition and is useful on its own.
+- **Recommendation:** (b). The sweep supplies evidence on both sides, and only one side is reversible: `src/scripts/attest_artifact.ts` is useful standalone as a tamper check, whereas per-turn re-injection turns a governed file into a standing injection amplifier — this roadmap's own counter-evidence — and that is hard to withdraw once hosts depend on it. Deciding (b) now unblocks Steps 6 and 7 without foreclosing (a) later.
+- **If you do nothing:** Phase 5 Steps 6 and 7 ship an attestation guarding an injection that may never exist, and Steps 1 to 5 land a bounded loop whose injection behaviour is undefined. Nothing outside Phase 5 waits on this.
+- **What to do:** pick exactly one —
+  1. (a) Approve per-turn re-injection and open a follow-up roadmap for it; Steps 6 and 7 remain its precondition.
+  2. (b) Mark the injection half out of scope and ship `src/scripts/attest_artifact.ts` plus `tests/scripts/attest_artifact.test.ts` on their own merit.
+  3. (c) Defer the whole of Phase 5's injection half until a context-rot incident is recorded with provenance.
 - **Resolved when:** the decision is recorded and either a follow-up roadmap opens for the injection half or it is marked out of scope.
 
 ## Risk Register


### PR DESCRIPTION
## What this does

The estate reported **0 active roadmaps** while 14 files of planned work sat at the active top level, all carrying `status: draft` — which excludes them from `collect()` and from the estate count. Draft-at-top-level was functioning as a second parking lot no count could see. This activates the roadmaps whose blocking condition has verifiably cleared, and nothing else.

| Action | Count |
|---|---:|
| Un-parked (`later/` → active) | 2 |
| Flipped `draft` → `ready` | 9 |
| Stay parked in `later/` | 63 |
| Stay `draft` | 5 |

Dashboard after: **11 open roadmaps · 344 steps · 11 open blockers in the active tree, 2 of them owner-reserved.**

## The two un-parkings

`skill-ecosystem-eval-integrity` and `skill-ecosystem-runtime-enforcement` hold queue positions 4 and 3 of the verification track. Both were parked on one condition: the 2026-08-05 council capped concurrently-open verification roadmaps at two. Both predecessors are now in `archive/` and `lint_roadmap_family_cap` measures **0/2 slots used** — the stated resume test. `eval-integrity`'s own `verification-slot` blocker instructs the move in as many words; it is marked resolved with that evidence. Position 5 stays parked because 3 and 4 fill the cap.

## Why 63 stay parked

Every one of the 65 parked roadmaps was probed against its own stated resume condition. **Not one trigger had fired.** The conditions are external without exception: a real consumer repo, a paid benchmark arm, host access this tree does not have (`worker_respawn` is `false` on every host in the manifest), an owner-reserved decision, or an empty measurement corpus — `gate-metrics.jsonl` holds 0 of the 10 required `r2_review` events, `injection-census.jsonl` does not exist, `agents/cost-tracking/` is absent.

Three are close and worth a cheap re-check later: `credible-install` (four-week window closes around 2026-09-09), `cost-parity-2` Phase 1 (waiting only on a maintainer authorisation), `surface-consolidation` (window elapses around 2026-08-26).

## Why 5 stay draft

Four carry an owner-reserved blocker on Phase 1 itself: `canonical-terms`, `capability-native-execution`, `merge-surface-zero`, `web-launch-readiness`.

`ten-across-the-board` stays draft for a different reason: it uses `## Wave 0`–`## Wave 5` headings, matches no canonical `Phase` heading, and `check_roadmap_trackable` would rightly call it invisible to the dashboard. Renaming a council-merged programme document's headings is a scope decision rather than bookkeeping, so it is left untouched — its net diff against `main` is empty.

## Two defects the activation exposed

Both were hidden by parking, because the gates scan the active top level only.

1. **`runtime-enforcement`'s two open blockers violated the decidability contract** — no `Recommendation:`, no `If you do nothing:`, and a `What to do:` carrying neither a command, a path, nor an enumerated option set. Both now carry an option set with real paths plus a recommendation. The decisions themselves stay the owner's.
2. **`contract-review-deadlines:196` carried a dangling risk-register anchor** — it cited `Phase 2 — put it where a PR can see it` against a heading reading `a pull request`.

## Estate ratchet

Measured: `active_roadmaps` 0 → 11, `open_blockers` 28 → 36, `later_roadmaps` 65 → 63. No roadmap file was created; all sixteen files already existed at `main`. The +8 blockers are pre-existing entries that were simply uncounted while draft — this change created none and **resolved** one.

- `estate_offset_exempt` on both un-parked files: `later/X` → `X` is classified an addition by one-in-one-out, and no archive move is available in a change that closes a slot-cap blocker.
- `estate_growth_exempt` on `eval-integrity` carries the count half for the whole sweep, with the measured numbers in the reason.

## Verification

All eleven relevant gates green on the committed tree: `lint_roadmap_later_disposition`, `lint_roadmap_blockers` (16 clean, 0 decidability violations), `check_roadmap_trackable`, `lint_roadmap_complexity`, `lint_empty_roadmaps`, `lint_roadmap_family_cap`, `lint_plan_risk_register`, `check_references`, `check_no_roadmap_refs`, `check_no_external_sources`, `check_estate_count`.

`check_roadmap_trackable:relates` reports 5 violations against a baseline of 9 — under the ratchet, and the five are files that carry no `relates:` block. Worth lowering the baseline to 5 in a follow-up so the gain cannot be given back silently.
