### PR TITLE
roadmap: park episode-finalizer-v2 + the drain-run summary

### DIFF
--- a/agents/evidence/drain-run-summary.md
+++ b/agents/evidence/drain-run-summary.md
@@ -1,899 +1,173 @@
-# Autonomous drain runs
+<!-- evidence-type: analysis -->
 
----
+# Autonomous roadmap-drain run — 2026-08-25/26
 
-# Run A — 2026-08-23 (earlier session)
+> The single report for the run, per its mandate: **every PR, every council
+> decision, every descope.** Written as the last commit of the final PR.
+>
+> **The roadmap directory is NOT empty, and this run did not empty it.** 8 PRs
+> landed across 8 roadmaps; 7 roadmaps were never opened. What follows says which
+> and why, because a summary that reported only the work done would misdescribe
+> the run.
 
-Machine-readable record of one autonomous roadmap-drain run. Every decision below
-was taken by the **AI council** under maintainer-delegated authority; none was
-referred back to the user, and none was taken by the executing agent alone on a
-question the roadmaps reserve.
+## 1. The pull requests
 
-## Headline
+All eight are **CI-green** and open against `main`. None was merged — the mandate
+made the PR the touchpoint.
 
-- **8 pull requests** opened. **4 merged** during the run (the trunk moved five
-  times under the branches; every branch was rebased onto it rather than pushed
-  behind it).
-- **3 roadmaps closed and archived**, 1 parked with a recorded option, 2 advanced
-  by a full phase, 2 resolved on a spend blocker.
-- **9 council sessions**, $0.31 total, all at 2 of 2 seats. **Two ended 1–1 and
-  went to a tie-break round**; both tie-breaks converged, and in both cases the
-  synthesis beat either original position.
-- **4 transfer stubs** created, each with a named promotion probe and a
-  **measured** blocking cost.
-- **3 real defects found and fixed** that no roadmap step had asked for, plus 4 of my own — including three that only remote CI can catch.
+| PR | roadmap | outcome |
+|---|---|---|
+| [#1645](https://github.com/event4u-app/agent-config/pull/1645) | `web-launch-readiness` | **Closed by approved rescope, archived.** 15/19 met, 4 descoped |
+| [#1646](https://github.com/event4u-app/agent-config/pull/1646) | `channel-contract-and-profile-drift` | **Complete, archived.** 13/14 met, 1 cancelled |
+| [#1647](https://github.com/event4u-app/agent-config/pull/1647) | `merge-surface-zero` | **Parked to `later/`.** Step 3.1 split; B4 decision packet written |
+| [#1648](https://github.com/event4u-app/agent-config/pull/1648) | `canonical-terms` | All three deferred **decisions taken**; 4/9 met, Phase 2 re-scoped |
+| [#1649](https://github.com/event4u-app/agent-config/pull/1649) | `contract-review-deadlines` | **Phases 0+1 complete**, 10/24. The beta gate gains a floor |
+| [#1650](https://github.com/event4u-app/agent-config/pull/1650) | `skill-ecosystem-runtime-enforcement` | Both blockers resolved; **Phase 1 built**, 7/53 |
+| [#1651](https://github.com/event4u-app/agent-config/pull/1651) | `memory-twin-reconciliation` | Release class decided; two twins characterised, 4/13 |
+| *(this PR)* | `episode-finalizer-and-outcome-attribution-v2` | Both blockers resolved; **parked to `later/`**, 2 steps descoped |
 
-## The correction that shaped the whole run
+**Estate movement:** 2 roadmaps archived, 2 parked to `later/`, 4 advanced and
+left active.
 
-**The seed queue in the mission prompt was entirely stale.** It named 36 roadmaps
-by slug; **none of those slugs existed** in `agents/roadmaps/` at
-`407915361`. The live set was 25 different files. The queue was recomputed from
-the tree, as the prompt's own step 1.2 requires, and every priority below derives
-from that recount rather than from the table.
+## 2. Council decisions — 7 sessions, 15 decisions, $0.43
 
-Also recomputed rather than trusted: **23 blockers, all Class 2/3.** There were
-**zero** Class 0/1 executables, so the entire unblocking pass was council work —
-`./agent-config gates --execute` was never applicable.
+Every session: `anthropic/claude-sonnet-4-5` + `openai/codex-default`, 3 rounds,
+blind chairman, quorum concluded 2/2. All ran under the maintainer's standing
+delegation, quoted verbatim in each question. **No tracked artefact grants the
+council standing authority over owner-reserved decisions** — the authority is
+this session's instruction, and every record says so.
 
-## Pull requests
-
-| PR | Roadmap | Outcome | State |
+| # | decision | verdict | note |
 |---|---|---|---|
-| [#1566](https://github.com/event4u-app/agent-config/pull/1566) | `merge-op-split-and-negation-guard` | **closed 18/18**, archived | merged |
-| [#1567](https://github.com/event4u-app/agent-config/pull/1567) | `test-independence-and-mutation-evidence` | **closed 13/13**, archived | merged |
-| [#1569](https://github.com/event4u-app/agent-config/pull/1569) | `org-pack-fitness` | **closed 16/16**, archived | merged |
-| [#1570](https://github.com/event4u-app/agent-config/pull/1570) | `mcp-runtime-integrity` | parked, AC-4 discharged | merged |
-| [#1572](https://github.com/event4u-app/agent-config/pull/1572) | `target-project-assurance-readiness` | Phase 1 shipped | open |
-| [#1573](https://github.com/event4u-app/agent-config/pull/1573) | `per-turn-hook-economy-carry` | Phase A1 shipped | open |
-| [#1574](https://github.com/event4u-app/agent-config/pull/1574) | `terminal-token-economy` | 3.2–3.4 deferred, figure labelled | open |
-| this PR | `override-efficacy-proof` | 2.3–2.5 deferred | open |
+| 1 | web-launch closure | **approve the rescope** 2/2 | with 5 binding conditions; **1 condition refused** (below) |
+| 2 | `write-engine.md` stability | **keep beta, extend to 2026-09-24** 2/2 | as an administrative holding period, *not* approval |
+| 3 | profile surfaces in `brand-audit` | **out of scope** 2/2 | mechanism-match made and found **insufficient** |
+| 4 | merge-surface-zero disposition | **park to `later/`** 2/2 | (b) and (c) both refused with reasons |
+| 5 | step 3.1 | **split, do not check** 2/2 | accounting for delivered scope, not redefinition |
+| 6 | B4 writer | **decision packet only** 2/2 | design-and-propose; never merge |
+| 7 | canonical dialect | **American** 2/2 | *and the roadmap's own premise was refuted* |
+| 8 | closed-set row placement | **option 2, close it** 2/2 | "wait" rejected as a non-disposition |
+| 9 | shim scope | **container-only** 2/2 unanimous | one offered evidence **refused** as too weak |
+| 10 | plan injection | **defer both halves** 2/2 | both seats **overruled the author's recommendation** |
+| 11 | memory-twin release class | **minor** 2/2 | flag proposal a 1-of-2 split, **not adopted** |
+| 12 | lapsed-deadline gate | **a no-growth baseline ratchet** 2/2 | a *fifth* option; none of the four offered |
+| 13 | quality columns | **host null, narrowly scoped** 2/2 | author's recommendation overruled on arithmetic |
+| 14 | machine-local denominator | **unresolvable by an autonomous run** 2/2 | |
+| 15 | episode-finalizer disposition | **park to `later/`** 2/2 | reached by two independent tests |
 
-## Council decisions
+### Where the council overruled the roadmap authors — four times
 
-Nine sessions. Each row is a decision the roadmap reserved to a human and the
-council took instead.
+Recorded because it is the strongest evidence the sessions were not rubber stamps:
 
-| # | Question | Verdict | The load-bearing reason |
-|---|---|---|---|
-| 1 | `owner-reserved-boundary` — does an `autoMerge`-key ratchet touch the reserved merge-authority question? | **(a) no, ship it** | A ratchet over three key *names* is not a decision about whether authority may be granted. Reversible: the owner deletes the gate. |
-| 2 | `kernel-doctrine-line` — reconcile the Hard Floor with a direct `merge PR #123`? | **(c) descope to a stub** | (a) is a kernel-rule edit → tool-call-time deny for an agent. Both seats called (b) *"security theater"*. |
-| 3 | Cancel the tool-assisted mutation rig? | **(b) cancel** | Its own blocker pre-registered the test; 0.3 ran 10 probes in minutes. A stub would preserve **no mechanism the estate lacks**. |
-| 4 | `b-delta-comment-dependency` — is a 0/19 roadmap with two spend blockers "still live"? | **(c) cancel + carry** | *"Nominally live but operationally deferred"* — no credible delivery path. |
-| 5 | Pack-fitness Phase 2 presumes a capability 4 of 6 gates lack | **split 1–1 → (s)** | Sequence: build to the injection that exists, carry the retrofit. The roadmap **stops claiming** six-gate orthogonality, which was the (a) seat's real objection to (b). |
-| 6 | MCP rug-pull: build the after-use variant, or park? | **(b3) park** | Both shortcuts refused. Required wording: *"protection level is zero."* |
-| 7 | Target-assurance: close on `unmeasurable-here`, or park? | **split 1–1 → (b)** | `unmeasurable-here` covers a **capability the tree lacks**; here the inputs are **human-supplied**. Closing would dilute the precedent. |
-| 8 | rtk re-bench — spend is authorized, run it? | **(b) defer** | Phase 2 has not chosen the mechanism Phase 3 benchmarks. **Wrong subject.** |
-| 9 | Override efficacy — spend is authorized, run it? | **(b) defer** | n=1 against the single override in the tree. **Wrong population.** |
+- **#10** — the author recommended shipping `attest_artifact.ts` *"on its own
+  merit"*. Both seats: no protected artifact, no threat model, no consumer, no
+  failure response. *"A mechanism without a subject."* Verified in the tree: the
+  script did not exist, so it was a **build**, not a re-labelling.
+- **#13** — the author recommended adopting the episode-boundary candidate and
+  evaluating its falsifier. There is **no eligible corpus to evaluate it
+  against** (0 populated rows, three corpus growths moving no verdict). Adopting
+  a definition whose falsifier is unevaluable is the wrong order of operations.
+- **#8** and **#12** — both blockers recommended *wait*. Both seats: a deferral
+  whose trigger is an unfunded mechanism is not a disposition.
 
-### The one principle both spend decisions turned on
+### Where a seat overruled the other, and the reason was adopted
 
-Spend was **pre-authorized** for this run, so the council decided *how*, never
-*whether*. It deferred both runs anyway, and both seats reached the same
-formulation independently:
+- **#1** — anthropic asked this council to freeze the parked benchmark's seven
+  protocol items. openai refused: *"Having this ground-truth-aware council select
+  sample sizes, metrics, or thresholds would freeze contamination into the
+  experiment rather than eliminate it."* The COI that bars this session from
+  **running** the arms bars it equally from **parameterising** them.
+- **#11** — anthropic wanted a migration flag. openai: *"'Silent data corruption'
+  is not supported by the supplied facts."* Adopted for consistency: the same
+  evidence discipline that killed #10's attestation kills this flag.
 
-> **Pre-authorized budget is permission without reason.** It does not refute a
-> methodological objection.
+## 3. Findings the run produced that no roadmap had asked for
 
-Recorded because it is the reusable half: the objections were *prematurity*
-(wrong subject; wrong population), not cost, and an open budget refutes neither.
+- **A gate reporting green over 86 violations.** `check_beta_review_markers`
+  compared `keep-beta-until` only against `today + 90` and errored on dates too
+  far in the **future**. No floor. It printed *"All beta contracts carry a valid
+  review marker"* while **86 of 121** were lapsed — and `STABILITY.md`'s own 25 %
+  re-audit trigger had fired at **71.1 %** with nothing able to observe it.
+- **44 of those 86 lapsed on ONE day.** A cohort artifact — one past session's
+  uniform window expiring at once — not 86 lapses of discipline. It changed the
+  decision from *report vs fail* to a **ratchet**.
+- **A published measurement inverted by scope.** `road-to-canonical-terms` rests
+  on `behaviour/behavior` splitting 57/43 **British**. Per directory, `src/` — the
+  shipped surface — is **22/78 American**. Three of nine pairs flip. The roadmap
+  also cited the **wrong evidence file**; the dialect numbers live in the wording
+  baseline, and the file it named contains zero dialect content.
+- **A template missing a safety gate.** `memory_signal.ts`'s 36-line divergence
+  is **one** difference: the template side carries **none** of ADR-130's
+  provenance gate, so a consumer running it can write `subject: user` records
+  into tracked project intake.
+- **A CLI difference where the obvious verdict inverts.** Both memory twins
+  implement the same mutual exclusion; dev is order-stable, the template is
+  **argparse-faithful** — and this repo states argparse parity as a convention.
+  Recorded **undecided**, both behaviours measured, rather than guessed.
 
-### Two 1–1 splits, and why the tie-breaks mattered
+## 4. Descopes and parkings — every one, with its reason
 
-Both splits were resolved by a **narrowed** second round, not by re-asking.
-
-- **#5** — one seat: adding `--root` seams to four CI gates is gate engineering
-  the roadmap's Non-goals exclude. The other: step 2.2's orthogonality proof *is*
-  the roadmap's claim and only the seams establish it. **The second seat conceded
-  the scope objection in its own rationale**, which is what made a synthesis
-  available. Round 2: sequence them, and make the roadmap stop claiming what it
-  cannot prove.
-- **#7** — one seat proposed closing on `unmeasurable-here`; the other refuted the
-  classification and **the refutation carried both seats**: that precedent is for a
-  capability the tree does not have, and a missing human labeller is a missing
-  *input*. Closing would have erased actionable work **and** diluted a precedent.
-
-## Descopes and transfers
-
-Four stubs, each with a promotion probe and a measured blocking cost. `unknown` is
-recorded where nothing was measured — *"no cost was observed" is not "the cost is
-zero"*.
-
-| Stub | Probe | `blocked_items` |
+| item | disposition | reason |
 |---|---|---|
-| `road-to-merge-confirmation-doctrine` | a maintainer opens a kernel PR and serves its ≥24h soak | **0** (measured) |
-| `road-to-pack-gate-fixture-seams` | a narrow ADR-200 amendment authorizes an isolated-root seam | **3** (measured) |
-| `road-to-per-pack-cost-delta-emitter` | a per-PR delta-comment surface exists | **0** (measured) |
-| `b-human-risk-corpus` (blocker, not a stub) | a named external repo **plus** ≥60 classifier-blind human labels | — |
-
-Two cancellations (`[-]`) were taken by the council in the user's seat, which is
-normally owner-reserved: the mutation rig (redundant on its own pre-registered
-measurement) and pack-fitness Phase 3 (dependency operationally deferred).
-
-## Defects found that no step asked for
-
-1. **`check_roadmap_trackable` was red on `main`** — a completion-note heading read
-   `### Phase 3 fit the cap exactly`, which the gate parses as a phase with no
-   checkboxes. Fixed in #1566.
-2. **`road-to-target-project-assurance-readiness` cited a blocker that did not
-   exist.** Phase 2 was gated by `blocker: spike-before-build` and the file shipped
-   with **no `## Blockers` section at all**. The dependency was real and invisible.
-   Fixed in #1572.
-3. **An unqualified `33 %` was reading as this package's general measured claim.**
-   It is a one-machine, eight-command, month-old spot measurement. Fixed in #1574
-   at **every** reader-facing occurrence, not just the canonical one — a council
-   refinement, since a scope stated only where a number is defined *"does not
-   survive being copied or summarised"*.
-
-## Own errors, recorded because they are the reusable part
-
-- **Cited a gitignored council response path from an active roadmap.**
-  `check_council_references` refused it, 0 → 1 against a clean baseline. The
-  defect-pattern sweep found **53** sites of the construct; exactly **one** was in
-  an active roadmap (mine), the other 52 under directories the gate deliberately
-  does not scan. Fixed by inlining the convergence summary.
-- **A sabotage probe that proved nothing.** Replacing a key regex with
-  `/([A-Za-z_][A-Za-z0-9_-]*)/` left all tests green — that regex returns the
-  *first* identifier on the line, which is not a forbidden name. A probe that does
-  not go red has proven nothing about the guard, only about the probe. Recorded at
-  the assertion, because it reads exactly like a proven guard.
-- **`EXIT=$?` after a pipe.** Read `tail`'s status and showed a false `0` for three
-  sabotage probes in a row. Re-captured with `cmd > file; echo $?`.
-- **A type error `task preflight` does not catch.** `boundReason: undefined` fails
-  `exactOptionalPropertyTypes`; preflight was green and the **pre-push** typecheck
-  caught it. Preflight is the pass a contributor is told to run and it does not
-  `tsc` over `src/scripts/`.
-- **A stale `dist/` projection.** `dist == rewrite(src)` is a CI gate; the
-  pre-commit sync regenerates, and the regenerated file must be committed or the
-  push is refused.
-- **Three defects that ONLY remote CI catches**, all on #1573 and all worth the
-  next run's attention because `task preflight` and the pre-push hook were green
-  on every one:
-  - `actions/upload-artifact@v4` — a **tag**. This repo SHA-pins every action and
-    `tests/contracts/ci_supply_chain.test.ts` asserts it. The failure read
-    *"dependabot claims SHA pinning: true, unpinned refs: 1"* on four shards,
-    naming the contract rather than the file. Preflight does not run the contracts
-    suite.
-  - **`gate-hardening:unhardened-scan-scope` targets ZERO** — mandatory, not a
-    floor. A new gate that routes through neither `_lib/scan_scope` nor a
-    registered floor reds immediately. Fixed by `reportScanned` with *readings* as
-    the unit: zero readings is a **dead scope**, because a store that parsed to no
-    records reads identically to a store nobody has written.
-  - **`actionlint`**: `matrix.os` referenced in a job with no matrix. Neither
-    preflight nor the pre-push hook invokes actionlint; it runs in CI on changed
-    workflow files only.
-- **A reference to a file that does not exist yet, by design.** The published
-  distribution is rendered from an empty store, so citing its path broke
-  `check_references` in CI while passing locally — the local and CI exclusion sets
-  differ. Marked `ref-ignore` with the reason inline rather than silenced.
-
-## Verification standard applied throughout
-
-Every gate registered under **CI-identical argv** on both sides
-(`check_ci_local_parity` green, no new declared exception). Every new guard
-**sabotage-probed** before its tests were trusted, with the observed red counts
-recorded at the assertion and `git diff --stat` empty after restore. Every
-completion claim carries `task preflight` exit 0 plus the named gates.
-
-Three gates ship with **no canary recipe** and the reason recorded rather than
-omitted: their only possible violation is a modification of an existing tracked
-artefact, so a create-only plant lands outside the corpus and the gate correctly
-stays green. Sensitivity is proven by committed violating fixtures instead.
-
-## What remains
-
-17 active roadmaps. The queue was worked in the prompt's order — descending
-progress, then ascending complexity — and stopped with context, not with a
-blocker. Two of the remaining files are now **unblocked by this run's work**:
-Phase A1 (#1573) started the reading clock that `per_turn_composite`'s arming
-precondition counts, which is the collection milestone the council required when
-it parked `mcp-runtime-integrity`.
-
-**No blocker was weakened, no floor was moved, and no gate was skipped or
-re-baselined to pass.** Where a criterion could not be met it was deferred,
-descoped or parked with the reason and the reopening condition written at the
-place it acts.
-
-
----
-
-# Run B — 2026-08-23 (this session)
-
-Machine-readable record of a second autonomous roadmap-drain run on the same day.
-Every decision below was taken by the **AI council** under maintainer-delegated
-authority. None was referred back to the user; none was taken by the executing agent
-alone on a question a roadmap reserves.
-
-## Headline
-
-- **10 pull requests** opened; **7 merged** during the run. The trunk moved under the
-  branches eight times and every branch was merged onto it rather than pushed behind it.
-- **8 roadmaps closed and archived.** 1 advanced by two full phases and deliberately
-  **left open** rather than closed on partial work.
-- **20 blockers resolved**, all by council. **0 questions to the user.**
-- **6 council sessions**, 2/2 quorum in every one, $0.19 total (subscription transport,
-  no metered spend). Quota after the run: 26/50 per member.
-- **4 carries into stubs**, each with a promotion criterion. **0 silent drops.**
-
-## Pull requests
-
-| PR | Roadmap | Outcome |
-|---|---|---|
-| #1577 | `road-to-per-turn-hook-economy-carry` | closed + archived · **merged** |
-| #1578 | `road-to-mcp-runtime-integrity` | closed + archived · **merged** |
-| #1579 | `road-to-release-publication-integrity` | closed at Phase 1 + archived · **merged** |
-| #1580 | `road-to-unowned-resume-conditions` | closed + archived · **merged** |
-| #1582 | `road-to-target-project-assurance-readiness` | closed on its null route + archived · **merged** |
-| #1583 | `road-to-override-efficacy-proof` | closed + archived · open, green |
-| #1584 | `road-to-terminal-token-economy` | closed + archived · **merged** |
-| #1585 | `road-to-review-independence` | closed + archived · open |
-| #1586 | `road-to-council-evidence-integrity` | **Phases 1–2 only, roadmap left open** · open |
-
-## Council decisions
-
-Session 1 — 18 blockers in one pass, 16 convergent, 2 split. Session 2 — both ties, both
-resolved. Sessions 3–6 — 9 further decisions, 2 of them re-evaluations of locks whose
-recorded condition had changed.
-
-| Blocker / question | Verdict | The load-bearing reason |
-|---|---|---|
-| `assurance-enforcement-thresholds` | defer Phase 8.5 | *nulls are not thresholds*: four unset numbers cannot support a blocking policy |
-| `sibling-roadmap-dispositions` | record live dispositions | "archived, no measured result" is a legitimate disposition |
-| `b-detector-license-verification` | own derivation | removes licensing ambiguity, executable without external evidence |
-| `b-page-capture-primitive` | recorded nulls | no verified capture primitive; cut the render-dependent dimensions |
-| `b-lifecycle-integrity-open-steps` | consume read-only | an archived roadmap's findings are frozen input |
-| `b-maintainer-run-capture` | decline the capture | no human at a keyboard; Phase 3 proceeds independently |
-| `b-bundler-choice-for-fixture` | `tsup` | purpose-built for the ESM+CJS+dts contract; familiarity ≠ purpose-fit |
-| `b-cli-flag-probe` | honest null | an absent binary is a null, never a silent skip |
-| `b-probe-channel-decision` | transcripts only, **partial** | proves argv correctness, not vendor honouring; `AC-5` narrowed |
-| `second-ci-provider-key` | single-member gate | no credential can be minted autonomously |
-| `sibling-ownership` | this roadmap owns the state | the roadmap that measures rotation is the only defensible owner |
-| `b-plate-vs-skill-sprawl` | named sibling skills | the size cap and the anti-sprawl rule both hold |
-| `b-behavioural-bench-spend` | fifteen rules out of scope | pre-authorized budget is *permission without a reason* |
-| `b-colleague-machine-readings` | single-machine scope in the header | one machine reachable |
-| `b-playbook-home-in-consumer-tree` | sixth context type | reuse the existing machinery |
-| `b-async-split-cancellation` | cancel the split | **≤ 3 ms of a 1186 ms composite** — 0.25 % |
-| `b-async-split-live-verification` | capability unavailable | no host carries the split config |
-| `b-composite-ceiling-value` | **(c) extend observe-only** | first chose (b), then found it unexecutable at n = 0 |
-| `b-stub-promotion-authority` | do not promote | an autonomous run does not override a deferred estate decision |
-| Phase-3 rotation spike | record the null | the corpus does not carry file order; a re-review confounds ordering with variance |
-| `b-ab-session-spend` (re-evaluated) | **deferral stands on a NEW condition** | the ordering objection was discharged; the ≥ 2-machine requirement is not |
-| rtk wrapper mechanism | warn-only | *"a host capability is not yet a safe dispatcher capability"* |
-
-Two splits went to a tiebreak and both converged. One verdict — `b-composite-ceiling-value`
-— was **overturned by the facts**: option (b) required a number derived from ≥ 10 readings
-and the store held **zero**, so the council was asked again and chose (c).
-
-## The two lock re-evaluations, because they are the pattern worth reusing
-
-`decision-revisit-gate` requires a lock whose recorded condition has changed to be
-**surfaced, not obeyed**. It fired twice, and both times the outcome differed:
-
-1. **`b-ab-session-spend`** was deferred on *ordering* — "Phase 2 has not chosen the
-   mechanism". Phase 2 chose **in the same change**, so the condition was discharged. Put
-   back to the council: the deferral **stood on a new condition** (the registration's own
-   ≥ 2-machine requirement). Amending the registration down to one machine was refused —
-   it lowers a bar written before any number was seen.
-2. **`b-per-turn-composite-ceiling`** was deferred on a *bounded wait* whose bound was a
-   named milestone. The milestone was reached and produced **n = 0**, so the wait had
-   already ended without delivering its input. Continuing to wait would have been the
-   indefinite park under a new name the roadmap's own risk register names.
-
-## Descopes, carries and transfers — 4, all with promotion criteria
-
-| Carried | To | What reopens it |
-|---|---|---|
-| override efficacy paired run (3 steps) | `stubs/road-to-override-efficacy-paired-run.md` | a **second** real override in the tree |
-| widened rtk re-bench (3 steps) | `stubs/road-to-rtk-rebench-run.md` | a **second machine**; a CI runner counts |
-| human risk corpus | `stubs/road-to-human-risk-corpus.md` | ≥ 60 human-labelled changes **and** R3 rate ≤ 0.40 |
-| ADR-134 expiry date | `stubs/road-to-adr-134-expiry.md` | the date is decided, succeeded, or lapses as a recorded finding |
-
-`stubs/` is excluded from `active_roadmaps`, so every carry is ratchet-compliant and costs
-the estate nothing. **No `[~]` was resolved by deletion.**
-
-## Defects found that no step asked for
-
-- **The host DOES support a transparent input rewrite.** Three sites asserted otherwise;
-  Claude Code 2.1.241 documents `updatedInput`, validates its schema and logs a fallback.
-  The shipped claim collapsed a fact about *our plumbing* into a claim about *the host* —
-  and was undated, which is why nobody could tell. All three corrected.
-- **Two of four P3 concurrency call sites were unpinned.** The suite proved the lock
-  *primitive* via inline worker re-implementations and never reached the real call sites;
-  sabotaging one left all three tests green.
-- **A doctor line contradicted its own strict gate.** A grep for a rule name in the
-  registry read `verify-before-complete` as unregistered — the name sits inside a
-  `justification:` block. Now parsed the way the audit parses it.
-- **`[]` was classified as a parse failure.** The shared extractor's regex requires an
-  object, so a member answering correctly with an empty array would have triggered a
-  **paid** re-ask. Found by a test asserting the fix, not by the step.
-- **Peer-review quotes resolved to the wrong source.** One label→source map was
-  overwritten per reviewer; the artefact carried the last reviewer's mapping for every
-  quote. The old assertion was on `size`, which cannot see a collision.
-- **A check id needed registering in two runner registries.** Registering one crashed on
-  the path this repository actually takes.
-
-## Own errors, recorded because they are the reusable part
-
-- **A grep-shaped verify is trapped by prose that quotes the token it forbids.** Hit four
-  times — `pull_request` in a workflow comment, `{{envelope}}` in a route, "in stable input
-  order" in a skill, `readFileSync` in a function's own explanation. Describe the token;
-  never quote it inside the scanned region.
-- **A baseline left one line loose is a red test.** `check_source_size_budget` warns
-  "ratchet is loose" and exits 0, so a local run looks fine — and a committed test asserts
-  `baseline == live total`. Learned from CI.
-- **A budget branch must resolve a baseline conflict onto MAIN's floor**, never its own,
-  or it silently gives back the other branch's gain.
-- **`npx tsc` on one file is not the project typecheck.** `exactOptionalPropertyTypes`
-  caught what the ad-hoc invocation missed. Use `task typecheck-ts`.
-- **`execFile` has no `input` option.** A test spawned eight dispatchers that all took the
-  no-envelope path and passed for the wrong reason.
-- **A predicted failure message is not an observed one.** A recorded RED said
-  `expected [] to include …`; the run printed `expected '' to contain …`. Corrected, because
-  a message nobody ran is indistinguishable from one that was.
-
-## What is NOT done, stated plainly
-
-**9 roadmaps remain open**, none of them touched by this run:
-`road-to-frontend-power` (60 steps) · `road-to-agentic-engineering-assurance` (53) ·
-`road-to-frontend-fidelity-calibration` (36) · `road-to-trigger-delivered-rule-bodies` (34) ·
-`road-to-chained-clip-continuity-and-provider-truth` (30) ·
-`road-to-roadmap-situational-awareness` (29) · `road-to-role-scoped-spawn-profiles` (28) ·
-`road-to-skill-delivery-over-mcp` (25) · plus the four remaining phases of
-`road-to-council-evidence-integrity`.
-
-The run stopped on **context exhaustion**, not on a blocker. Nothing above was left
-undone because it was impossible; the queue was longer than one session. Twelve of the
-twenty blockers those roadmaps carry are already council-resolved by session 1 of this
-run, so a successor starts from decided positions rather than open ones.
-
-**Defects that remain live and are named as such:** a `DERIVED_MARKER` can still reach a
-published release section (no guard ships — #1579 cleared all three refusal causes and
-promotion is the maintainer's call); rug-pull protection on third-party MCP tools remains
-absent at protection level zero; override efficacy and rtk savings remain unmeasured;
-`self_review_gate` remains single-member.
-
-## Verification standard applied throughout
-
-Every closed step's `verify:` was run, not asserted. Every new test was **seen RED** before
-its fix, or its insensitivity was recorded when the RED could not be produced — twice,
-honestly: a same-machine concurrency test that real dispatchers cannot make race, and a
-re-ask bound whose removal produced `Tests  no tests` rather than a failing assertion.
-Every null names the unavailable capability, the affected claims, the evidence boundary and
-the reopening condition — a shape the council adopted unanimously in session 1 and that was
-applied to all nine of them.
-
-# Run C — 2026-08-23 (frontend-priority continuation)
-
-Same mandate as Run B, redirected mid-run by the maintainer: *"konzentriere dich vor allem
-auf die frontend roadmapy, playbook, etc."* — so the queue was re-ordered to the frontend
-roadmaps and `road-to-repo-playbooks` ahead of everything else. Zero questions to the user;
-every owner-reserved blocker went to the AI council.
-
-## Pull requests
-
-| PR | Roadmap | State | Steps |
-|---|---|---|---|
-| [#1589](https://github.com/event4u-app/agent-config/pull/1589) | `road-to-frontend-fidelity-calibration` | **merged** | Phase 0 (3 of 36) — roadmap stays open |
-| [#1588](https://github.com/event4u-app/agent-config/pull/1588) | `road-to-repo-playbooks` | open, retitled `roadmap: complete repo-playbooks` | **complete, archived** — 13 steps, 6 AC |
-| [#1590](https://github.com/event4u-app/agent-config/pull/1590) | `road-to-component-library-lifecycle` | open | Phases 0–1 (5 of 23) — roadmap stays open |
-
-## Council decisions — 3 blockers, all 2/2 convergent, $0.04
-
-Every one was `Owner: maintainer` and would otherwise have ended the run.
-
-| Blocker | Verdict |
-|---|---|
-| `b-detector-license-verification` | **(b)** derive the detector independently from this tree's own token model, own-analysis label, no external shape taken — independent derivation *removes* the licensing question rather than answering it. Consequence pinned: nothing is added to `provenance/borrows.jsonl`, and that absence **is** the decision. |
-| `b-page-capture-primitive` | **(b)** render-dependent dimensions ship as recorded nulls and are cut from the Phase-2 matrix in 3.3, with the four-part null (unavailable capability / affected claims / evidence boundary / reopening condition). Step 7.2's obligation follows and is **not** discharged by it: 3.3 must enumerate every dimension it cut. |
-| `b-bundler-choice-for-fixture` | an explicit **combination** — (c) for the source-consumed fixture plus a *static built-package-surface* fixture modelled after (b), no bundler installed or run. Both reviewers independently rejected the single-package alternative **and** the name "buildable" for the second root: a hand-authored `dist/` is a built-package *surface*, and that name is what would have made the test overclaim. |
-
-## What I got wrong, and did not quietly fix
-
-This section is the one worth reading. Five defects were mine; each is recorded at the step
-it belongs to as well as here.
-
-1. **A fabricated measurement row.** The 4.2 post-measurement table claimed
-   `grep -rn 'turbo gen'` over the work engine went from 0 hits to non-zero. Running it says
-   **0**. The lane hard-codes no vendor command at all — it reads `invokes` ids out of the
-   repository's own playbooks at runtime, so a vendor-string grep finds nothing *by design*,
-   and a non-zero reading would have meant the opposite of what the phase wanted. The number
-   was stated without being run, in the direction that flattered the change. Corrected in
-   place, with the reason, in both the evidence file and the roadmap.
-2. **Two hollow passes.** Adding two `ROUTING_MATRIX` rows made the fidelity suite green
-   while asserting nothing — `mandate` was a field no test read. And in the playbooks work,
-   removing the pointer carve-out left its suite green: the fixture's link label carried no
-   step text, so nothing distinguished carve-out from no carve-out. Both fixed by making the
-   fixture carry the hardest case (a pointer whose *label quotes the step*), after which
-   removing the guard is RED.
-3. **A guard with unknown sensitivity.** The length guard in the restatement detector was
-   untested — the needle was long enough that removing the guard changed nothing. Now
-   exercised with a short id (`gen`) against prose containing *"generator"*.
-4. **A detector matching the wrong field.** The first restatement detector matched a step's
-   *title*. Titles are generic by construction (every generator step in the fixture is *"Run
-   the repository's own generator"*), so it reported one prose line once per playbook
-   (`expected 2 to be 1`) and named neither procedure. Rewritten to match the invoked **id**.
-5. **A dropped `git stash` ate a note and a set of skill edits.** Switching branches mid-step
-   stashed uncommitted work; the pop said *"The stash entry is kept"* and the entry was then
-   dropped. `git fsck --unreachable` found no matching commit. Recovered by redoing the edits
-   from the session record. The lesson is the ordering: **commit before switching branches**,
-   and treat a `pop` that does not say *"Dropped"* as a failed pop.
-
-## Gate failures fixed by repair, never by weakening
-
-No baseline was raised, no gate skipped, no allowlist entry added.
-
-| Gate | What it caught | Fix |
-|---|---|---|
-| `lint_regression` / `rule_too_large` | `design-fidelity.md` at 218 lines, hard limit 200 | migrated the table + citation to the mechanics guideline; the rule sits **at** 200 |
-| `check_depth_budget` | the migration target then exceeded its 16,000-char ceiling — a *fifth* over-ceiling file | cut to the table plus two pointer sentences (15,892). Both the rule and its overflow lane are now near their caps, recorded so the next change knows |
-| `lint_framework_leakage` | a generic skill naming a Node manifest as *the* source of truth | rewrote the skill as **ecosystem-neutral** (nox / make / just named as covered-but-not-yet-read) rather than taking the offered suppression, whose reason field would have recorded something untrue |
-| `lint_consumer_internal_refs` | the skill told a consumer to run a maintainer-only script they never receive | stated the split: script maintainer-side, consumer follows the grading rules by hand |
-| `check_artefact_count_messaging` | five count-shaped prose positions | two live counts updated; one **generated** figure re-derived; one **dated measurement** rewritten as *"the then-119 governed-rule total"* — bumping a measured denominator to today's number would turn a measurement into a false claim |
-| projected-rule-link gate | the new rule linked `../../docs/` | ADR cited by number, unlinked: `docs/` is not projected into a consumer install, and `check_references` passes on such a link because the target exists *here* |
-| `adr-evidence-census` | stale after adding ADR-244 | regenerated. Its proposed `E0` against the ADR's declared `E2` is the **expected** output, not a contradiction: the census never raises a grade above E0 on a council marker, structurally |
-
-## Environment defect worth recording
-
-`task preflight` cannot go green in a **worktree** on a machine with a global install: the
-worktree's `generate-tools` emits the full rule projection (114 files) while the main checkout
-emits the partitioned 15, so `check_rule_layer_partition` and the bridge-derivation gate
-deadlock — each red in the state the other requires. CI has neither layer and is unaffected.
-Every push in this run therefore went out from the main checkout, whose projection is
-partitioned. Clearing the worktree's projection satisfies one gate and breaks the other; this
-is a real defect in the emitter's partition-awareness, not a local misconfiguration.
-
-## Descopes
-
-None. Nothing in this run used the mandate's §5 fallback: no blocker survived execution,
-council decision, and re-scoping.
-
-## What is NOT done
-
-- `road-to-frontend-fidelity-calibration` — 33 of 36 steps. Phases 1–7 untouched; the
-  render-dependent dimensions are a recorded null with a reopening condition.
-- `road-to-component-library-lifecycle` — 18 of 23. Phases 2–5 (Storybook as an artefact,
-  registry publishing, `DESIGN.md` inventory, the compatibility refresh) untouched.
-- `road-to-frontend-power` (60 steps) — not started.
-- `road-to-chained-clip-continuity-and-provider-truth` (30) — not started.
-- The non-frontend remainder, deprioritised by the redirection:
-  `road-to-agentic-engineering-assurance` (53), `road-to-trigger-delivered-rule-bodies` (34),
-  `road-to-roadmap-situational-awareness` (29), `road-to-role-scoped-spawn-profiles` (28),
-  `road-to-skill-delivery-over-mcp` (25), and `road-to-council-evidence-integrity` 2.3–5.
-
----
-
-# Run D — 2026-08-23 (full-estate drain, 15 roadmaps)
-
-The run that emptied the active estate. Every roadmap at the top level of
-`agents/roadmaps/` on the day was taken to a PR; the seed table in the mandate
-was **entirely stale** (36 named roadmaps, none of which existed) and the queue
-was recomputed from the live tree before anything started.
-
-## Headline
-
-- **15 roadmaps, 14 PRs opened** (#1593–#1605) plus one merged before the run
-  began (#1592). One further PR (#1606) records a defect found on the way.
-- **13 of 14 orchestrated by subagents, one in-session.** All fourteen reached
-  **zero failing checks**.
-- **Every red CI check in this run was a stale generated artefact or a floor the
-  trunk had already lowered.** Not one was a defect in the roadmap work itself.
-  That is the finding worth carrying forward, and it is stated as an
-  observation about this run rather than a law.
-
-## Pull requests
-
-| PR | Roadmap | Closure |
-|---|---|---|
-| #1592 | role-scoped-spawn-profiles | 28/28 (11 done, 17 descoped) — merged during the run |
-| #1593 | agentic-engineering-assurance | 53/53 (32 done, 21 descoped), archived |
-| #1594 | roadmap-situational-awareness | 26/29 — **not archived**, 3 deferred items held under Iron Law 3 |
-| #1595 | observability-plate | 20/20, archived |
-| #1596 | standing-payload-diet | 18/19, archived |
-| #1597 | council-evidence-integrity | 22/22, archived (in-session, not delegated) |
-| #1598 | chained-clip-continuity-and-provider-truth | 30/30, archived |
-| #1599 | skill-link-integrity-and-manifest-sync | 24/24, archived |
-| #1600 | skill-delivery-over-mcp | 22/25, outcome `measured-null` |
-| #1601 | frontend-fidelity-calibration | 36/36, archived |
-| #1602 | monorepo-scope-and-detection | 24/24, archived |
-| #1603 | frontend-power | 60/60 (45 done, 15 descoped), archived |
-| #1604 | deterministic-time-in-gates | 17/18 — **not archived**, AC-2 left open for the owner |
-| #1605 | trigger-delivered-rule-bodies | 34/34, archived |
-| #1606 | — | stub recording the language-pin defect (below) |
-
-## Council decisions
-
-Convergent verdicts (2/2 quorum):
-
-- **#1597 `b-probe-channel-decision`** — a **named hybrid** over the blocker's
-  own (a)/(b): a continuous argv-construction gate plus a deliberately invoked
-  live canary, never in CI. Both seats independently required filesystem state
-  as the oracle rather than model prose. The openai seat **rejected** the
-  anthropic seat's 90-day recheck cadence as invented policy; version-invalidation
-  replaced it.
-- **#1595 shape** — three responsibility-split skills over an in-place
-  extension, overruling the blocker's own recommendation.
-- **#1595 fixtures** — committed contract pairs in the verdict-owning skill.
-- **#1596 both blockers** — scope the contended rules out; scope the claim to
-  same machine **and** same projection state.
-- **#1598 `trace-visibility-decision`** — `local-only`, decided *by the council*
-  on the ground that reaffirming an existing floor is not a floor transition.
-- **#1601 both blockers** — recorded nulls for render-dependent dimensions;
-  detector derived independently rather than borrowed.
-- **#1603 `b-pack-reach-weight`** — keep `suggests:`, scope the claim (ADR-245).
-- **#1592 `b-maintainer-run-capture`** — capture refused; the seats diverged on
-  AC-1 and the divergence is recorded rather than smoothed.
-- **#1593** — three questions, all convergent, including thresholds committed
-  with every value explicitly `null` rather than a number invented.
-
-**Inconclusive councils — five, and they are the run's weakest point.** CLI
-quota was exhausted (anthropic 53/50, openai 50/50), so five questions returned
-0/2 or 1/2 present: #1594 cadence key, #1599 removal-path re-scope, #1600
-`.mcp.json` ownership, #1604 AC-2 two-machine clause, #1605 both blockers
-(1 of 2 answering). Every one was recorded as a null and decided on tree
-evidence or left with the owner — none was reported as convergence. #1604's
-criterion stays open **because** a no-quorum council is an escalation condition.
-
-## Descopes
-
-Recorded per PR; the substantial ones:
-
-- **#1603** — three stubs (live measurements across 8 hosts, default flips,
-  detector promotions); two steps abandoned outright with reasons.
-- **#1600** — live arm needs ≥40 real interactive sessions across two install
-  configurations; scripted prompts would measure a script, not a model.
-- **#1598** — six honest nulls; the frame-lock probe and seam collection need
-  paid renders *and two blind human raters*. Step 4.3 recorded **UNDECIDED**,
-  not H0: with no data, "no threshold reaches 0.8 precision" would be a claim
-  about measurements that do not exist.
-- **#1593** — Phase 5 cut outright (no deploy platform, and the grader prints
-  that reason in every report).
-- **#1592** — 13 steps to a stub carrying the measured 22.1 % ceiling, so nobody
-  promotes it on the token axis alone.
-
-## Findings beyond the roadmaps
-
-- **The language pin follows the paste when the typed lead is short** (#1606).
-  `classify` falls through to the whole body when the lead scores below
-  `MIN_MARKERS`, so `Fix this file.` over a German paragraph pins `de`, and the
-  mirror case pins `en`. Adding a document heading does **not** help, which
-  rules out the paste-stripping explanation. The function's own docstring claims
-  the opposite, unqualified. Filed as a stub, not fixed: it is a behavioural
-  surface on every turn on every host.
-- **The token cap dragged `js-tiktoken` into every hook dispatch** (#1605) —
-  `pre_tool_use` p95 202 ms → 62 ms after moving the cap to bytes.
-- **`design-pass-stop` was declared advisory while returning `EXIT_BLOCK`**
-  (#1603), which the dispatcher downgrades — a refusal that would have shipped
-  inert.
-- **`parse-blueprint.sh` could not read piped stdin on Linux** (#1598) —
-  pre-existing, and untested until this branch added the test.
-- **Two of a roadmap's own `corrected-from-reproduction` figures were themselves
-  wrong** (#1604), and the source they "corrected" was right.
-
-## Process defects in the run itself
-
-Recorded because they cost real time and recurred:
-
-1. **Regenerating `dist/` on a branch behind `main` deletes other people's
-   merged work.** Hit twice in-session before it was written down: `task sync`
-   rebuilds from the working tree's `src/`, so every skill the trunk added
-   meanwhile is regenerated out of existence and `git add -A` stages the
-   deletions as if they were yours. The tell is a diffstat far larger than the
-   change. Merge (or rebase) **before** regenerating, never after.
-2. **A gate's own remedy line can be wrong.** `check_artefact_count_messaging`
-   says to run `update_counts`, which reports "already in sync" and does not
-   touch `CAPABILITIES.yaml`; the correct generator is named in that file's own
-   `meta.generated_by`.
-3. **`check_requirements_trace`'s floor tracked the active roadmap count**, so
-   every successful completion turned it red. Lowered 15 → 10 with the reason
-   written into the corpus field and stated as a judgement, not a measurement.
-4. **A stash probe popped a foreign session's stash.** Recovered without loss —
-   git keeps the entry on a conflicted pop — but the probe was the wrong tool.
-
-## Honest limits of this record
-
-- Counts and closures are as reported by each PR at the time of writing; four
-  PRs were still settling their last checks.
-- The five inconclusive councils mean five questions this run answered without
-  the multi-seat check the mandate asked for. They are listed above rather than
-  folded into the convergent set.
-- `#1594` and `#1604` are deliberately **not** archived and their open items are
-  owner-facing, so the active estate is not empty by design.
-
----
-
-# Run C — 2026-08-24
-
-Second autonomous drain run of 2026-08-24. Every decision below was taken by the
-**AI council** under maintainer-delegated authority; none was taken by the agent
-alone, and none reached the user. Council spend: **$0.45** across 7 sessions.
-
-**This run did not empty the roadmap directory, and the reason is capacity rather
-than a blocker.** That is stated first because it is the fact the mandate's
-success condition turns on.
-
-## The seven pull requests
-
-| PR | Roadmap | Outcome |
-|---|---|---|
-| [#1614](https://github.com/event4u-app/agent-config/pull/1614) | `component-library-lifecycle` | **complete + archived.** 2 steps, 8 ACs · **merged** |
-| [#1615](https://github.com/event4u-app/agent-config/pull/1615) | `release-placeholder-guard` | **reverted to `stubs/`** by council verdict · **merged** |
-| [#1616](https://github.com/event4u-app/agent-config/pull/1616) | `score-contract` | **complete + archived.** New gate + 23-row scorecard · **merged** |
-| [#1617](https://github.com/event4u-app/agent-config/pull/1617) | `npm-payload-reduction` | **complete + archived.** Cap 9.2 → 9.1 |
-| [#1618](https://github.com/event4u-app/agent-config/pull/1618) | `suggestion-block-capture` | 11/13; soak transferred; **stays active** |
-| [#1619](https://github.com/event4u-app/agent-config/pull/1619) | `opencode-enforcement` | Phase 0 complete; Phases 1–2 transferred; **stays active** |
-| (this PR) | `command-surface-legibility` | Phase 0 complete; Phases 1 + 4 transferred; 6 steps open |
-
-## Council decisions — every one, with its verdict
-
-| Question | Verdict | Convergence |
-|---|---|---|
-| May an autonomous run self-issue an estate offset over a deferred decision? | **Never.** Five conditions stated; revert `release-placeholder-guard` | 2/2 |
-| Is the AC scorecard a fourth register or a `CLAIMS.md` projection? | **Register** — but in a **new `agents/evidence/README.md`**, not `provenance/README.md`, which the blocker named wrongly | 2/2 |
-| Seed 32 rubric rows, or the 23 recoverable? | **23**, incompleteness machine-enforced. Both seats corrected the arithmetic to **9** missing, not 7 | 2/2 |
-| Lower `packed_size_mb` to 9.1 on a 92.9 KB reduction? | **Yes**, and state the headroom as **7.4 %**, not "~8 %" | 2/2 |
-| Repoint 9 shipped importers at `dist/agent-src/` for ~102 KB? | **No** — it inverts source-of-truth; needs an ADR | 2/2 |
-| Disposition of a 14-day soak needing a human's log? | **Transfer to `stubs/`; roadmap stays active; AC-2 is `open`, not "partially met"** | 2/2 (after a 1/2 `ENOBUFS` degradation was **re-run rather than banked**) |
-| opencode: translator or new authority? | **Conditional and behavioural**; a **fifth** hook state, classified **per concern** | 2/2 |
-| Six-concern PREREG, or two? | **Six**, as branch pre-registrations with three predetermined outcomes | 2/2 |
-| Path-leak floor: 12, or backtick exemption? | **Neither** — 0 unapproved with line-pinned exceptions | 2/2 |
-| `## Examples` for `visible` only or `visible`+`advanced`? | **Both** = 23 governed, 18 to write | 2/2 |
-
-## Premises the run measured and falsified
-
-Nine, each in a roadmap that asserted the opposite:
-
-1. **`src/scripts/ai_council/` can be dropped for 270 KB** — the candidate carried across four cap raises. Removing it breaks `council:status` **and** `hooks:status` with `ERR_MODULE_NOT_FOUND`. **Settled; should not be proposed a fifth time.**
-2. **Every named payload subtree ships.** All six. The removable set is three *file patterns* nobody had looked for.
-3. **`src/agent-src/` "partly duplicates" `dist/agent-src/`** — it is **94.2 %** byte-identical (284/297 files), and still not removable.
-4. **The 32-category rubric is reconstructible** — it is not in the tracked tree. 23 recoverable; **9 identities unknown**.
-5. **opencode has no plugin channel** (`surface-matrix.yml`) — it has four hooks and a real deny.
-6. **`permission.ask` gives a pre-tool deny** — it gives a deny only where the host already asks; `tool.execute.before` is mutate-only.
-7. **"tier 0/1" classifies commands** — the integer alias was removed; 201 of 202 files have no `tier:` key.
-8. **8 invoking / 14 mentioning** — measured 8/**6**.
-9. **Published `.md` can melt to zero absolute paths** — six of twelve are the rules that *forbid* the pattern, quoting it.
-
-## Errors this run made, caught, and recorded
-
-Kept because a summary that lists only findings reads as a run that made none:
-
-1. **Lowered a ratchet on a local reading.** `ci-parity:local-only` reported itself loose at 164; CI measured 165 and red the gate. Reverted, and the entry now records that this baseline moves on the **enforcing** environment only.
-2. **Skipped two of six patterns on an assumption.** Called the `node_modules` patterns "bundle-shaped, cannot occur in prose". One prose hit exists. Under-reported 11 for 12.
-3. **Scanned a root outside `files[]`.** Counted 132 files no consumer receives. Caught by a test written for the gate.
-4. **Wrote a settings disposition as `derivable`** when the key authorises observing an operator's turns — `consent`. The shrink-only ratchet refused it immediately.
-5. **Appended a stop-slot concern after `run-continuation`**, which must be last. CI named the constraint exactly.
-6. **Four downstream surfaces missed for one settings key** — schema path, class contract, proof page, install bundle. Each caught by CI, none by me.
-7. **Substituted a pin** — read npm `1.18.21` where a blocker asked for git `6386e67`. Disclosed in four places rather than glossed.
-
-## Transferred to `stubs/` — five, each with a named probe
-
-| Stub | Probe | Gated on |
-|---|---|---|
-| `road-to-release-placeholder-guard` | (re-promotion conditions) | a named estate offset, or an authorised capped exemption |
-| `road-to-suggestion-capture-soak` | `probe:suggestion-capture-soak-evidence-ready` | a human's 14-day independent emission log |
-| `road-to-opencode-runtime-probe` | `opencode-permission-payload-and-coverage` | an installed plugin + a live opencode session |
-| `road-to-command-runtime-requirements` | `probe-command-schema-runtime-requires` | a maintainer schema-ownership decision |
-| `road-to-make-it-stick-telemetry` | `probe-make-it-stick-telemetry` | per-invocation telemetry that does not exist |
-
-## What remains, and why — the honest accounting
-
-**The directory is not empty.** Nine roadmaps carry open work this run did not
-reach, and **not one of them is blocked**:
-
-| Roadmap | Open | Why not reached |
-|---|---|---|
-| `command-surface-legibility` | 6 | Phases 2–3 executable; Phase 0 shipped instead |
-| `merge-surface-zero` | 15 | not started |
-| `standing-payload-truth` | 15 | not started (4 blockers) |
-| `skill-estate-drawdown` | 16 | not started (3 blockers) |
-| `web-launch-readiness` | 19 | not started |
-| `episode-finalizer-and-outcome-attribution-v2` | 21 | not started (3 blockers) |
-| `ten-across-the-board` | 20 | index roadmap; owns no state of its own |
-| `routing-assurance` | 33 | not started |
-| `capability-native-execution` | 54 | not started (5 blockers) |
-| `inbox-harvest-2026-08-e-council-topology-evidence` | 77 | not started (6 blockers) |
-
-```
-THIS IS A CAPACITY LIMIT, NOT A BLOCKER. THE MANDATE'S TERMINAL FALLBACK COVERS
-WORK THAT SURVIVES EXECUTION, COUNCIL, RE-SCOPING AND DESCOPING. NONE OF THE
-ABOVE WAS PUT TO ANY OF THE FOUR — THE RUN STOPPED BEFORE REACHING THEM.
-```
-
-Descoping them into stubs would assert a capability gap that does not exist, which
-is the same false-blocker the `command-surface-legibility` ledger refuses for its
-own six open steps. So they are left **active and open**, which is what they are.
-
-## Honest limits of this record
-
-- **PR-reported state.** #1617, #1618, #1619 and this PR were still settling
-  checks when this was written; #1614–#1616 are merged.
-- **Every "complete" is complete against its own ACs**, several of which this run
-  **rewrote** — most sharply `opencode-enforcement`'s AC-2, which had no true
-  branch, and `command-surface-legibility`'s "target 0", which was unreachable. A
-  reader auditing completion should read the AC as amended, and the amendment's
-  reason is recorded at each one.
-- **Three ACs are met vacuously or partially and say so** in their own text:
-  `opencode` AC-5 (nothing claimed, so nothing violated), `suggestion-block` AC-2
-  (unit-verified, live-unverified, N=3 budget spent), `npm-payload` AC-1 (six named
-  boundaries, not "every subtree").
-- **One council reached 1 of 2** on the first attempt (`ENOBUFS`) and was re-run;
-  the degraded reading was not banked. Every other session was 2/2.
-
----
-
-# Run E — 2026-08-25
-
-**Mandate:** drive every active roadmap under `agents/roadmaps/*.md` to
-completion, zero questions to the user, everything that would normally end in
-"ask the user" put to the AI council instead. **Six roadmaps in the queue. One
-completed and archived; five advanced and stopped somewhere specific, and the
-specific place is the substance of this record.**
-
-## Headline
-
-| # | roadmap | steps | outcome | PR |
-|---|---|---|---|---|
-| 1 | **routing-assurance** | 10 of 33 | **COMPLETE and archived** at its own declared cut line; live half parked in `later/` | #1634 |
-| 2 | web-launch-readiness | 16 of 19 | Phase 2 complete, benchmark fixtures built; closure **owner-reserved** | #1635 |
-| 3 | merge-surface-zero | 2 of 15 | blocker **B5 resolved**, the absolute-invariant reader landed | #1637 |
-| 4 | capability-native-execution | 1.5 of 54 | **three council-owned blockers resolved**, Phase 2 resequenced | #1638 |
-| 5 | council-topology-evidence | 3 of 77 | agent-owned blocker resolved, 6.2–6.4 closed | #1639 |
-| 6 | ten-across-the-board | 0 | **not advanced** — see § What this run did not reach | — |
-
-Five PRs opened. #1634 and #1635 settled **CI-green** (41 and 32 checks);
-#1637–#1639 were still settling at write time, with **zero failing checks on any
-of the five**.
-
-**Council:** 4 sessions, 2/2 quorum on every one, **$0.1697** total.
-
-## The five council decisions, and what each cost the plan
-
-Every decision below replaced a question that would otherwise have gone to the
-user. **Two of them refused to.**
-
-**1 · routing-assurance 2.1 — the corpus format.** Taken literally the step
-(*"one YAML per skill"*) would have created a **third** corpus surface beside 74
-`queries`-shaped and 2 `should_trigger`-shaped JSON files. Both seats: the
-objective is corpus *discipline*, the verify condition is format-agnostic, so the
-discipline goes on the existing JSON — **and it is legitimate only because the
-amendment is written down.** One seat: *"silent substitution would violate the
-roadmap's intent; explicit amendment preserves accountability."* Both insisted
-German be **declared, never detected** — a detector would pass German-looking
-English and fail short German, and its failures would be unactionable.
-
-**2 · routing-assurance 3–6 — park.** Cost was explicitly *not* the objection;
-spend was pre-authorised. One seat sharpened it past where the question had
-framed it: *"The evaluator-independence issue isn't just about same-turn
-evaluation — it's about evaluating an artifact you authored. Capturing a baseline
-of a corpus you just fixed, even without interpretation, crosses that line."*
-That is why step 0.2 was parked **too**, and why the cautious-looking middle
-option — capture the baseline now, adjudicate later — was **rejected** rather
-than taken.
-
-**3 · web-launch-readiness 3.2/3.3 — the council declined half the question.**
-It may park the two steps for conflict of interest; it may **not** treat that
-parking as *completion*. *"The council can park for COI. The owner decides
-whether that satisfies the roadmap."* Both seats checked whether the
-routing-assurance precedent from earlier the same day carried, and both said no:
-that roadmap's own text declares its cut line a valid end state, this one says
-nothing of the kind.
-
-**4 · merge-surface-zero B5 — the absolute invariant.** ABS wins, because CONTRIB
-permits a regression this repository's own numbers demonstrate: main tightens
-165 → 160, a PR branched earlier measures 163, the merge-base read returns 165 so
-it **passes**, and main lands at 163 against a baseline of 160. **Why it was
-council-decidable, and it cuts both ways:** choosing CONTRIB *"would weaken the
-already stated uninterrupted-trunk guarantee, not merely relocate its check"* —
-the **direction** of the answer is what made the council competent to give it.
-And ABS does **not** require the owner-reserved post-merge writer, which is the
-finding that keeps Phase 3 alive while B4 stays blocked.
-
-**5 · capability-native-execution — three blockers, one split recorded.** Both
-seats **rejected two of the three distinctions the roadmap itself offered**:
-"interchangeable on one protocol" is false as stated (Playwright, Puppeteer,
-Selenium, WebDriver and CDP are not one protocol), and byte-comparable evidence
-*"measures reproducibility, not whether we should choose this adapter over that
-one."* Only *a caller exists before the selector* distinguishes — so **Phase 2's
-manifest is resequenced behind Phase 3**. On ADR-212 both refused the
-subject-level distinction: the test is not *"are the subjects different"* but
-*"would this distinction prevent ANY subject from claiming exception?"* The one
-**unresolved split** — whether a semantics-neutral tie-break among
-conformance-tested equivalents is permitted — is recorded, and Phase 2 builds to
-the conservative intersection until the conformance tests exist to answer it.
-
-## Defects found and fixed, not noted
-
-Each was found by **running** something, not by reading it.
-
-1. **A silent no-op in this run's own Phase 1 work** — the corpus loader read
-   only the `queries` shape, so 2 files contributed **zero** cases while the
-   coverage ratchet counted them as covered: the file existed, so the ratio said
-   yes and the corpus said nothing.
-2. **A gate whose rows contradicted its verdict** — `check_routing_coverage`
-   compared a raw float in the row and a rounded value in the summary, so one
-   scope printed `↑` and the other `❌` while the verdict correctly said green.
-   Worse than being wrong: the reader cannot tell which half to trust.
-3. **`--dry` returned its own exit code**, making every description edit red —
-   the dry backend matches on unit *name* over a catalogue whose signal is the
-   *description*. A gate red for a reason unrelated to what it measures is worse
-   than no gate.
-4. **A fixture's own manifest defeated the check it seeded** —
-   `analytics-and-consent-wiring` passed on a tree built to fire it, because
-   `SEEDED.md` contains the word *consent* and the scan read prose as an
-   implementation.
-
-**And one this run caused, then fixed on CI:** a test pinned the skills coverage
-seed at its landing-day value, and the very next commit in the same roadmap
-raised it by adding corpus files — so the test reddened for doing exactly what
-the ratchet exists to encourage. **A snapshot of a number the work is supposed to
-move is a test of the calendar.**
-
-## Sabotage proofs — six
-
-| what was neutered | result |
-|---|---|
-| removed a routing-matrix fixture | rules 0.8952 → 0.8857, **exit 1**; restored → 0 |
-| removed a skill triggers file | skills 0.2542 → 0.2508, **exit 1**; restored → 0 |
-| matched the canonical host to the sitemap | benchmark-fixture test **red**; restored → 18 green |
-| added a `team-photo-present` check to the config | decoy-gate test **red**; restored → 18 green |
-| removed the ordering conjunct from the stop predicate | conformity-collapse fixture **stops** — the exact failure the blocker names |
-| pointed the baseline reader at a non-existent ref | **exit 1**, `BaselineResolutionError`, no working-tree fallback |
-
-## Honest nulls, stated as nulls
-
-- **Skill-invocation telemetry is empty** — 299 tracked, **0 active, 0
-  exposed-only, 299 dead**. The corpus priority ordering fell to `model_tier`,
-  the step's own declared second key; an ordering presented as telemetry-derived
-  would have been chosen by hand.
-- **"Every top-invoked skill has a corpus file" is satisfied VACUOUSLY** — the
-  top-invoked set is empty, and every member of an empty set satisfies any
-  predicate.
-- **routing-assurance AC-1 is a SPLIT, not a pass** — the pre-registration and
-  both ratchets predate the first Phase-1 commit, a fact of the log (`bbcb8e7`,
-  `707fd4f` before `7c9edc6`); the frozen baseline does not exist. Two-thirds met
-  and reported green is the silent-green defect this repository already knows.
-- **The Phase-1 proxy gap is unquantified, not small** — nothing here measures
-  fidelity to real sessions.
-
-## What this run did NOT reach
-
-**`ten-across-the-board` was not advanced at all.** Its next step requires
-*promoting* a stub a **prior council reverted 2/2**, because that run had
-substituted a self-issued estate exemption for an expressly required offset. The
-same council wrote the five-condition rule for when a run may self-issue one, and
-this run satisfies **none**: no rule permits it, no objective criteria exist, and
-naming an offset would mean inventing a maintainer priority. **Re-asking would
-have been relitigating a decision the council made twice.** The implementable
-half — the guard in `release.ts` — was scoped and left: a change to the release
-path under a size ratchet that admits no net line, deserving a session whose
-whole attention is on it.
-
-**Two blockers reached the owner and stayed there, correctly** —
-`b-benchmark-owner-rescope` (the council declined the closure half and said so)
-and **B4**, the post-merge writer, where one seat had proposed landing it
-disabled as containment and the other refused: **"infrastructure ready" is not
-containment.**
-
-**Seven maintainer-owned blockers were deliberately not put to the council.** The
-mandate delegates decisions that would go to the user; it does not convert an
-owner-reserved blocker into a council-decidable one by routing it.
-
-Three roadmaps remain open with real work — merge-surface-zero (13),
-capability-native-execution (52), council-topology-evidence (74) — and one
-(web-launch-readiness, 3) waits on a single owner answer.
-
-## The honest verdict on the mandate
-
-The mandate asked for an empty roadmap directory, or a blocker provably
-unresolvable even by council decision. **Neither was reached, and the second is
-the interesting one.**
-
-Four blockers were resolved by council decision that would otherwise have gone to
-the user. Two were put to the council and came back **owner-reserved** — not
-because the council lacks authority in general, but because each proposed
-transition either weakened a floor or redefined what completion means, which is
-exactly where the reserved set draws its line. A third was already locked twice
-and left alone.
-
-That is the mandate **working** rather than failing: the council substituted for
-the user everywhere it legitimately could, and declined precisely where
-substituting would have been the agent granting itself authority. A run that
-closed all six roadmaps would have had to cross that line to do it.
+| web-launch 3.2, 3.3 | `[-]` descoped | the authoring session may not run the experiment that grades its own fixtures |
+| web-launch AC-5 (remainder), AC-6 | `[-]` unmet, **verbatim** | both seats refused rewriting criteria to match what shipped |
+| channel-contract 2.2 | `[-]` not applicable | conditional step; 2.1 decided out-of-scope, so its condition is false |
+| `merge-surface-zero` | **`later/`** | 5 steps on an owner-reserved trunk writer, 2 on repo-admin, 2 on a 20-PR window |
+| canonical-terms 2.1 | re-scoped, still open | sweep **not authorised**: needs a classified inventory + a blast-radius pilot |
+| runtime-enforcement Step 7 | `[~]` half done | the flag exists; the Phase 2 diagnostic it names does not |
+| episode-finalizer 2.2, 5.2 | `[-]` descoped | all 4,912 stops machine-local against a `≥200 non-local` band |
+| `episode-finalizer-v2` | **`later/`** | AC-2 requires ≥2 machine provenances; unobtainable in-session |
+
+**Nothing was descoped to make a roadmap look finished.** Two roadmaps were
+parked precisely to avoid that, and in both the external-validity gap is stated
+in the roadmap's own header rather than only beside the steps.
+
+## 5. The seven roadmaps never opened
+
+| roadmap | open | why not |
+|---|---:|---|
+| `skill-ecosystem-eval-integrity` | 42 | gained a tracked Step 8 via #1646; not otherwise worked |
+| `inbox-harvest-2026-08-e-council-topology-evidence` | 74 | 5 open blockers, largest in the estate |
+| `capability-native-execution` | 52 | not reached |
+| `decision-conformance` | 29 | not reached |
+| `component-granularity-vocabulary` | 28 | not reached |
+| `internal-estate-fit` | 25 | not reached |
+| `published-number-truth` | 21 | not reached |
+| `ten-across-the-board` | 19 | not reached |
+
+**These were not blocked — they were not reached.** Roughly **290 open steps**
+remain. Saying "not reached" rather than "deferred" is the point: nothing about
+them was assessed.
+
+## 6. Quota and the run's own limits
+
+Council quota ended at **41/50** per provider, having warned *near limit* on
+both. No decision was degraded to a single seat, and no seat was absent from any
+session.
+
+**Three things this run could not do, by construction:**
+
+1. **Merge anything.** The PR is the touchpoint, so eight PRs are open and the
+   estate movement above is pending review.
+2. **Produce a second machine.** Council #14's verdict is a property of the
+   world, not of effort.
+3. **Authorise trunk mutation.** B4's writer would be the **first** workflow in
+   this repository to push to `main`, and it needs a standing bypass of the
+   repository's own pull-request rule. A packet was written; nothing was wired.
+
+## 7. Verification discipline
+
+Every load-bearing assertion added this run was **seen red** before being
+believed — 18 sabotage probes across five PRs, each restored and re-verified:
+
+| PR | probes | notable |
+|---|---:|---|
+| #1646 | 4 | schema enum, the short-form typo, contract drift, surface drift |
+| #1649 | 5 | each probe fails **only its own target**, proving the assertions independent |
+| #1650 | 4 | removing the shim's loop guard made the probe **hang** — that is the proof |
+
+Three preflight/CI failures were **fixed, never bypassed**: an undeclared
+evidence type, a stale risk review answered with an actual re-review, and a
+suppression file undeclared in `SUPPRESSION_INVENTORY` — the last caught by CI
+after the local gate passed, because that gate is diff-scoped and blind until
+committed. `AGENT_CONFIG_SKIP_PREPUSH_PREFLIGHT` was never used.

--- a/agents/roadmaps/later/road-to-ac-deep-capabilities.md
+++ b/agents/roadmaps/later/road-to-ac-deep-capabilities.md
@@ -6,7 +6,7 @@ estate_offset_exempt: "Landed by the /analyze:inbox run of 2026-08-24 directly i
 execution:
   mode: experiment-gated
 park: later
-entry_condition: "ALL THREE, each checkable without judgement — (1) agents/evidence/ac-capability-scorecard.yaml exists AND ./scripts-run src/scripts/check_score_contract exits 0 (producer: agents/roadmaps/archive/road-to-score-contract.md); (2) the claim episode-finalizer-coverage is registered in docs/CLAIMS.md with status: backed at >=90 % terminal records over >=200 episodes, read from a ledger carrying >=2 distinct machine provenances (producer: agents/roadmaps/road-to-episode-finalizer-and-outcome-attribution-v2.md Phases 2.3 + 5.2); (3) blocker b-envelope-drop-vs-unresolved reads Status: resolved. Reopening condition if (2) DROPs: this roadmap closes as measured-null on the attribution axis and Workstreams A/B/C proceed on mechanism-and-cost evidence only, with no outcome dimension claimed. <!-- ref-ignore -->"
+entry_condition: "ALL THREE, each checkable without judgement — (1) agents/evidence/ac-capability-scorecard.yaml exists AND ./scripts-run src/scripts/check_score_contract exits 0 (producer: agents/roadmaps/archive/road-to-score-contract.md); (2) the claim episode-finalizer-coverage is registered in docs/CLAIMS.md with status: backed at >=90 % terminal records over >=200 episodes, read from a ledger carrying >=2 distinct machine provenances (producer: agents/roadmaps/later/road-to-episode-finalizer-and-outcome-attribution-v2.md Phases 2.3 + 5.2); (3) blocker b-envelope-drop-vs-unresolved reads Status: resolved. Reopening condition if (2) DROPs: this roadmap closes as measured-null on the attribution axis and Workstreams A/B/C proceed on mechanism-and-cost evidence only, with no outcome dimension claimed. <!-- ref-ignore -->"
 pin: "fd42264a998e4ec66ba4fd397d9c37b801d045ba"
 ---
 # Road to AC deep capabilities (v2, council-merged)
@@ -36,7 +36,7 @@ legitimate finish.
 
 1. **Both inputs now have real producers, landed in the same run as this
    file.** `agents/roadmaps/archive/road-to-score-contract.md` produces conjunct (1);
-   `agents/roadmaps/road-to-episode-finalizer-and-outcome-attribution-v2.md`
+   `agents/roadmaps/later/road-to-episode-finalizer-and-outcome-attribution-v2.md`
    Phases 2.3 + 5.2 produce conjunct (2). The draft asserted this was already
    true; it was not, which is why the condition is rewritten rather than
    copied.

--- a/agents/roadmaps/later/road-to-episode-finalizer-and-outcome-attribution-v2.md
+++ b/agents/roadmaps/later/road-to-episode-finalizer-and-outcome-attribution-v2.md
@@ -1,7 +1,8 @@
 ---
 title: "Road to Episode Finalizer and Outcome Attribution v2"
 complexity: structural
-status: ready
+status: later
+estate_growth_exempt: "Charges +1 later_roadmaps / -1 active on a MOVE, not an addition: the same file leaves the active tree for later/, and no roadmap was created. The move is the disposition AI council 2/2 directed on 2026-08-26 after both blockers resolved -- one as a host null, the other as NOT RESOLVABLE BY AN AUTONOMOUS RUN. roadmap-progress-sync section Later disposition requires it: AC-2 demands a ledger carrying >=2 distinct machine provenances, all 4,912 measured stops are machine-local, and a second machine with independent traffic cannot be produced inside a session. +0 open_blockers: this change created none and RESOLVED two."
 estate_offset_exempt: "Landed by the /analyze:inbox run of 2026-08-24. The one-in-one-out half fires on every added agents/roadmaps/road-to-*.md whatever its status, and this run archived only status: draft roadmaps, which were never counted and so are unavailable as offsets. Its predecessor road-to-episode-finalizer-and-outcome-attribution was never landed in the active estate either, so the supersedes edge offsets nothing countable."
 execution:
   mode: phase-checkpoints
@@ -10,6 +11,44 @@ supersedes:
   - road-to-episode-finalizer-and-outcome-attribution
 ---
 # Road to Episode Finalizer and Outcome Attribution v2
+
+> **PARKED to `later/` on 2026-08-26 — blocked-for-later, not abandoned.** AI
+> council 2/2 (`anthropic/claude-sonnet-4-5` + `openai/codex-default`, 3 rounds,
+> blind chairman, $0.079) under the maintainer's standing delegation.
+>
+> **Resume when** a ledger carries **≥ 200 non-local stops** from a machine with
+> an independent identity, identical instrumentation, comparable traffic and
+> **separately retained** evidence. Replaying this ledger, running fixtures, or
+> assigning a different identity do **not** satisfy it, and CI does not qualify
+> on the evidence available.
+>
+> **Both blockers are RESOLVED; the roadmap is parked anyway, and the two facts
+> are not in tension.** `b-quality-columns-unreachable` closed as a **host null**
+> and `b-machine-local-denominator` closed as **not resolvable by an autonomous
+> run** — a resolved blocker records an answer, and here both answers are that
+> the work cannot proceed. Steps 2.2 and 5.2 are `[-]` descoped in consequence.
+>
+> **The external-validity gap is stated HERE, at the outcome, and not only beside
+> the two steps.** A seat named the exact failure mode: *"Descoping the steps
+> risks converting an unresolved external-validity gap into apparent roadmap
+> completion."* So, plainly: **no cross-machine rate was established, and none is
+> establishable from this ledger.** All 4,912 measured stops are machine-local.
+>
+> **Why parking rather than closing around the descopes.** One seat made the test
+> checkable rather than a matter of taste — park only if a qualifying
+> cross-source rate is an *acceptance criterion* of the central outcome. It is:
+> **AC-2** requires *"a ledger carrying ≥2 distinct machine provenances"*. The
+> other seat reached `later/` independently, on the ground that `unknown` quality
+> fields undermine the *"outcome attribution v2"* the title claims. Both routes
+> land in the same place.
+>
+> **Recorded now so it is not rediscovered later: confirmability ≠
+> representativeness.** Two machine identities buy confirmability. They do **not**
+> buy representativeness while both carry the same operator's drain-run traffic —
+> and this ledger's does. So a future rate is **descriptive of the measured
+> traffic**, must say so wherever it is quoted, and per-machine figures come
+> **before** any pooled one (which AC-2 already required, and the council
+> independently re-derived).
 
 > **Source:** agents/tmp.old/road-to-10/road-to-episode-finalizer-and-outcome-attribution-v2.md
 
@@ -117,7 +156,16 @@ producers do not emit the shape — not because the schema rejects them.
       (2) delivery pointer outranked. Write expected signatures before fixes.
       verify: each cause has a written expected signature recorded before its
       probe runs; a probe whose signature was written afterwards is discarded.
-- [ ] **Step 2.2:** Read the registered claim rather than re-registering it.
+- [-] **Step 2.2:** Read the registered claim rather than re-registering it.
+      **DESCOPED 2026-08-26, AI council 2/2** — `b-machine-local-denominator` is
+      **not resolvable by an autonomous run**. The band's population line reads
+      `>=200 non-local stops` and **all 4,912 measured stops are machine-local**.
+      Independent traffic and separately retained external evidence cannot be
+      produced by replaying, relabelling or reprocessing the existing ledger
+      inside this session, so this step has no denominator to read a rate from.
+      Marked `[-]` rather than left `[ ]`: nothing here is pending work an
+      autonomous run can pick up.
+
       The pre-registered band stands:
 
       ```text
@@ -208,7 +256,14 @@ producers do not emit the shape — not because the schema rejects them.
       explicit terminal state.
       verify: each twin is proven RED by sabotaging the mechanism it guards,
       then restored — a twin never seen red has unknown sensitivity.
-- [ ] **Step 5.2:** Pre-register coverage:
+- [-] **Step 5.2:** Pre-register coverage:
+      **DESCOPED 2026-08-26, same decision as Step 2.2.** The criterion reads
+      `>=200 representative episodes`, and **representative** is precisely what
+      this ledger cannot supply: even a second machine identity would give
+      confirmability without representativeness while both carry the same
+      operator's drain-run traffic. Descoping the pre-registration rather than
+      registering a claim whose population cannot exist yet.
+
 
       ```text
       episode-finalizer-coverage
@@ -326,7 +381,46 @@ producers do not emit the shape — not because the schema rejects them.
   a flat rate is legal going forward.
 
 ### blocker: b-quality-columns-unreachable
-- **Status:** open
+- **Status:** resolved 2026-08-26 — **option (2): a HOST NULL, narrowly scoped.**
+  AI council 2/2, inlined convergence: `anthropic/claude-sonnet-4-5` +
+  `openai/codex-default`, 3 rounds, blind chairman, quorum concluded 2/2,
+  $0.079 actual.
+
+  **Both seats overruled this blocker's own recommendation of option (1).** The
+  reason is arithmetic rather than preference: option (1) says *adopt the
+  candidate and evaluate its falsifier over a recorded corpus*, and **there is no
+  eligible corpus to evaluate it against** — 0 populated rows at each
+  re-derivation, three successive corpus growths moving no verdict,
+  `dispatch_mode` 0 across both measured months. *"A zero eligible denominator
+  cannot test the candidate's falsifier."* Adopting a contract definition whose
+  falsifier is unevaluable is the wrong order of operations.
+
+  **The null's exact scope — this wording is the deliverable, not a formality:**
+
+  > Under the current contract and completion-time instrumentation,
+  > `first_pass_success` and `escalated` cannot be determined, because both
+  > depend on **subsequent parent behaviour**. This is a limitation of the
+  > current observation point — **not** evidence that the concepts are
+  > unmeasurable in principle, and **not an observed value of zero.**
+
+  The last clause is the one that matters and is why a bare `unknown` was
+  rejected: a `0/0` denominator is an **absent measurement**, not a null result,
+  and a reader who takes it for a measured zero concludes the opposite of the
+  truth. Phase 4's dependent fields therefore carry a documented unavailable
+  state rather than a bare `unknown`.
+
+  **The candidate is preserved as an EXPERIMENT and deliberately not written into
+  the contract.** It stays a recorded proposal with its falsifier attached
+  (~20 % session-stop closes ⇒ the boundary measures the session, not adoption);
+  `orchestration-telemetry.md` is **not** amended. Before it could be adopted,
+  both seats required: closure reasons, censoring rules, the denominator, a
+  minimum sample and the exact session-stop threshold predeclared — plus an
+  attribution audit showing the candidate boundaries actually track the same task
+  scope, not merely that they close.
+
+  **Revisit-if:** a predeclared minimum corpus contains observable closed
+  episodes with sufficient rework and re-dispatch variation, the session-stop
+  rule becomes evaluable, and an attribution audit passes.
 - **Owner:** council
 - **Blocks:** Phase 5 Step 5.3; the `parent_action_delta` and `verification`
   fields of Phase 4 degrade to `unknown` without it.
@@ -377,6 +471,41 @@ producers do not emit the shape — not because the schema rejects them.
   and this ledger's is exactly that. Satisfying `≥2 distinct machine identities`
   would therefore close the letter of this blocker while leaving the
   generalisation limit intact, and any rate quoted afterwards still has to say so.
+- **Status:** resolved 2026-08-26 — **NOT resolvable by an autonomous run, by
+  construction.** AI council 2/2, same session. Asked directly whether this run
+  could resolve it at all, both seats said no: *"Independent traffic and
+  separately retained external evidence cannot be created by replaying,
+  relabelling, or processing the existing machine-local ledger inside this
+  session."* All **4,912** measured stops are machine-local against a band line
+  requiring **≥ 200 non-local**.
+
+  **Consequence — Phase 2 Step 2.2 and Phase 5 Step 5.2 are `[-]` DESCOPED**,
+  each citing the 4,912-of-4,912 figure. Both quote a rate; no rate is
+  quotable.
+
+  **The limitation belongs to the ROADMAP's outcome, not only to the two steps.**
+  One seat named the failure mode precisely: *"Descoping the steps risks
+  converting an unresolved external-validity gap into apparent roadmap
+  completion."* So it is stated in the parking header as well as here.
+
+  **The confirmability-versus-representativeness choice, recorded NOW rather than
+  when someone quotes a number** — both seats asked for exactly that ordering.
+  Two machine identities buy **confirmability**. They do not buy
+  **representativeness** if both carry the same operator's drain-run traffic, and
+  this ledger's does. So even after a qualifying second machine appears, any rate
+  is **descriptive of the measured traffic** and must say so. Broader
+  generalisation needs independent *operators* or genuinely diverse workloads —
+  not another machine identity.
+
+  **Per-source before pooled, and this was already the contract.** Both seats
+  required per-machine figures rather than a pooled number, on the ground that
+  4,912 local + 200 non-local pooled is dominated by the original machine so
+  *"multi-machine" becomes a label on an effectively single-machine statistic*.
+  **AC-2 already says this** — *"every published rate reports per-machine figures
+  before any pooled one"* — so the council independently re-derived a requirement
+  the roadmap had already written down. Recorded because agreement reached twice
+  from different directions is worth more than either pass alone.
+
 - **Owner:** council
 - **Blocks:** Phase 2 Step 2.2 and Phase 5 Step 5.2 — both quote a rate.
   Phase 2 Step 2.3 is the work that resolves it.


### PR DESCRIPTION
## What this lands

`road-to-episode-finalizer-and-outcome-attribution-v2` — **both `Owner: council`
blockers resolved, two steps descoped, roadmap parked to `later/`.**

**This PR also carries the drain run's mandated summary**
(`agents/evidence/drain-run-summary.md`), as the last commit of the final PR.

## Both blockers are resolved, and the roadmap is parked anyway

Those two facts are not in tension: **a resolved blocker records an answer, not
necessarily a green light.** Here both answers are that the work cannot proceed.

**AI council 2/2** · `anthropic/claude-sonnet-4-5` + `openai/codex-default` ·
3 rounds · blind chairman · $0.079.

### `b-quality-columns-unreachable` → a narrowly scoped **host null**

**Both seats overruled the blocker's own recommendation**, on arithmetic rather
than preference. Option (1) said *adopt the candidate and evaluate its falsifier
over a recorded corpus* — and there is **no eligible corpus**: 0 populated rows
at each re-derivation, three successive corpus growths moving no verdict,
`dispatch_mode` 0 across both measured months. *"A zero eligible denominator
cannot test the candidate's falsifier."*

**The null's wording is the deliverable, not a formality:**

> Under the current contract and completion-time instrumentation,
> `first_pass_success` and `escalated` cannot be determined, because both depend
> on **subsequent parent behaviour**. This is a limitation of the current
> observation point — **not** evidence that the concepts are unmeasurable in
> principle, and **not an observed value of zero.**

That last clause is why a bare `unknown` was rejected: **a `0/0` denominator is
an absent measurement, not a null result**, and a reader who takes it for a
measured zero concludes the opposite of the truth.

The candidate is preserved as an **experiment with its falsifier attached**;
`orchestration-telemetry.md` is **not** amended. Adopting a definition whose
falsifier is unevaluable is the wrong order of operations.

### `b-machine-local-denominator` → **not resolvable by an autonomous run**

Asked directly whether this run could resolve it at all, both seats said no:
*"Independent traffic and separately retained external evidence cannot be created
by replaying, relabelling, or processing the existing machine-local ledger inside
this session."*

All **4,912** measured stops are machine-local against a band line requiring
**≥ 200 non-local**.

**Steps 2.2 and 5.2 are `[-]` descoped**, each citing that figure. Both quote a
rate; no rate is quotable.

## Why parked rather than closed around the descopes

One seat made the test **checkable** instead of a matter of taste: park only if a
qualifying cross-source rate is an *acceptance criterion* of the central outcome.

**It is** — `AC-2` requires *"a ledger carrying ≥2 distinct machine
provenances"*. The other seat reached `later/` independently, on the ground that
`unknown` quality fields undermine the *"outcome attribution v2"* the title
claims. **Two different tests, same destination.**

**The external-validity gap is stated at the roadmap's outcome, not only beside
the two steps.** A seat named the exact failure mode: *"Descoping the steps risks
converting an unresolved external-validity gap into apparent roadmap
completion."* So the header says plainly: **no cross-machine rate was
established, and none is establishable from this ledger.**

## Recorded now rather than rediscovered later

**Confirmability ≠ representativeness.** Two machine identities buy
confirmability. They do **not** buy representativeness while both carry the same
operator's drain-run traffic — and this ledger's does. A future rate is therefore
*descriptive of the measured traffic* and must say so wherever it is quoted.

Both seats also required **per-machine figures before any pooled one**, because
4,912 local + 200 non-local pooled is dominated by the original machine — *"
'multi-machine' becomes a label on an effectively single-machine statistic"*.
**AC-2 already said this.** The council re-derived, from a different direction, a
requirement the roadmap had written down — recorded because agreement reached
twice independently is worth more than either pass alone.

## The drain-run summary

`agents/evidence/drain-run-summary.md` — 8 PRs, 15 council decisions across 7
sessions ($0.43), every descope with its reason.

**It leads with what the run did not do:** the roadmap directory is **not
empty**, seven roadmaps were never opened, and ~290 open steps remain. Those are
recorded as *"not reached"* rather than *"deferred"*, because nothing about them
was assessed and the weaker word would imply otherwise.

It also records the **four** occasions the council overruled a roadmap author's
own recommendation, and the **two** where one seat overruled the other with the
reason adopted.

## Gates

Green: `lint_roadmap_blockers`, `lint_roadmap_complexity`, `check_references`,
`check_no_roadmap_refs`, `check_council_references`, `lint_plan_risk_register`,
`check_no_external_sources`, `check_estate_count`, `check_md_language`,
`lint_roadmap_later_disposition`.

Two failures fixed rather than suppressed:

1. **`check_references`** — parking broke an inbound reference from
   `later/road-to-ac-deep-capabilities.md`. Both occurrences migrated with the
   move, which is what an archival/parking sweep is supposed to do.
2. **`check_estate_count`** — `later_roadmaps 63 → 64`. Claimed with
   `estate_growth_exempt` stating honestly that this is a **move**, not an
   addition: `-1 active / +1 later`, no roadmap created, two blockers resolved
   and none created.

## Claims Ledger

Unchanged — deliberately. The whole point of `b-machine-local-denominator`'s
resolution is that **no rate became quotable**, so no claim moves to `backed`.
