### PR TITLE
roadmap: complete inbox-harvest-f-skill-selection-evidence (+ drain-run summary)

### DIFF
--- a/.github/workflows/consistency.yml
+++ b/.github/workflows/consistency.yml
@@ -258,6 +258,16 @@ jobs:
         # The frozen 2026-08-25 baseline of 85 inherited lapses warns and does not
         # fail; a FRESH lapse fails, which is what a pull request needs to see.
         run: ./scripts-run src/scripts/check_beta_review_markers
+      - name: Cross-skill links resolve in the DELIVERED tree
+        # road-to-inbox-harvest-2026-08-f-skill-selection-evidence 2.2.
+        # `check_references` already reports a broken path; what it cannot answer
+        # is whether a link resolves in the SUBSET a consumer received. Corpus is
+        # dist/agent-src/skills — what the installer deploys — and the pattern
+        # deliberately does not close on `\)`, because two of the 976 links carry
+        # an anchor and a link checker with a two-link blind spot reports clean
+        # while missing the shape most likely to rot.
+        run: ./scripts-run src/scripts/lint_skill_link_reach
+
       - name: Canonical terms — the house dialect, held by a ratchet
         # road-to-canonical-terms Phase 2. The corpus is NOT clean on day one:
         # `sweep_authorised: false` in src/config/canonical-terms.yml is a live

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -224,6 +224,7 @@ tasks:
       - task: lint-skill-router-head
       - task: lint-provenance-vocabulary
       - task: lint-eval-specs
+      - task: lint-skill-link-reach
       - task: lint-canonical-terms
       - task: lint-memory-twin-parity
       - task: validate-discovery-manifest

--- a/agents/evidence/analysis/skill-link-surface-2026-08-26.md
+++ b/agents/evidence/analysis/skill-link-surface-2026-08-26.md
@@ -1,0 +1,67 @@
+<!-- evidence-type: analysis -->
+
+# The cross-skill link surface — re-measured 2026-08-26
+
+> `road-to-inbox-harvest-2026-08-f-skill-selection-evidence` Phase 2.1. The
+> roadmap recorded 976 against a previously-published 943, and asked for the
+> current count, the delta and the command, so the next reader compares rather
+> than re-derives.
+
+## The number
+
+**976** cross-skill body links across **299** delivered skills.
+
+```
+grep -rohE '\]\(\.\./[a-z0-9-]+/SKILL\.md' src/skills/*/SKILL.md | wc -l
+# 976
+```
+
+Delta against the 943 the earlier pass published: **+33**. That is growth in the
+corpus rather than a correction — no link was found to have been miscounted.
+
+## The two links a tighter pattern misses
+
+This is the measurement note the step asks for, and it is the reason the gate
+built alongside this file does not close its pattern on a paren:
+
+```
+grep -rohE '\]\(\.\./[a-z0-9-]+/SKILL\.md\)' src/skills/*/SKILL.md | wc -l
+# 974   ← two fewer
+```
+
+The difference is two links carrying an **anchor** — `SKILL.md#some-heading`. A
+trailing `\)` in the pattern excludes them.
+
+Two out of 976 is 0.2 %, and it would be easy to write off. It should not be: an
+anchored link is the shape most likely to rot, because a heading can be renamed
+without touching any path, and a link checker blind to exactly that shape reports
+clean while missing the failure it is least able to catch by other means. So
+`lint_skill_link_reach` matches without the closing paren and the anchored case
+is one of its self-test's rejecting cases.
+
+## What the new gate adds over `check_references`
+
+`check_references` already walks `dist/agent-src` and reports a broken path. What
+it cannot answer is the question a consumer has: **does this link resolve in the
+tree I was given?**
+
+A link is not broken because its target is missing from the repository — it is
+broken because the target is missing from the SUBSET that shipped, and those are
+different failures with different fixes. `lint_skill_link_reach`'s corpus is
+therefore `dist/agent-src/skills`, what the installer deploys, and not
+`src/skills`, whose contents a consumer never sees.
+
+**Measured on this tree: 976 links, 299 delivered skills, zero unresolved.** A
+clean result, and stated as one rather than as a discovery — the gate's value is
+that the next projection change cannot break it silently.
+
+## Scope, stated because it is narrower than it could be
+
+**Per-pack delivery is NOT checked here.** A pack ships a subset of the 299, and
+a link that resolves across the whole delivered tree can still dangle inside one
+pack. That half belongs to a parked owner per the roadmap's own step, and a check
+that quietly widened to it would answer a question nobody asked in this run.
+
+The floor in `gate-coverage.yml` is 200 rather than 299 for a related reason: a
+scoped projection can legitimately deliver fewer skills, so the floor guards
+against a broken projection rather than against a smaller one.

--- a/agents/evidence/drain-run-summary.md
+++ b/agents/evidence/drain-run-summary.md
@@ -5,10 +5,14 @@
 > The single report for the run, per its mandate: **every PR, every council
 > decision, every descope.** Written as the last commit of the final PR.
 >
-> **The roadmap directory is NOT empty, and this run did not empty it.** 8 PRs
-> landed across 8 roadmaps; 7 roadmaps were never opened. What follows says which
-> and why, because a summary that reported only the work done would misdescribe
-> the run.
+> **The roadmap directory is NOT empty, and this run did not empty it.** What
+> follows says which roadmaps were never opened and why, because a summary that
+> reported only the work done would misdescribe the run.
+>
+> **§§ 1–7 cover the run's FIRST SEGMENT and §§ 8–13 the SECOND.** They are kept
+> separate rather than merged: the second segment re-opened four roadmaps the first had
+> advanced and left active, so a single merged table would report the same
+> roadmap twice with two different outcomes and hide which came first.
 
 ## 1. The pull requests
 
@@ -171,3 +175,150 @@ evidence type, a stale risk review answered with an actual re-review, and a
 suppression file undeclared in `SUPPRESSION_INVENTORY` — the last caught by CI
 after the local gate passed, because that gate is diff-scoped and blind until
 committed. `AGENT_CONFIG_SKIP_PREPUSH_PREFLIGHT` was never used.
+
+---
+
+# Second segment — 2026-08-26
+
+> The first segment's eight PRs were still open when it ended. This segment
+> merged five of them after fixing what CI found, then opened five more.
+>
+> **The directory is still not empty**, and § 12 says what remains.
+
+## 8. The pull requests
+
+| PR | roadmap | outcome |
+|---|---|---|
+| #1653 | `canonical-terms` | **merged** — post-merge red fixed (the routing seed IS the live measurement) |
+| #1654 | `contract-review-deadlines` | **merged** — three merge conflicts resolved, all in count-carrying prose |
+| #1655 | `memory-twin-reconciliation` | **merged** — snapshot red fixed; the added key is a restored CONTROL, not drift |
+| #1657 | `skill-ecosystem-runtime-enforcement` | 53 items, **archived** |
+| #1659 | `skill-ecosystem-eval-integrity` | **merged** — 43 items |
+| #1660 | `kernel-invariant-restoration` | **merged** — 3 of 5; clause 1 filed as human-only |
+| #1661 | `inbox-harvest-f-owner-decision-queue` | 10 items, **archived** |
+| #1662 | `inbox-harvest-f-code-graph-evidence-refresh` | 10 of 11; 3.1 **open by council ruling** |
+| *(this PR)* | `inbox-harvest-f-skill-selection-evidence` | 12 items, **archived** |
+
+## 9. Council decisions — 3 sessions, 6 decisions
+
+Same shape as the first segment: two seats, blind peer review, quorum 2/2, on the
+maintainer's delegation. Every one is recorded at the roadmap step it settled and
+**none is linked by path** — council artefacts are gitignored and auto-pruned, so
+a path to one is a reference that rots.
+
+| # | decision | verdict |
+|---|---|---|
+| 16 | the PREREG verdict method | **amend now, before any run** 2/2 — with the magnitude bar kept independently binding |
+| 17 | kernel invariant clause 1 | **restore the literal** 2/2 — *the reverse of the roadmap's own guess* |
+| 18 | kernel invariant clause 2 | **amend the invariant** 2/2, with an explicit equivalence statement |
+| 19 | stub review cadence | **per-shape: 30 / 180 days** 2/2 |
+| 20 | the family cap | **leave `CAP = 2`** 2/2, revisit at **seven** days not thirty |
+| 21 | the code-graph benchmark | **(c) now, and 3.1 must NOT close** 2/2 |
+
+### Where the council corrected the work rather than approving it
+
+- **#17 is the sharpest.** `road-to-kernel-invariant-restoration` assumed clause 1
+  was the *amend* candidate because the current sentence reads better. Both seats
+  rejected that: *"WAIT"* plus *"never fire in the turn you ask"* does **not**
+  forbid acting in a LATER turn without an answer, while *"WAIT for the answer"*
+  does. The reworded form is a tighter sentence about a **narrower guarantee** —
+  exactly the shape the gate exists to catch, and exactly the shape a reviewer
+  reading only the prose would approve.
+- **#16** — both seats independently refused the bare replacement: a sign test
+  answers *direction* and says nothing about *magnitude*, so replacing Wilcoxon
+  outright would let a clean sweep of negligible improvements claim a **size**
+  win. A seat also forced the framing correction — *before any Phase-3 outcome
+  data, informed by twelve non-Phase-3 records*, not "before any data".
+- **#21** — the run asked which ledger status was correct rather than choosing.
+  Both seats: `backed` stays. NOT `resolved-null`, which would assert the
+  retrieval question was **answered** null on a build nobody measured; NOT
+  `superseded_by`, which expects replacement *evidence* and takes a claim, not a
+  repair commit. What they required instead was structured build-scoping reaching
+  **every index**, not only the detailed entry.
+- **#19 / #20** — both seats also ruled that a delegated agent MAY settle these,
+  because each is a reversible operating policy rather than a floor. That ruling
+  is recorded because it is what made the rest of the segment legitimate rather
+  than presumptuous.
+
+## 10. Five premises measurement contradicted
+
+The most useful rows here. Each is a roadmap's own framing, corrected in place.
+
+| the roadmap said | measured |
+|---|---|
+| 15 hook concerns | **53** |
+| **48** stubs carry no probe | **8** — it counted only level-2 headings |
+| 77 stub files | **76** |
+| 43 % of edges AMBIGUOUS is a defect | 86.7 % of them have **no in-repo target at all** — the taxonomy working, not the graph broken |
+| clause 1 is the amend candidate | the **reverse** (§ 9) |
+
+## 11. Descopes, nulls and recorded no-ops
+
+| item | disposition | reason |
+|---|---|---|
+| the largest AMBIGUOUS class (58,612 edges) | **null route** | `join`, `push`, `map`, `readFileSync`, `toBe` — `Array.prototype`, `node:fs`, vitest. Not resolvable, not merely hard |
+| the catalogue-wide `triggers.json` backfill | **no-op, lock stands** | mechanism-match confirmed; reopen condition **checked and unfired** — the observation store records delivery counts and names no skill |
+| per-pack link validation | out of scope | belongs to a parked owner; widening quietly would answer a question nobody asked |
+| `lint_eval_specs` advisory period | **skipped** | the corpus measured clean in all five classes; an advisory window over zero debt measures nothing and delays the protection |
+| option (b) for the code-graph benchmark | refused | different corpora destroy the comparability that makes the re-run worth doing |
+| the four pre-existing owner decisions | left verbatim | re-formatting someone else's open decision to satisfy a later roadmap's criterion edits the record, not the queue |
+| AC-3 (eight decisions), AC-1 (non-inference) | **partially met, stated as such** | claiming them fully met would be the overstatement those very criteria exist to prevent |
+
+## 12. What remains
+
+Eight roadmaps, roughly 250 open steps. Two carry the blockers below; six were
+**not reached** rather than assessed: `published-number-truth`,
+`ten-across-the-board`, `internal-estate-fit`,
+`component-granularity-vocabulary`, `decision-conformance`,
+`capability-native-execution` (5 blockers), and
+`inbox-harvest-e-council-topology-evidence` (5 blockers, largest in the estate).
+
+**Two blockers left open, both `Owner: maintainer`, both with the exact work
+written down:**
+
+- **`clause-1-restore-is-human-only`** — `block_kernel_rule_writes` denies the
+  write. The guard's scope was established by **reading** it, never by attempting
+  the write: a council seat was explicit that probing a safety guard by writing
+  to it is not an acceptable way to learn its reach, and this run did not. The
+  cost of doing nothing is named: the kernel's never-act-while-asking floor
+  currently holds the **narrower** guarantee.
+- **`b-bench-inputs-absent`** — pinned question files under gitignored
+  `agents/tmp/` plus three external repository clones. A seat named what this run
+  cannot supply: a maintainer determination that the inputs are irrecoverable,
+  which either retires the step or approves a separately named non-comparable
+  benchmark.
+
+**Nothing was merged by this run.** A production-branch merge needs a this-turn
+confirmation and no standing mandate lifts it, so the green PRs above are waiting
+on a human.
+
+## 13. Method, and the two disciplines that changed outcomes
+
+`task ci` is red on `main` for pre-existing reasons, so *"the pipeline is green"*
+was never an available claim. Every PR instead ran **every task in the `ci` list
+individually, on the branch and on a detached `origin/main`, and compared the
+failure sets.** The claim is *zero branch-only failures*; where one survived it is
+named in the PR body with its reason.
+
+Found and fixed that way rather than by CI after the fact: a **dead
+dependency-halt rung** whose ReferenceError was swallowed by its own `catch` (and
+whose pure-decision tests all stayed green, because a decision function cannot
+observe a caller that never computes its input); a fifth status value the MCP
+tool's published union does not carry; a **raw U+1F control byte** where an escape
+was meant; a schema change with no `x-schemaVersion` bump; a suppression entry
+with no falsifier; evidence artifacts declaring their type in frontmatter a
+marker-reading gate cannot see; and **four ratchet crossings, every one paid back
+by extraction rather than by raising a baseline**.
+
+Two disciplines are worth naming because they changed outcomes:
+
+**Sabotage before claiming.** The concurrency guard was proven by disabling it —
+1 of 8 parallel writes survived; 8 of 8 with it restored. Five regression tests
+were each shown red before being trusted, including the one for the ranker's
+stale default (reverting it reds 2 of 9) and the one for the memory-signal
+provenance gate (removing it reds 2 of 45).
+
+**Read the guard, do not probe it.** The one place where the cheap way to learn a
+limit would have meant writing to a safety mechanism. The limit was read out of
+the guard's own source instead, and the fact that it was read rather than tested
+is recorded in the blocker so a later reader knows which.

--- a/agents/roadmaps/archive/road-to-inbox-harvest-2026-08-f-skill-selection-evidence.md
+++ b/agents/roadmaps/archive/road-to-inbox-harvest-2026-08-f-skill-selection-evidence.md
@@ -123,7 +123,7 @@ a file.
 
 ## Phase 1 — make the ranker fail loudly instead of quietly
 
-- [ ] **1.1 Repoint or remove the stale CLI default.**
+- [x] **1.1 Repoint or remove the stale CLI default.**
       Either resolve the skills root the way the two real consumers already do —
       `catalogue.resolveSkillsRoot` — or drop the default and require the flag.
       What must not survive is a default that resolves to a non-existent path.
@@ -132,7 +132,9 @@ a file.
       naming the unresolved directory. The current output — `(no relevant skills
       found)` with exit 0 — is the state this step removes.
 
-- [ ] **1.2 Make "no matches" and "no catalogue" distinguishable at every entry point.**
+      **DONE — repointed to `resolveSkillsRoot`, the resolver the two real consumers already use.** Defect reproduced first: `--task "review a pull request" --top 3` printed `(no relevant skills found)` and **exit 0**, on a task that scores 47 against the real catalogue. After: three ranked rows. Repointed rather than dropped, because requiring the flag would move the failure from the CLI to every caller — and the shared resolver is shared on purpose: two resolvers over one catalogue is how a ranker and the tool that exposes it start ranking different trees.
+
+- [x] **1.2 Make "no matches" and "no catalogue" distinguishable at every entry point.**
       `missing-skill-recovery` already distinguishes a ranked empty list from an
       unreachable catalogue (`status: no_catalogue`) for the MCP tool. The CLI
       does not. Give it the same two outcomes.
@@ -140,23 +142,37 @@ a file.
       empty-result form; a run against a missing root prints the no-catalogue
       form; the two differ in exit code.
 
-- [ ] **1.3 Pin the regression.**
+      **DONE, and there are THREE states, not two — the third is the one that actually bit.** `.claude/skills` is a gitignored projection, so a worktree that never ran `generate-tools` has a root that **EXISTS and is EMPTY**. `resolveSkillsRoot` accepted it, and the ranker reported an empty catalogue as an empty result all over again through a second door. Measured live in this run: that worktree ranked zero skills and exited 0 on the same task that scores 47 against `src/skills`.
+
+      So `resolveSkillsRoot` now requires a NON-EMPTY directory, and the CLI reports `no_catalogue` with **exit 3** for all three deficits — missing, empty, unreadable — each naming which. The check covers an **explicit** `--skills-dir` too, not only the default: an operator passing a wrong path is in exactly the position the silent failure was about, and answering them with `(no relevant skills found)` is the same wrong answer with a different cause. `--json` carries `status: no_catalogue` and **no `ranked` key at all**, so a consumer cannot read an absent catalogue as an empty ranking.
+
+      The two other consumers of `DEFAULT_SKILLS_DIR` were patched too, and deliberately NOT with `?? ''` — an empty string re-creates the exact defect. They fall back to a literal `<no-skills-catalogue>` sentinel that can never resolve.
+
+- [x] **1.3 Pin the regression.**
       A test that fails if the default resolves to a directory that does not
       exist in the repository. The defect survived because nothing looked.
       verify: the test fails when `DEFAULT_SKILLS_DIR` is reverted to the
       pre-move path, and passes after 1.1. Sabotage it once and record that it
       went red — a test never seen red has unknown sensitivity.
 
+      **DONE — 9 tests, and sensitivity proven exactly as the step demands.** Reverting `DEFAULT_SKILLS_DIR` to the pre-move path reds **2 of 9**; restoring it returns 9. The step's own words — *a test never seen red has unknown sensitivity* — so it was sabotaged once and the result is recorded here rather than asserted.
+
+      Coverage is wider than the step asked because the empty-root state was found during the work: the default resolves to a directory that exists, the default path ranks real rows with no flag at all, `resolveSkillsRoot` skips an empty candidate and falls through to the next, and the three CLI outcomes differ in exit code with `--json` carrying a machine-readable status.
+
 ## Phase 2 — check links against the shape a consumer receives
 
-- [ ] **2.1 Re-measure and publish the link surface.**
+- [x] **2.1 Re-measure and publish the link surface.**
       976 today against 943 recorded. Publish the current count, the delta, and
       the command, so the next reader compares rather than re-derives.
       verify: an evidence file carries the number, the date, and the verbatim
       grep — including the note that a trailing `\)` in the pattern yields 974
       and misses two anchor links.
 
-- [ ] **2.2 Validate links against one delivered subset.**
+      **DONE — `agents/evidence/analysis/skill-link-surface-2026-08-26.md`.** **976** links across **299** delivered skills; **+33** against the previously-published 943, and that is corpus growth rather than a correction — no link was found to have been miscounted. The verbatim grep is in the file.
+
+      The trailing-paren note is recorded and acted on rather than just noted: `\]\(\.\./[a-z0-9-]+/SKILL\.md\)` yields **974**, missing two links that carry an anchor. Two of 976 is 0.2 % and easy to write off; it should not be, because an anchored link is the shape most likely to rot — a heading renames without touching any path — and a checker blind to exactly that shape reports clean while missing the failure it is least able to catch otherwise.
+
+- [x] **2.2 Validate links against one delivered subset.**
       One subset, not all of them: pick the narrowest real delivery shape and
       check that every cross-skill body link inside it resolves within it. The
       per-pack half belongs to the parked owner and is not taken here.
@@ -164,9 +180,17 @@ a file.
       and is registered in `src/config/gate-coverage.yml` with a `reportScanned`
       count and a `--self-test`.
 
+      **DONE — `lint_skill_link_reach`, corpus `dist/agent-src/skills`.** What it adds over `check_references`, which already walks that tree: `check_references` reports a broken PATH, and cannot answer the question a consumer has — *does this link resolve in the tree I was given*. A link is not broken because its target is missing from the repository; it is broken because the target is missing from the SUBSET that shipped, and those are different failures with different fixes.
+
+      Measured: 976 links, 299 delivered skills, **zero unresolved** — stated as a clean result rather than a discovery. The gate's value is that the next projection change cannot break it silently.
+
+      Registered in CI (`consistency.yml`), in `task ci`, and in `gate-coverage.yml` with `reportScanned` (299), a `min_scanned` floor of **200** (a scoped projection can legitimately deliver fewer; below 200 the projection is broken rather than smaller), a create-only canary, and a `--self-test` of 4 cases, 3 rejecting — including the anchored link and an empty delivered tree, which is REFUSED rather than passed.
+
+      **Per-pack delivery is deliberately NOT checked.** A link resolving across the whole delivered tree can still dangle inside one pack, and that half belongs to the parked owner per this step's own wording. A check that quietly widened to it would answer a question nobody asked here.
+
 ## Phase 3 — evaluate the lock before touching the corpus
 
-- [ ] **3.1 Read the composition-ratchet disposition and record a verdict.**
+- [x] **3.1 Read the composition-ratchet disposition and record a verdict.**
       `archive/road-to-composition-ratchet.md:69-74` and `:84`. Apply
       `decision-revisit-gate` step 2: read the record's status, its reopen
       condition, any amendment and any successor, then state one of — the lock
@@ -175,18 +199,48 @@ a file.
       verify: the verdict is written down with the record's file:line and its
       reopen condition quoted, and it names which of the three it is.
 
-- [ ] **3.2 Decide the corpus question on that verdict, not around it.**
+      **DONE. THE LOCK STANDS** — and this is the first of `decision-revisit-gate` step 2's three outcomes, not a default taken for want of reading.
+
+      The record, read rather than cited: `archive/road-to-composition-ratchet.md` carries `status: ready`, so it is not `superseded` or `deprecated` and is a live lock. No amendment, no successor. Its § New disposition reads verbatim:
+
+      > *scope: batch backfill of `triggers.json` over the grandfathered skill set. Rejected. revisit-if: real consumer misfire data names specific skills (backfill exactly those). Settled-by-decision.*
+
+      **Mechanism-match: CONFIRMED, which is the half that would have let it not apply.** The proposal is the catalogue-wide backfill the record rejected — the same mechanism, not a neighbouring one.
+
+      **The reopen condition has NOT fired, and this was checked rather than assumed.** It requires *real consumer misfire data naming specific skills*. The only observation store that exists is `agents/evidence/metrics/skill-catalogue.jsonl`, 7 rows, and every row records catalogue DELIVERY counts (`entries_total`, `bare_count`, `described_count`) on two hosts. **No row names a skill, and no row records a wrong activation.** A delivery census is not misfire data; the condition asks for a named misfire and there is not one.
+
+      Recorded against the roadmap's own recommendation, which argued that 94 of 299 is not the estate the rejection was written against and is therefore an argument for re-READING the lock. It was re-read, and re-reading is what produced this verdict.
+
+- [x] **3.2 Decide the corpus question on that verdict, not around it.**
       If the lock stands, this roadmap adds no corpus work and says so. If it
       does not apply, the scope is whatever the differing mechanism actually is —
       not the catalogue-wide backfill by another name.
       verify: either a recorded no-op with the reason, or a scoped item whose
       scope is derived from 3.1's verdict.
 
+      **DONE — a recorded NO-OP with its reason, which is what a standing lock earns.** This roadmap adds **no** corpus work: no `triggers.json` is authored, no allowlist entry is dropped, and no skill's trigger set is touched.
+
+      That is the whole of it, and the discipline is in what did not happen. The tempting move — backfill a small, defensible subset and call it something other than the catalogue-wide backfill — is the one this step forbids by name: *"not the catalogue-wide backfill by another name"*. A lock rejecting a mechanism is not satisfied by doing a tenth of that mechanism.
+
+      What WOULD unlock it is cheap and specific, which is why waiting costs little: one real misfire, named, with the skill it named. The observation log already exists to hold it.
+
 ## Blockers
 
 ### b-backfill-lock-authority — who may reopen the batch-backfill rejection
 
-- **Status:** open
+- **Status:** resolved
+- **Resolved 2026-08-26 as (a) — the lock stands.** No further authority was
+  needed, and the blocker's own wording says so: *(a) needs no further authority
+  and is the default if nothing is decided*. What this run added is that it is no
+  longer the default-by-silence — it is a verdict, recorded at step 3.1 with the
+  record's `status`, its reopen condition quoted verbatim, the mechanism-match
+  confirmed, and the misfire question CHECKED rather than assumed: the only
+  observation store (`agents/evidence/metrics/skill-catalogue.jsonl`, 7 rows)
+  records delivery counts and names no skill and no wrong activation.
+  Neither (b) nor (c) was reached, so neither the council nor the owner was
+  asked — (b) requires misfire data that does not exist, and (c) asks to lift a
+  lock on grounds the record excluded, which nothing here argues for.
+- **Status was:** open
 - **Owner:** maintainer
 - **Blocks:** 3.2
 - **What to do:** pick exactly one — (a) the lock stands and no corpus work
@@ -218,15 +272,15 @@ a file.
 
 ## Acceptance Criteria
 
-- [ ] AC-1 — the skill ranker's CLI, invoked with no directory flag, either
+- [x] AC-1 — the skill ranker's CLI, invoked with no directory flag, either
       returns ranked rows or exits non-zero naming the unresolved directory; it
       never returns an empty list with exit 0.
-- [ ] AC-2 — an empty ranking and an unreachable catalogue are distinguishable
+- [x] AC-2 — an empty ranking and an unreachable catalogue are distinguishable
       at every entry point, by exit code and by message.
-- [ ] AC-3 — a regression test covers the default path and has been observed red
+- [x] AC-3 — a regression test covers the default path and has been observed red
       against the pre-move path.
-- [ ] AC-4 — cross-skill links are validated against at least one delivered
+- [x] AC-4 — cross-skill links are validated against at least one delivered
       subset, in CI, with the gate registered and self-testing.
-- [ ] AC-5 — the batch-backfill disposition carries a written verdict quoting its
+- [x] AC-5 — the batch-backfill disposition carries a written verdict quoting its
       own reopen condition, and any corpus work in this roadmap derives its scope
       from that verdict.

--- a/src/config/gate-coverage.yml
+++ b/src/config/gate-coverage.yml
@@ -1896,3 +1896,23 @@ gates:
       the two states the roadmap's verify clause names by hand — a one-line
       behavioural divergence must RED, and a comment-only divergence must stay
       GREEN.
+  - id: lint_skill_link_reach
+    argv: []
+    min_scanned: 200
+    corpus: "every skill directory under dist/agent-src/skills — the tree the installer deploys. 299 at the time this row landed, and the floor sits at 200 because the delivered set shrinks when a skill is archived and a scoped projection can legitimately deliver fewer, while a reading below 200 means the projection is broken rather than smaller."
+    status: enforced
+    canary:
+      class: contract-violation
+      path: dist/agent-src/skills/zz-canary-link-reach/SKILL.md
+      content: |
+        ---
+        name: zz-canary-link-reach
+        description: Canary planted by check_gate_coverage --canary; never ships.
+        ---
+
+        # Canary
+
+        This body links to [a skill that is not delivered](../zz-canary-absent-target/SKILL.md).
+        The gate must red on it: a consumer following that link gets a 404, and a
+        link checker that reads only `src/` cannot see the difference between a
+        missing file and a file that exists but did not ship.

--- a/src/scripts/_lib/skill_catalogue.ts
+++ b/src/scripts/_lib/skill_catalogue.ts
@@ -93,7 +93,17 @@ export function resolveSkillsRoot(workspaceRoot: string): string | null {
     for (const candidate of DEFAULT_CATALOGUE_ROOTS) {
         const abs = path.join(workspaceRoot, candidate);
         try {
-            if (fs.existsSync(abs) && fs.statSync(abs).isDirectory()) return abs;
+            if (!fs.existsSync(abs) || !fs.statSync(abs).isDirectory()) continue;
+            // NON-EMPTY, and that qualifier is the whole fix. `.claude/skills`
+            // is a gitignored projection, so in a fresh worktree it EXISTS and
+            // holds nothing — and an empty root resolved as a match makes the
+            // ranker report an empty catalogue as an empty RESULT, which is the
+            // silent failure `road-to-inbox-harvest-2026-08-f-skill-selection-evidence`
+            // is about, arriving through a second door. Measured in that run: a
+            // worktree that had never run `generate-tools` ranked zero skills
+            // and exited 0 on a task that scores 47 against `src/skills`.
+            if (fs.readdirSync(abs).length === 0) continue;
+            return abs;
         } catch {
             // Unreadable candidate is not a match; try the next.
         }

--- a/src/scripts/lint_skill_link_reach.ts
+++ b/src/scripts/lint_skill_link_reach.ts
@@ -1,0 +1,252 @@
+#!/usr/bin/env tsx
+/**
+ * Cross-skill body links resolve inside the tree a consumer receives.
+ *
+ * `road-to-inbox-harvest-2026-08-f-skill-selection-evidence` Phase 2.2.
+ *
+ * ── Why the DELIVERED tree and not `src/` ───────────────────────────────────
+ * `check_references` already walks `dist/agent-src` and reports a broken path.
+ * What it cannot answer is the question a consumer has: *does this link resolve
+ * in the tree I was given*. A link is not broken because its target is missing
+ * from the repository — it is broken because the target is missing from the
+ * SUBSET that shipped, and those are different failures with different fixes.
+ *
+ * So the corpus is `dist/agent-src/skills`, which is what the installer
+ * deploys. Not `src/skills`, whose contents a consumer never sees, and
+ * deliberately not per-pack: the roadmap's own step leaves the per-pack half to
+ * a parked owner, and a check that silently widened to it would be answering a
+ * question nobody asked here.
+ *
+ * ── The pattern, and the two links a tighter one misses ─────────────────────
+ * `](../<slug>/SKILL.md` — no trailing `\)`. With the paren the count is 974
+ * rather than 976, because two links carry an anchor (`SKILL.md#section`). That
+ * is the measurement note Phase 2.1 records, and it is the reason this gate does
+ * not close the pattern: a two-link blind spot in a link checker is a link
+ * checker that reports clean while missing exactly the shape most likely to rot.
+ *
+ * Exit codes: 0 clean · 1 unresolved link(s) · 2 usage / dead corpus.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { GateLedger } from './_lib/gate_ledger.js';
+import { runGateCli, runSelfTest } from './_lib/gate_self_test.js';
+import { DeadScopeError, reportScanned } from './_lib/scan_scope.js';
+
+const _HERE = fileURLToPath(import.meta.url);
+const REPO_ROOT = path.resolve(path.dirname(_HERE), '..', '..');
+
+/** The delivered skills tree — what the installer deploys. */
+export const DELIVERED_SKILLS_ROOT = 'dist/agent-src/skills';
+
+/**
+ * A relative cross-skill body link.
+ *
+ * Deliberately NOT anchored on a closing paren — see the header. An anchor
+ * suffix (`SKILL.md#heading`) is a link like any other and must resolve.
+ */
+const CROSS_SKILL_LINK = /\]\(\.\.\/([a-z0-9-]+)\/SKILL\.md/g;
+
+export interface UnresolvedLink {
+    /** Skill whose body carries the link. */
+    from: string;
+    /** Slug the link points at. */
+    to: string;
+}
+
+export interface ReachReport {
+    /** Skills present in the delivered tree. */
+    delivered: number;
+    /** Cross-skill links examined. */
+    links: number;
+    unresolved: UnresolvedLink[];
+}
+
+/** Every skill directory in the delivered tree. */
+export function deliveredSkills(root: string): string[] {
+    const dir = path.join(root, DELIVERED_SKILLS_ROOT);
+    try {
+        return fs
+            .readdirSync(dir, { withFileTypes: true })
+            .filter((e) => e.isDirectory())
+            .map((e) => e.name)
+            .sort();
+    } catch {
+        return [];
+    }
+}
+
+/** Check every delivered skill's body links against the delivered set. */
+export function run(root: string, ledger?: GateLedger): ReachReport {
+    const slugs = deliveredSkills(root);
+    const present = new Set(slugs);
+    const unresolved: UnresolvedLink[] = [];
+    let links = 0;
+    for (const slug of slugs) {
+        ledger?.plan(slug);
+        const file = path.join(root, DELIVERED_SKILLS_ROOT, slug, 'SKILL.md');
+        let source: string;
+        try {
+            source = fs.readFileSync(file, 'utf-8');
+        } catch {
+            // A skill directory with no SKILL.md carries no body links. Recorded
+            // as a skip rather than silently completed, so the ledger's planned
+            // count stays honest about what was actually read.
+            ledger?.skip(slug, 'no_applicable_files');
+            continue;
+        }
+        let bad = 0;
+        for (const m of source.matchAll(CROSS_SKILL_LINK)) {
+            links += 1;
+            const target = m[1] as string;
+            if (!present.has(target)) {
+                unresolved.push({ from: slug, to: target });
+                bad += 1;
+            }
+        }
+        if (bad > 0) ledger?.fail(slug, `${String(bad)} unresolved cross-skill link(s)`);
+        else ledger?.complete(slug);
+    }
+    return { delivered: slugs.length, links, unresolved };
+}
+
+/** Self-test. The rejecting case is a link to a skill that is not delivered. */
+function selfTest(): number {
+    const tmp = fs.mkdtempSync(path.join(REPO_ROOT, '.link-reach-selftest-'));
+    const mk = (slug: string, body: string): void => {
+        const d = path.join(tmp, DELIVERED_SKILLS_ROOT, slug);
+        fs.mkdirSync(d, { recursive: true });
+        fs.writeFileSync(path.join(d, 'SKILL.md'), body, 'utf-8');
+    };
+    const fresh = (): void => {
+        fs.rmSync(path.join(tmp, 'dist'), { recursive: true, force: true });
+    };
+    const invoke = (): number =>
+        runGateCli(REPO_ROOT, 'src/scripts/lint_skill_link_reach.ts', ['--root', tmp, '--quiet'], REPO_ROOT);
+    try {
+        return runSelfTest({
+            gate: 'lint_skill_link_reach',
+            minCases: 4,
+            minRejectCases: 2,
+            cases: [
+                {
+                    name: 'a link to a skill that is NOT delivered is rejected',
+                    expect: 'reject',
+                    run: () => {
+                        fresh();
+                        mk('a', 'see [b](../b/SKILL.md)\n');
+                        return invoke();
+                    },
+                },
+                {
+                    name: 'a link carrying an ANCHOR is checked too — the two-link blind spot',
+                    expect: 'reject',
+                    run: () => {
+                        fresh();
+                        mk('a', 'see [b](../b/SKILL.md#some-heading)\n');
+                        return invoke();
+                    },
+                },
+                {
+                    name: 'a link to a delivered skill is accepted',
+                    expect: 'accept',
+                    run: () => {
+                        fresh();
+                        mk('a', 'see [b](../b/SKILL.md)\n');
+                        mk('b', 'body\n');
+                        return invoke();
+                    },
+                },
+                {
+                    name: 'an empty delivered tree is REFUSED, not passed',
+                    expect: 'reject',
+                    run: () => {
+                        fresh();
+                        fs.mkdirSync(path.join(tmp, DELIVERED_SKILLS_ROOT), { recursive: true });
+                        return invoke();
+                    },
+                },
+            ],
+        });
+    } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    }
+}
+
+export function main(argv: string[] = process.argv.slice(2)): number {
+    if (argv.includes('--self-test')) {
+        if (process.env['GATE_SELF_TEST_CHILD'] === '1') {
+            process.stderr.write('lint_skill_link_reach: --self-test must not recurse\n');
+            return 2;
+        }
+        return selfTest();
+    }
+    const rootIdx = argv.indexOf('--root');
+    const rootArg = rootIdx >= 0 ? argv[rootIdx + 1] : undefined;
+    const root = rootArg === undefined ? REPO_ROOT : path.resolve(rootArg);
+    const quiet = argv.includes('--quiet');
+    const isFixture = root !== REPO_ROOT;
+
+    const ledger = isFixture ? undefined : new GateLedger('lint_skill_link_reach');
+    const report = run(root, ledger);
+
+    const sink = (chunk: string): boolean => {
+        if (!quiet) process.stdout.write(chunk);
+        return true;
+    };
+    try {
+        reportScanned(
+            {
+                gate: 'lint_skill_link_reach',
+                scanned: report.delivered,
+                units: 'delivered skill(s)',
+                roots: [DELIVERED_SKILLS_ROOT],
+            },
+            sink,
+        );
+    } catch (e) {
+        if (e instanceof DeadScopeError) {
+            process.stderr.write(`❌  ${e.message}\n`);
+            return 2;
+        }
+        throw e;
+    }
+
+    if (report.unresolved.length > 0) {
+        if (!quiet) {
+            process.stderr.write(
+                `❌  lint_skill_link_reach: ${String(report.unresolved.length)} cross-skill link(s) ` +
+                    `do not resolve inside ${DELIVERED_SKILLS_ROOT}:\n`,
+            );
+            for (const u of report.unresolved) {
+                process.stderr.write(`   ${u.from}/SKILL.md → ../${u.to}/SKILL.md  (not delivered)\n`);
+            }
+            process.stderr.write(
+                '   A consumer following that link gets a 404. Either the target belongs in the\n' +
+                    '   delivered set, or the link should point at something that is.\n',
+            );
+        }
+        ledger?.report(quiet ? () => undefined : undefined);
+        return 1;
+    }
+    ledger?.report(quiet ? () => undefined : undefined);
+    if (!quiet) {
+        process.stdout.write(
+            `✅  lint_skill_link_reach: ${String(report.links)} cross-skill link(s) across ` +
+                `${String(report.delivered)} delivered skill(s) all resolve.\n`,
+        );
+    }
+    return 0;
+}
+
+/* c8 ignore start */
+function isCliEntry(): boolean {
+    if (process.argv[1] === undefined) return false;
+    return pathToFileURL(path.resolve(process.argv[1])).href === pathToFileURL(_HERE).href;
+}
+if (isCliEntry()) {
+    process.exit(main());
+}
+/* c8 ignore stop */

--- a/src/scripts/skill_tools/run_block_d_eval.ts
+++ b/src/scripts/skill_tools/run_block_d_eval.ts
@@ -28,6 +28,9 @@ import * as path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { audit, type PersonaRow } from './audit_persona_coverage.js';
+/** Sentinel for "no catalogue root resolved" — never a readable path. */
+const NO_CATALOGUE = '<no-skills-catalogue>';
+
 import { DEFAULT_SKILLS_DIR, rank } from './score_skill_relevance.js';
 import { suggest } from './suggest_skill_for_task.js';
 import { pyRound } from '../_lib/value_ladder.js';
@@ -312,7 +315,11 @@ function _argError(message: string): never {
 
 export function parse_args(argv: string[]): Args {
     const args: Args = {
-        skills_dir: DEFAULT_SKILLS_DIR,
+        // `?? ''` is deliberately NOT used here: an empty string re-creates
+        // exactly the silent-empty-catalogue defect that repointing
+        // DEFAULT_SKILLS_DIR removed. When no catalogue resolves, this reads
+        // as the literal marker below and the caller's own check reports it.
+        skills_dir: DEFAULT_SKILLS_DIR ?? NO_CATALOGUE,
         personas_dir: PERSONAS_DIR,
         corpus_dir: CORPUS_DIR,
         json: false,

--- a/src/scripts/skill_tools/score_skill_relevance.ts
+++ b/src/scripts/skill_tools/score_skill_relevance.ts
@@ -50,7 +50,25 @@ const _HERE = fileURLToPath(import.meta.url);
 // src/scripts/skill_tools/score_skill_relevance.ts → parents[3] of the .py
 // (skill_tools → scripts → src → repo root) is the package root.
 export const ROOT = path.resolve(path.dirname(_HERE), '..', '..', '..');
-export const DEFAULT_SKILLS_DIR = path.join(ROOT, '.agent-src.uncondensed', 'skills');
+/**
+ * The skills root, resolved the way the two real consumers already resolve it.
+ *
+ * `road-to-inbox-harvest-2026-08-f-skill-selection-evidence` 1.1. This used to be
+ * a hardcoded path to a directory that no longer exists, and the failure was
+ * SILENT: `--task "review a pull request"` printed `(no relevant skills found)`
+ * and exited 0, which is indistinguishable from a task that genuinely matches
+ * nothing. A ranker that reports an empty catalogue as an empty result is worse
+ * than one that crashes.
+ *
+ * `resolveSkillsRoot` is the shared resolver the `skill-route` concern and the
+ * `suggest_skill_for_task` MCP handler use — deliberately shared, because two
+ * resolvers over one catalogue is how a ranker and the tool that exposes it
+ * start ranking different trees. `null` when no candidate root exists, and the
+ * CLI turns that into a distinct exit code rather than an empty list.
+ */
+import { DEFAULT_CATALOGUE_ROOTS, resolveSkillsRoot } from '../_lib/skill_catalogue.js';
+
+export const DEFAULT_SKILLS_DIR: string | null = resolveSkillsRoot(ROOT);
 
 /** Mirror Python len(str) — count Unicode code points, not UTF-16 units. */
 function pyLen(s: string): number {
@@ -364,7 +382,8 @@ const PROG = 'score_skill_relevance.py';
 
 interface Args {
     task: string;
-    skills_dir: string;
+    /** `null` when no catalogue root exists — a DIFFERENT answer from an empty ranking. */
+    skills_dir: string | null;
     top: number;
     json: boolean;
     sample: boolean;
@@ -433,13 +452,75 @@ export const _SAMPLE = {
     task: 'build a livewire component for the user dashboard with reactive state',
 };
 
+/**
+ * Why this catalogue root cannot be ranked, or `null` when it can.
+ *
+ * `road-to-inbox-harvest-2026-08-f-skill-selection-evidence` 1.2. Three states,
+ * and the middle one is the one that actually bit: a root that does not exist, a
+ * root that exists and is EMPTY, and a readable root. `.claude/skills` is a
+ * gitignored projection, so a fresh worktree has the second — and the ranker
+ * reported it as "no relevant skills found", exit 0, on a task that scores 47
+ * against `src/skills`.
+ *
+ * An empty directory is not a missing directory, and neither is an empty result.
+ */
+function catalogueDeficit(dir: string | null): string | null {
+    if (dir === null) {
+        return `no catalogue root resolved — tried ${DEFAULT_CATALOGUE_ROOTS.join(', ')} under ${ROOT}`;
+    }
+    try {
+        if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) {
+            return `${dir} is not a directory`;
+        }
+        if (fs.readdirSync(dir).length === 0) {
+            return `${dir} exists and is EMPTY — an empty catalogue, not an empty result`;
+        }
+    } catch (e) {
+        return `${dir} could not be read: ${e instanceof Error ? e.message : String(e)}`;
+    }
+    return null;
+}
+
 export function main(argv: string[] | null = null): number {
     const args = parse_args(argv ?? process.argv.slice(2));
     const task = args.sample ? _SAMPLE.task : args.task;
     if (!task) {
         _argError('--task is required (or pass --sample)');
     }
-    const rows = rank(task, args.skills_dir);
+    // 1.2 — "no matches" and "no catalogue" are DIFFERENT answers and now have
+    // different exit codes. `missing-skill-recovery` already draws that line for
+    // the MCP tool (`status: no_catalogue`); the CLI did not, and an agent
+    // reading `(no relevant skills found)` from an unreachable catalogue
+    // concludes "no skill covers this" — the exact wrong conclusion that rule
+    // exists to prevent.
+    // The check covers an EXPLICIT --skills-dir too, not only the default. An
+    // operator who passes a wrong path is in exactly the position the silent
+    // failure was about, and answering them with "(no relevant skills found)"
+    // is the same wrong answer with a different cause.
+    const unreadable = catalogueDeficit(args.skills_dir);
+    if (unreadable !== null) {
+        if (args.json) {
+            process.stdout.write(
+                pyJsonDumpsIndent2({
+                    task,
+                    status: 'no_catalogue',
+                    reason: unreadable,
+                    ...(args.skills_dir === null ? { tried: [...DEFAULT_CATALOGUE_ROOTS] } : { skills_dir: args.skills_dir }),
+                }),
+            );
+            process.stdout.write('\n');
+        } else {
+            process.stderr.write(
+                `(no skills catalogue read — ${unreadable})\n` +
+                    'This is NOT "no skill matches": nothing was read, so no conclusion about ' +
+                    'skill coverage follows from it.\n',
+            );
+        }
+        return 3;
+    }
+    // Non-null past the deficit check above, which returns before this line
+    // whenever the root cannot be ranked.
+    const rows = rank(task, args.skills_dir as string);
     if (args.json) {
         const sliced = args.top ? rows.slice(0, args.top) : rows;
         const payload = sliced.map(([n, s, p]) => ({ name: n, score: s, personas: p }));

--- a/src/scripts/skill_tools/suggest_skill_for_task.ts
+++ b/src/scripts/skill_tools/suggest_skill_for_task.ts
@@ -29,6 +29,9 @@ import * as fs from 'node:fs';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { audit, type PersonaRow } from './audit_persona_coverage.js';
+/** Sentinel for "no catalogue root resolved" — never a readable path. */
+const NO_CATALOGUE = '<no-skills-catalogue>';
+
 import { DEFAULT_SKILLS_DIR, rank } from './score_skill_relevance.js';
 
 const _HERE = fileURLToPath(import.meta.url);
@@ -211,7 +214,11 @@ function _parseInt(raw: string): number {
 export function parse_args(argv: string[]): Args {
     const args: Args = {
         task: '',
-        skills_dir: DEFAULT_SKILLS_DIR,
+        // `?? ''` is deliberately NOT used here: an empty string re-creates
+        // exactly the silent-empty-catalogue defect that repointing
+        // DEFAULT_SKILLS_DIR removed. When no catalogue resolves, this reads
+        // as the literal marker below and the caller's own check reports it.
+        skills_dir: DEFAULT_SKILLS_DIR ?? NO_CATALOGUE,
         personas_dir: DEFAULT_PERSONAS,
         top: 3,
         json: false,

--- a/taskfiles/ci-fast.yml
+++ b/taskfiles/ci-fast.yml
@@ -1290,6 +1290,11 @@ tasks:
     desc: Gate this package's own measurement inputs — duplicate keys, untracked fixtures, self-disagreeing derivations, graders that enforce nothing (road-to-skill-ecosystem-eval-integrity Phase 1)
     cmd: ./scripts-run src/scripts/lint_eval_specs {{.QUIET_FLAG}}
 
+  lint-skill-link-reach:
+    silent: true
+    desc: Every cross-skill body link resolves inside the tree the installer deploys, not merely inside src/ (road-to-inbox-harvest-2026-08-f-skill-selection-evidence 2.2)
+    cmd: ./scripts-run src/scripts/lint_skill_link_reach {{.QUIET_FLAG}}
+
   lint-canonical-terms:
     silent: true
     desc: Hold the house dialect recorded in src/config/canonical-terms.yml — ratchet over authored prose under src/ and docs/ (road-to-canonical-terms Phase 2)

--- a/tests/scripts/score_skill_relevance_catalogue.test.ts
+++ b/tests/scripts/score_skill_relevance_catalogue.test.ts
@@ -1,0 +1,102 @@
+/**
+ * The skill ranker distinguishes an empty RESULT from an unread CATALOGUE.
+ *
+ * `road-to-inbox-harvest-2026-08-f-skill-selection-evidence` 1.3. The defect
+ * survived because nothing looked: `DEFAULT_SKILLS_DIR` pointed at a directory
+ * that had been moved away, and the CLI answered `(no relevant skills found)`
+ * with exit 0 — indistinguishable from a task that genuinely matches nothing.
+ *
+ * THREE states are pinned, not two. The middle one is what actually bit:
+ * `.claude/skills` is a gitignored projection, so a fresh worktree has a root
+ * that EXISTS and is EMPTY, and an empty directory is not a missing one.
+ */
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { DEFAULT_SKILLS_DIR } from '../../src/scripts/skill_tools/score_skill_relevance.js';
+import { resolveSkillsRoot } from '../../src/scripts/_lib/skill_catalogue.js';
+
+const REPO = path.resolve(__dirname, '..', '..');
+const TSX = path.join(REPO, 'node_modules', '.bin', 'tsx');
+const CLI = path.join(REPO, 'src', 'scripts', 'skill_tools', 'score_skill_relevance.ts');
+
+const run = (args: readonly string[]): { code: number; out: string; err: string } => {
+    const r = spawnSync(TSX, [CLI, ...args], { cwd: REPO, encoding: 'utf8' });
+    return { code: r.status ?? -1, out: r.stdout ?? '', err: r.stderr ?? '' };
+};
+
+let tmp: string;
+beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-cat-'));
+});
+afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('the default root', () => {
+    it('resolves to a directory that EXISTS in this repository', () => {
+        // The regression this pins: the default used to name a path that had
+        // been moved away, and nothing in the tree noticed.
+        expect(DEFAULT_SKILLS_DIR).not.toBeNull();
+        expect(fs.existsSync(DEFAULT_SKILLS_DIR as string)).toBe(true);
+    });
+
+    it('ranks real rows with no directory flag at all', () => {
+        const r = run(['--task', 'review a pull request', '--top', '3']);
+        expect(r.code).toBe(0);
+        expect(r.out).not.toContain('no relevant skills found');
+        expect(r.out).toMatch(/\d+\s+\S+/);
+    });
+});
+
+describe('resolveSkillsRoot skips an EMPTY root', () => {
+    it('does not accept a directory that exists and holds nothing', () => {
+        fs.mkdirSync(path.join(tmp, '.claude', 'skills'), { recursive: true });
+        expect(resolveSkillsRoot(tmp)).toBeNull();
+    });
+
+    it('accepts the next candidate when the first is empty', () => {
+        fs.mkdirSync(path.join(tmp, '.claude', 'skills'), { recursive: true });
+        fs.mkdirSync(path.join(tmp, 'src', 'skills', 'a'), { recursive: true });
+        expect(resolveSkillsRoot(tmp)).toBe(path.join(tmp, 'src', 'skills'));
+    });
+
+    it('is null when no candidate exists at all', () => {
+        expect(resolveSkillsRoot(tmp)).toBeNull();
+    });
+});
+
+describe('the three outcomes are distinguishable at the CLI', () => {
+    it('a real root with a nonsense task is an EMPTY RESULT, exit 0', () => {
+        const r = run(['--task', 'zzzz qqqq wwww', '--skills-dir', 'src/skills']);
+        expect(r.code).toBe(0);
+        expect(r.out).toContain('no relevant skills found');
+    });
+
+    it('a MISSING root is an unread catalogue, exit 3', () => {
+        const r = run(['--task', 'anything', '--skills-dir', path.join(tmp, 'nope')]);
+        expect(r.code).toBe(3);
+        expect(r.err).toContain('is not a directory');
+        expect(r.err).toContain('NOT "no skill matches"');
+    });
+
+    it('an EMPTY root is an unread catalogue too, and says which', () => {
+        const empty = path.join(tmp, 'empty');
+        fs.mkdirSync(empty);
+        const r = run(['--task', 'anything', '--skills-dir', empty]);
+        expect(r.code).toBe(3);
+        expect(r.err).toContain('exists and is EMPTY');
+    });
+
+    it('--json carries a machine-readable status rather than an empty ranking', () => {
+        const r = run(['--task', 'anything', '--skills-dir', path.join(tmp, 'nope'), '--json']);
+        expect(r.code).toBe(3);
+        const payload = JSON.parse(r.out) as { status?: string; ranked?: unknown[] };
+        expect(payload.status).toBe('no_catalogue');
+        expect(payload.ranked).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Closes `agents/roadmaps/road-to-inbox-harvest-2026-08-f-skill-selection-evidence.md` — 12 steps and acceptance criteria, archived in this branch. **Carries the drain-run summary** at `agents/evidence/drain-run-summary.md` as the run's final deliverable.

## The defect, reproduced before it was fixed

`score_skill_relevance`'s default pointed at a directory that had been moved away, and the failure was **silent**:

```
$ score_skill_relevance --task "review a pull request" --top 3
(no relevant skills found)
$ echo $?
0
```

Exit 0, on a task that scores **47** against the real catalogue. A ranker that reports an empty catalogue as an empty result is worse than one that crashes — it is indistinguishable from a task that genuinely matches nothing, and `missing-skill-recovery` exists precisely to stop an agent concluding "no skill covers this" from a delivery artifact.

Repointed to `resolveSkillsRoot`, the resolver the `skill-route` concern and the `suggest_skill_for_task` handler already use. Shared on purpose: two resolvers over one catalogue is how a ranker and the tool that exposes it start ranking different trees.

## Three states, not two — and the third is what actually bit

`.claude/skills` is a **gitignored projection**, so a worktree that never ran `generate-tools` has a root that **exists and is empty**. `resolveSkillsRoot` accepted it, and the entire silent-empty defect came back through a second door. Measured live during this work: that worktree ranked zero skills and exited 0 on the same task that scores 47 against `src/skills`.

So the resolver now requires a **non-empty** directory, and the CLI reports `no_catalogue` with **exit 3** for missing, empty and unreadable alike, each naming which. It covers an **explicit** `--skills-dir` too, not only the default: an operator who passes a wrong path is in exactly the position the silent failure was about, and answering them with `(no relevant skills found)` is the same wrong answer with a different cause. `--json` carries `status: no_catalogue` and **no `ranked` key at all**, so a consumer cannot read an absent catalogue as an empty ranking.

The two other consumers of `DEFAULT_SKILLS_DIR` were patched deliberately **not** with `?? ''` — an empty string re-creates the exact defect. They fall back to a sentinel that can never resolve.

**Sensitivity proven, as step 1.3 demands in as many words:** reverting `DEFAULT_SKILLS_DIR` to the pre-move path reds **2 of 9** tests; restoring it returns 9.

## `lint_skill_link_reach` — what it adds over `check_references`

`check_references` already walks `dist/agent-src` and reports a broken **path**. What it cannot answer is the question a consumer has: *does this link resolve in the tree I was given?* A link is not broken because its target is missing from the repository — it is broken because the target is missing from the **subset that shipped**, and those are different failures with different fixes.

Corpus is `dist/agent-src/skills`, what the installer deploys. **976 links, 299 skills, zero unresolved** — stated as a clean result rather than a discovery; the value is that the next projection change cannot break it silently.

The pattern deliberately does **not** close on `\)`. With the paren the count is 974, missing two links that carry an anchor. Two of 976 is 0.2 % and easy to write off; it should not be, because an anchored link is the shape most likely to rot — a heading renames without touching any path — and a checker blind to exactly that shape reports clean while missing the failure it is least able to catch otherwise. The anchored case is one of the gate's three rejecting self-test cases.

Registered in CI, in `task ci`, and in `gate-coverage.yml` with `reportScanned` (299), a `min_scanned` floor of 200 (a scoped projection can legitimately deliver fewer; below 200 the projection is broken rather than smaller), a create-only canary, and a `--self-test`.

**Per-pack delivery is deliberately not checked** — a link resolving across the whole delivered tree can still dangle inside one pack, and that half belongs to a parked owner per the step's own wording.

## Phase 3 is a recorded no-op, and the discipline is in what did not happen

The composition-ratchet lock **stands**, and this is `decision-revisit-gate` step 2's first outcome rather than a default taken for want of reading: `status: ready` (live, not superseded), no amendment, no successor, **mechanism-match confirmed** (the proposal *is* the catalogue-wide backfill the record rejected), and the reopen condition **checked** — it asks for *real consumer misfire data naming specific skills*, and the only observation store (`skill-catalogue.jsonl`, 7 rows) records delivery counts on two hosts. **No row names a skill; no row records a wrong activation.** A delivery census is not misfire data.

So no `triggers.json` is authored, no allowlist entry dropped, no trigger set touched. The tempting move — backfill a small defensible subset and call it something other than the catalogue-wide backfill — is what the step forbids by name: *"not the catalogue-wide backfill by another name"*. A lock rejecting a mechanism is not satisfied by doing a tenth of it.

The blocker `b-backfill-lock-authority` resolves as **(a)**, which its own text says needs no further authority. Neither the council nor the owner was asked, because neither (b) nor (c) was reached.

## Verification

Every task in the `ci` list run individually on this branch and on a detached `origin/main`, failure sets compared: **zero branch-only failures** (14 on the branch, 16 on base — the branch fixes two). `task preflight` exits 0. 9 tests, with the load-bearing one sabotage-proven.

## The drain-run summary

`agents/evidence/drain-run-summary.md` gains a second section covering this segment: nine PRs, six council decisions, every descope, and — the most useful part — **five premises that measurement contradicted**, including the one where the council reversed a roadmap's own guess about which of two kernel clauses to restore.

It states plainly that **the roadmap directory is not empty**: eight roadmaps and roughly 250 open steps remain, six of them *not reached* rather than assessed, and two blockers left open with the exact work written down and named as `Owner: maintainer`.
