### PR TITLE
docs(roadmaps): stop the three-tree sample from doing priority work

### DIFF
--- a/agents/roadmaps/road-to-consumer-repo-reality.md
+++ b/agents/roadmaps/road-to-consumer-repo-reality.md
@@ -245,19 +245,20 @@ tests say.
       one side, and the mixed verdict names the governing convention per region
       rather than for the file as a whole.
 - [ ] **4.2 Add the server-composed bootstrap payload to the render-security
-      surface, with a named enforcement mechanism.** A payload assembled
+      surface, and state plainly that nothing enforces the judgement.** A payload assembled
       server-side and serialised into the page for a client island is a
       data-exposure surface: whatever is put in it is readable by anyone who can
-      load the page. Enforcement is the existing pattern for this class — a
-      checklist entry in the render-security skill (advisory, model-carried) plus
-      a diff-scoped grep gate over the framework-named payload channels that
-      fires when a field is **added** to such a payload. The gate
-      ships **advisory, non-blocking**: a grep over framework-named channels
-      cannot tell a privileged field from a public one, so blocking on it would
-      buy false reds at the cost of the checklist being ignored. State plainly
-      that the deterministic half only flags a site for review and that the
-      judgement is model-carried; a checklist entry alone is not enforcement and
-      must not be described as one.
+      load the page. The question — *should this field be
+      here* — is not decidable by any check: a grep over the framework-named
+      payload channels cannot tell a privileged field from a public one. So this
+      step ships **discovery, not enforcement**, and the two halves are labelled
+      as such. A diff-scoped grep over those channels, advisory and
+      non-blocking, **locates** a payload a field was added to; a checklist entry
+      in the render-security skill carries the **judgement**, model-carried like
+      every other obligation of that class. Neither half refuses anything, and
+      the step must not be written as though one did — `enforced_by: none` is the
+      honest field, and the value of the deterministic half is that it puts the
+      question in front of a reader who would otherwise never see it.
       verify: the checklist names the pattern and the per-field question; the
       gate is registered in the gate coverage registry with its scanned count,
       and a fixture adding a privileged field to a payload channel is flagged

--- a/agents/roadmaps/road-to-consumer-repo-reality.md
+++ b/agents/roadmaps/road-to-consumer-repo-reality.md
@@ -32,6 +32,15 @@ purely in-house convention is just as expressible as a universal one.
    The anchor is cited in the phase. "We saw it in our repositories" is a
    discovery, not an anchor.
 
+**Frequency inside the sample is not an input to either test, and not an
+input to ordering.** How many of the three trees showed a shape says something
+about one organisation's toolchain and nothing about the shape's reach, so the
+counts recorded in the phases below are provenance — where the shape was seen —
+never an argument for its priority or its admission. Phases are ordered by what
+their anchor implies about blast radius on an arbitrary consumer: a silent
+mis-read that makes every later routing decision wrong outranks one that
+degrades a single skill's output.
+
 A step whose anchor is a single organisation's practice is marked
 **anchor-pending** and does not get built until a second, independent,
 external instance is recorded next to it. One such step is marked below rather
@@ -56,8 +65,12 @@ and a manifest pin diverging from an installed artefact is the ordinary
 manifest-versus-lockfile drift every package ecosystem has. Neither depends on
 who the consumer is.
 
-The sharpest finding, because it is silent and it was present in two of the
-three trees. A root instruction file listed an agent layer — rules, skills,
+This phase is first because of what its anchor implies, not because of what
+the sample showed: a dangling pointer is read as a working one, so **every**
+routing decision downstream of it is made against a layer that is not there,
+and nothing surfaces the fault. That is the widest blast radius on the list.
+The counts below are provenance only. A root instruction file listed an agent
+layer — rules, skills,
 guidelines — under a path that **did not exist in the tree**. In one repository
 the entire layer was absent while the file still described it; in another the
 layer existed but two of its four advertised directories did not. An agent
@@ -112,13 +125,15 @@ public, before any code.
       zero matches, and the count is reported so a future addition is visible.
 - [ ] **1.5 Carry the discipline on the agent side, not only in a command.**
       A path named by an instruction file is a claim, not a fact — probe before
-      routing on it, and say which source answered. The obligation belongs next
-      to [`missing-skill-recovery`](../../src/rules/missing-skill-recovery.md),
-      which already covers the mirror case of a **catalogue that under-reports**;
-      this is an **instruction file that over-reports**, and the two are one
-      discipline stated from opposite sides.
-      verify: that rule (or its named successor) states the over-reporting
-      direction explicitly and is reachable from the diagnostic's own output.
+      routing on it, and say which source answered. [`missing-skill-recovery`](../../src/rules/missing-skill-recovery.md)
+      covers the mirror case — a **catalogue that under-reports** — and **does
+      not cover this one**. An instruction file that **over-reports** is the
+      opposite direction and is currently carried by nothing. Whether that rule
+      is extended or a sibling is added is a placement decision to be made and
+      recorded the same way 1.1 makes its own, not asserted here.
+      verify: the placement is recorded with its reasoning; whichever artefact
+      carries it states the over-reporting direction explicitly, and is
+      reachable from the diagnostic's own output.
 
 ## Phase 2 — Configuration resolution follows the chain
 
@@ -153,9 +168,12 @@ while the standards sit one hop away.
       **Invention** is writing a version string that no source in the repository
       produced. **Lookup failure** is having searched the declared version
       sources — catalogue, workspace protocol, existing manifests, lockfile —
-      and found none. The two get opposite handling: invention is forbidden;
-      lookup failure is reported as unresolved, and the version comes from the
-      user or from the registry with that provenance stated. Silence is neither.
+      and found none. The two get opposite handling, and **only the first is
+      forbidden**: on lookup failure, resolving the version from the registry or
+      from the user is the correct move, not a violation — it is reported as
+      unresolved-then-resolved with the source named. What the rule forbids is
+      producing a version with no source and no report. Silence is the failure,
+      never the fallback.
       verify: the supply-chain intake step names the version-source lookup as a
       precondition and distinguishes the two outcomes; a fixture manifest using
       a catalogue protocol is not rewritten to a literal, and a fixture with no
@@ -218,9 +236,14 @@ tests say.
       idioms.** Per path: which conventions hold there, what the neighbouring
       files actually do, and whether a modern idiom is an improvement or a
       foreign body. The verdict is per path, never per repository.
+      A **mixed** verdict is not a refusal to decide: it
+      carries which convention governs which region of the file, and which of
+      the two an edit at a given point must follow. A verdict that says only
+      "mixed" leaves the caller exactly where it started.
       verify: run it against a fixture with both halves; every path gets a
-      verdict, and a file mixing both is reported as mixed rather than assigned
-      to one side.
+      verdict, a file mixing both is reported as mixed rather than assigned to
+      one side, and the mixed verdict names the governing convention per region
+      rather than for the file as a whole.
 - [ ] **4.2 Add the server-composed bootstrap payload to the render-security
       surface, with a named enforcement mechanism.** A payload assembled
       server-side and serialised into the page for a client island is a
@@ -228,9 +251,13 @@ tests say.
       load the page. Enforcement is the existing pattern for this class — a
       checklist entry in the render-security skill (advisory, model-carried) plus
       a diff-scoped grep gate over the framework-named payload channels that
-      fires when a field is **added** to such a payload. State plainly which half
-      is deterministic and which is not; a checklist entry alone is not
-      enforcement and must not be described as one.
+      fires when a field is **added** to such a payload. The gate
+      ships **advisory, non-blocking**: a grep over framework-named channels
+      cannot tell a privileged field from a public one, so blocking on it would
+      buy false reds at the cost of the checklist being ignored. State plainly
+      that the deterministic half only flags a site for review and that the
+      judgement is model-carried; a checklist entry alone is not enforcement and
+      must not be described as one.
       verify: the checklist names the pattern and the per-field question; the
       gate is registered in the gate coverage registry with its scanned count,
       and a fixture adding a privileged field to a payload channel is flagged


### PR DESCRIPTION
Follow-up to #1672, which merged before these five fixes landed. Same file, no
new roadmap — the estate is unchanged.

## The blocking finding, conceded

The merged revision added a generality bar and then undercut it: the Source
block calls three trees a **discovery channel, never a validation sample**, and
Phase 1 opened with *"the sharpest finding, because it is silent and it was
present in two of the three trees."* That is the sample doing priority work.
How many trees of one organisation showed a shape says something about that
organisation's toolchain and nothing about the shape's reach.

Two changes close it:

- The generality bar states that sample frequency is an input to **neither
  test and not to ordering**, and that the counts in the phases are provenance
  — where a shape was seen — never an argument for priority or admission.
- Phase 1 justifies its position by what its **anchor** implies instead: a
  dangling pointer is read as a working one, so every routing decision
  downstream of it is made against a layer that is not there, with nothing
  surfacing the fault. That is the widest blast radius on the list, and it
  would be true if the sample had been a single tree.

## Four precision fixes

| Finding | Fix |
|---|---|
| 1.5 delegates over-reporting recovery to a rule that does not cover it | Conceded. `missing-skill-recovery` covers the mirror case — a catalogue that **under**-reports — and does **not** cover an instruction file that **over**-reports. The step now says so, and makes placement a recorded decision the way 1.1 does, rather than asserting a home it does not have. |
| 2.3's "never invent a version" forbids a necessary fallback | It was meant to permit it and did not say so clearly. Only invention is forbidden; resolving from the registry or the user after a lookup failure is the **correct** move, reported as unresolved-then-resolved with the source named. Silence is the failure, never the fallback. |
| 4.2's grep gate is not stated as non-blocking | Now declared advisory and non-blocking, with the reason: a grep over payload channels cannot separate a privileged field from a public one, so blocking buys false reds at the cost of the checklist being ignored. The deterministic half flags a site; the judgement stays model-carried. |
| 4.1's "per-path verdict" is under-specified for mixed files | A **mixed** verdict is not a refusal to decide. It must name which convention governs which region, and which one an edit at a given point follows. A verdict that says only "mixed" leaves the caller where it started. |

One advisory is deliberately not acted on: the risk register's
`risk-review` header attribution is the template's own format, not a claim any
individual risk needs to cite.

## Gates

`lint_roadmap_complexity`, `lint_plan_risk_register`, `check_references` and
`check_estate_count` green locally. The estate is untouched — this modifies an
active roadmap rather than adding one.