### PR TITLE
roadmap: three drafts from the evolve/evolver inbox drain

### DIFF
--- a/agents/evidence/analysis/consolidation-lineage-census-2026-08-26.md
+++ b/agents/evidence/analysis/consolidation-lineage-census-2026-08-26.md
@@ -31,34 +31,68 @@ consolidate**, and it says so in its own header:
 
 - `road-to-gated-harness-evolution-deep-v4.md:9-13` claims to supersede the
   planning shape of both parents the `evolve/` master names.
-- `road-to-outcome-grounded-harness-evolution.md:9-11` carries
+- `road-to-outcome-grounded-harness-evolution.md:10-12` carries
   `supersedes_analysis:` listing both parents the `evolver/` master names.
-- `road-to-frontend-operating-system.md:6-10` carries `research.basis:` listing
-  exactly the three parents the `impeccable/` master names.
+- `road-to-frontend-operating-system.md:6-11` carries `research.basis:` listing
+  the three parents the `impeccable/` master names **plus** a fourth entry,
+  `chat(3).txt`. Stated precisely because this third case is weaker than the
+  other two: `research.basis:` is a grounding list, not a supersession claim, so
+  reading it as a self-declared later synthesis is an inference. The first two
+  cases declare supersession in as many words; this one does not.
 
 So the consolidation reached the first generation and stopped one generation
-short, three times independently.
+short, three times independently — twice on the artefact's own declaration, once
+on inference.
 
 *Competing-terminal-syntheses* (1 of 4). `road-to-one-spine.md` and
 `road-to-redundancy-governance-master.md` are two masters over the **same four**
 parents, both dated 2026-08-25, both marked PROPOSAL, and neither names the
-other. Different mechanism, same consequence: an artefact that reads as the
-settled answer while a peer of equal standing exists.
+other: an artefact that reads as the settled answer while a peer of equal
+standing exists.
+
+**Corrected 2026-08-26, after a neutral review of this file: the two shapes are
+not as separate as the headings above suggest, and the `redundanz/` case is not
+the only one that fits the second.** In `evolve/`,
+`road-to-gated-harness-evolution-deep-v4.md:10-11` declares supersession over
+*exactly* the two parents the master names, and neither document names the other
+— which is the competing-terminal-syntheses shape verbatim. The same holds in
+`evolver/`, where `supersedes_analysis:` and `consolidates:` list the identical
+pair. So the second shape occurs in **three** folders, not one, and the first is
+best read as a description of what the master did rather than as a disjoint
+class. Anything built on the distinction — including a check that expects the
+second shape in one folder only — must use the three-folder count.
 
 **Why it matters, stated as the consequence rather than the count.** A
 consolidating roadmap presents its content as adjudicated — parents named,
 conflicts resolved, a kill register listing what was rejected and why. When a
 parent is missing from that list, its content is not *killed*; it is
-*undiscussed*, and nothing in the artefact distinguishes the two. Measured on the
-two `tmp/` folders by a structural read of the omitted parents, this produced 13
-and 17 substantive items respectively — mechanisms, exit criteria and
-acceptance criteria — that appear in no master and carry no kill ID. Several
-reverse a decision the master made: in one case the master adopted verbatim a
-mutation-arity rule the omitted parent had raised to doctrine level, in another
-the master adopted an anti-forgery predicate the omitted parent named by name as
-defective, and in a third the master planned a delivery mechanism that ships in
-the tree (`src/scripts/_lib/lean_projection_mode.ts:19`) and that the omitted
-parent had killed for that reason.
+*undiscussed*, and nothing in the artefact distinguishes the two. Measured on the two
+`tmp/` folders by a structural read of the omitted parents, this produced 13 and
+17 substantive items — mechanisms, exit criteria and acceptance criteria — that
+appear in no master and carry no kill ID. **Those two figures are the counts the
+structural reads reported and no command reproduces them.** They are a judgement
+about what counts as one substantive item, and they are recorded as such rather
+than dressed as a measurement. A `grep -c` over the `from-skipped-parent` markers
+in the emitted roadmaps is *not* a substitute: it counts lines mentioning the
+marker, prose about it included, it does not distinguish an adopted item from a
+discussion of one, and it drifts with ordinary editing — it moved while this
+correction was being written. Three of them
+bear on a decision the master made, in three different ways, and the differences
+matter more than the count:
+
+- the master **omitted** a mutation-arity rule the skipped parent had raised to
+  doctrine level — it reduced the mutation *alphabet* to three dimensions, which
+  is a different invariant from limiting a candidate's *arity*;
+- the master **adopted** an anti-forgery predicate the skipped parent named by
+  name as defective;
+- the master **planned** a delivery mechanism that ships in the tree
+  (`src/scripts/_lib/lean_projection_mode.ts:19`) and that the skipped parent had
+  killed for exactly that reason.
+
+An earlier revision of this paragraph described the first as the master having
+"adopted verbatim" the arity rule. That was wrong in both directions — it was
+not adopted, and an adoption would not have been a reversal — and it contradicted
+the roadmap derived from this file, which states the omission correctly.
 
 **What this census does not establish.** It does not show that the omitted
 content was *better* — only that it was not considered. It does not measure
@@ -67,7 +101,11 @@ n=4 it cannot distinguish a property of this consolidation pattern from a
 property of the four sessions that happened to run it; a fifth folder with a
 complete lineage would not refute the finding but would bound it.
 
-**Reproduction.** The two `tmp/` rows are reproducible until those folders are
-consumed into `tmp.old/`; all four rows are reproducible from `tmp.old/` while
+**Reproduction.** The two `tmp/` rows in the table above name the paths as they
+were when the census ran; the same drain that produced this file then moved both
+folders, so they now read `agents/tmp.old/evolve/` and
+`agents/tmp.old/evolver/`. The table is left as measured rather than rewritten,
+and this note is the pointer.
+Those two rows are reproducible from their new location; all four rows are reproducible from `tmp.old/` while
 that directory is retained. Both directories are gitignored, so this file is the
 durable record and the paths above are pointers, not citable evidence in a clone.

--- a/agents/evidence/analysis/consolidation-lineage-census-2026-08-26.md
+++ b/agents/evidence/analysis/consolidation-lineage-census-2026-08-26.md
@@ -1,0 +1,73 @@
+<!-- evidence-type: analysis -->
+# Consolidation-lineage census — 2026-08-26
+
+**What was measured.** Every inbox folder in `agents/tmp/` and
+`agents/tmp.old/` that contains a *consolidating* roadmap — a file declaring
+itself a master over sibling proposals, via a `consolidates:` /
+`supersedes_analysis:` frontmatter key, an "Inputs consolidated" list, or a
+"Master-Konsolidierung" heading. For each, the declared parent set was compared
+against the sibling roadmaps actually present in the same folder.
+
+**How the population was found.**
+`grep -rl 'consolidates:\|supersedes_analysis:\|Ersetzt als führendes Proposal\|Master-Konsolidierung' agents/tmp.old agents/tmp`
+plus a per-folder `ls`. This finds folders whose consolidation is *declared*.
+A consolidation that declares nothing is invisible to this census, so the
+population is a lower bound.
+
+**Result: 4 folders, 4 with an incomplete lineage.**
+
+| Folder | Consolidating file | Parents declared | Sibling roadmaps present | Omitted | Shape |
+|---|---|---|---|---|---|
+| `tmp/evolve/` | `road-to-governed-harness-evolution-master.md` | 2 | 3 | `road-to-gated-harness-evolution-deep-v4.md` (1925 lines, Phases 0–10, K1–K12) | skipped-deeper-parent |
+| `tmp/evolver/` | `road-to-experience-loop-master.md` | 2 (`consolidates:`) | 3 | `road-to-outcome-grounded-harness-evolution.md` (2728 lines, 25 phases, EVO-1–20) | skipped-deeper-parent |
+| `tmp.old/impeccable /` | `road-to-frontend-power.md` | 3 (`consolidates:`) | 4 | `road-to-frontend-operating-system.md` | skipped-deeper-parent |
+| `tmp.old/redundanz/` | `road-to-redundancy-governance-master.md` | 4 ("Inputs consolidated") | 5 | `road-to-one-spine.md` | competing-terminal-syntheses |
+
+**Two distinct shapes, one class.**
+
+*Skipped-deeper-parent* (3 of 4). The omitted sibling is not an unrelated file —
+in every case it is a **later synthesis over the very parents the master did
+consolidate**, and it says so in its own header:
+
+- `road-to-gated-harness-evolution-deep-v4.md:9-13` claims to supersede the
+  planning shape of both parents the `evolve/` master names.
+- `road-to-outcome-grounded-harness-evolution.md:9-11` carries
+  `supersedes_analysis:` listing both parents the `evolver/` master names.
+- `road-to-frontend-operating-system.md:6-10` carries `research.basis:` listing
+  exactly the three parents the `impeccable/` master names.
+
+So the consolidation reached the first generation and stopped one generation
+short, three times independently.
+
+*Competing-terminal-syntheses* (1 of 4). `road-to-one-spine.md` and
+`road-to-redundancy-governance-master.md` are two masters over the **same four**
+parents, both dated 2026-08-25, both marked PROPOSAL, and neither names the
+other. Different mechanism, same consequence: an artefact that reads as the
+settled answer while a peer of equal standing exists.
+
+**Why it matters, stated as the consequence rather than the count.** A
+consolidating roadmap presents its content as adjudicated — parents named,
+conflicts resolved, a kill register listing what was rejected and why. When a
+parent is missing from that list, its content is not *killed*; it is
+*undiscussed*, and nothing in the artefact distinguishes the two. Measured on the
+two `tmp/` folders by a structural read of the omitted parents, this produced 13
+and 17 substantive items respectively — mechanisms, exit criteria and
+acceptance criteria — that appear in no master and carry no kill ID. Several
+reverse a decision the master made: in one case the master adopted verbatim a
+mutation-arity rule the omitted parent had raised to doctrine level, in another
+the master adopted an anti-forgery predicate the omitted parent named by name as
+defective, and in a third the master planned a delivery mechanism that ships in
+the tree (`src/scripts/_lib/lean_projection_mode.ts:19`) and that the omitted
+parent had killed for that reason.
+
+**What this census does not establish.** It does not show that the omitted
+content was *better* — only that it was not considered. It does not measure
+whether a lineage-completeness check would have been cheap at the time. And with
+n=4 it cannot distinguish a property of this consolidation pattern from a
+property of the four sessions that happened to run it; a fifth folder with a
+complete lineage would not refute the finding but would bound it.
+
+**Reproduction.** The two `tmp/` rows are reproducible until those folders are
+consumed into `tmp.old/`; all four rows are reproducible from `tmp.old/` while
+that directory is retained. Both directories are gitignored, so this file is the
+durable record and the paths above are pointers, not citable evidence in a clone.

--- a/agents/evidence/reviews/inbox-evolve-drain-2026-08-26.findings.md
+++ b/agents/evidence/reviews/inbox-evolve-drain-2026-08-26.findings.md
@@ -19,8 +19,9 @@ each one appears in the roadmap with the `file:line` it was checked at. The
 verification changed the plan in nine places, each marked
 `corrected-from-reproduction` in the emitted roadmap:
 
-- `bench_ab_clone.ts` already carries a `--variant` flag with three values, so
-  the planned "axis extension" is a new enum member.
+- `bench_ab_clone.ts` already carries a `--variant` flag with three real variants
+  (its choice list is five, the other two being the aggregates `both` and `all`),
+  so the planned "axis extension" is a new enum member.
 - `lean_projection_mode.ts:19` already defines
   `eager-all | thin | delivery`, so a planned per-task delivery build would have
   rebuilt a shipped mechanism.
@@ -50,13 +51,50 @@ exists with 10 queries, which is what makes the recommended first cut executable
 `lint_roadmap_family_cap` (0/2) · `check_roadmap_trackable` ·
 `lint_roadmap_ci_steps` · `lint_empty_roadmaps` · `check_references` (1692
 scanned, none broken) · `check_no_roadmap_refs` · `check_md_language` on all four
-files · `lint_evidence_artifacts` (1 added, typed) · `check_estate_count`
+files · `lint_evidence_artifacts` (2 added on the branch, both typed) · `check_estate_count`
 (`+3 active / -0 disposed, 3 exempt` — both halves, re-run after the rebase onto
 a base whose active count had moved to the floor).
 
 ## What this skip does not cover
 
-The three roadmaps are proposals and carry open owner decisions, including two
-blockers that must be answered before their later phases can start. Nothing here
+The three roadmaps are proposals and carry open owner decisions, including four
+blockers that must be answered before their later phases can start —
+`merge-authority`, `runtime-consumption-of-experience`,
+`experience-retention-policy` and `lineage-check-enforcement-surface`. Nothing here
 asserts the plans are correct — only that the claims inside them were checked
 and that the change ships no executable surface.
+
+## Neutral review of this change, and what it corrected
+
+A cross-model reviewer was run over the whole branch delta with a neutral prompt
+(no expected outcome stated, scope the full diff rather than a subset chosen by
+the author). It returned 26 findings, four of which it judged blocking. All four
+reproduced on independent check and all four are fixed on this branch:
+
+- **The staleness window was stale.** Both roadmaps claimed `1899f92b9` was "HEAD
+  minus one commit, so the staleness window is empty". True when the verification
+  started, false after the branch was rebased — `git rev-list --count` reads 7,
+  three of them upstream. The sentence was never re-measured.
+- **The estate figure was inverted, and it carried a decision.** Both roadmaps
+  read "`active_roadmaps 3` against a floor of 7 — four slots of headroom". The
+  gate reports 7 against a floor of 7: zero headroom. #1676, inside the unclosed
+  window above, is where the four came from. This reverses the force of the
+  estate-placement decision in both files.
+- **A `verify:` line was refuted by its own evidence.** The lineage roadmap's 2.3
+  expected the two-artefacts-one-parent-set finding in one folder; it occurs in
+  three, including both folders this drain analysed.
+- **The census contradicted the roadmap derived from it** on whether the master
+  adopted or omitted the mutation-arity rule. The roadmap was right.
+
+Twelve further findings were smaller and are also fixed: a misattributed
+`from-skipped-parent` marker, two `grep`-based "zero hits" claims that now
+self-hit, a negative verification scoped to a directory holding no commands, four
+legacy declaration shapes that are five, two off-by-one counts, an item-count pair now recorded as a
+judgement rather than a measurement, a `verify:` line asking a markdown contract to import a
+module, and two external statistics doing load-bearing work in kill entries while
+the closing section claimed nothing external was load-bearing.
+
+The reviewer also checked roughly 45 citations and reproduced them, including
+every verbatim quotation and all four corpus counts. Recording both halves
+because a review reported only by its findings understates what was checked, and
+one reported only by its pass rate hides what it caught.

--- a/agents/evidence/reviews/inbox-evolve-drain-2026-08-26.findings.md
+++ b/agents/evidence/reviews/inbox-evolve-drain-2026-08-26.findings.md
@@ -1,0 +1,62 @@
+# Completion review — inbox drain of `agents/tmp/{evolve,evolver}`
+
+**Skipped:** no code surface for this completion — the diff is three draft roadmap proposals under `agents/roadmaps/`, one measurement under `agents/evidence/analysis/`, and this artefact, and the gate measures zero code paths of four changed files, scope 0dbb4fa9ec138d429351f24651c05a8dd7c3f4dba5eeef10eb0c6fd0e39ddb50, declared 2026-08-26
+
+## Why a skip rather than a review
+
+Nothing in this change executes. There is no function, no gate, no schema and no
+generated tree in it — the four files are prose, and the three roadmaps ship
+`status: draft`, which excludes them from the dashboard, from
+`/roadmap:process-*`, and from the archival sweep until a maintainer flips the
+status. A completion review over this diff would have nothing to exercise.
+
+## What was verified instead, and how
+
+The load-bearing risk in an inbox drain is not a code defect but a transcribed
+claim. Every repository assertion carried from the source proposals into the
+three roadmaps was re-checked against this tree before it was written down, and
+each one appears in the roadmap with the `file:line` it was checked at. The
+verification changed the plan in nine places, each marked
+`corrected-from-reproduction` in the emitted roadmap:
+
+- `bench_ab_clone.ts` already carries a `--variant` flag with three values, so
+  the planned "axis extension" is a new enum member.
+- `lean_projection_mode.ts:19` already defines
+  `eager-all | thin | delivery`, so a planned per-task delivery build would have
+  rebuilt a shipped mechanism.
+- `rule_injection.ts` plus the `router_match` parity test already enforce one
+  shared matcher, which a second one would have silently broken.
+- Two outcome enums exist (`audit-log-v1:77`, `outcome_envelope.ts:24-30`) and
+  one proposal planned to write a value into the stream that lacks it.
+- `trigger_eval_grandfather.json` reads 205 entries against its own "frozen at
+  221" note, so the ratchet has already walked down.
+- The proxy gap documented at `description_route_check.ts:18-30` is
+  proxy-versus-host, not description-versus-body — two unmeasured gaps, not one.
+- `ADR-239:188` records merge authority as open, so "only humans promote" was an
+  intention in every source proposal rather than a property.
+- Two roadmap names cited as existing plans appear nowhere in the repository.
+- `lint_roadmap_family_cap.ts:41` scopes the family cap to
+  `road-to-skill-ecosystem-`, so the estate concern the sources raised could not
+  have fired.
+
+Reproduced steps were run as written rather than read: the three corpus counts
+(94, 299, 175) each reproduce exactly, and `code-intelligence/evals/triggers.json`
+exists with 10 queries, which is what makes the recommended first cut executable.
+
+## Gates run on the final tree
+
+`lint_roadmap_blockers` (12 clean, decidability 0 violations) ·
+`lint_plan_risk_register` (12 scanned) · `lint_roadmap_complexity` (12 clean) ·
+`lint_roadmap_family_cap` (0/2) · `check_roadmap_trackable` ·
+`lint_roadmap_ci_steps` · `lint_empty_roadmaps` · `check_references` (1692
+scanned, none broken) · `check_no_roadmap_refs` · `check_md_language` on all four
+files · `lint_evidence_artifacts` (1 added, typed) · `check_estate_count`
+(`+3 active / -0 disposed, 3 exempt` — both halves, re-run after the rebase onto
+a base whose active count had moved to the floor).
+
+## What this skip does not cover
+
+The three roadmaps are proposals and carry open owner decisions, including two
+blockers that must be answered before their later phases can start. Nothing here
+asserts the plans are correct — only that the claims inside them were checked
+and that the change ships no executable surface.

--- a/agents/roadmaps/road-to-consolidation-lineage-integrity.md
+++ b/agents/roadmaps/road-to-consolidation-lineage-integrity.md
@@ -42,21 +42,29 @@ conflicts resolved, a kill register saying what was rejected and why. When a
 parent is missing from that list its content is not killed, it is undiscussed —
 and **nothing in the artefact distinguishes those two states.** On the two
 current folders a structural read of the omitted parents surfaced 13 and 17
-substantive items carrying no kill ID, several of which reverse a decision the
-master made on the same mechanism.
+substantive items carrying no kill ID, several of which bear on a decision the
+master made on the same mechanism. Those two figures are what the structural
+reads reported, and **no command reproduces them** — they are a judgement about
+what counts as one substantive item, not a count of anything the tree holds.
+Corrected after a neutral review asked for their provenance; a first attempt at
+that correction offered a `grep -c` marker count as a reproducible proxy, which
+was worse than no number: it counts lines mentioning the marker, including prose
+about it, and it moved while these very corrections were being written.
 
 ## Phase 1 — Make the lineage declarable and comparable
 
-- [ ] **1.1 Fix one field name for the parent set.** The four measured folders
-      used four different forms: `consolidates:` frontmatter, a
-      `supersedes_analysis:` key, a prose "Inputs consolidated" list, and a
-      "Master-Konsolidierung" heading with a table. A check cannot read four
-      shapes reliably, and the diversity is itself part of why nobody noticed.
-      Pick one — `consolidates:` is already used by two of the four and is the
-      recommendation — and state the others as deprecated spellings a reader may
-      still encounter.
+- [ ] **1.1 Fix one field name for the parent set.** The measured folders used
+      **five** distinguishable forms, corrected after a neutral review found the
+      earlier count of four had omitted one that the census's own `grep` searches
+      for: `consolidates:` frontmatter · a `supersedes_analysis:` key · a prose
+      "**Inputs consolidated:**" list · a "Master-Konsolidierung" heading with a
+      table · and a prose "**Ersetzt als führendes Proposal:**" list. A check
+      cannot read five shapes reliably, and the diversity is itself part of why
+      nobody noticed. Pick one — `consolidates:` is already used by two of the
+      four folders and is the recommendation — and state the rest as deprecated
+      spellings a reader may still encounter.
       verify: the field is documented in the roadmap template contract, and a
-      fixture in each of the four legacy shapes parses to the same parent set or
+      fixture in each of the five legacy shapes parses to the same parent set or
       is explicitly reported as unparseable.
 - [ ] **1.2 Require the field on any artefact that claims to consolidate.** The
       trigger is the claim, not the filename: `-master` in a name is not the
@@ -78,12 +86,21 @@ master made on the same mechanism.
       authored from this inbox carry a verified instance of this shape — a master
       citing a plan that exists nowhere in the repository.
       verify: a declared parent with no matching file is reported with its name.
-- [ ] **2.3 Detect the second shape: two masters, one parent set.** When two
+- [ ] **2.3 Detect the second shape: two artefacts, one parent set.** When two
       artefacts in one folder declare overlapping parent sets and neither names
-      the other, report both. This is the `redundanz/` case and a plain set
-      comparison finds it.
-      verify: the `redundanz/` folder produces this finding and the other three
-      do not.
+      the other, report both. A plain set comparison finds it.
+      **Corrected after a neutral review: this fires on three of the four census
+      folders, not on `redundanz/` alone.** In `evolve/`,
+      `road-to-gated-harness-evolution-deep-v4.md:10-11` declares supersession
+      over *exactly* the two parents the master names, and neither document names
+      the other; in `evolver/`, `supersedes_analysis:` and `consolidates:` list
+      the identical pair. So the two shapes the census presented as disjoint
+      overlap, and an earlier `verify:` line here expected the finding in one
+      folder while the data produces it in three — a verification that would have
+      failed on its own evidence.
+      verify: `evolve/`, `evolver/` and `redundanz/` each produce this finding
+      and `impeccable /` does not, since there the omitted sibling declares a
+      `research.basis:` grounding list rather than an overlapping parent set.
 
 ## Phase 3 — Put the obligation where the artefacts are produced
 
@@ -91,9 +108,18 @@ master made on the same mechanism.
       already triages inbox folders, already has a `recurrence` column in its
       Phase 2 table, and already asks "is this the second time?" in Phase 4c.
       Lineage completeness is one more triage column on the same pass, and no
-      other artefact in the tree carries this discipline — verified: zero hits
-      for parallel-session or lineage vocabulary across `src/skills/`,
-      `src/rules/` and `src/agent-src/commands/`.
+      other artefact in the tree carries this discipline.
+      **The verification behind that last clause was corrected after a neutral
+      review.** It originally cited zero hits across `src/skills/`, `src/rules/`
+      and `src/agent-src/commands/` — but that third path holds only `evals/`,
+      no command prose at all, so the zero was guaranteed by the scope rather
+      than by absence. Command bodies live under `src/domains/`, including the
+      target of this step
+      (`src/domains/analysis-workbench/analyze/inbox/command.md`). Re-run over
+      `src/skills/`, `src/rules/` and `src/domains/`, there is exactly **one**
+      hit — `src/domains/product-basic/roadmap/next/command.md`, and it concerns
+      the concurrent-session register, not consolidation lineage. The conclusion
+      holds; the earlier evidence for it did not.
       verify: the command's Phase 2 table gains the column, and its Phase 5
       artefact-mapping table says what an omission becomes.
 - [ ] **3.2 Say what an omission obliges.** Not "consolidate it too" — that is a
@@ -146,14 +172,19 @@ master made on the same mechanism.
 
 ## Acceptance Criteria
 
-- [ ] AC-1 — Running the comparison over the four census folders reproduces the
-      census table exactly, and running it over a synthetic complete folder
-      produces zero findings.
+- [ ] AC-1 — Running the comparison over a committed fixture set that mirrors the
+      four census folders reproduces the census table exactly, and running it over
+      a synthetic complete folder produces zero findings. **The fixtures are the
+      criterion, not the live folders**: both inbox directories are gitignored and
+      `agents/tmp/` is already emptied, so an acceptance criterion phrased against
+      them would be satisfiable on one machine and nowhere else. Corrected after a
+      neutral review; E4 carries the same limitation from the retention side.
 - [ ] AC-2 — A declared parent with no matching file is reported by name, and a
       present sibling absent from the declared set is reported by name.
-- [ ] AC-3 — Each of the four legacy declaration shapes either parses to the same
+- [ ] AC-3 — Each of the five legacy declaration shapes either parses to the same
       parent set as the canonical field or is reported as unparseable — never as
-      an empty set.
+      an empty set. The count is five, not four: a parser fixed at four accepts
+      the omitted shape blind, and the omitted shape is one the census greps for.
 - [ ] AC-4 — `/analyze:inbox` carries the lineage column and enumerates the three
       discharges for an omission, so an omission cannot be discharged by silence.
 - [ ] AC-5 — The enforcement surface is a recorded decision, and if a script
@@ -169,6 +200,8 @@ master made on the same mechanism.
   apply to a council synthesis or a review that claims a scope. Out of scope
   here; worth naming so it is not rediscovered.
 - **E4 — Retention of `agents/tmp.old/`.** The census is reproducible only while
-  that directory is retained. It is gitignored and has 345 entries; if it is ever
-  pruned, the evidence file becomes the only record. No action asked for — just
+  that directory is retained. It is gitignored and holds **347** entries — an
+  earlier revision said 345, which was the count before this drain moved its own
+  two folders there. If it is ever pruned, the evidence file becomes the only
+  record. No action asked for — just
   the awareness that this finding's substrate is not durable.

--- a/agents/roadmaps/road-to-consolidation-lineage-integrity.md
+++ b/agents/roadmaps/road-to-consolidation-lineage-integrity.md
@@ -1,0 +1,174 @@
+---
+complexity: lightweight
+status: draft
+execution:
+  mode: phase-checkpoints
+estate_offset_exempt: "Added as a draft proposal, not as active work. Archiving is impossible (nothing has run), parking in later/ would grow the later_roadmaps floor instead of the active one, and it cannot fold into either sibling roadmap because the defect is in the process that produced both of them, not in either subject."
+---
+# Road to consolidation lineage integrity
+
+> **Source:** `agents/evidence/analysis/consolidation-lineage-census-2026-08-26.md`,
+> a census run while analysing `agents/tmp/evolve/` and `agents/tmp/evolver/`.
+> The finding is not about either subject — it is about the consolidation
+> pattern both folders used, and it reproduced on two older folders too.
+
+## Goal
+
+A consolidating roadmap cannot silently omit a sibling proposal. When this is
+finished, every artefact that declares itself a consolidation states its parent
+set in a machine-readable field, a check compares that set against the siblings
+actually present, and an omission is a reported finding rather than an invisible
+one. The obligation lives on the command that already produces these artefacts,
+not on a new surface.
+
+This roadmap does **not** try to make consolidations better. It makes an
+incomplete one visible.
+
+## The measurement
+
+Four inbox folders contain a declared consolidation. All four have an incomplete
+lineage — full table and method in the census file.
+
+Three of the four share one shape and it is the sharper one: the omitted sibling
+is a **later synthesis over the very parents the master did consolidate**, and
+says so in its own header. The consolidation reached the first generation and
+stopped one generation short, three times independently, in three unrelated
+subject areas. The fourth folder holds two masters over the same four parents,
+neither naming the other.
+
+The consequence is what makes this worth a plan rather than a note. A
+consolidating roadmap presents its content as adjudicated: parents named,
+conflicts resolved, a kill register saying what was rejected and why. When a
+parent is missing from that list its content is not killed, it is undiscussed —
+and **nothing in the artefact distinguishes those two states.** On the two
+current folders a structural read of the omitted parents surfaced 13 and 17
+substantive items carrying no kill ID, several of which reverse a decision the
+master made on the same mechanism.
+
+## Phase 1 — Make the lineage declarable and comparable
+
+- [ ] **1.1 Fix one field name for the parent set.** The four measured folders
+      used four different forms: `consolidates:` frontmatter, a
+      `supersedes_analysis:` key, a prose "Inputs consolidated" list, and a
+      "Master-Konsolidierung" heading with a table. A check cannot read four
+      shapes reliably, and the diversity is itself part of why nobody noticed.
+      Pick one — `consolidates:` is already used by two of the four and is the
+      recommendation — and state the others as deprecated spellings a reader may
+      still encounter.
+      verify: the field is documented in the roadmap template contract, and a
+      fixture in each of the four legacy shapes parses to the same parent set or
+      is explicitly reported as unparseable.
+- [ ] **1.2 Require the field on any artefact that claims to consolidate.** The
+      trigger is the claim, not the filename: `-master` in a name is not the
+      signal, because two of the four omissions were in files without it.
+      verify: an artefact using consolidation vocabulary without the field is
+      reported.
+
+## Phase 2 — Compare the declared set against what is present
+
+- [ ] **2.1 Report every sibling roadmap in the same folder that the declared
+      set omits.** Plain set difference over `road-to-*.md` in the
+      consolidation's own directory. No judgement about whether the omission was
+      correct — the output is "declared 2, present 3, omitted X".
+      verify: run against all four census folders and reproduce the census table
+      exactly; run against a synthetic complete folder and get zero findings.
+- [ ] **2.2 Report the reverse direction too.** A declared parent that is not
+      present is the other half of the same defect and cheaper to get wrong: it
+      means the lineage names a file nobody can open. Both sibling roadmaps
+      authored from this inbox carry a verified instance of this shape — a master
+      citing a plan that exists nowhere in the repository.
+      verify: a declared parent with no matching file is reported with its name.
+- [ ] **2.3 Detect the second shape: two masters, one parent set.** When two
+      artefacts in one folder declare overlapping parent sets and neither names
+      the other, report both. This is the `redundanz/` case and a plain set
+      comparison finds it.
+      verify: the `redundanz/` folder produces this finding and the other three
+      do not.
+
+## Phase 3 — Put the obligation where the artefacts are produced
+
+- [ ] **3.1 Extend `/analyze:inbox` rather than adding a surface.** That command
+      already triages inbox folders, already has a `recurrence` column in its
+      Phase 2 table, and already asks "is this the second time?" in Phase 4c.
+      Lineage completeness is one more triage column on the same pass, and no
+      other artefact in the tree carries this discipline — verified: zero hits
+      for parallel-session or lineage vocabulary across `src/skills/`,
+      `src/rules/` and `src/agent-src/commands/`.
+      verify: the command's Phase 2 table gains the column, and its Phase 5
+      artefact-mapping table says what an omission becomes.
+- [ ] **3.2 Say what an omission obliges.** Not "consolidate it too" — that is a
+      judgement the operator makes. The obligation is to **name it**: either fold
+      the omitted parent in, or record a kill ID for it, or state that it was
+      read and adds nothing. Silence is the failure mode; any of the three is a
+      discharge.
+      verify: the command text enumerates the three discharges and forbids
+      silence.
+- [~] **3.3 Consider a gate.** Deferred: needs E1. A check that runs over
+      gitignored inbox directories cannot be a CI gate, because CI never sees
+      them. It could run locally from the command, or as a pre-commit check on
+      any roadmap carrying the field. Whether it enforces or reports is E2.
+
+## Blockers
+
+### lineage-check-enforcement-surface
+
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** Phase 3 step 3.3 only. Phases 1, 2 and steps 3.1–3.2 land
+  regardless.
+- **What to do:** pick exactly one — (a) local-only, invoked by
+  `/analyze:inbox`, reporting and never blocking, since the inputs are
+  gitignored and CI cannot see them; or (b) local-only for inbox folders **plus**
+  a tracked-tree check on any roadmap in `agents/roadmaps/` carrying the field,
+  which CI *can* run; or (c) no check at all — the command text carries the
+  obligation and the honest enforcement note says `instruction-only`.
+- **Resolved when:** the decision is recorded and, if (a) or (b), the script is
+  registered in `src/config/gate-coverage.yml` with a `reportScanned` count and a
+  `--self-test`.
+- **Recommendation:** (b). The inbox half must be local because the data is
+  gitignored, and the tracked half is where an omission would actually survive
+  into the estate — a consolidating roadmap that lands with a missing parent is
+  the case worth blocking, and it is the only one CI can see.
+- **If you do nothing:** Phases 1–2 produce a script nothing runs, and 3.1–3.2
+  make the obligation model-carried. That is the same honesty position several
+  rules in this tree already state, and it is a legitimate outcome — but it
+  should be a decision, not a default reached by not deciding.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-08-26 | reviewer: claude/host -->
+
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | The check becomes a nag on legitimate folders | product | An inbox folder often holds files that are not parents — transcripts, notes, an unrelated roadmap. A set difference over `road-to-*.md` will report those, and a finding that is usually wrong gets ignored, which is worse than no finding | 2.1 is validated in both directions against all four census folders and a synthetic complete folder; 3.2 makes naming-it a one-line discharge so a false positive costs a sentence, not a re-run | Phase 2 — Compare the declared set against what is present |
+| 2 | Four legacy declaration shapes are silently misparsed | implementation | The measured folders used four different forms. A parser that reads one and returns empty for the others reports every legacy consolidation as declaring zero parents — a finding storm that discredits the check on its first run | 1.1 requires a fixture per legacy shape that either parses identically or is reported as unparseable, never as empty | Phase 1 — Make the lineage declarable and comparable |
+| 3 | A gate that cannot see its own inputs | implementation | The inbox directories are gitignored, so a CI gate over them scans nothing and exits green — the "gates that scan nothing exit green" failure this tree has recorded before | The blocker forces the surface decision before the script is registered, and option (b) splits the check into the half CI can see and the half it cannot | Phase 3 — Put the obligation where the artefacts are produced |
+| 4 | n=4 is read as a law | product | Four folders is enough to show the pattern is not an outlier and not enough to characterise the population. A plan written as if the rate were known invites a mechanism sized for a certainty that does not exist | The census states its own bound explicitly, and this roadmap's deliverable is visibility rather than prevention | Phase 1 — Make the lineage declarable and comparable |
+
+## Acceptance Criteria
+
+- [ ] AC-1 — Running the comparison over the four census folders reproduces the
+      census table exactly, and running it over a synthetic complete folder
+      produces zero findings.
+- [ ] AC-2 — A declared parent with no matching file is reported by name, and a
+      present sibling absent from the declared set is reported by name.
+- [ ] AC-3 — Each of the four legacy declaration shapes either parses to the same
+      parent set as the canonical field or is reported as unparseable — never as
+      an empty set.
+- [ ] AC-4 — `/analyze:inbox` carries the lineage column and enumerates the three
+      discharges for an omission, so an omission cannot be discharged by silence.
+- [ ] AC-5 — The enforcement surface is a recorded decision, and if a script
+      exists it is registered with a scanned count and a self-test.
+
+## Open maintainer decisions
+
+- **E1 — Enforcement surface.** See Blockers.
+- **E2 — Report or block,** if a check lands at all. Reporting is the safe start
+  given risk 1.
+- **E3 — Does this generalise beyond consolidations?** The same shape —
+  an artefact asserting it adjudicated a set, without stating the set — could
+  apply to a council synthesis or a review that claims a scope. Out of scope
+  here; worth naming so it is not rediscovered.
+- **E4 — Retention of `agents/tmp.old/`.** The census is reproducible only while
+  that directory is retained. It is gitignored and has 345 entries; if it is ever
+  pruned, the evidence file becomes the only record. No action asked for — just
+  the awareness that this finding's substrate is not durable.

--- a/agents/roadmaps/road-to-experience-loop-broadening.md
+++ b/agents/roadmaps/road-to-experience-loop-broadening.md
@@ -9,13 +9,24 @@ estate_offset_exempt: "Added as a draft proposal, not as active work. Archiving 
 
 > **Source:** `agents/tmp.old/evolver/` — three session proposals plus the
 > operator transcript. Every repo claim below was re-verified against this tree
-> on 2026-08-26; the proposals were drafted against `1899f92b9`, which is HEAD
-> minus one commit, so the staleness window is empty.
+> on 2026-08-26; the proposals were drafted against `1899f92b9`.
+>
+> **Corrected after a neutral review: the staleness window is not empty.** An
+> earlier revision said `1899f92b9` was "HEAD minus one commit" — true when the
+> verification started, false by the time this branch was pushed, because the
+> branch was rebased in between and the sentence was never re-measured.
+> `git rev-list --count 1899f92b9..HEAD` reads **7**, of which three are
+> upstream: `387dd3e68`, `82e47cefc` (#1676) and `9e8344a3f`. None of them touch
+> the contracts or scripts this roadmap cites — those were re-checked against the
+> post-rebase tree — but #1676 changed the estate that E1 reasons about, and the
+> first version of E1 carried the pre-rebase number.
 >
 > **The consolidation those files produced was incomplete, and that is the first
 > finding.** `road-to-experience-loop-master.md` declares
 > `consolidates: [road-to-outcome-informed-assets, road-to-evidence-gated-self-evolving-agent-config]`
-> — two files. The folder holds a third,
+> — two files. (That key is quoted verbatim; the arithmetic sentence below is
+> translated from the German original at `road-to-experience-loop-master.md:243`,
+> so it is a rendering rather than a quotation.) The folder holds a third,
 > `road-to-outcome-grounded-harness-evolution.md` (2728 lines, 25 phases, 20
 > acceptance criteria, its own kill register), whose frontmatter declares it
 > supersedes **both** of the two the master consolidated. The master's own
@@ -50,7 +61,7 @@ learning loop; every phase widens the one in the tree.
 |---|---|---|
 | "No persistent learning loop" | `docs/contracts/audit-log-v1.md` — append-only JSONL per `/work` phase carrying `outcome`, `rules_applied`, `confidence_band`, `risk_class`; corrections only as a new `type=supersede` line | `:44` the example line, `:77` the outcome enum, `:85` the `type` enum, `:114` the supersede rule |
 | "No pattern mining" | `src/scripts/extract_audit_patterns.ts` — mints patterns across **independent** `work_id` values behind a `--min-count` floor, exit 2 below it | `:7-8` flags and exit codes, `:14` "across INDEPENDENT runs — distinct `work_id` values" |
-| "No promotion gate" | `src/skills/learning-to-rule-or-skill/SKILL.md`, named by the contract as the human review gate | contract `:26` |
+| "No promotion gate" | `src/skills/learning-to-rule-or-skill/SKILL.md` | the contract's consumer row `:26` names a human review gate but attributes it to `extract_audit_patterns`; the skill itself is named at `:11` and `:147-148` ("Skill that consumes promoted patterns") — corrected after a neutral review |
 | "No runtime taxonomy; the ADRs contradict the code" | ADR-124 already classifies: Class A embedded/per-invocation, Class B resident with its own escalation path, Class C state stores prohibited | `ADR-124:110` Class A incl. the termination clause, `:153` the Class-B escalation, `:170-177` Class C plus the state-store test |
 | "Experience needs a new home" | ADR-094 removed Layer 2 (the companion package) and **kept** Layer 1 (file-first `agents/memory/` plus intake JSONL) | `ADR-094:25` Layer 1, `:44` remove Layer 2, `:51` keep Layer 1 |
 | "Deterministic capture is impossible" | `src/scripts/hooks/telemetry_usage_hook.ts` — `post_tool_use` with `tool_name === "Skill"` present in **164 of 164** real invocations across 14,171 records | `:15-19` verbatim |
@@ -120,12 +131,20 @@ parents must restate the letter's meaning rather than carry it.
       (`success · blocked · skipped · error`);
       `src/scripts/_lib/outcome_envelope.ts:24-30` has six
       (`success · clean-no-op · blocked · approval-required · exhausted ·
-      stagnated`). Phase 2 below writes `clean-no-op` into the audit stream,
-      where that value does not exist. This step owns the reconciliation; the
-      sibling roadmap `road-to-governed-harness-evolution.md` names the same
-      defect and defers to this one.
-      verify: one module exports the enum both the contract and the envelope
-      import, and a lint rejects an inline duplicate.
+      stagnated`). One of this roadmap's source proposals planned
+      to write `clean-no-op` into the audit stream, where that value does not
+      exist — which is how the split was found. Phase 2 below deliberately does
+      **not** write it: which outcome an empty-but-contract-satisfying return
+      resolves to is E3, and E3 cannot be answered before this step. Corrected
+      after a neutral review caught the earlier wording attributing that plan to
+      Phase 2 itself. This step owns the reconciliation; the sibling roadmap
+      `road-to-governed-harness-evolution.md` names the same defect and defers to
+      this one.
+      verify: one module is the single definition, `outcome_envelope.ts` imports
+      it rather than declaring its own, and the contract's enum table is either
+      generated from it or lint-checked against it — a markdown contract cannot
+      import, so the binding is the check, not an import. A lint rejects an
+      inline duplicate.
 - [ ] **1.4 Carry a privacy class on every captured event, and a redaction rule
       for anything free-form.** `from-skipped-parent`, and this is the gap with
       the sharpest consequence. The master has **no** privacy, redaction or
@@ -332,10 +351,11 @@ parents must restate the letter's meaning rather than carry it.
       `corrected-from-reproduction`: the master called this "the mechanical core
       of `road-to-canonical-wording-and-propagation`" and an attachment point
       for "the open script-twin decision from PR #1636". Verified on this tree:
-      **no file anywhere in the repository mentions
-      `canonical-wording-and-propagation`** — zero hits from `grep -rl` over
-      `*.md`, `*.ts` and `*.json`. It is not active, not parked, not a stub, not
-      archived. The PR reference was **not checked**: that is an external system
+      **no plan by that name exists.** `grep -rl` over `*.md`, `*.ts` and
+      `*.json` returned zero hits when the check was run, and now returns exactly
+      one — this roadmap, because the name is written here; a reader re-running it
+      should expect that single self-hit and nothing else. It is not active, not
+      parked, not a stub, not archived. The PR reference was **not checked**: that is an external system
       and this analysis ran offline by its own bound, so it is unverified rather
       than false. Either author the parent or drop the framing; do not cite a
       plan that does not exist.
@@ -435,7 +455,7 @@ parents must restate the letter's meaning rather than carry it.
 | 4 | Measuring self-report as if it were outcome | implementation | An aggregation built before the anti-forgery gate cannot separate a claimed success from a real one afterwards | Phase 2 lands before Phase 6; 6.1 counts a missing signal as unknown; 6.2 makes an estimated figure visibly estimated | Phase 2 — Outcome integrity: anti-forgery at the subagent return |
 | 5 | A win rate that cannot be acted on | implementation | Without the activation-versus-adherence split, a low rate points at the asset's content when the real cause may be that the router never activated it. The wrong fix follows deterministically | Phase 5 adds the five-state split, with `unknown` where no evidence exists | Phase 5 — Activation versus adherence |
 | 6 | The one core metric cannot be computed | implementation | Repeats and regressions arrive after the audit line is terminal. Without an amendment path the repeated-failure rate systematically under-reports | Phase 3 adds the episode lifecycle with append-only amendment | Phase 3 — Episode lifecycle and delayed amendment |
-| 7 | Schema extension against a value that does not exist | implementation | Phase 2 writes `clean-no-op`; the audit contract's enum has four values and does not include it. The write looks successful and the consumer silently does not read it | 1.3 reconciles the two enums before either is extended; 9.1 makes reintroduction lintable | Phase 1 — Broaden capture |
+| 7 | Schema extension against a value that does not exist | implementation | A source proposal planned to write `clean-no-op` into a stream whose enum has four values and does not include it. Such a write looks successful while the consumer silently does not read it — live for any later step that resolves an outcome before the vocabulary is settled | 1.3 reconciles the two enums before either is extended; 9.1 makes reintroduction lintable | Phase 1 — Broaden capture |
 | 8 | A rolling buffer makes a pre-registered floor unreachable | implementation | Already recorded once in this tree at `docs/CLAIMS.md:691`. A ledger whose retention rotates cannot back a floor above its window, and the discovery comes at verdict time | The `experience-retention-policy` blocker decides it before the report is relied on | Phase 6 — Evaluation: a per-asset report, read-only |
 | 9 | The unknown share is treated as noise | product | A report whose unknown share is large reads as weak data and gets ignored, when the unknown share *is* the measurement of the capture gap and the most actionable number on the page | 6.1 reports unknown as a first-class share, never folded into neutral | Phase 6 — Evaluation: a per-asset report, read-only |
 | 10 | Cards accumulate faster than they are reviewed | product | A card store growing without expiry becomes a second undocumented authority surface competing with rules, and a global-scope card mined from one repository's runs generalises on no evidence | 7.2 makes expiry, falsifier and epistemic type mandatory; 7.4 routes promotion through the human gate; 7.5 adds the scope ladder and transfer requirement; 9.3 requires a removal | Phase 7 — Experience cards |
@@ -497,11 +517,20 @@ is refuted, cheaply.
   `src/scripts/lint_roadmap_family_cap.ts:41` sets
   `FAMILY_PREFIX = 'road-to-skill-ecosystem-'` and counts only top-level active
   roadmaps, so that gate **cannot** fire on this name or the sibling's; it
-  reports 0/2 slots used. The gate that does apply is `check_estate_count`,
-  reading `active_roadmaps 3` against a floor of 7 — four slots of headroom. The
-  real question is whether this roadmap and
-  `road-to-governed-harness-evolution.md` stay separate or fold into one; they
-  overlap on trigger evals, on the paired-verdict mechanism, and on step 1.3.
+  reports 0/2 slots used. The gate that does apply is `check_estate_count`.
+
+  **Corrected after a neutral review, and it reverses this decision's force.** An
+  earlier revision read "`active_roadmaps 3` against a floor of 7 — four slots of
+  headroom". That was a pre-rebase reading; #1676 landed four roadmaps in the
+  window named above. The gate now reports
+  `active_roadmaps 7 (floor 7 at origin/main, +0)` — **at the floor, zero
+  headroom.** These three clear it only because `status: draft` excludes them from
+  the counted set and each carries `estate_offset_exempt` for the file-based half.
+  So flipping any of them to `ready` without a disposal in the same change raises
+  a floor already at its ceiling. The question is whether this roadmap and
+  `road-to-governed-harness-evolution.md` stay separate or fold into one — they
+  overlap on trigger evals, on the paired-verdict mechanism and on step 1.3 — and
+  on the estate axis folding is now the cheaper answer, not just the tidier one.
 - **E2 — audit-log v2:** confirm the schema-bump procedure — supersede lines, or
   a new file generation?
 - **E3 — Does `clean-no-op` count as its own outcome in the report?
@@ -519,11 +548,16 @@ is refuted, cheaply.
 - **E9 — Terminology:** one canonical word for the card object, then propagate
   it. Phase 9's discipline applies reflexively to this decision.
 - **E10 — Host scope.** The master scopes capture to Claude Code, the one host
-  with a measured 164/164. `from-skipped-parent` required at least three
-  materially different hosts plus a capability matrix with
+  with a measured 164/164. The skipped parent required at least three materially
+  different hosts (`road-to-outcome-grounded-harness-evolution.md:1662`,
+  `:2500`). The capability matrix with
   `required / optional / unavailable / inferred` per field and the rule "never
-  manufacture parity". One host is defensible; the rule against manufacturing
-  parity should be adopted either way.
+  manufacture parity" is **not** from the skipped parent — it sits in one of the
+  two declared parents
+  (`road-to-evidence-gated-self-evolving-agent-config.md:1365-1373`), so the
+  master dropped it having read it, which is a different failure from never
+  having seen it. Corrected after a neutral review caught the marker on the wrong
+  side. One host is defensible; the parity rule should be adopted either way.
 - **E11 — Owner-reserved actions.** `from-skipped-parent` lists relaxing an
   evaluator threshold as owner-reserved. Confirm that, or name what else is.
 
@@ -532,7 +566,7 @@ is refuted, cheaply.
 | ID | Rejected | Reason |
 |---|---|---|
 | K1 | A new `src/` asset family, and pre-seeded strategy families | Additive push with no verified defect behind it; the card form in Phase 7 covers the empirical core and only ever arises from the mining gate. |
-| K2 | Hub / network / credit / reputation-index / team-sharing / interop adapters | The one independent measurement of that design reports ~2 % asset reuse and >84 % of released assets bypassing meaningful validation — the failure mode is publication reward, not sharing. ADR-088 and ADR-216 also stand. |
+| K2 | Hub / network / credit / reputation-index / team-sharing / interop adapters | Stands on this tree: ADR-088 and ADR-216 (internal scope, adoption is not a goal) already settle it, and no defect verified here asks for any of it. The source proposals additionally cited an independent measurement reporting ~2 % asset reuse and >84 % of released assets bypassing validation; that figure was **not** checked here and is not load-bearing — recorded because it points the same way, not because it decides. |
 | K3 | The ADR-reopen package | The runtime taxonomy exists (ADR-124 Class A/B/C); ADR-094 is owner-decided with revival behind an unmet gate. The single legitimate door is the Phase 9 blocker. |
 | K4 | SQLite as the *source* of experience | Class C by the state-store test, quoted verbatim in 6.5. Admissible only as a rebuildable index. |
 | K5 | An evaluator-mesh framework, personality/mutation objects, strategy presets, session-spawn directives, auto-issue-filing | No verified defect behind any of them, and several rest on mechanics that could not be inspected. Adopted from that cluster: exactly one rule — a missing signal is `unknown`, never `success`. |

--- a/agents/roadmaps/road-to-experience-loop-broadening.md
+++ b/agents/roadmaps/road-to-experience-loop-broadening.md
@@ -1,0 +1,554 @@
+---
+complexity: structural
+status: draft
+execution:
+  mode: phase-checkpoints
+estate_offset_exempt: "Added as a draft proposal, not as active work. Archiving is impossible (nothing has run), parking in later/ would grow the later_roadmaps floor instead of the active one, and folding it into road-to-governed-harness-evolution is exactly the open question E1 puts to the owner — pre-merging would decide it by authoring."
+---
+# Road to experience loop broadening
+
+> **Source:** `agents/tmp.old/evolver/` — three session proposals plus the
+> operator transcript. Every repo claim below was re-verified against this tree
+> on 2026-08-26; the proposals were drafted against `1899f92b9`, which is HEAD
+> minus one commit, so the staleness window is empty.
+>
+> **The consolidation those files produced was incomplete, and that is the first
+> finding.** `road-to-experience-loop-master.md` declares
+> `consolidates: [road-to-outcome-informed-assets, road-to-evidence-gated-self-evolving-agent-config]`
+> — two files. The folder holds a third,
+> `road-to-outcome-grounded-harness-evolution.md` (2728 lines, 25 phases, 20
+> acceptance criteria, its own kill register), whose frontmatter declares it
+> supersedes **both** of the two the master consolidated. The master's own
+> arithmetic gives it away: "17 DI phases + 8 OIA phases compressed to M0–M8"
+> does not include the third parent's 25. So the deepest parent was skipped, and
+> most of what looks settled in the master was never discussed. This roadmap
+> folds it back in.
+>
+> Items marked `corrected-from-reproduction` differ from the master because
+> checking its step produced something else. Items marked `from-skipped-parent`
+> come from that third file and appear in no master.
+
+## Goal
+
+The learning loop this repository already runs is broadened until it can answer
+*which guidance was loaded, whether it was followed, and whether the outcome was
+real* — and until a repeated failure pattern can become a reviewed candidate for
+authority rather than a line nobody reads again. When this is finished a
+per-asset effectiveness report exists that a human or CI reads; every recorded
+success is backed by a non-empty change *against that task's expected output
+contract*; every derived figure states whether it was measured or estimated; and
+the one question that would let runtime *consume* that experience is a named
+owner decision rather than a silent default.
+
+The correction that reshaped this plan, and it applies to all three source
+proposals: **the loop is not missing.** It is narrow. Nothing here builds a
+learning loop; every phase widens the one in the tree.
+
+## What already exists — verified, do not rebuild
+
+| Claimed gap | What is actually there | Verified on this tree |
+|---|---|---|
+| "No persistent learning loop" | `docs/contracts/audit-log-v1.md` — append-only JSONL per `/work` phase carrying `outcome`, `rules_applied`, `confidence_band`, `risk_class`; corrections only as a new `type=supersede` line | `:44` the example line, `:77` the outcome enum, `:85` the `type` enum, `:114` the supersede rule |
+| "No pattern mining" | `src/scripts/extract_audit_patterns.ts` — mints patterns across **independent** `work_id` values behind a `--min-count` floor, exit 2 below it | `:7-8` flags and exit codes, `:14` "across INDEPENDENT runs — distinct `work_id` values" |
+| "No promotion gate" | `src/skills/learning-to-rule-or-skill/SKILL.md`, named by the contract as the human review gate | contract `:26` |
+| "No runtime taxonomy; the ADRs contradict the code" | ADR-124 already classifies: Class A embedded/per-invocation, Class B resident with its own escalation path, Class C state stores prohibited | `ADR-124:110` Class A incl. the termination clause, `:153` the Class-B escalation, `:170-177` Class C plus the state-store test |
+| "Experience needs a new home" | ADR-094 removed Layer 2 (the companion package) and **kept** Layer 1 (file-first `agents/memory/` plus intake JSONL) | `ADR-094:25` Layer 1, `:44` remove Layer 2, `:51` keep Layer 1 |
+| "Deterministic capture is impossible" | `src/scripts/hooks/telemetry_usage_hook.ts` — `post_tool_use` with `tool_name === "Skill"` present in **164 of 164** real invocations across 14,171 records | `:15-19` verbatim |
+
+**corrected-from-reproduction — ADR-094 is a *gated* no, not an absolute one,
+and the gate is the thing to cite.** The master called Layer 2 revival a "Hard
+No". `ADR-094:85` records the alternative as "Revive Layer 2 later. Gated:
+requires ≥2 funded consumer projects with a …". The gate is unmet, so the
+practical answer is the same — but a plan that says "forbidden" invites a
+re-litigation that a plan saying "gated, gate unmet, here is the gate" does not.
+
+## A hazard the parents created for each other
+
+`from-skipped-parent`, and it is worth one line because acting on it wrong is
+silent: the two same-lineage parents both use an `A/B/C/D` runtime-class
+taxonomy, **with B and C swapped**. One has B = resident local runtime and
+C = derived persistence; the other has B = derived local persistence and
+C = resident runtime. Neither matches ADR-124, where Class C is the class that
+is *prohibited*. So a cross-citation between those two documents silently
+inverts "the thing to build" and "the thing that is banned". Every class letter
+in this roadmap refers to **ADR-124 only**, and any future citation into those
+parents must restate the letter's meaning rather than carry it.
+
+## Phase 0 — Scope, classification, decisions
+
+- [ ] **0.1 Write a classification note, not an ADR rewrite.** Every runtime
+      component lacking an explicit ADR-124 class label gets one. No ADR is
+      rewritten, because the taxonomy the parents wanted to author already
+      exists.
+      verify: every entry in the runtime registry carries a class label, and
+      `git diff docs/decisions/` is empty for ADR-124.
+- [ ] **0.2 Fix the boundaries in writing.** ADR-094 untouched (Layer 2 revival
+      stays behind its own gate); the runtime-consumption question is carried
+      only as the Phase 9 gate, never assumed either way.
+      verify: no step below reads experience data at selection or routing time.
+- [ ] **0.3 Adopt consumer-before-producer for every metric.**
+      `from-skipped-parent`, and it is the rule this repository has already paid
+      for not having: each metric declares its `consumer`, the `decision` it
+      feeds, and what fails if it is missing. "A metric with no consumer is
+      telemetry decoration and should not land." The tree's own worked example
+      is the 0.27 % dispatch capture this roadmap cites in 1.1 — a collector
+      whose consumer arrived after the data did.
+      verify: a metric added without those three fields fails the lint.
+- [ ] **0.4 Settle estate placement.** See E1.
+
+## Phase 1 — Broaden capture
+
+- [ ] **1.1 Spike whether the dispatch event is as reliable as the skill
+      event.** `docs/CLAIMS.md:328` records the measured reality verbatim:
+      "0.27% telemetry capture (370 dispatches, 1 recorded line)". The skill
+      event by contrast is 164/164. Pre-register the numbers before building:
+      success is ≥ 95 % capture over ≥ 50 dispatches; below that the result is an
+      honest null and the work rescales to skill events.
+      verify: the pre-registration commit precedes the measurement commit, and
+      the measured rate is reported whichever way it lands.
+- [ ] **1.2 Add `skills_applied` to the audit line.**
+      `corrected-from-reproduction`: verified — `audit-log-v1` carries
+      `rules_applied` (`:82`, bounded to ≤ 32) and carries **no** skills field at
+      all. Migrate by `type=supersede` lines, exactly as that contract already
+      prescribes for corrections.
+      verify: a fixture proves real emission of the new field from a live phase.
+      A "collector exists" proxy is not evidence — the tree's own 0-of-89
+      finding (`telemetry_usage_hook.ts:11`) is what that mistake costs.
+- [ ] **1.3 Reconcile the two outcome vocabularies before extending either.**
+      `corrected-from-reproduction`, and no proposal in either folder noticed:
+      this tree holds **two** outcome enums. `audit-log-v1:77` has four values
+      (`success · blocked · skipped · error`);
+      `src/scripts/_lib/outcome_envelope.ts:24-30` has six
+      (`success · clean-no-op · blocked · approval-required · exhausted ·
+      stagnated`). Phase 2 below writes `clean-no-op` into the audit stream,
+      where that value does not exist. This step owns the reconciliation; the
+      sibling roadmap `road-to-governed-harness-evolution.md` names the same
+      defect and defers to this one.
+      verify: one module exports the enum both the contract and the envelope
+      import, and a lint rejects an inline duplicate.
+- [ ] **1.4 Carry a privacy class on every captured event, and a redaction rule
+      for anything free-form.** `from-skipped-parent`, and this is the gap with
+      the sharpest consequence. The master has **no** privacy, redaction or
+      purge content at all, while its card phase writes mined experience into
+      `agents/memory/` — verified **tracked**, five files under
+      `git ls-files agents/memory`. Persistent experience can retain source
+      excerpts, secrets, user messages and customer data. Structured references
+      by default; raw snippets off, or bounded and secret-scanned; a privacy
+      class as a mandatory event field. This is the shape
+      `domain-safety-pii` § Surface 2 already prescribes for logs: make the
+      event type incapable of holding free-form content rather than scrubbing it
+      afterwards.
+      verify: the event type has no field able to hold a prompt, a file body or
+      a path; a fixture attempting to write one fails to compile.
+- [ ] **1.5 Everything default-off and local.** No dark-channel ratchet is
+      touched.
+      verify: with the feature off, zero telemetry file operations and zero
+      network calls — the shape `telemetry_usage_hook.ts:21-29` already
+      documents for itself.
+
+## Phase 2 — Outcome integrity: anti-forgery at the subagent return
+
+- [ ] **2.1 Dock onto the existing stub, do not open a parallel plan.**
+      `agents/roadmaps/stubs/road-to-subagent-return-gate.md` exists on this
+      tree — verified — and carries the council decision this phase extends.
+      verify: the stub is the referenced parent and no second gate is authored.
+- [ ] **2.2 Gate anti-forgery on the task's expected output contract, not on
+      the diff alone.** `corrected-from-reproduction`, and this reverses the
+      master. The master ships the unconditional form — claimed success × empty
+      diff ⇒ never `success`. The skipped parent named exactly that form as the
+      reference implementation's defect: "zero diff may be valid. Therefore
+      'zero diff = failure' must **not** be global. The gate must use expected
+      artifact contract." Analysis, review and read-only research dispatches are
+      a large share of this repository's subagent traffic and legitimately
+      produce no diff; the unconditional rule would mark them all as failures
+      and poison the very aggregation Phase 4 depends on.
+      verify: a read-only analysis dispatch returning no diff but satisfying its
+      declared output contract resolves to `success`; a code dispatch claiming
+      success with an empty diff does not.
+- [ ] **2.3 Count empty cycles separately.** A double trigger must not read as
+      two outcomes.
+      verify: a synthetic double trigger produces one outcome and one empty-cycle
+      increment.
+- [ ] **2.4 State the reason in the contract, not only in the code.** Without
+      this gate every later aggregation poisons its own data, because an
+      unverified self-report is indistinguishable from a result.
+      verify: the contract text carries the rationale and the failure it
+      prevents.
+
+## Phase 3 — Episode lifecycle and delayed amendment
+
+- [ ] **3.1 Give an episode a lifecycle, because outcomes arrive late.**
+      `from-skipped-parent`: rework and regressions arrive after a task is
+      already terminal, so an episode needs `open → terminal → observed →
+      amended`, with historical events never rewritten — an amendment is a new
+      record. The master has no lifecycle and no amendment path, while its
+      **single** pre-registered core metric is the repeated-failure rate. A
+      repeat is precisely the signal that surfaces after the audit line is
+      written, so without amendment the master's one metric cannot be computed
+      correctly.
+      verify: an amendment arriving after a terminal state produces a new record
+      and leaves the original byte-identical; the repeated-failure rate reads the
+      amended view.
+
+## Phase 4 — Loop guards for drain and continuation
+
+- [ ] **4.1 Detect more than two shapes.** The master carries two counters —
+      consecutive empty cycles, and the same signal or roadmap in ≥ 3 of the
+      last 8 runs. `from-skipped-parent` adds three the master dropped: the same
+      failure *signature* recurring, the same tactic repeated after it was
+      rejected, and the same asset activating repeatedly with no progress. The
+      last two are the ones a counter over signals cannot see.
+      verify: a synthetic run repeating a rejected tactic trips suppression even
+      when the signal string differs.
+- [ ] **4.2 No strategy presets.** Suppression escalates through the existing
+      triage ladder.
+      verify: a run of 8 with 3 repeats trips suppression exactly once, and a run
+      of 8 with 2 repeats does not.
+
+## Phase 5 — Activation versus adherence
+
+- [ ] **5.1 Separate "was it loaded" from "was it followed".**
+      `from-skipped-parent`, and the master has no `adherence` token anywhere,
+      which makes its per-asset win rate uninterpretable. The five states are
+      `not available / available-not-activated / activated-not-followed /
+      activated-followed / unknown`. The reason, in the parent's own worked
+      case: skill content may be excellent, the router may never activate it,
+      and changing the skill would improve nothing. A low success rate without
+      this split leads to the wrong fix by construction.
+      verify: a failing case is classifiable into one of the five states, and a
+      case with an unobserved rung reports `unknown` rather than a success or a
+      failure.
+- [ ] **5.2 Prefer deterministic adherence evidence where a rule has an
+      observable footprint.** `from-skipped-parent`'s example: test-first
+      discipline is provable from the order of the first observed write to a test
+      file versus a production file. Where no footprint exists, adherence stays
+      `unknown` — never inferred.
+      verify: at least one rule has a deterministic adherence detector, and the
+      rest report `unknown` rather than a model's guess.
+
+## Phase 6 — Evaluation: a per-asset report, read-only
+
+- [ ] **6.1 Aggregate over the audit JSONL.** Per rule and per skill: win rate,
+      streak, and the harmful / neutral / **unknown** shares. A missing signal
+      counts as unknown, never as success.
+      verify: an asset with no signal appears with unknown ≠ 0 and win rate
+      undefined, not with a fabricated score.
+- [ ] **6.2 Every derived figure states its basis.** `from-skipped-parent`, and
+      both a parent and the master's own rationale depend on it: each number
+      carries `basis: measured | estimated:<method> | inferred | unknown`. The
+      master lists win-rate, streak and the share fields and has no basis field,
+      so a measured cost and an estimated one render identically — the exact
+      self-report failure Phase 2 exists to prevent, reintroduced one layer up.
+      verify: a report line with an estimated component that does not name its
+      method fails the lint.
+- [ ] **6.3 Report only. No runtime consumption.** A human or CI reads it;
+      nothing in selection or routing does. Crossing that line is the Phase 9
+      gate, not an implementation detail.
+      verify: no import of the report module from any routing or selection path.
+- [ ] **6.4 Wire the report to retirement, with a safety carve-out.**
+      `from-skipped-parent` on both halves. The report's most obvious near-term
+      consumer is the existing utilization-window retirement path — the ledger
+      supplies the data, the rules stay the authority. And precisely there:
+      pruning on low usage can delete a rare but important safety behaviour, so
+      authority and safety assets are **excluded** from usage-based pruning. The
+      master dropped both the wiring and the carve-out.
+      verify: a low-usage safety-classified asset is not proposed for
+      retirement, and a low-usage ordinary asset is.
+- [ ] **6.5 Defer the SQLite index until latency is measured.** Allowed **only**
+      as a rebuildable Class-A artefact under `agents/runtime/state/`; as the
+      *source* of experience it is a contract violation.
+      `docs/contracts/no-runtime-boundary.md:40` states the test verbatim: "if
+      deleting the artifact changes *what* the tool can answer rather than only
+      *how fast* it answers, it is a state store and prohibited".
+      verify: deleting the index changes only runtime, and a rebuild reproduces
+      it byte-for-byte from the JSONL.
+
+## Phase 7 — Experience cards
+
+- [ ] **7.1 Cards come only from the mining gate.** `extract_audit_patterns`
+      count ≥ 2 over independent `work_id`s, outcome-differentiated — or from an
+      explicit seed block. Never invented, never pre-seeded as families.
+      verify: an attempt to author a card with no backing pattern is refused.
+- [ ] **7.2 Field set, with a size budget.** Scope, trigger context, the
+      strategy itself (compact), falsifier, confidence, contradictions,
+      supersedes, expiry / review-by — plus an **epistemic type**
+      (`observed | derived | inferred | hypothesized`), `from-skipped-parent`.
+      The type is not decoration: only observed and derived statements may ever
+      act as a hard filter, and inferred or hypothesized ones may at most
+      influence ranking with reduced weight. That restriction is what makes the
+      Phase 9 gate answerable in degrees instead of all-or-nothing.
+      verify: a card missing a falsifier, an expiry or an epistemic type fails
+      the lint.
+- [ ] **7.3 Failures narrow, they never widen.** A failure adds an anti-pattern
+      entry; it never extends the card's applicability scope.
+      verify: a fixture where a failure attempts a scope widening is refused.
+- [ ] **7.4 A card is not a rule.** Empirical, scoped and probabilistic versus
+      normative. A duplicate lint runs against the existing rule and skill
+      corpus, and promotion into authority happens only through
+      `learning-to-rule-or-skill`.
+      verify: a card whose text duplicates a live rule fails the lint.
+- [ ] **7.5 Promote by scope, one level at a time, with transfer evidence.**
+      `from-skipped-parent`: a card carries a scope on the ladder
+      `session → repo → workspace → organization → global`, promotion moves one
+      level at a time, and a raise beyond repo scope requires held-out or
+      independent evidence rather than the same runs that produced it. The
+      master gates promotion only on the human review skill, so a card mined
+      from one repository's runs can become global on that repository's evidence
+      alone.
+      verify: a two-level raise is refused, and a raise past repo scope with only
+      development-pool evidence is refused.
+- [~] **7.6 Incremental card updates rather than rewrites.** Deferred: needs
+      E8. `from-skipped-parent` promoted `ADD / UPDATE / REMOVE` delta-updates
+      from optional to core, with a reflector/curator split whose boundary is
+      "the model may interpret evidence; it may not rewrite the evidence". The
+      master cites the source paper and carries neither the mechanism nor a
+      decision about it.
+
+## Phase 8 — Trigger-shift pairs, offline
+
+- [ ] **8.1 Extend `triggers.json` backward-compatibly.** A `shift_of` field
+      plus an axis set, producing an offline train-versus-shifted gap report in
+      the `description_route_check` neighbourhood. The master lists three axes
+      (wrapper, temporal, phrasing); `from-skipped-parent` adds host framing and
+      context/tool availability, which are the two a purely textual shift cannot
+      express. Pilot scope is a decision (E6).
+      verify: existing `triggers.json` files parse unchanged, and the gap report
+      is produced with zero live-harness calls.
+- [ ] **8.2 The live-floors park stays parked.**
+      `agents/roadmaps/later/road-to-routing-assurance-live-floors.md` exists on
+      this tree and its council decision (2/2, evaluator independence) is not
+      reopened here.
+      verify: no step in this roadmap invokes a live routing harness.
+
+## Phase 9 — Canonical enums, effect, and the consumption door
+
+- [ ] **9.1 One shared module per enum family** that appears in both
+      `src/scripts/` and a template or prompt, plus a lint against inline
+      duplicates. Phase 1.3's outcome-vocabulary split is the worked example and
+      the first customer.
+      verify: the lint fails on a reintroduced inline duplicate of any covered
+      enum.
+- [ ] **9.2 State what this is part of, without inventing a parent.**
+      `corrected-from-reproduction`: the master called this "the mechanical core
+      of `road-to-canonical-wording-and-propagation`" and an attachment point
+      for "the open script-twin decision from PR #1636". Verified on this tree:
+      **no file anywhere in the repository mentions
+      `canonical-wording-and-propagation`** — zero hits from `grep -rl` over
+      `*.md`, `*.ts` and `*.json`. It is not active, not parked, not a stub, not
+      archived. The PR reference was **not checked**: that is an external system
+      and this analysis ran offline by its own bound, so it is unverified rather
+      than false. Either author the parent or drop the framing; do not cite a
+      plan that does not exist.
+      verify: the roadmap text cites only artefacts a `grep` in this tree finds.
+- [ ] **9.3 Show that the loop can make the estate smaller.**
+      `from-skipped-parent`, an acceptance criterion in both parents and absent
+      from the master: self-evolution must be able to *remove*. Prefer modify,
+      merge, delete and crystallize over add. In a repository governed by an
+      estate ratchet and a one-in-one-out gate, a learning loop that can only
+      add is a growth engine.
+      verify: at least one repeated card has resulted in a removal — a
+      deterministic query or helper replacing a prose instruction, with the
+      prose deleted in the same change.
+- [ ] **9.4 One pre-registered paired question.** Not a metric catalogue.
+      Exactly one core metric: the repeated-failure rate out of
+      `extract_audit_patterns` (patterns whose outcome ≠ success across
+      independent `work_id`s), read from the amended view per Phase 3. The
+      verdict is a vector — quality held × cost × repeated failures — and a
+      failed arm yields inconclusive, never a fabricated score. Both directions
+      are written into the claims ledger before the data lands.
+      verify: the negative consequence is committed before the measurement run.
+- [ ] **9.5 Freeze the experiment set.** `from-skipped-parent`: evaluator,
+      corpus, task definition, baseline and protected fixtures are frozen for
+      the duration of a comparison.
+      verify: a mid-run change to any of the five aborts the comparison rather
+      than continuing it.
+- [~] **9.6 The Class-C question, as an owner decision.** Deferred: may
+      selection or routing consume experience at runtime? Reading it at runtime
+      means deleting it changes *what* the system does, which the state-store
+      test classifies Class C. Without an owner yes it stays a report. 7.2's
+      epistemic type is what makes a partial yes expressible.
+      <!-- blocked-by: runtime-consumption-of-experience -->
+
+## Blockers
+
+### runtime-consumption-of-experience
+
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** Phase 9 step 9.6 only. Phases 0–8 and steps 9.1–9.5 are
+  unaffected by design — this roadmap is cut so that a "no" leaves them fully
+  valuable.
+- **What to do:** pick exactly one — (a) grant runtime consumption, which
+  requires a Class-C escalation under
+  `docs/decisions/ADR-124-embedded-engine-doctrine.md:153` and an amendment to
+  the state-store test in `docs/contracts/no-runtime-boundary.md:40`, or (b)
+  refuse it, and the per-asset report stays a report a human and CI read, or (c)
+  defer until 9.4 has produced a measured effect, so the decision is taken
+  against evidence instead of against an intention, or (d) grant a **partial**
+  yes bounded by 7.2's epistemic type — observed and derived statements may
+  filter, inferred and hypothesized ones may not.
+- **Resolved when:** the answer is recorded in ADR-124 or in the no-runtime
+  boundary contract, either as a granted escalation with its scope or as a
+  refusal with its reason.
+- **Recommendation:** (c), then reconsider (d). The question is cheap to answer
+  once 9.4 has a number and expensive to answer now, and nothing in Phases 0–8
+  depends on it.
+- **If you do nothing:** everything except 9.6 remains executable, and the
+  effectiveness report exists without being consumed. That is a real outcome,
+  not a stalled one — evidence, integrity and hygiene all land.
+
+### experience-retention-policy
+
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** Phase 6 step 6.1 at the point where the report is expected to
+  clear a pre-registered floor; Phase 9 step 9.4's power claim.
+- **What to do:** pick exactly one — (a) declare the ledger append-only with an
+  explicit rotation rule and state the rule, (b) declare a rolling buffer and
+  accept that any pre-registered floor above the retained window is structurally
+  unreachable, stating so at the claim rather than at the roadmap, or (c)
+  measure the growth rate first and decide after one month of real data.
+- **Resolved when:** the retention rule is written into
+  `docs/contracts/audit-log-v1.md` and the corresponding claim states its
+  reachability.
+- **Recommendation:** (a). This repository has already paid for the alternative:
+  `docs/CLAIMS.md:691` records a pre-registered ≥ 20-run floor that is
+  "**structurally unreachable with this instrument at default retention**",
+  because the timing source is a rolling buffer at `DEFAULT_MAX_SESSIONS = 5` —
+  "Waiting therefore does not fill this window; it rotates it." The same entry
+  names the two exits: a source that is not a rolling buffer, or an explicit
+  retention change **with its own privacy review**, which is why this blocker
+  and step 1.4 are the same decision seen from two sides.
+- **If you do nothing:** the report is built and its floor may be unreachable,
+  and nobody finds out until a verdict is expected and cannot be given. That is
+  the exact failure mode already recorded once in this tree, and a parent raised
+  it as an open decision that the master then did not carry.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-08-26 | reviewer: claude/host -->
+
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | Rebuilding the loop instead of widening it | implementation | All three source proposals independently concluded that no learning loop existed. It does. A parallel loop produces two histories of the same work and no test catches it | The "What already exists" table is verified with file:line citations and every phase is phrased as a widening of a named carrier | Phase 1 — Broaden capture |
+| 2 | Persistent experience retains what it must not | product | Mined experience lands in `agents/memory/`, a **tracked** path (verified: five files). Source excerpts, secrets, user text and customer data can ride along, and once committed a leak is not undone by a later edit | 1.4 makes the event type structurally incapable of holding free-form content, with a mandatory privacy class — the shape `domain-safety-pii` § Surface 2 prescribes | Phase 1 — Broaden capture |
+| 3 | Anti-forgery marks legitimate work as failure | implementation | The unconditional "empty diff ⇒ not success" rule fails every read-only analysis and review dispatch. Those are a large share of this repository's subagent traffic, so the aggregation is poisoned in the direction that looks like rigour | 2.2 gates on the task's expected output contract instead of on the diff alone | Phase 2 — Outcome integrity: anti-forgery at the subagent return |
+| 4 | Measuring self-report as if it were outcome | implementation | An aggregation built before the anti-forgery gate cannot separate a claimed success from a real one afterwards | Phase 2 lands before Phase 6; 6.1 counts a missing signal as unknown; 6.2 makes an estimated figure visibly estimated | Phase 2 — Outcome integrity: anti-forgery at the subagent return |
+| 5 | A win rate that cannot be acted on | implementation | Without the activation-versus-adherence split, a low rate points at the asset's content when the real cause may be that the router never activated it. The wrong fix follows deterministically | Phase 5 adds the five-state split, with `unknown` where no evidence exists | Phase 5 — Activation versus adherence |
+| 6 | The one core metric cannot be computed | implementation | Repeats and regressions arrive after the audit line is terminal. Without an amendment path the repeated-failure rate systematically under-reports | Phase 3 adds the episode lifecycle with append-only amendment | Phase 3 — Episode lifecycle and delayed amendment |
+| 7 | Schema extension against a value that does not exist | implementation | Phase 2 writes `clean-no-op`; the audit contract's enum has four values and does not include it. The write looks successful and the consumer silently does not read it | 1.3 reconciles the two enums before either is extended; 9.1 makes reintroduction lintable | Phase 1 — Broaden capture |
+| 8 | A rolling buffer makes a pre-registered floor unreachable | implementation | Already recorded once in this tree at `docs/CLAIMS.md:691`. A ledger whose retention rotates cannot back a floor above its window, and the discovery comes at verdict time | The `experience-retention-policy` blocker decides it before the report is relied on | Phase 6 — Evaluation: a per-asset report, read-only |
+| 9 | The unknown share is treated as noise | product | A report whose unknown share is large reads as weak data and gets ignored, when the unknown share *is* the measurement of the capture gap and the most actionable number on the page | 6.1 reports unknown as a first-class share, never folded into neutral | Phase 6 — Evaluation: a per-asset report, read-only |
+| 10 | Cards accumulate faster than they are reviewed | product | A card store growing without expiry becomes a second undocumented authority surface competing with rules, and a global-scope card mined from one repository's runs generalises on no evidence | 7.2 makes expiry, falsifier and epistemic type mandatory; 7.4 routes promotion through the human gate; 7.5 adds the scope ladder and transfer requirement; 9.3 requires a removal | Phase 7 — Experience cards |
+| 11 | Retirement deletes a rare safety behaviour | product | Usage-based pruning is the report's most natural consumer, and a safety rule that fires rarely looks exactly like a dead one | 6.4 excludes authority and safety assets from usage-based pruning | Phase 6 — Evaluation: a per-asset report, read-only |
+
+## Acceptance Criteria
+
+- [ ] AC-1 — Every phase names an existing carrier it widens, and no phase
+      introduces a second store, second loop, or second promotion path.
+- [ ] AC-2 — No recorded `success` in the audit stream is backed by an empty
+      change *against that task's declared output contract*, and a read-only
+      analysis dispatch that satisfies its contract is not marked a failure.
+- [ ] AC-3 — The captured event type has no field capable of holding a prompt, a
+      file body, or a path, and every event carries a privacy class.
+- [ ] AC-4 — The per-asset report distinguishes helpful, neutral, harmful and
+      unknown, reports unknown as its own share, and states a basis on every
+      derived figure.
+- [ ] AC-5 — A failing case is classifiable into one of the five
+      activation/adherence states, and `unknown` is used wherever no evidence
+      exists rather than a model's inference.
+- [ ] AC-6 — One outcome vocabulary is authoritative, or the mapping between the
+      two is a committed module both readers import.
+- [ ] AC-7 — Nothing in any selection or routing path imports the experience
+      report, until and unless the Phase 9 blocker is resolved with a yes.
+- [ ] AC-8 — The retention rule is written into the contract, and every claim
+      resting on the ledger states whether its floor is reachable at that
+      retention.
+- [ ] AC-9 — At least one repeated-failure pattern has produced a reviewed card,
+      and at least one card has been either promoted through
+      `learning-to-rule-or-skill` or expired — so the lifecycle closes in both
+      directions rather than only accumulating.
+- [ ] AC-10 — At least one removal has landed that the loop itself motivated:
+      prose replaced by a deterministic query or helper, with the prose deleted
+      in the same change.
+
+## First cut — recommended start
+
+Phase 1.2 plus Phase 1.3, together, on one real phase of `/work`.
+
+Adding `skills_applied` is the smallest change that turns the existing loop from
+rule-only into rule-and-skill, and it cannot be done correctly without settling
+the enum split first — which makes the pair a genuine vertical slice: a schema
+decision, a contract edit, a supersede migration, and a fixture proving real
+emission. It touches no new persistence and no external system, so none of the
+open contract questions gate it.
+
+`from-skipped-parent` adds the reason to insist on a real slice this early:
+that parent placed a mandatory end-to-end learning proof at the middle of its
+programme rather than the end, with the framing question "are we building
+self-evolution or just telemetry?" A master that ends at a report plus one owner
+question is exactly the shape that question is aimed at. If the fixture cannot
+prove real emission from a live phase, the capture premise of every later phase
+is refuted, cheaply.
+
+## Open maintainer decisions
+
+- **E1 — Estate placement.** `corrected-from-reproduction`: the master raised
+  this as a family-cap risk. Verified —
+  `src/scripts/lint_roadmap_family_cap.ts:41` sets
+  `FAMILY_PREFIX = 'road-to-skill-ecosystem-'` and counts only top-level active
+  roadmaps, so that gate **cannot** fire on this name or the sibling's; it
+  reports 0/2 slots used. The gate that does apply is `check_estate_count`,
+  reading `active_roadmaps 3` against a floor of 7 — four slots of headroom. The
+  real question is whether this roadmap and
+  `road-to-governed-harness-evolution.md` stay separate or fold into one; they
+  overlap on trigger evals, on the paired-verdict mechanism, and on step 1.3.
+- **E2 — audit-log v2:** confirm the schema-bump procedure — supersede lines, or
+  a new file generation?
+- **E3 — Does `clean-no-op` count as its own outcome in the report?
+  (Recommendation: yes.)**
+- **E4 — Card location** under `agents/memory/<type>/`, the per-card size
+  budget, and — given risk 2 — whether cards belong in a tracked path at all.
+- **E5 — SQLite index:** only at a measured JSONL latency limit, or not at all.
+- **E6 — Phase 8 pilot scope** (proposal: 10 of the 94 eval-bearing skills, one
+  shift pair per positive query) and which of the five shift axes are in.
+- **E7 — The Phase 9 question** (placeholder: does showing the per-asset report
+  in the review context reduce the repeated-failure rate?).
+- **E8 — Incremental card updates (7.6):** adopt `ADD / UPDATE / REMOVE` deltas
+  with a reflector/curator split, or keep full rewrites? One parent moved this
+  from optional to core; the master cites the source and carries neither.
+- **E9 — Terminology:** one canonical word for the card object, then propagate
+  it. Phase 9's discipline applies reflexively to this decision.
+- **E10 — Host scope.** The master scopes capture to Claude Code, the one host
+  with a measured 164/164. `from-skipped-parent` required at least three
+  materially different hosts plus a capability matrix with
+  `required / optional / unavailable / inferred` per field and the rule "never
+  manufacture parity". One host is defensible; the rule against manufacturing
+  parity should be adopted either way.
+- **E11 — Owner-reserved actions.** `from-skipped-parent` lists relaxing an
+  evaluator threshold as owner-reserved. Confirm that, or name what else is.
+
+## Killed — do not reintroduce without new evidence
+
+| ID | Rejected | Reason |
+|---|---|---|
+| K1 | A new `src/` asset family, and pre-seeded strategy families | Additive push with no verified defect behind it; the card form in Phase 7 covers the empirical core and only ever arises from the mining gate. |
+| K2 | Hub / network / credit / reputation-index / team-sharing / interop adapters | The one independent measurement of that design reports ~2 % asset reuse and >84 % of released assets bypassing meaningful validation — the failure mode is publication reward, not sharing. ADR-088 and ADR-216 also stand. |
+| K3 | The ADR-reopen package | The runtime taxonomy exists (ADR-124 Class A/B/C); ADR-094 is owner-decided with revival behind an unmet gate. The single legitimate door is the Phase 9 blocker. |
+| K4 | SQLite as the *source* of experience | Class C by the state-store test, quoted verbatim in 6.5. Admissible only as a rebuildable index. |
+| K5 | An evaluator-mesh framework, personality/mutation objects, strategy presets, session-spawn directives, auto-issue-filing | No verified defect behind any of them, and several rest on mechanics that could not be inspected. Adopted from that cluster: exactly one rule — a missing signal is `unknown`, never `success`. |
+| K6 | A resident runtime or daemon in this roadmap | ADR-124 § 5 is the named door and no defect here asks for it. |
+| K7 | A metric catalogue without pre-registration | Exactly one core metric, per 9.4, and 0.3 requires a consumer for any metric at all. |
+| K8 | The code graph as the foundation of episode linking, before re-measurement | `docs/CLAIMS.md:447` records mean recall 0.365 versus grep 0.797 with `code_graph.enabled` default false. **corrected-from-reproduction, and this makes the kill stronger than the master stated:** that claim now carries a 2026-08-26 scope correction saying the figures were measured on 2026-07-28 "against a build predating the extractor repair of 2026-08-22, so they describe a build that no longer exists". The null is stale by construction, not merely unreplaced — the honest position is *unknown*, in both directions. The re-run obligation sits in `agents/roadmaps/stubs/road-to-code-graph-benchmark-rerun.md`, which exists on this tree and is blocked on corpus inputs this machine does not hold. |
+| K9 | An experience graph as a product surface | One parent specified twenty node types and twelve edge types; the other refused it for v1 and kept edges only where a query needs them. Append-only events plus a derived index first. |
+| K10 | A global win score, popularity ranking, or publication reward | Effectiveness profiles with a denominator, a scope and an unknown share instead — the anti-Goodhart line both parents drew and the master kept. |
+
+## Unverified in this analysis — carried as unverified, not as fact
+
+The parents' mechanism citations into the external reference repository (signal
+handling, the shift evaluator, the shared enum module, the solidify-learning
+asymmetry) could **not** be checked here: that tree is not in this repository and
+this analysis ran offline by its own bound. The *shapes* adopted in Phases 2, 4,
+7.3 and 9.1 are justified by defects verified in **this** tree and stand on that
+basis alone. No external line number is load-bearing anywhere above, and none
+should be added without a fresh check. The same applies to the papers cited in
+the parents and to the PR reference in 9.2.

--- a/agents/roadmaps/road-to-governed-harness-evolution.md
+++ b/agents/roadmaps/road-to-governed-harness-evolution.md
@@ -1,0 +1,626 @@
+---
+complexity: structural
+status: draft
+execution:
+  mode: phase-checkpoints
+estate_offset_exempt: "Added as a draft proposal, not as active work. Archiving is impossible (nothing has run), parking in later/ would grow the later_roadmaps floor instead of the active one, and folding it into road-to-experience-loop-broadening is the open question E2 puts to the owner — pre-merging would decide it by authoring."
+---
+# Road to governed harness evolution
+
+> **Source:** `agents/tmp.old/evolve/` — three session proposals plus the
+> operator transcript. Every repo claim below was re-verified against this tree
+> on 2026-08-26; the proposals were drafted against `1899f92b9`, which is HEAD
+> minus one commit, so the staleness window is empty.
+>
+> **The consolidation those files produced was incomplete, and that is the first
+> finding.** `road-to-governed-harness-evolution-master.md` names two parents it
+> supersedes — `road-to-gated-self-evolution` v3 (128 lines) and
+> `road-to-evidence-driven-harness-evolution` (1977 lines). It does **not** name
+> `road-to-gated-harness-evolution-deep-v4.md` (1925 lines, Phases 0–10, kill
+> register K1–K12), whose own header claims to supersede **both** of the parents
+> the master did consolidate. So the deepest parent was skipped, and most of
+> what looks "killed" in the master is in fact undiscussed. This roadmap folds
+> that third parent back in.
+>
+> Items marked `corrected-from-reproduction` differ from the master because
+> running or checking its step produced something else. Items marked
+> `from-skipped-parent` come from deep-v4 and appear in no master.
+
+## Goal
+
+An evolution laboratory exists that can generate candidate variants of a single
+harness dimension, isolate them from the working tree, and evaluate them against
+a frozen corpus — where the verdict comes from the paired-verdict mechanism the
+tree already owns, and promotion into canonical `agent-config` remains a human
+act. When this is finished, a candidate harness change can be shown to be better
+or not better on pre-registered evidence; no candidate reaches canonical without
+a named human decision; and the programme itself can be declared a success or a
+failure against criteria written before the first run.
+
+The load-bearing constraint: **most of what the source proposals wanted to build
+already exists in this tree under other names.** This roadmap redirects to those
+carriers and builds only the remainder.
+
+## What already exists — verified, do not rebuild
+
+| Wanted capability | Existing carrier | Verified on this tree |
+|---|---|---|
+| Candidate worktrees, isolated checkout, no writes to the original tree | `src/scripts/bench_ab_clone.ts` | `--variant` already accepts three values (`with`, `without`, `with-rdp`), plus `--refresh`, `--print-shape-hash`, `target_shape_hash` (`:197`) |
+| Leakage assertion / path-ownership sabotage fails closed | `src/scripts/bench_ab_integrity.ts` | present; byte-wise clone comparison |
+| Paired verdict, direction over magnitude, `underpowered` is not a pass | `src/scripts/_lib/paired_verdict.ts` | `:25-26` four outcomes, `underpowered` "deliberately not a kind of pass"; `:54-65` the minimum discordant-trial floor is **derived** from the exact sign test, not chosen |
+| Planted bad candidate rejected cheaply | `src/scripts/_lib/eval_publication.ts` | `PlantedItem` `:13`, `discriminationDeficit` `:31` |
+| Evaluator hygiene, blinding, order-swap | `src/scripts/_lib/judge_hygiene.ts` | `:5-9` both orders; a flip resolves to `inconsistent` rather than to a winner |
+| Deterministic lexical shortlist (no embeddings) | `src/scripts/_lib/lexical_index.ts` | `:9-15` the BM25 core ADR-061 already sanctions — pure Node stdlib, deterministic, in-memory per invocation |
+| **Per-task delivery itself** | `src/scripts/_lib/lean_projection_mode.ts` | `:19` `LeanProjectionMode = 'eager-all' \| 'thin' \| 'delivery'`, `:21` default `eager-all`. **Three arms exist; `delivery` is simply not the shipped default.** |
+| **One shared matcher across offline model and runtime** | `src/scripts/_lib/rule_injection.ts` | `:1-19` "THE single module both the offline model and the runtime concern read"; trigger semantics live in `_lib/router_match.ts`, "the single implementation for every surface", pinned by `tests/scripts/router_match_parity.test.ts` |
+| Append-only evidence state precedent | `docs/contracts/audit-log-v1.md` | `:26` correction only via a new `type=supersede` line; `:85` the `type` enum |
+
+**corrected-from-reproduction — the isolation work is smaller than the master
+claimed.** The master described `bench_ab_clone` as living on a single "package
+present / absent" axis needing an axis extension. It already carries a
+`--variant` flag whose third value sits on a different axis entirely. Adding a
+candidate variant is a new enum member on existing multi-variant machinery.
+
+## The parent disagreements — decide these, do not inherit a silent pick
+
+The master resolved seven mechanism conflicts by adopting one parent's version
+without recording that the other differed. Each is a real choice and each is
+listed as a decision below rather than settled here.
+
+| # | Mechanism | Parent A (evidence-driven) | Parent B (deep-v4, skipped) | Decision |
+|---|---|---|---|---|
+| 1 | Activation-ladder arity | 4 states: `eligible → selected → injected → consumed/adhered` | 6 states, splitting `projected/delivered` from `visible` | E4 |
+| 2 | Minimality tie-break order | tokens → artifacts → scope → precedence | scope → precedence → tokens → artifacts → **simpler mechanism** (5th criterion) | E5 |
+| 3 | Curator operation set | `ADD / MERGE / REVISE / SKIP` | `KEEP / ADD / MERGE / REPLACE / SPLIT / RETIRE / SKIP`, arguing by name that the 4-op set is "incomplete … because split and retire are first-class anti-sprawl actions" | E6 |
+| 4 | When the sealed holdout opens | every cascade run (stage 8 of 9) | **killed** as every-iteration; three partitions, sealed set for promotion candidates only | E7 |
+| 5 | State-taxonomy arity | 4 classes | 5 — adaptive split into experiment-adaptive and production-adaptive, the latter prohibited/default-off | E8 |
+| 6 | Cascade stage set | 9 stages, no distinct activation or adherence stage | 12 stages, with activation/delivery and adherence as their own | E9 |
+| 7 | Candidate arity | 9 mutation dimensions, no arity limit | **one primary dimension per candidate**, consolidation as a separate re-run | E10 |
+
+Conflicts 1, 6 and 7 interact and should be decided together: Phase 1's exit
+criterion asks for a content-vs-activation-vs-adherence classification that a
+9-stage cascade with no adherence stage cannot produce, and a per-candidate
+metric vector is uninterpretable if a candidate may change several dimensions at
+once.
+
+## Phase 0 — Constitution, reconciliation, budget, stop conditions
+
+- [ ] **0.1 Write the inventory matrix as this phase's exit criterion.** A table
+      of `planned capability → existing carrier in the tree → redirect / extend /
+      build new (with the reason)`. Starting content is the table above. The
+      phase does not close while a row reads "build new" without a stated reason
+      no carrier fits.
+      verify: `agents/evidence/analysis/` carries the matrix with an
+      `<!-- evidence-type: analysis -->` first line, and every later phase names
+      a row in it.
+- [ ] **0.2 Reconcile the estate with an explicit disposition per overlapping
+      plan.** `from-skipped-parent`: the skipped parent made this a P0 exit
+      criterion with a five-verb disposition — `own here / fold into existing /
+      depend on existing / supersede proposal / drop` — and the closing
+      invariant "no duplicate execution owner". The master demoted the same
+      question to an unanswered open item. The five-verb form is strictly
+      stronger and covers roadmap-vs-roadmap ownership, which the capability
+      matrix in 0.1 does not.
+      verify: every roadmap this one overlaps carries one of the five verbs, and
+      no capability has two execution owners.
+- [ ] **0.3 Name the state classes without touching any claim.** Label
+      authoritative / derived / evidence / adaptive state, citing
+      `docs/contracts/audit-log-v1.md` as the already-sanctioned evidence-state
+      precedent. Whether the adaptive class splits in two (E8) is decided here.
+      Explicitly out of scope: the `no-runtime-daemon` public claim.
+      verify: `grep -c 'claim:no-runtime-daemon' README.md` still returns 1 and
+      `docs/CLAIMS.md` shows no diff for that entry.
+- [ ] **0.4 Make the evaluator trust boundary detectable, not just declared.**
+      `from-skipped-parent`, and this is the gap that mattered most: the master
+      defines which fields are proposer-visible and which are evaluator-private
+      and stops there. Add a per-field `visibility_class` on every observation, a
+      log of every field disclosed to a proposer, and a run abort when holdout
+      truth appears in proposer context.
+      verify: a run in which a holdout value reaches proposer context exits
+      non-zero, and the disclosure log names the field.
+- [ ] **0.5 Pre-register the budget invariant.** Candidate count, trial
+      repetitions and a spend ceiling per run, fixed before the run. Exceeding it
+      aborts rather than truncates — a truncated run yields `underpowered`, which
+      `paired_verdict` refuses to call a pass and which a reader mistakes for one.
+      verify: a run configured past the ceiling exits non-zero before spending.
+- [ ] **0.6 Pre-register stop conditions on epistemic invalidity, not only on
+      spend.** `from-skipped-parent`: both parents carried eight or nine stop
+      conditions; the master compressed them into the budget cap. A spend cap
+      stops on cost, and most of those conditions stop on validity — holdout
+      becomes underpowered · evaluator leakage detected · candidate diversity
+      collapses to semantic duplicates · cross-component interference prevents
+      credit assignment. Stopping with INDETERMINATE is a valid result, and an
+      honest null is a success when it prevents unnecessary architecture.
+      verify: each condition has a detector or is explicitly marked
+      model-carried; a synthetic diversity collapse trips the stop.
+- [ ] **0.7 Define programme success and failure before the first run.**
+      `from-skipped-parent`: the master has no success-criteria section at all.
+      It adopts the per-candidate metric vector and drops the per-programme
+      metrics, so nothing defines when Phases 0–7 as a whole have succeeded.
+      Carry the four families both parents named: harness-update quality ·
+      harness benefit · system quality · **evolution efficiency** (cost per
+      promoted improvement, trials per frontier improvement, share rejected at
+      cheap cascade stages, proposer cost against solver benefit).
+      verify: the criteria are committed before the first candidate run and are
+      falsifiable in both directions.
+- [~] **0.8 Merge authority resolved.** Deferred: owner decision, see
+      Blockers. <!-- blocked-by: merge-authority -->
+
+## Phase 1 — Observation and the activation ladder
+
+- [ ] **1.1 Record the activation ladder, not a flat category.** Per E4, either
+      the 4-state or the 6-state form; the recommendation is the 6-state one
+      because Phase 6 measures delivery and `delivered ≠ visible` is exactly
+      that axis. Add the precedence receipt naming why a step did not advance
+      (lost to a higher-priority rule · host restriction · pack filter · missing
+      projection · context budget · contradictory instruction). This replaces the
+      master's flat `rule/skill/hook/router/host/model` attribution, which names
+      a category and not a place.
+      verify: a deliberately failing trigger eval is classifiable as *content*
+      vs *activation* vs *adherence* from the recorded receipt alone.
+- [ ] **1.2 A missing state stays unknown.** `from-skipped-parent`, one line
+      and load-bearing: a state that was not observed must remain
+      missing/unknown and is never silently converted to success. This is the
+      ladder's soundness invariant; without it every downstream rate is inflated
+      by exactly the capture gap.
+      verify: a record with an unobserved rung reports `unknown` for it, and no
+      aggregation folds `unknown` into a success denominator.
+- [ ] **1.3 Extend an existing carrier, do not add a store.** The receipt is a
+      field addition to `audit-log-v1` or `decision-trace-v1`, migrated by
+      `type=supersede` lines as that contract already prescribes.
+      verify: the contract's schema table carries the new field and the
+      append-only migration note; no new path under `agents/runtime/state/`.
+- [ ] **1.4 Reconcile the two outcome vocabularies before extending either.**
+      `corrected-from-reproduction`, and no proposal in either folder noticed:
+      this tree holds **two** outcome enums — `audit-log-v1:77` has four values
+      (`success · blocked · skipped · error`) and
+      `src/scripts/_lib/outcome_envelope.ts:24-30` has six
+      (`success · clean-no-op · blocked · approval-required · exhausted ·
+      stagnated`). The sibling roadmap
+      `road-to-experience-loop-broadening.md` owns the reconciliation and plans
+      to write `clean-no-op` into the audit stream, where that value does not
+      exist. This step depends on that one; it does not duplicate it.
+      verify: one module exports the enum both readers import, and a lint
+      rejects an inline duplicate.
+
+## Phase 2 — Trigger corpus: census first, coverage second
+
+- [ ] **2.1 Run a census before naming a target.**
+      `corrected-from-reproduction` **and** `from-skipped-parent`, and this
+      reverses the master's phase title. The master titled its phase
+      "Trigger corpus 94 → 299". The skipped parent explicitly **killed** that
+      shape — "100 % trigger coverage as a vanity target … coverage must have
+      discriminative fixtures; non-self-activating artifacts are treated
+      explicitly" — and forbade reusing 94/99/299 without explaining what each
+      counts. Reproduced on this tree: `ls src/skills/*/evals/triggers.json | wc
+      -l` → **94**; `ls -1d src/skills/*/ | wc -l` → **299**;
+      `find src -path "*/evals/*" -name "*.json" | wc -l` → **175** total
+      specification files, of which 99 are `triggers.json` (94 skills plus 5
+      under `src/domains/`). Separately the *gate* surface is
+      `src/scripts/trigger_eval_grandfather.json`: its own note reads "Frozen
+      2026-07-08 at 221 of 264 skills" and it currently holds **205** entries,
+      so the shrink-only ratchet has already walked down 16. Partition 299 into
+      routable and non-self-activating before choosing any denominator.
+      verify: the census file names the exclusion criterion per non-routable
+      skill, and the phase target cites a partitioned number, not 299.
+- [ ] **2.2 Prioritise waves, do not sweep.** Order corpus work by defect
+      evidence, not alphabetically.
+      verify: the wave order is committed with a stated criterion per wave.
+- [ ] **2.3 Author a four-class corpus, not two.** `from-skipped-parent`: the
+      master's recipe is positives plus near-misses. Both parents required
+      success exemplars, failures, near-misses **and** counterexamples, with
+      selection seeing the full frozen corpus — the mechanism against
+      survivorship bias in the corpus itself.
+      verify: every corpus file carries all four classes, and a fixture proves
+      selection reads the whole frozen set.
+- [ ] **2.4 The grandfather list may only shrink.**
+      verify: `./scripts-run src/scripts/check_trigger_eval_presence` green and
+      the grandfather entry count strictly below 205.
+- [ ] **2.5 Freeze the holdout partition here, before any proposer exists.** If
+      the pipeline that later optimises against the corpus also grew it, the
+      holdout is compromised before it is used.
+      verify: the partition is content-hash pinned in a committed file whose
+      hash predates the first Phase 5 commit.
+
+## Phase 3 — Candidate isolation and lifecycle
+
+- [ ] **3.1 Add a candidate variant to the existing variant enum.** A new member
+      plus its surface definition; `bench_ab_integrity` keeps asserting
+      byte-wise against it.
+      verify: five candidates materialised and destroyed with no diff in the
+      original tree; sabotaging a path ownership makes `bench_ab_integrity` exit
+      non-zero.
+- [ ] **3.2 One primary dimension per candidate.** `from-skipped-parent`, raised
+      to doctrine level there and absent from the master. Reducing the mutation
+      *alphabet* to three dimensions — which the master did — is not the same
+      invariant as limiting a candidate's *arity*. If routing and body both
+      change and the score moves, the credit is ambiguous and the Phase 4 metric
+      vector cannot be read per candidate. Multi-dimension consolidation is a
+      separate, later re-run, not a candidate.
+      verify: the schema rejects a candidate touching two primary dimensions,
+      and a consolidation run is a distinct record type.
+- [ ] **3.3 Restrict the mutation alphabet to three dimensions.** `activation`,
+      `routing`, `content`. Precedence, composition, verification, tool
+      strategy, budget and scope are named and unimplemented until the three
+      carry.
+      verify: the schema rejects a mutation naming a fourth dimension.
+- [ ] **3.4 A candidate lifecycle state enum, so "mutated" and "accepted" cannot
+      be confused.** `from-skipped-parent`: both parents made this the
+      structural guard, one tracing the defect to the reference implementation
+      passing `mutated` in where `accepted` was expected. The master has no
+      lifecycle states. Minimum set: proposed → diagnostic-evaluated →
+      selection-evaluated → promotion-eligible → sealed-evaluated →
+      promotion-proposed → promoted | rejected | retired.
+      verify: no code path reads a candidate as accepted from the mere fact that
+      it exists; a state transition skipping a stage is refused.
+- [ ] **3.5 Ship a deterministic proposer first.** Fixed recipes for known
+      defect classes, so the loop is validated without model quality as a
+      confound.
+      verify: the same input produces byte-identical candidates across two runs.
+- [ ] **3.6 Give the operator a command surface.** `from-skipped-parent`: a
+      verb set (`inspect`, `propose`, `run`, `compare`, `explain`, `promote`,
+      `clean`) with no background loop. This is what makes "command-scoped, no
+      daemon" enforced rather than asserted, and the master's Phase 3 exit
+      criterion — "five candidates can be created and destroyed" — names no verb
+      that would do it.
+      verify: every phase's exit criterion is reachable through a named verb,
+      and no verb starts a resident process.
+
+## Phase 4 — Evaluation
+
+- [ ] **4.1 Cascade cheap to expensive, abort on the first hard failure.** The
+      stage set is E9; if the 12-stage form is chosen, activation/delivery and
+      adherence are their own stages, which is what Phase 1's exit criterion
+      requires.
+      verify: a candidate failing the cheapest stage consumes no model call, and
+      the stage list can produce the Phase 1 classification.
+- [ ] **4.2 Report a metric vector, never a weighted total.** Include an
+      `artifact-count delta` row — that is where the sprawl concern belongs,
+      inside the gate where it can prevent something.
+      verify: no code path computes a single scalar score.
+- [ ] **4.3 Make the verdict hierarchy explicit.** `paired_verdict` per metric
+      decides; `underpowered` is not a pass; a Pareto frontier may only order
+      candidates that are already non-dominated and never promotes.
+      verify: a fixture where the frontier prefers a candidate whose
+      `paired_verdict` is `underpowered` produces no promotion.
+- [ ] **4.4 Keep a pathology archive, not only a frontier.**
+      `from-skipped-parent`, and it was that parent's headline contribution: a
+      pure frontier loses the information about *why* a candidate exists, so
+      archive the best intervention per `WHERE × WHY` failure cell over closed
+      vocabularies. The master adopted the attack "search collapses into
+      paraphrases" and dropped the mechanism proposed to prevent it, with no
+      kill ID.
+      verify: two candidates with equal vectors but different pathology cells
+      are both retained, and a diversity-collapse stop (0.6) reads the archive.
+- [ ] **4.5 Minimality breaks ties.** Order per E5, and include the fifth
+      criterion the skipped parent added: simpler mechanism. Note that the two
+      parents' orders invert, so identical candidates resolve differently
+      depending on the choice — this is not a formatting detail.
+      verify: two candidates with identical vectors resolve deterministically
+      under the committed order.
+- [ ] **4.6 Select regressions from the affected neighbourhood.**
+      `from-skipped-parent`: use the code graph to choose which regressions to
+      run for a given candidate. The master adopted the attack "local
+      improvement, global regression" as a risk with no mechanism behind it.
+      This is distinct from the killed curriculum generator — it selects
+      existing regressions, it does not author tasks.
+      verify: a candidate touching one surface runs the regressions its
+      neighbourhood names, and a fixture proves a neighbour regression is caught.
+- [ ] **4.7 Reuse the discrimination and hygiene machinery.**
+      `eval_publication.PlantedItem` for plants, `judge_hygiene` for order-swap.
+      Add the evaluator-promotion procedure the master omitted: an old and a new
+      evaluator must cross-grade frozen candidate sets, and evaluator promotion
+      itself requires discrimination plants.
+      verify: a planted candidate the control arm also satisfies is reported as
+      a discrimination deficit, not as a win; an evaluator change with no
+      cross-grade is refused.
+
+## Phase 5 — Body signal and the proposer roles
+
+- [ ] **5.1 Measure the description-vs-body signal, honest null permitted.**
+      `corrected-from-reproduction`: the master justified this by pointing at a
+      proxy gap the tree documents as unquantified. That gap is real but it is a
+      **different** gap. `src/scripts/description_route_check.ts:18-30`
+      documents the *proxy-to-real-session* gap — "a green run here is evidence
+      that the description signal did not regress. It is NEVER evidence that
+      production routing works … until that measurement exists the gap is
+      unquantified rather than small". Whether the skill *body* carries
+      additional routing signal is a second, separately unmeasured question.
+      Pre-register a threshold for the body question specifically; an honest null
+      is a legitimate outcome. Carry proxy-to-real fidelity as its own metric —
+      it bounds the validity of every routing conclusion in this roadmap.
+      verify: the pre-registration lands before the first measurement commit and
+      names both gaps separately.
+- [ ] **5.2 Keep the live-floors park intact.** No live harness.
+      `agents/roadmaps/later/road-to-routing-assurance-live-floors.md` exists on
+      this tree — verified — and its council park (2/2) is not reopened here.
+      verify: no step in this roadmap invokes a live routing harness.
+- [ ] **5.3 Split the roles: analyzer, curator, proposer.**
+      `from-skipped-parent`, which states the failure directly — do not collapse
+      them into one unconstrained rewrite prompt. The master has one LLM
+      proposer plus a one-shot compiler, so the curator role that owns lifecycle
+      operations has no home. An optional judge model grades rubric questions
+      only, under a frozen evaluator contract.
+      verify: the three roles are separate prompts with separate input sets, and
+      the judge cannot see outcome truth.
+- [ ] **5.4 An LLM proposer must beat the deterministic one to survive.** On at
+      least one pre-registered eval family, with an explicit hypothesis and a
+      named falsifier per mutation. Otherwise the deterministic path stays.
+      verify: the comparison is a `paired_verdict` run, not an argument.
+- [ ] **5.5 Curator operation set per E6.** The skipped parent argues the 4-op
+      set is insufficient because split and retire are first-class anti-sprawl
+      actions; the 7-op set is the recommendation. Candidates only, never
+      promotions. Run `src/scripts/_lib/shingle_similarity.ts` as a
+      deterministic pre-stage before any model judgment.
+      verify: a near-duplicate candidate is caught by the similarity stage with
+      zero model calls.
+- [ ] **5.6 Cheap proposer models first, and track evolution ROI.**
+      `from-skipped-parent`, and this one is self-undercutting in the master:
+      its own cross-critique faults both parents as cost-blind and answers with
+      a hard budget cap, while dropping the only cost-*reduction* mechanism both
+      parents proposed. Improvement per evolution dollar is a reported figure.
+      verify: the ROI figure appears in every run report, and a cheaper model is
+      tried before an expensive one on each defect class.
+
+## Phase 6 — Delivery: measure the existing substrate first
+
+- [ ] **6.1 Run the three-arm experiment on what already ships.**
+      `corrected-from-reproduction`, and this is the strongest single finding of
+      the analysis. The master's delivery phase builds a BM25 per-task subset.
+      Verified on this tree:
+      `src/scripts/_lib/lean_projection_mode.ts:19` already defines
+      `LeanProjectionMode = 'eager-all' | 'thin' | 'delivery'` with `eager-all`
+      as the default (`:21`) — the third arm exists and is simply not shipped.
+      The skipped parent named exactly this as its major correction and killed
+      "new delivery engine from scratch". Building the subset before measuring
+      `eager-all` against `thin` against `delivery` is the parallel-rebuild
+      failure this roadmap's own top risk names, committed inside the roadmap
+      whose thesis it is.
+      verify: the three arms are measured against one another before any new
+      retrieval component is written.
+- [ ] **6.2 Preserve one matcher.** `from-skipped-parent`, and the tree already
+      enforces it: `src/scripts/_lib/rule_injection.ts:1-19` is "THE single
+      module both the offline model and the runtime concern read", trigger
+      semantics live in `_lib/router_match.ts` as "the single implementation for
+      every surface", and `tests/scripts/router_match_parity.test.ts` pins it.
+      An experiment whose offline pricing and runtime delivery use different
+      matchers measures nothing.
+      verify: the parity test stays green and no second matcher is introduced.
+- [ ] **6.3 Only then consider a lexical shortlist, and only as a shortlist.**
+      Over the existing BM25 core. No embeddings —
+      `docs/contracts/no-runtime-boundary.md:40` classifies a vector/embedding
+      index as a **contract violation**, not a preference: "a vector/embedding
+      index fails — it enables query semantics absent from source, and stays
+      Class C". The BM25 core passes the same test. The skipped parent proposed
+      the shortlist and explicitly refused it as final truth.
+      verify: the shortlist feeds a later stage and never decides alone.
+- [ ] **6.4 Pre-register the loss ceiling, and measure set compatibility.**
+      Recall-loss ceiling and token target fixed first; report precision,
+      recall, false activation, context cost, benefit **conditional on**
+      activation — and, `from-skipped-parent`, **set compatibility**: cases
+      where two individually relevant skills are jointly wrong. The right
+      question is which *set* to deliver together, not only which single
+      artefact is closest. The corpus fixtures for it are authored in 2.3.
+      verify: the ceiling is committed before the run, and the corpus contains
+      at least one jointly-wrong pair.
+- [ ] **6.5 Index the body only if 5.1 measured a signal.** Otherwise
+      description-only.
+      verify: the indexer's input set derives from the 5.1 verdict file.
+
+## Phase 7 — Promotion bridge and the lifecycle after it
+
+- [ ] **7.1 One evidence package per promotion, in the fuller form.** The master
+      adopted a 9-field package; the skipped parent's has 14, and the five extra
+      are exactly the fields that make 3.2, 4.4 and 7.3 auditable: pathology
+      cell, candidate lineage, mutation dimension, selection results, sealed
+      result, cost, scope.
+      verify: a promotion attempt with any field absent is refused.
+- [ ] **7.2 Route through the existing gate, not a second governance system.**
+      Reuse the evidence-grading vocabulary already in the tree
+      (`authority_basis`, `evidence.strength`, `reopen_policy`,
+      `protected_dimensions`).
+      verify: no new governance verb, no new approval path.
+- [ ] **7.3 Promote by scope, with a transfer gate.** `from-skipped-parent`,
+      raised to doctrine level in both parents and absent from the master's
+      promotion path: a candidate carries a scope (episode → repo → stack →
+      profile/pack → global) and moving up a level requires independent transfer
+      evidence from a second solver or host configuration. Without it, every
+      promotion goes straight to canonical and the anti-bloat doctrine has no
+      teeth. This is not what the parked curriculum generator was.
+      verify: a promotion with no scope field is refused, and a scope raise with
+      one configuration's evidence is refused.
+- [ ] **7.4 Reject semantic no-ops.** `from-skipped-parent`: a no-op detector
+      plus a minimum material-improvement threshold. The master kept the
+      cooldown and lineage from the same attack and dropped both gates.
+      verify: a paraphrase-only candidate is refused before the cascade.
+- [ ] **7.5 Roll out by canary, never silently.** `from-skipped-parent`: opt-in
+      candidate bundles.
+      verify: no promotion changes a shipped default without an opt-in stage.
+- [ ] **7.6 A promoted artefact is not immortal.** `from-skipped-parent`, and
+      it is the only anti-monotonic-growth mechanism *after* the gate — the
+      `artifact-count delta` row guards the gate, the estate needs its own:
+      post-promotion re-evaluation with `KEEP / REVISE / MERGE / SPLIT /
+      RETIRE`. The master's promotion phase ends at the evidence package plus a
+      cooldown, so nothing reopens a promoted artefact and the lifecycle is
+      manual-only at exactly the point where growth accumulates.
+      verify: a promoted artefact reaching its review trigger produces one of the
+      five verdicts, and at least one `RETIRE` path is exercised in a fixture.
+- [ ] **7.7 Best-known-state reference on regression.** Roll back to the
+      recorded best-known state; lineage, not endless append.
+      verify: an injected regression triggers the rollback path in a fixture.
+
+## Blockers
+
+### merge-authority
+
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** Phase 0 step 0.8, and by consequence every promotion step in
+  Phase 7.
+- **What to do:** pick exactly one — (a) resolve ADR-239 § Decision 3 by
+  granting preauthorized merge authority with its scope written into that
+  record, or (b) resolve it by refusing preauthorized merge authority, making
+  "only humans promote" a property rather than an intention, or (c) declare
+  Phases 1–6 legal while it is unresolved and gate only Phase 7 on it — the
+  cheapest option and the one this roadmap is cut for. Read
+  `docs/decisions/ADR-239-drain-command-surface-and-merge-authority.md:79-81`
+  and its decision table at `:188`.
+- **Resolved when:** ADR-239 § Decision 3 no longer reads as an open question
+  and its `review_trigger` no longer names the `merge-authority` blocker as the
+  reopen condition.
+- **Recommendation:** (c). Phases 1–6 build measurement and isolation and
+  promote nothing, so they are unaffected by where merge authority lands; (a)
+  and (b) are owner-reserved and should not be forced by a plan that merely
+  wants to start.
+- **If you do nothing:** Phases 1–6 remain executable and Phase 7 cannot be
+  entered, because the guardrail it rests on is documented in this tree as
+  undecided. All three source proposals asserted that guardrail as a fact;
+  verified 2026-08-26, it is not one.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-08-26 | reviewer: claude/host -->
+
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | Parallel rebuild of machinery that exists | implementation | A second isolation mechanism next to `bench_ab_clone`, a second verdict next to `paired_verdict`, a second delivery path next to `lean_projection_mode`, a second matcher next to `router_match`. Two truths about "better" and no test catches it, because neither is wrong on its own terms. The source proposals committed this four times, once inside the document whose thesis it was | The inventory matrix is 0.1's exit criterion; 0.2 adds the roadmap-ownership half; 6.1 measures the existing substrate before writing a new one; 6.2 keeps the parity test as the detector | Phase 0 — Constitution, reconciliation, budget, stop conditions |
+| 2 | A consolidation that skips its deepest parent | implementation | Verified twice in this inbox: each folder's master named two parents and omitted the third, which itself claimed to supersede both named ones. The result reads as a decided plan while most of its content was never discussed | This roadmap folds the skipped parent back in and marks every such item `from-skipped-parent`; the sibling roadmap `road-to-consolidation-lineage-integrity.md` makes the check mechanical | Phase 0 — Constitution, reconciliation, budget, stop conditions |
+| 3 | The corpus becomes the overfitting vehicle | implementation | If the pipeline that optimises against the trigger corpus also grew it, the holdout is compromised before the first candidate runs | Corpus work completes and the holdout is hash-frozen in 2.5, before any proposer exists in Phase 5; 2.3 adds counterexamples so selection cannot see only successes | Phase 2 — Trigger corpus: census first, coverage second |
+| 4 | Coverage as a vanity target | product | "94 → 299" is a number that can be reached by authoring low-discriminative fixtures, which raises the metric and measures nothing. One parent killed this shape by name; the master adopted it as a phase title | 2.1 requires a partitioned census with a stated exclusion criterion before any denominator is chosen, and 2.3 requires discriminative classes | Phase 2 — Trigger corpus: census first, coverage second |
+| 5 | Ambiguous credit from multi-dimension candidates | implementation | If a candidate changes routing and content together and the vector moves, no metric row can be attributed. The metric vector then looks informative and is not | 3.2 limits candidate arity to one primary dimension; consolidation is a separate record type | Phase 3 — Candidate isolation and lifecycle |
+| 6 | Cost blindness turns a truncated run into a false pass | implementation | Cascade evaluation over candidates × task families × repeated trials is the dominant cost. Truncating to fit budget yields `underpowered`, which a reader treats as a pass | 0.5 aborts rather than truncates; 4.3 makes `underpowered` a non-pass in code; 5.6 reduces the cost instead of only capping it | Phase 0 — Constitution, reconciliation, budget, stop conditions |
+| 7 | Stopping only on spend | implementation | Six of the parents' nine stop conditions detect epistemic invalidity, which a spend cap never sees. A run can complete inside budget and be worthless | 0.6 pre-registers the validity conditions with detectors, and names the ones that stay model-carried | Phase 0 — Constitution, reconciliation, budget, stop conditions |
+| 8 | Monotonic estate growth after the gate | product | Every promotion adds; nothing reopens a promoted artefact. The gate-side `artifact-count delta` does not constrain the estate over time | 7.6 adds post-promotion re-evaluation with an exercised RETIRE path; 7.3 keeps most promotions below global scope | Phase 7 — Promotion bridge and the lifecycle after it |
+| 9 | Search becomes the product | product | One parent warned against this and then listed a meta-evolver, a curriculum generator and a routing tree as phases. The surface doubles before a single trustworthy run exists | Those three are killed or parked below; this roadmap stops at seven phases and 6.1 takes the measurable core | Phase 6 — Delivery: measure the existing substrate first |
+| 10 | A declared trust boundary with no detector | implementation | Naming proposer-visible and evaluator-private fields does not prevent holdout truth reaching a proposer; nothing observes the disclosure | 0.4 adds a per-field visibility class, a disclosure log, and a run abort | Phase 0 — Constitution, reconciliation, budget, stop conditions |
+
+## Acceptance Criteria
+
+- [ ] AC-1 — Every capability this roadmap builds has a row in the 0.1 inventory
+      matrix stating why no existing carrier fits, and no step duplicates a
+      carrier named in the "What already exists" table.
+- [ ] AC-2 — Every overlapping plan in the estate carries one of the five
+      dispositions from 0.2, and no capability has two execution owners.
+- [ ] AC-3 — A candidate variant of one harness dimension can be materialised,
+      evaluated and destroyed without any diff in the original tree, and a
+      deliberate path-ownership sabotage exits non-zero.
+- [ ] AC-4 — A candidate changing two primary dimensions is refused by the
+      schema, and "mutated" is not readable as "accepted" anywhere in the data
+      model.
+- [ ] AC-5 — Promotion is decided by `paired_verdict` per metric with
+      `underpowered` refused as a pass, and no code path computes a weighted
+      total score.
+- [ ] AC-6 — The holdout partition's content hash predates the first commit of
+      any proposer capability, and a run leaking a holdout value into proposer
+      context exits non-zero.
+- [ ] AC-7 — The three existing delivery arms have been measured against one
+      another before any new retrieval component exists, and
+      `router_match_parity.test.ts` is still green.
+- [ ] AC-8 — Programme success and failure criteria from 0.7 were committed
+      before the first candidate run, and the run report carries an
+      evolution-ROI figure.
+- [ ] AC-9 — At least one promoted artefact has been through post-promotion
+      re-evaluation and at least one RETIRE path has been exercised, so the
+      lifecycle is shown to close in both directions.
+- [ ] AC-10 — The `no-runtime-daemon` claim in `README.md` and its
+      `docs/CLAIMS.md` entry are byte-identical to their pre-roadmap state.
+
+## First cut — recommended start
+
+One defect, one mutation dimension, existing machinery only. Target:
+`code-intelligence` activation.
+
+`src/skills/code-intelligence/SKILL.md` carries three literal triggers in its
+description ("who calls", "where is this used", "call graph") — a narrow,
+checkable activation surface — and **verified: it already has
+`evals/triggers.json` with 10 queries**, so the cut is executable as written.
+
+1. Generate 3–5 candidate descriptions deterministically (3.5), one dimension
+   only (3.2), each entering the lifecycle enum at `proposed` (3.4).
+2. Isolate via the candidate variant, assert with `bench_ab_integrity` (3.1).
+3. Evaluate against the existing trigger corpus, verdict via `paired_verdict`,
+   discrimination plant via `eval_publication` (4.3, 4.7).
+4. No receipt, no LLM proposer, no frontier, no pathology archive.
+
+**corrected-from-reproduction — this cut is not free.** A full
+`description_route_check` run routes through a model backend behind a cache
+layer (`src/scripts/description_route_check.ts:112-125`), so it is
+spend-bearing. The budget invariant from 0.5 must exist before step 3 of this
+cut, not after Phase 4. The master presented the cut as needing "no new
+persistence, therefore none of the open contract questions" — true of
+persistence, untrue of spend.
+
+If this cut fails, the architecture is refuted before anything is built.
+
+## Open maintainer decisions
+
+- **E1 — Merge authority.** See Blockers. Verified open at `ADR-239:188`
+  ("Preauthorized merge authority is granted or refused | owner | **open**").
+- **E2 — Estate placement.** `corrected-from-reproduction`: the master framed
+  this as an overlap with "two already leading proposals",
+  `road-to-experience-loop-master` and `road-to-evidence-routed-skills-master`
+  v2. Verified on this tree: the second name **appears nowhere in the
+  repository** — not in `agents/roadmaps/` in any disposition and not in any
+  tracked file (`grep -rl` over `*.md`, `*.ts`, `*.json`, zero hits). The first
+  exists only as the sibling inbox proposal, now
+  `road-to-experience-loop-broadening.md`. Also verified:
+  `lint_roadmap_family_cap` **cannot** fire on either name —
+  `src/scripts/lint_roadmap_family_cap.ts:41` sets
+  `FAMILY_PREFIX = 'road-to-skill-ecosystem-'`, and it reports 0/2 slots used.
+  The gate that does apply is `check_estate_count`, reading
+  `active_roadmaps 3` against a floor of 7 — four slots of headroom. So the real
+  question is narrow: fold the sibling in, or keep both. 0.2's five-verb
+  disposition is where it gets answered.
+- **E3 — Budget ceiling** for 0.5 (candidates × trials × spend per run) and the
+  sampling strategy for the 5.1 body variant.
+- **E4 — Activation-ladder arity:** 4 states or 6? Recommendation: 6, because
+  Phase 6 measures delivery and `delivered ≠ visible` is that axis.
+- **E5 — Minimality tie-break order,** and whether the fifth criterion (simpler
+  mechanism) is in. The two parents' orders invert, so this changes outcomes.
+- **E6 — Curator operation set:** 4 ops or 7? Recommendation: 7 — split and
+  retire are the anti-sprawl actions, and 7.6 depends on them existing.
+- **E7 — Sealed-holdout cadence:** every cascade, or promotion candidates only?
+  One parent killed every-iteration as an adaptive-overfitting risk; the other
+  runs it every cascade.
+- **E8 — State-taxonomy arity:** 4 classes or 5, splitting experiment-adaptive
+  from production-adaptive with the latter prohibited by default?
+- **E9 — Cascade stage set:** 9 stages or 12? If 9, Phase 1's exit criterion
+  cannot be produced and must be rewritten.
+- **E10 — Mutation dimensions:** do `activation/routing/content` stand alone, or
+  does `verification` join immediately? Separate from 3.2, which is about arity.
+- **E11 — Second opinion:** is the fixture holdout enough, or does a council
+  blind round attach as an independent evaluator when Phase 4 blocks?
+- **E12 — Receipt location:** field extension in `audit-log-v1` /
+  `decision-trace-v1`, or a sidecar?
+- **E13 — Control arm:** is the deterministic proposer kept permanently as a
+  control even after an LLM proposer wins?
+- **E14 — Reach of the inventory matrix:** this workstream only, or a general
+  obligation for every roadmap? The source records the
+  plan-what-already-exists failure at its third occurrence; this analysis makes
+  it the fourth.
+
+## Killed — do not reintroduce without new evidence
+
+| ID | Rejected | Reason |
+|---|---|---|
+| K1 | The external reference as a dependency or runtime | Wrong layer (a Python benchmark laboratory). Shapes yes, code no. |
+| K2 | Embedding / vector index for routing | **Contract violation**, not a preference: `docs/contracts/no-runtime-boundary.md:40` classifies it Class C, verbatim, while the BM25 core passes the same test. |
+| K3 | Ungated autonomous self-evolution in canonical | Dense self-updates degrade in the cited external work. Autonomy belongs in the laboratory, not at the authority boundary. |
+| K4 | An episodic memory layer | ADR-094 removed Layer 2 and kept Layer 1; the intake JSONL plus its fold step is already that layer. `ADR-094:85` records revival as **gated** (≥2 funded consumer projects) — so this is a gated no with an unmet gate, and the gate is the thing to cite, not a prohibition. |
+| K5 | A separate sprawl dashboard | Replaced by the minimality tie-break (4.5) and the `artifact-count delta` row (4.2) — inside the gate, where it prevents something. |
+| K6 | Weighted total fitness score, or a frontier as promotion criterion | Two truths next to `paired_verdict`. |
+| K7 | Superseding "no runtime" as an identity statement | `README.md:19` carries `<!-- claim:no-runtime-daemon -->`, bound in `docs/CLAIMS.md`. A governed public claim with its own procedure, and unnecessary: the contract already permits git-as-state, file I/O, single-shot subprocesses and deterministically rebuildable indexes, which is everything Phases 0–7 need. |
+| K8 | Meta-evolver / evolving the evolver | Contradicts the parents' own warning, and there is no run history to feed it. |
+| K9 | Curriculum generator and routing tree as phases | To `later/`. They double the surface before Phases 0–4 produce one trustworthy run. 6.1 takes the measurable core, from the existing substrate. |
+| K10 | Copying benchmark numbers from external papers into this repo's docs | Unreproduced; the claims ledger governs. |
+| K11 | A new delivery engine from scratch | The three arms already exist (`lean_projection_mode.ts:19`). Killed by the skipped parent and re-killed here on direct verification. |
+| K12 | 100 % trigger coverage as a target | Reachable by authoring low-discriminative fixtures. Killed by the skipped parent; 2.1 replaces it with a partitioned census. |
+
+## Unverified in this analysis — carried as unverified, not as fact
+
+The parents' citations into the external reference repository could **not** be
+checked here: that tree is not in this repository and this analysis ran offline
+by its own bound. Every adopted mechanism above is justified by a defect or a
+carrier verified in **this** tree and stands on that basis alone. No external
+line number is load-bearing anywhere in this roadmap, and none should be added
+without a fresh check. The same applies to the papers cited in the parents:
+their numbers are unreproduced here and are not used to justify any step.

--- a/agents/roadmaps/road-to-governed-harness-evolution.md
+++ b/agents/roadmaps/road-to-governed-harness-evolution.md
@@ -9,8 +9,17 @@ estate_offset_exempt: "Added as a draft proposal, not as active work. Archiving 
 
 > **Source:** `agents/tmp.old/evolve/` — three session proposals plus the
 > operator transcript. Every repo claim below was re-verified against this tree
-> on 2026-08-26; the proposals were drafted against `1899f92b9`, which is HEAD
-> minus one commit, so the staleness window is empty.
+> on 2026-08-26; the proposals were drafted against `1899f92b9`.
+>
+> **Corrected after a neutral review: the staleness window is not empty.** An
+> earlier revision of this line said `1899f92b9` was "HEAD minus one commit", which
+> was true when the verification started and false by the time this branch was
+> pushed — the branch was rebased in between and the sentence was never
+> re-measured. `git rev-list --count 1899f92b9..HEAD` reads **7**, of which three
+> are upstream: `387dd3e68`, `82e47cefc` (#1676, four database-mastery roadmaps)
+> and `9e8344a3f`. That matters here specifically: #1676 changed the very estate
+> the E2 decision below reasons about, and reading a pre-rebase number is exactly
+> how the first version of E2 got its figure wrong.
 >
 > **The consolidation those files produced was incomplete, and that is the first
 > finding.** `road-to-governed-harness-evolution-master.md` names two parents it
@@ -45,7 +54,7 @@ carriers and builds only the remainder.
 
 | Wanted capability | Existing carrier | Verified on this tree |
 |---|---|---|
-| Candidate worktrees, isolated checkout, no writes to the original tree | `src/scripts/bench_ab_clone.ts` | `--variant` already accepts three values (`with`, `without`, `with-rdp`), plus `--refresh`, `--print-shape-hash`, `target_shape_hash` (`:197`) |
+| Candidate worktrees, isolated checkout, no writes to the original tree | `src/scripts/bench_ab_clone.ts` | `--variant` already carries three real variants (`with`, `without`, `with-rdp`) — its choice list is five, the other two being the aggregates `both` and `all` (`:289`, `:303`) — plus `--refresh`, `--print-shape-hash`, `target_shape_hash` (`:197`) |
 | Leakage assertion / path-ownership sabotage fails closed | `src/scripts/bench_ab_integrity.ts` | present; byte-wise clone comparison |
 | Paired verdict, direction over magnitude, `underpowered` is not a pass | `src/scripts/_lib/paired_verdict.ts` | `:25-26` four outcomes, `underpowered` "deliberately not a kind of pass"; `:54-65` the minimum discordant-trial floor is **derived** from the exact sign test, not chosen |
 | Planted bad candidate rejected cheaply | `src/scripts/_lib/eval_publication.ts` | `PlantedItem` `:13`, `discriminationDeficit` `:31` |
@@ -58,8 +67,9 @@ carriers and builds only the remainder.
 **corrected-from-reproduction — the isolation work is smaller than the master
 claimed.** The master described `bench_ab_clone` as living on a single "package
 present / absent" axis needing an axis extension. It already carries a
-`--variant` flag whose third value sits on a different axis entirely. Adding a
-candidate variant is a new enum member on existing multi-variant machinery.
+`--variant` flag whose third real value (`with-rdp`) sits on a different axis
+entirely. Adding a candidate variant is a new enum member on existing
+multi-variant machinery.
 
 ## The parent disagreements — decide these, do not inherit a silent pick
 
@@ -177,9 +187,10 @@ once.
       `src/scripts/_lib/outcome_envelope.ts:24-30` has six
       (`success · clean-no-op · blocked · approval-required · exhausted ·
       stagnated`). The sibling roadmap
-      `road-to-experience-loop-broadening.md` owns the reconciliation and plans
-      to write `clean-no-op` into the audit stream, where that value does not
-      exist. This step depends on that one; it does not duplicate it.
+      `road-to-experience-loop-broadening.md` owns the reconciliation; one of its
+      source proposals planned to write `clean-no-op` into the audit stream,
+      where that value does not exist, which is how the split was found. This
+      step depends on that one; it does not duplicate it.
       verify: one module exports the enum both readers import, and a lint
       rejects an inline duplicate.
 
@@ -490,7 +501,7 @@ once.
 | 6 | Cost blindness turns a truncated run into a false pass | implementation | Cascade evaluation over candidates × task families × repeated trials is the dominant cost. Truncating to fit budget yields `underpowered`, which a reader treats as a pass | 0.5 aborts rather than truncates; 4.3 makes `underpowered` a non-pass in code; 5.6 reduces the cost instead of only capping it | Phase 0 — Constitution, reconciliation, budget, stop conditions |
 | 7 | Stopping only on spend | implementation | Six of the parents' nine stop conditions detect epistemic invalidity, which a spend cap never sees. A run can complete inside budget and be worthless | 0.6 pre-registers the validity conditions with detectors, and names the ones that stay model-carried | Phase 0 — Constitution, reconciliation, budget, stop conditions |
 | 8 | Monotonic estate growth after the gate | product | Every promotion adds; nothing reopens a promoted artefact. The gate-side `artifact-count delta` does not constrain the estate over time | 7.6 adds post-promotion re-evaluation with an exercised RETIRE path; 7.3 keeps most promotions below global scope | Phase 7 — Promotion bridge and the lifecycle after it |
-| 9 | Search becomes the product | product | One parent warned against this and then listed a meta-evolver, a curriculum generator and a routing tree as phases. The surface doubles before a single trustworthy run exists | Those three are killed or parked below; this roadmap stops at seven phases and 6.1 takes the measurable core | Phase 6 — Delivery: measure the existing substrate first |
+| 9 | Search becomes the product | product | One parent warned against this and then listed a meta-evolver, a curriculum generator and a routing tree as phases. The surface doubles before a single trustworthy run exists | Those three are killed or parked below; this roadmap stops at Phase 7 and 6.1 takes the measurable core | Phase 6 — Delivery: measure the existing substrate first |
 | 10 | A declared trust boundary with no detector | implementation | Naming proposer-visible and evaluator-private fields does not prevent holdout truth reaching a proposer; nothing observes the disclosure | 0.4 adds a per-field visibility class, a disclosure log, and a run abort | Phase 0 — Constitution, reconciliation, budget, stop conditions |
 
 ## Acceptance Criteria
@@ -560,16 +571,29 @@ If this cut fails, the architecture is refuted before anything is built.
   `road-to-experience-loop-master` and `road-to-evidence-routed-skills-master`
   v2. Verified on this tree: the second name **appears nowhere in the
   repository** — not in `agents/roadmaps/` in any disposition and not in any
-  tracked file (`grep -rl` over `*.md`, `*.ts`, `*.json`, zero hits). The first
+  tracked file. `grep -rl` over `*.md`, `*.ts` and `*.json` returned zero hits
+  when the check was run; it now returns exactly one, this roadmap, because the
+  name is written above. A reader re-running it should expect that single
+  self-hit and nothing else. The first
   exists only as the sibling inbox proposal, now
   `road-to-experience-loop-broadening.md`. Also verified:
   `lint_roadmap_family_cap` **cannot** fire on either name —
   `src/scripts/lint_roadmap_family_cap.ts:41` sets
   `FAMILY_PREFIX = 'road-to-skill-ecosystem-'`, and it reports 0/2 slots used.
-  The gate that does apply is `check_estate_count`, reading
-  `active_roadmaps 3` against a floor of 7 — four slots of headroom. So the real
-  question is narrow: fold the sibling in, or keep both. 0.2's five-verb
-  disposition is where it gets answered.
+  The gate that does apply is `check_estate_count`.
+
+  **Corrected after a neutral review, and the correction reverses this
+  decision's force.** An earlier revision read "`active_roadmaps 3` against a
+  floor of 7 — four slots of headroom". That was a pre-rebase reading; #1676
+  landed four database-mastery roadmaps in the window named above. The gate now
+  reports `active_roadmaps 7 (floor 7 at origin/main, +0)` — **at the floor, zero
+  headroom.** These three roadmaps clear it only because `status: draft` excludes
+  them from the counted set and each carries `estate_offset_exempt` for the
+  file-based half. So the choice is not between two comfortable options: flipping
+  any of them to `ready` without a disposal in the same change raises a floor at
+  its ceiling, which makes folding the cheaper path on the estate axis rather
+  than merely the tidier one. 0.2's five-verb disposition is where it gets
+  answered, and it should be answered before any status flip.
 - **E3 — Budget ceiling** for 0.5 (candidates × trials × spend per run) and the
   sampling strategy for the 5.1 body variant.
 - **E4 — Activation-ladder arity:** 4 states or 6? Recommendation: 6, because
@@ -603,8 +627,8 @@ If this cut fails, the architecture is refuted before anything is built.
 | ID | Rejected | Reason |
 |---|---|---|
 | K1 | The external reference as a dependency or runtime | Wrong layer (a Python benchmark laboratory). Shapes yes, code no. |
-| K2 | Embedding / vector index for routing | **Contract violation**, not a preference: `docs/contracts/no-runtime-boundary.md:40` classifies it Class C, verbatim, while the BM25 core passes the same test. |
-| K3 | Ungated autonomous self-evolution in canonical | Dense self-updates degrade in the cited external work. Autonomy belongs in the laboratory, not at the authority boundary. |
+| K2 | Embedding / vector index for routing | **Contract violation**, not a preference: `docs/contracts/no-runtime-boundary.md:40` says verbatim that "a vector/embedding index fails — it enables query semantics absent from source, and stays Class C". That line names the code-graph cache as passing and says nothing about BM25; that the BM25 core also passes is this roadmap's own inference from `lexical_index.ts:9-15` (deterministic, in-memory, rebuilt per invocation), not a quotation. |
+| K3 | Ungated autonomous self-evolution in canonical | Autonomy belongs in the laboratory, not at the authority boundary — and that argument stands on this tree alone: `ADR-239:188` records merge authority as open, so nothing here may promote autonomously regardless of what the literature says. The source proposals justified this kill with external findings that dense self-updates degrade; those were not checked here and are **not** load-bearing for the kill. |
 | K4 | An episodic memory layer | ADR-094 removed Layer 2 and kept Layer 1; the intake JSONL plus its fold step is already that layer. `ADR-094:85` records revival as **gated** (≥2 funded consumer projects) — so this is a gated no with an unmet gate, and the gate is the thing to cite, not a prohibition. |
 | K5 | A separate sprawl dashboard | Replaced by the minimality tie-break (4.5) and the `artifact-count delta` row (4.2) — inside the gate, where it prevents something. |
 | K6 | Weighted total fitness score, or a frontier as promotion criterion | Two truths next to `paired_verdict`. |


### PR DESCRIPTION
Drains `agents/tmp/evolve/` and `agents/tmp/evolver/` — ten files, two parallel
workstreams on harness self-evolution, each holding session proposals plus a
consolidating master. Output is three **draft** roadmaps, one measurement, and a
completion-review artefact.

Nothing here is adopted. All three roadmaps ship `status: draft`, which keeps
them out of the dashboard, out of `/roadmap:process-*`, and out of the archival
sweep until you flip the status. That flip is the adoption act — and see the
estate note below before you make it.

## What the verification changed

The masters were high quality and pinned to `1899f92b9`. What they got wrong was
the tree, not the calendar. Every claim was re-checked with a `file:line`; nine
changed the plan, each marked `corrected-from-reproduction` in the roadmap:

- **Per-task delivery already ships.** `_lib/lean_projection_mode.ts:19` defines
  `eager-all | thin | delivery`, default `eager-all`. One master planned to build
  a BM25 subset for it; another proposal had killed exactly that and said "measure
  the three existing arms first". The build would have been the parallel-rebuild
  failure that master's own top risk names.
- **One shared matcher is already an enforced invariant.**
  `_lib/rule_injection.ts` is "THE single module both the offline model and the
  runtime concern read", pinned by `router_match_parity.test.ts`. An experiment
  with a second matcher measures nothing.
- **`bench_ab_clone` already carries three real variants**, not one axis — so
  candidate isolation is a new enum member, not a subsystem.
- **Two outcome vocabularies exist.** Four values in `audit-log-v1:77`, six in
  `_lib/outcome_envelope.ts:24-30`. A source proposal planned to write
  `clean-no-op` into the stream that has no such value. No master noticed.
- **Anti-forgery cannot be unconditional.** "Claimed success × empty diff ⇒ never
  success" fails every read-only analysis and review dispatch — a large share of
  this repo's subagent traffic. Now gated on the task's output contract.
- **Mined experience lands in `agents/memory/`, a tracked path** (five tracked
  files). No proposal carried privacy, redaction or retention. Added, with the
  rolling-buffer precedent from `CLAIMS.md:691` as its own blocker.
- **Two cited roadmaps exist nowhere in the repository**, and the family cap
  cannot fire on either new name (`FAMILY_PREFIX = 'road-to-skill-ecosystem-'`).
- **Merge authority is open** at `ADR-239:188`, so "only humans promote" was an
  intention in every proposal, not a property. It is a blocker.
- **The code-graph honest null is stale by construction**, not just unreplaced:
  `CLAIMS.md:447` now records that its figures describe a build that no longer
  exists. That makes the kill stronger and the honest position *unknown*.

Reproduced rather than read: the three corpus counts (94 / 299 / 175) reproduce
exactly, the grandfather list reads 205 against its own "frozen at 221" note, and
`code-intelligence/evals/triggers.json` exists with 10 queries — which is what
makes the recommended first cut executable as written.

## The third finding: both consolidations skipped their deepest parent

Each folder's master named two parents and omitted a third — and in both cases
that third file declares in its own header that it supersedes the two the master
did consolidate. The `evolver` master's arithmetic gives it away: "17 + 8 phases
compressed" leaves out the omitted parent's 25.

A census over `agents/tmp.old/` found the same class in two older folders:
**four of four** declared consolidations have an incomplete lineage. Structural
reads of the two omitted parents surfaced items carrying no kill ID, several
bearing on a decision the master made on the same mechanism — including the
delivery rebuild above.

The consequence is why it earned a roadmap: a consolidation presents its content
as adjudicated, and a missing parent means content that is *undiscussed* rather
than *killed*, with nothing in the artefact distinguishing the two.

## A neutral review ran over this branch, and it found real defects

A cross-model reviewer was dispatched over the full delta with a neutral prompt —
no expected outcome stated, scope the whole diff rather than a subset I chose. It
checked ~45 citations and reproduced them, including every verbatim quotation and
all four corpus counts, and returned 26 findings. **Four were blocking, all four
reproduced on independent check, and all four were mine:**

1. **The staleness window was itself stale.** Both roadmaps said the pin was
   "HEAD minus one commit, so the window is empty". True when the verification
   started; the branch was rebased and the sentence was never re-measured.
   `git rev-list --count 1899f92b9..HEAD` = 7, three of them upstream.
2. **The estate figure was inverted, and it carried a decision.** Both roadmaps
   read "`active_roadmaps 3` against a floor of 7 — four slots of headroom". The
   gate reports **7 against a floor of 7 — zero headroom**; #1676 landed four
   database-mastery roadmaps inside the unclosed window above. This reverses the
   force of the estate-placement decision: **flipping any of these three to
   `ready` without a disposal in the same change raises a floor already at its
   ceiling.** Folding is now the cheaper answer on the estate axis, not just the
   tidier one.
3. **A `verify:` line was refuted by its own evidence.** The lineage roadmap
   expected its two-artefacts-one-parent-set finding in one folder; it occurs in
   three, including both folders this drain analysed.
4. **The census contradicted the roadmap derived from it** on whether the master
   adopted or omitted the mutation-arity rule. The roadmap was right.

Twelve smaller findings also fixed: a misattributed `from-skipped-parent` marker,
two `grep` "zero hits" claims that now self-hit their own file, a negative
verification scoped to a directory holding no command prose, four legacy
declaration shapes that are five, three off-by-one counts, a `verify:` line
asking a markdown contract to import a module, and two external statistics doing
load-bearing work in kill entries while the closing section claimed nothing
external was load-bearing.

One correction was itself corrected: a first pass offered a `grep -c` marker
count as a reproducible proxy for two item figures. It counts prose mentions and
it moved while the edits were being written, so both files now record those
figures as a judgement rather than a measurement.

Every correction is marked in place, with what the earlier revision said. The
review's prompt shape and its pass rate are recorded alongside its findings in
`inbox-evolve-drain-2026-08-26.findings.md`.

## Files

| File | What it is |
|---|---|
| `agents/roadmaps/road-to-governed-harness-evolution.md` | The evolution laboratory: candidate isolation, evaluation, promotion bridge. Blocker: merge authority. |
| `agents/roadmaps/road-to-experience-loop-broadening.md` | Widens the learning loop that already exists. Blockers: runtime consumption of experience, retention policy. |
| `agents/roadmaps/road-to-consolidation-lineage-integrity.md` | Makes an incomplete consolidation visible. Extends `/analyze:inbox`; no new surface. Blocker: enforcement surface. |
| `agents/evidence/analysis/consolidation-lineage-census-2026-08-26.md` | The four-folder measurement, with its own stated bound. |
| `agents/evidence/reviews/inbox-evolve-drain-2026-08-26.findings.md` | Completion-review skip (zero code paths) plus the neutral-review record. |

## What you decide

Four blockers and roughly two dozen open decisions, all recorded in the roadmaps.
The two that gate anything:

1. **Merge authority** (`ADR-239` § Decision 3, open). Recommendation: declare
   the measurement phases legal while unresolved and gate only promotion — they
   promote nothing.
2. **Estate placement**, now sharper than when this PR opened. The two subject
   roadmaps overlap on trigger evals, on the paired-verdict mechanism and on the
   enum reconciliation, and the active count sits at its floor. Fold them or keep
   both — I did not pre-merge, because that would have decided it by authoring.

## Gates

All green: `lint_roadmap_blockers` (12 clean, decidability 0) ·
`lint_plan_risk_register` · `lint_roadmap_complexity` ·
`lint_roadmap_family_cap` (0/2) · `check_roadmap_trackable` ·
`lint_roadmap_ci_steps` · `lint_empty_roadmaps` · `check_references` (1693
scanned) · `check_no_roadmap_refs` · `check_md_language` · `check_estate_count`
(`+3 active / -0 disposed, 3 exempt`, both halves) · `lint_evidence_artifacts`
(2 added, typed) · `check_completion_review`.

Consumed inbox files moved to `agents/tmp.old/{evolve,evolver}/`; both
directories are gitignored, so that move is not in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
