### PR TITLE
roadmap: answer the two blocking review findings on #1681, and one roadmap out of three survivors

### DIFF
--- a/agents/evidence/analysis/mixed-analysis-inbox-verification-2026-08-27.md
+++ b/agents/evidence/analysis/mixed-analysis-inbox-verification-2026-08-27.md
@@ -37,14 +37,53 @@ harvest). The verification below is per track.
 
 ## The headline finding
 
-**Roughly seventy per cent of the eight tracks is already owned by this tree** —
-by a shipped mechanism, by an active or parked roadmap, or by a recorded
-decision that is stronger than what the source proposes. The estate holds 66
-parked roadmaps, about twenty of them harvest roadmaps from earlier cycles, and
-the source's own third challenge loop asks whether more per-package analysis
-"will actually produce more insight, or only more roadmaps, terminology, and
-merge conflicts". Measured against this tree, the second reading is the better
-supported one.
+> **Corrected 2026-08-27, after the PR's own adversarial-review gate flagged it
+> `74007388aa70` (high, blocking-advisory): "Headline 70% ownership claim lacks
+> denominator".** The finding is right and the percentage is withdrawn rather
+> than re-derived. What follows is the countable version. The original sentence
+> read: *"Roughly seventy per cent of the eight tracks is already owned by this
+> tree."* It was never computed against a stated set — a claim of exactly the
+> shape this record exists to refuse, made by the record itself.
+
+**The denominator, stated.** The source program carries **47 numbered sub-items**
+across its eight tracks (`grep -c '^## [GRHKPWSX][0-9]\.'` over `FINAL-ROADMAP.md`
+in `agents/tmp.old/mixed-analysis/`). This record verifies **16 claims**; the
+composition roadmap's dropped table names **6** items with an owner. So:
+
+| Set | Count |
+|---|---|
+| Numbered sub-items in the source program | 47 |
+| Claims verified in this record | 16 |
+| Of those, carrying an explicit ownership verdict (`already-fixed` 1, `already-owned` 2, `already-decided` 1) | **4** |
+| Of those, `corrected` — right claim, colliding remedy | 2 |
+| Of those, `still-true` — the gap holds | 9 |
+| `unverifiable` under this command's reproduction bound | 1 |
+| **Sub-items never checked at all** | **31** |
+
+**What is therefore supportable:** of the sixteen claims this record actually
+checked, **four** are owned outright and two more are right-but-colliding. That
+is a statement about 16 claims, not about 47 sub-items and not about 8 tracks.
+Two thirds of the program was never verified, and the two roadmaps this drain
+landed were selected from the third that was.
+
+*The ownership count fell from five to four on 2026-08-27* — the prose
+detect/edit row was re-checked during the post-merge reconciliation and its
+`already-fixed` verdict did not hold. A count that moves when a row is
+re-examined is the reason the percentage above was withdrawn rather than
+recomputed.
+
+**What is not supportable, and was asserted anyway:** any percentage over the
+program. The tracks are not equal in size (8 sub-items in one, 4 in another), so
+even a complete per-item count would not license a per-track percentage without
+a weighting nobody chose.
+
+The qualitative reading survives the correction and is worth keeping separate
+from the number: the estate holds 66 parked roadmaps, about twenty of them
+harvest roadmaps from earlier cycles, and the source's own third challenge loop
+asks whether more per-package analysis "will actually produce more insight, or
+only more roadmaps, terminology, and merge conflicts". Every claim this record
+did check that bore on that question pointed the same way. That is a direction
+supported by 16 of 47, not a measured proportion.
 
 That is not a criticism of the source. It is drafted against a repository whose
 `agents/` tree is largely invisible from outside, so it could not have seen the
@@ -73,8 +112,61 @@ something here.
 | Make `delivery` observable, then migrate in stages | already-owned | `later/road-to-thin-flip-under-anchor-scoring.md` — three gates, two recorded failed measurements (36.2 % against a 48 % floor; a length-neutral rerun inconclusive at κ=0.46), ADR-202 |
 | One automatic routing hop; a second router is an experiment | already-decided, more strongly | a second retrieval router was rejected by council on 2026-07-07; `later/road-to-deferred-rule-retriever.md` holds it behind three named re-open conditions |
 | Merge state is not a correctness label | already-owned | `agents/roadmaps/road-to-evidence-gated-change.md` |
-| A separately invokable prose detect/edit/preserve capability | already-fixed | the `humanizer` skill, plus `lint_output_slop.ts` and `lint_design_slop.ts` |
+| A separately invokable prose detect/edit/preserve capability | **corrected 2026-08-27 — `still-true` for the agent's own output** | Was `already-fixed`, citing `humanizer`. Too coarse: `humanizer` is scoped to **deliverable** prose (posts, articles, drafts), sits in `domain: product` under the `gtm-marketing` pack, and that pack has no `default_install` and lists `workspaces: [gtm, founder]` — an engineering install does not receive it. `lint_output_slop.ts` scans authored markdown for placeholders, not emitted prose for AI tells. The obligation is real; its home is the undeclared-82 cohort, not a new skill — see § Post-merge reconciliation |
 | Two preprints are cited for the disclosure-depth and merge-label claims | unverifiable | no network under this command's reproduction bound; carried as unverified, not as fact |
+
+## The authorization defect, independently verified
+
+> **Added 2026-08-27, after the PR's own adversarial-review gate flagged it
+> `45e24dabfed9` (critical, blocking-advisory): "Authorization defect claim
+> depends on a single evidence file with no independent verification".** The
+> finding was correct as written — the claim rested entirely on two prose lines
+> in `agents/evidence/pr-drain-run-summary.md`, which is a narrative record of
+> one run. Two independent legs are added here. The claim survives both, and a
+> second instance of the same defect class was found while verifying it.
+
+**Leg 1 — the host records a task notification as a user turn.** Session
+transcripts carry each turn with its role. Counting the exact user-role form
+across this project's transcript store:
+
+```
+grep -l  '"role":"user","content":"<task-notification>'  → 92 of 167 sessions
+grep -ho '"role":"user","content":"<task-notification>'  → 561 occurrences
+```
+
+Every occurrence carries `"type":"user","message":{"role":"user"}`. A background
+completion is therefore not merely *treated* as a prompt by one hook — it **is** a
+user turn in the host's own record, 561 times across 92 sessions. This is a
+different instrument from the drain summary (a transcript store, not a
+narrative), it is re-runnable, and it does not depend on any one session.
+
+**Leg 2 — the writer replaces the ledger on every non-empty prompt.**
+`git_authorization_hook.ts:468-513`: `run()` returns early only when the prompt
+text is empty (`:490`), then builds the ledger from
+`classifyAuthorization(prompt)` (`:494`) and writes it with
+`prompt_chars: prompt.length` (`:512`). A notification's text is non-empty and
+carries no git prose, so `authorized` is `[]`. Nothing in the path distinguishes
+its origin.
+
+The two legs together entail the defect without the drain summary: the host
+delivers the notification as a user turn, and the writer clears the ledger on
+any user turn. The summary remains as the *operational* record — two stalls, and
+the foreground-wait workaround — but it is no longer the sole basis.
+
+**A discriminator exists, which the roadmap's Phase 1 had left open.** The
+notification's content begins with the literal element `<task-notification>` and
+carries `<task-id>`, `<tool-use-id>`, `<status>` and `<summary>` children. That
+is a field in the prompt text itself, present in all 561 occurrences, so the
+"if no field differs, this roadmap stops here" branch does not fire.
+
+**A second instance, same function, found while verifying.** `takePending`
+(`:427`) is called on **every** prompt (`:499`) and `rmSync`s the pending-refusal
+file at `:440` — before any affirmative check and before any origin check. So a
+background notification arriving between a refusal and the user's "ja" **deletes
+the pending record**, and the affirmative that follows has nothing to confirm.
+This is the sibling the roadmap's step 3.2 sweep was written to look for; it is
+recorded here so the step starts from one confirmed instance rather than from
+zero.
 
 ## Steps reproduced
 
@@ -82,7 +174,7 @@ something here.
 |---|---|---|---|
 | 1 | "Generate current inventory of skills, rules, commands, guidelines, hooks" | counted the directories | reproduced — 299 skills, 120 rules, 114 guidelines, 56 hook concerns |
 | 2 | "Hard lint: enums, statuses, lifecycle values, command verbs, evidence terms, artifact types" | ran `lint_canonical_terms` | reproduced, and the premise is already satisfied — the lint exists and is ratcheted; the source's item is a scope extension, not a new mechanism |
-| 3 | "Read the current dispatcher/resolvers and document the real order" | read the hook contract | diverged — hook dispatch order **is** documented; the rule and context load order across projection layers is not, so the item is half-owned and the surviving half is narrower than stated |
+| 3 | "Read the current dispatcher/resolvers and document the real order" | read `docs/contracts/hook-architecture-v1.md:210-226`, then grepped `rule-router.md`, `kernel-membership.md` and `agent-authority.md` for a load-order or precedence statement — zero hits | **`reproduced`, with a bounded result** — corrected 2026-08-27 per gate finding `eb0533f7b0f8`. The step said "read and document"; reading it succeeded and produced a definite two-part answer, so the verdict is `reproduced`, not `diverged`. The earlier `diverged` label conflated *the step failing* with *the answer being partial*. The answer: hook dispatch order **is** documented; rule and context load order across projection layers is **not**, and `agent-authority.md` states authority-band precedence rather than load order |
 | 4 | "Repair the PR-drain authorization persistence defect" | read the writer | diverged, and the divergence is the finding — `git_authorization_hook.ts:28` states per-turn replacement is deliberate. The defect is the **input classification**, not the retention; "make it durable" would break a correct property to hide a different bug |
 | 5 | "Adopt `implements / requires / extends / replaces / …`" | read the schema | unexecutable as written — `requires` is a reserved key; adopting the list verbatim breaks the discovery manifest |
 | 6 | "Parallel read-only deep dives, one agent per external package" | not attempted | out-of-bound — the command's reproduction bound forbids network access |
@@ -90,6 +182,34 @@ something here.
 The three ceilings (12 steps, 20 minutes, 3 attempts per step) did not fire;
 step selection stopped at six because the remaining instructions were neither
 paired with an asserted outcome nor phrased as reusable procedures.
+
+## The inbox folder was never committed — and what that does and does not settle
+
+> Recorded 2026-08-27 against gate finding `6eeb76b47521` (medium, security):
+> "No validation that `tmp.old/mixed-analysis/` was sanitized before commit".
+
+**The premise does not hold, and saying so is the whole answer to half of it.**
+`agents/tmp.old/` is gitignored — `git check-ignore -v` resolves it to
+`.gitignore:51` — so the folder was never staged, never committed, and is not in
+the diff the gate read. There was no commit to sanitize before.
+
+**The half that does hold, and how it was discharged.** Both roadmaps cite
+`agents/tmp.old/mixed-analysis/` on their `Source:` line, so the tracked tree
+points at content no reviewer can open from a clone. That is by design here —
+[`source-confidentiality`](../../../src/rules/source-confidentiality.md) keeps
+raw named evidence local-only — but it means the tracked side carries the whole
+burden of not leaking. That side **was** validated:
+`./scripts-run src/scripts/check_no_external_sources` ran green over the tracked
+tree before the PR was opened, and the drop names eight external repositories
+and two preprints, none of which appears in any emitted artefact.
+
+**What is still not validated, stated rather than closed.** Nothing scans the
+untracked folder itself for secrets or injected instructions before an agent
+reads it, and this record's own reproduction bound (no network, no secret reads)
+is model-carried. A future inbox drop containing a credential would be read, not
+refused. That is a real gap in the `/analyze:inbox` path, it is not this
+change's to fix, and it is named here so a later reader does not mistake the
+green `check_no_external_sources` run for a scan of the input.
 
 ## What was emitted, and why so little
 
@@ -108,6 +228,54 @@ Everything else is either already owned or a duplicate. The estate stood at
 `active_roadmaps 7 (floor 7, +0)` when this ran, so each addition costs a
 recorded exemption line; adding eight tracks would have been the roadmap
 explosion the source itself warns against.
+
+## Post-merge reconciliation — the three claimed survivors, checked
+
+> Added 2026-08-27 after `612b817` merged. The operator's reconciliation of the
+> source program against this drain named **three** items as neither owned by
+> the tree nor landed here, and asked for them to be set up. Each was checked
+> before anything was written. One survives, two do not, and the reason is the
+> same discipline this record was built on.
+
+**1. "Slop-resistant surfaces — no skill catches AI tells in the agent's own
+output."** *Partly right, and the drain's own table was too coarse.* This record
+originally marked it `already-fixed` citing the `humanizer` skill. That verdict
+does not hold on inspection: `humanizer`'s description scopes it to **deliverable
+prose** ("posts, articles, drafts"), it sits in `domain: product` under the
+`gtm-marketing` pack, and that pack carries no `default_install` and lists
+`workspaces: [gtm, founder]` — so an engineering install does not receive it.
+`lint_output_slop.ts` is a different thing again: it scans authored markdown for
+placeholder patterns, not emitted prose for AI tells.
+
+*But the remedy does not follow.* Traced further, the four rules that carry this
+obligation — `communication-through-line`, `direct-answers`, `no-cheap-questions`,
+`user-interaction` — are all inside `check_enforcement_coverage`'s **undeclared
+82**. The gap is not a missing skill; it is 82 rules whose enforcement nobody has
+dispositioned. That is `road-to-undeclared-obligation-disposition`, and it is the
+only roadmap this reconciliation emits.
+
+**2. "Output-shaping contract — the shape is scattered."** *Real gap, no
+observed failure, therefore no roadmap.* There is no typed output-shape contract;
+the obligations sit across `direct-answers`, `user-interaction`,
+`communication-through-line` and `reply-close-mechanics`. A fifth artefact
+consolidating four is exactly the new-architecture-term this session learned to
+refuse, and nothing in the tree records a failure caused by the scattering.
+Recorded as a candidate; it earns a roadmap when a failure is measured, not
+before.
+
+**3. "Runtime load-order and depth selector."** *Gap confirmed, no observed
+failure, therefore no roadmap.* Grepping `rule-router.md`,
+`kernel-membership.md` and `agent-authority.md` for a load-order or precedence
+statement returns nothing — `agent-authority.md` states **authority-band**
+precedence, which is a different axis. So the gap is real. No measured failure
+is attributable to it. Same disposition as (2).
+
+**One claimed anchor was checked and is closed.** A prior measurement recorded
+that `lint_hidden_unicode` could not see `src/scripts/`, so a raw control byte
+there escaped every gate. At `612b817` the linter runs a **second pass** over
+all tracked text files — `source pass: 8462 tracked text file(s) read for raw C0
+control bytes` — and the gap no longer exists. Checking it was the cheapest step
+in this reconciliation and it removed the strongest-looking anchor for (1).
 
 ## Not emitted, deliberately
 

--- a/agents/evidence/reviews/drain-advisories-and-survivors.findings.md
+++ b/agents/evidence/reviews/drain-advisories-and-survivors.findings.md
@@ -1,0 +1,58 @@
+# Completion review — drain-advisories-and-survivors
+
+**Skipped:** no code surface for this completion — the branch changes 5 files and 0 of them is a code path: one evidence record amended with a withdrawn claim and an independent verification, two roadmaps amended with the review findings that landed on them, one new roadmap, and one new stub, scope 0f518c3a280678847b6f068ab8ef2249dab960e2eaf21dd54aeb5b5d1bc0f583, declared 2026-08-27
+
+## Why there is no code to review
+
+The change answers the adversarial-review findings on PR #1681 and the
+reconciliation that followed the merge. Every answer is prose: a withdrawn
+claim, a verification recorded against instruments that already exist, a
+roadmap that plans work, and a stub that names a defect rather than fixing it.
+No script, schema, hook, template or projection is touched, and the gate itself
+measures zero code paths of five changed files.
+
+The two blocker-heading repairs are the closest thing to code here and are not:
+each is one word added to a markdown heading so an existing parser can see a
+section that was already written.
+
+## What was verified instead, and how
+
+The two blocking-advisory findings were answered against the tree, not argued.
+
+**`74007388aa70` (high) — the 70% ownership claim.** Withdrawn rather than
+recomputed. The denominator is now stated: 47 numbered sub-items in the source
+program, 16 claims checked, 4 owned outright, 31 sub-items never checked. The
+ownership count fell from 5 to 4 during the same pass, when one row's
+`already-fixed` verdict was re-examined and did not hold — which is itself the
+argument for withdrawing a percentage rather than restating it.
+
+**`45e24dabfed9` (critical) — the authorization defect on one evidence file.**
+Two independent legs added. A `<task-notification>` is stored as a user-role
+turn **561 times across 92 of 167** session transcripts
+(`grep -l`/`grep -ho` over the transcript store, both counts reported). The
+writer rebuilds the ledger on every non-empty prompt and reads nothing about
+origin (`git_authorization_hook.ts:468-513`). Verifying it surfaced a second
+instance in the same function: `takePending` (`:427`, called `:499`) removes the
+pending-refusal file at `:440` before any affirmative or origin check.
+
+Four advisory findings were also answered: the step-3 classification, the
+tmp.old sanitization premise, the composition roadmap's kill-criterion detector,
+and its context-fingerprint and authority-citation gaps.
+
+**One finding was made by this change rather than answered by it.** The
+dashboard reported the new roadmap's blocker count as zero. `BLOCKER_HEADING_RE`
+(`update_roadmap_progress.ts:439`) requires a literal `blocker:` prefix; six
+headings across five roadmaps lack it, `open_blockers` is a ratcheted metric
+running on the resulting undercount, and `lint_roadmap_blockers` reported the
+affected file clean because a file with zero parsed blockers passes vacuously.
+Two instances repaired, four recorded in
+`stubs/road-to-blocker-parse-visibility.md`.
+
+## Gates run
+
+`check_estate_count` (active 10 → 11 on an offset exemption; `open_blockers`
+42 → 44 on a growth claim stating the rise is a correction),
+`check_roadmap_trackable` (7 violations against a baseline of 9),
+`lint_roadmap_blockers`, `lint_plan_risk_register`, `check_references`,
+`check_no_external_sources`, `lint_evidence_artifacts`, and the dashboard
+regenerated. All green.

--- a/agents/roadmaps/road-to-composition-before-creation.md
+++ b/agents/roadmaps/road-to-composition-before-creation.md
@@ -10,7 +10,10 @@ relates: []
 # 783 roadmap file(s) across active/later/stubs/archive, 348 remote branch(es),
 # 3 live session record(s), 0 inbox file name(s). No sibling roadmap on the
 # topic, no remote branch carrying the slug, and no open-PR file overlap for
-# this roadmap. Context fingerprint 1fad1aa7901bc34b, base 0be1cf6b7.
+# this roadmap. The "context fingerprint" is the probe's own digest of the
+# inputs it read, printed by `agent-config roadmap:context`; a later run whose
+# fingerprint differs has seen a changed estate and the relates block should be
+# re-probed. Fingerprint 1fad1aa7901bc34b, base 0be1cf6b7.
 estate_offset_exempt: "No disposal is available in this change — the dashboard reports 6/205 steps done across the seven active roadmaps, so nothing is near archival, and parking this would grow the later_roadmaps floor instead of the active one. No sibling owns the subject: grepping every active and parked roadmap for `incumbent`, `composition gate`, `overlap gate` and `declared delta` returns one file, `later/road-to-catalogue-host-fit.md:280`, where the word is incidental prose about record dating, not an authoring gate."
 ---
 # Road to composition before creation — the estate grew to 299 skills and nothing ever asked "what does this extend?"
@@ -62,6 +65,17 @@ source will otherwise re-propose all six.
 | One automatic routing hop | already-decided, more strongly | a second retrieval router was REJECTED by council 2026-07-07; `later/road-to-deferred-rule-retriever.md` holds it behind three named re-open conditions |
 | Eight-state finding lifecycle | corrected — extend, do not add | `check_finding_dispositions.ts` already ships a committed ledger with `fixed \| false_positive \| accepted_risk` plus rationale and `verified_by`. A parallel eight-state vocabulary is the duplicate-terminology failure the source's own third-pass challenge names |
 
+**The rows do not share one kind of authority, and the table should not read as
+if they do** — added 2026-08-27 per gate finding `75d4bd8c5efc` (low): only one
+row cites an ADR, which invites the reading that the others are weaker. They are
+not weaker, they are different: rows 1, 2 and 6 cite a **shipped script**, which
+is the strongest form here because it can be run; row 3 cites an **active
+roadmap**; row 4 cites a parked roadmap **plus** ADR-202; row 5 cites a **council
+REJECT of 2026-07-07** whose record lives in the archived flow-learnings and
+whose re-open conditions are carried in `later/road-to-deferred-rule-retriever.md:12`
+— a council decision, not an ADR, and citing an ADR number it does not have
+would be the fabrication this table exists to avoid.
+
 ## Corrected from reproduction — two collisions in the source's own text
 
 - **The field name `requires:` is taken.** The source's relationship block lists
@@ -89,11 +103,20 @@ source will otherwise re-propose all six.
       low, it is a new field. Write which, and why, before Phase 2 starts.
       verify: the sentence names the measured count out of twenty, not an
       impression.
-- [ ] **1.3 Kill criterion.** If 15 or more of the 20 already carry a searchable
-      record, Phases 2 to 4 are cancelled and this roadmap closes with the
-      measurement as its deliverable.
-      verify: the criterion is evaluated in writing against 1.1's table, with the
-      cancel or continue stated.
+- [ ] **1.3 Kill criterion, with its own detector validated first.** If 15 or
+      more of the 20 already carry a searchable record, Phases 2 to 4 are
+      cancelled and this roadmap closes with the measurement as its deliverable.
+      **The criterion may not be evaluated until 1.1's detection has been checked
+      in both directions** — added 2026-08-27 per gate finding `e76ae09bb9f2`
+      (medium): a criterion whose instrument is unvalidated can cancel real work
+      on a miss, or authorise unnecessary work on a false hit, and neither is
+      visible from the count alone.
+      verify: before the count is read, one artefact known to carry a record and
+      one known to carry none are run through the same detection and come back
+      positive and negative respectively. Then the criterion is evaluated in
+      writing against 1.1's table, with the cancel or continue stated **and the
+      two-direction check cited**. A count from an instrument never seen fail is
+      not a count.
 
 ## Phase 2 — One disposition vocabulary, reconciled
 

--- a/agents/roadmaps/road-to-composition-before-creation.md
+++ b/agents/roadmaps/road-to-composition-before-creation.md
@@ -169,7 +169,7 @@ would be the fabrication this table exists to avoid.
 
 ## Blockers
 
-### disposition-vocabulary-authority
+### blocker: disposition-vocabulary-authority
 
 - **Status:** open
 - **Owner:** maintainer

--- a/agents/roadmaps/road-to-turn-bound-authorization-integrity.md
+++ b/agents/roadmaps/road-to-turn-bound-authorization-integrity.md
@@ -71,20 +71,53 @@ encourages.
 The repair therefore has a home: it is a predicate in the existing writer, not a
 new store, not a new slot, and not a new contract.
 
+## Independently verified, 2026-08-27 — the claim no longer rests on one file
+
+> The PR that landed this roadmap carried a **critical** blocking-advisory from
+> its own adversarial-review gate (`45e24dabfed9`): the defect claim depended on
+> a single evidence file with no independent verification. It was correct. Two
+> legs were added; the claim survives both, and the verification answered part of
+> Phase 1 before it ran. Full working:
+> `agents/evidence/analysis/mixed-analysis-inbox-verification-2026-08-27.md`
+> § The authorization defect, independently verified.
+
+- **Leg 1, the host's own record.** A `<task-notification>` is stored as
+  `"type":"user","message":{"role":"user"}` — **561 occurrences across 92 of 167**
+  session transcripts in this project's store. It is not merely treated as a
+  prompt by one hook; it **is** a user turn to the host.
+- **Leg 2, the writer.** `git_authorization_hook.ts:468-513` returns early only
+  on empty prompt text (`:490`), then rebuilds and writes the ledger from
+  `classifyAuthorization(prompt)` (`:494`). Nothing in the path reads origin.
+- **A second instance, same function.** `takePending` (`:427`) is called on every
+  prompt (`:499`) and `rmSync`s the pending-refusal file at `:440` **before** any
+  affirmative or origin check. A notification arriving between a refusal and the
+  user's "ja" deletes the pending record, so the affirmative confirms nothing.
+  Step 3.2's sweep therefore starts from one confirmed sibling, not from zero.
+
 ## Phase 1 — Establish what the writer actually receives
+
+> **Partly answered before execution (2026-08-27).** The discriminator exists:
+> the prompt text begins with the literal element `<task-notification>` and
+> carries `<task-id>`, `<tool-use-id>`, `<status>` and `<summary>` children, in
+> all 561 measured occurrences. The "no field differs, so stop here" branch does
+> not fire. Phase 1 is now confirmation and capture, not discovery.
 
 - [ ] **1.1 Capture the raw payload of a machine wake.** Record one
       `user_prompt_submit` payload produced by a background task notification and
       one produced by a typed human prompt, both to `agents/runtime/tmp/`, and
       diff their fields.
-      verify: two captured payloads exist and the diff names at least one field
-      that differs; if no field differs, this roadmap stops here and says so —
-      an undetectable wake cannot be classified and Phase 2 is void.
+      verify: two captured payloads exist and the diff shows the
+      `<task-notification>` element present in one and absent in the other. The
+      transcript measurement is over stored turns; this confirms the same
+      element survives into the payload the hook actually receives, which is the
+      one thing a transcript cannot show.
 - [ ] **1.2 State the discriminator, or state that there is none.** Write the
       field and value that separates the two, in one sentence, into the roadmap
       itself.
       verify: the sentence names a field that appears in the 1.1 capture, quoted
-      verbatim from it rather than from documentation.
+      verbatim from it rather than from documentation or from the 2026-08-27
+      transcript measurement above — a payload key and a stored-turn key are not
+      guaranteed to be the same key.
 
 ## Phase 2 — Classify the wake, and leave a machine wake's ledger alone
 
@@ -113,17 +146,28 @@ new store, not a new slot, and not a new contract.
       replaced it.
       verify: the file names this roadmap and the commit that landed Phase 2.
 - [ ] **3.2 Check for siblings.** Grep the tree for other state that a
-      `user_prompt_submit` concern replaces per turn and would be cleared by the
-      same wake.
-      verify: the count and the file list are reported, zero included. One
-      instance is a sample, not the population.
+      `user_prompt_submit` concern replaces or consumes per turn and would be
+      cleared by the same wake. **One sibling is already confirmed** and is the
+      floor, not the answer: `takePending` (`git_authorization_hook.ts:427`,
+      called at `:499`) `rmSync`s the pending-refusal file at `:440` before any
+      affirmative or origin check.
+      verify: the count and the file list are reported, zero included, and the
+      count is ≥ 1 because the sibling above is known. One instance is a sample,
+      not the population.
+- [ ] **3.3 Decide whether the pending path takes the same predicate.** The
+      Phase 2 predicate answers "did a human type this turn?"; `takePending`
+      needs the same answer before it deletes. State whether it reuses the
+      predicate or is left alone, with the reason.
+      verify: the decision is written into the roadmap, and if it reuses the
+      predicate, a test drives `takePending` with the 1.1 machine payload and
+      asserts the pending file still exists afterwards.
 
 ## Risk Register
 <!-- risk-review: v1 | reviewed: 2026-08-27 | reviewer: claude/host -->
 
 | Rank | Item | Risk type | Description | Mitigation | Anchored under |
 |------|------|-----------|-------------|------------|----------------|
-| 1 | The two payloads are indistinguishable | implementation | The host may deliver a task notification through the identical shape as a typed prompt. Then no predicate exists and every later phase is building on a field that is not there | 1.1 is written to terminate the roadmap rather than to proceed on an assumption, and 1.2 forces the discriminator to be quoted from the capture rather than from documentation | Phase 1 — Establish what the writer actually receives |
+| 1 | The stored turn and the hook payload carry different keys | implementation | Downgraded 2026-08-27 from "the two payloads are indistinguishable", which the transcript measurement refutes: the `<task-notification>` element is present in all 561 measured turns. The residual risk is narrower and real — the transcript records what the host STORED, and the hook reads what the host SENDS. A host that strips the element on the way to the payload would leave 1.1 with nothing to match | 1.1 captures the payload the hook actually receives rather than trusting the transcript, and 1.2 forbids quoting the discriminator from the transcript measurement for exactly this reason | Phase 1 — Establish what the writer actually receives |
 | 2 | The fallback is set the wrong way | product | A predicate that answers "machine" on an unrecognised payload would retain authorization across turns — a strictly worse failure than the one being fixed, and a silent one | 2.1 fixes the unknown case to the clearing branch and requires a unit test on exactly that branch, so the safe direction is asserted rather than intended | Phase 2 — Classify the wake, and leave a machine wake's ledger alone |
 | 3 | The repair is proved by a test that never could fail | implementation | A test driving a writer whose predicate is stubbed, or asserting on a file the test itself wrote, passes against any implementation | 2.3 makes sensitivity an explicit step with both observations recorded, not an implied property of a green run | Phase 2 — Classify the wake, and leave a machine wake's ledger alone |
 | 4 | Only this one consumer is repaired | product | The wake misclassification is a property of the slot, not of this concern, so any other per-turn state has the same defect and would keep it | 3.2 makes the sibling sweep a step with a reported count rather than a closing remark | Phase 3 — Retire the workaround, in writing |
@@ -140,4 +184,9 @@ new store, not a new slot, and not a new contract.
 - [ ] AC-3 — The foreground-wait workaround is documented as retired at the place
       it was documented as required, naming the commit that replaced it.
 - [ ] AC-4 — The sibling sweep for other per-turn state has run and reported a
-      count and a file list. Zero is a reported answer.
+      count and a file list. The count is **≥ 1**: `takePending` is a confirmed
+      instance, so zero here means the sweep is broken, not that the population
+      is empty.
+- [ ] AC-5 — The pending-refusal path has an explicit written decision — reuse
+      the wake predicate or leave it alone — and if it reuses it, a test drives
+      `takePending` with a machine payload and asserts the pending file survives.

--- a/agents/roadmaps/road-to-undeclared-obligation-disposition.md
+++ b/agents/roadmaps/road-to-undeclared-obligation-disposition.md
@@ -1,0 +1,209 @@
+---
+complexity: structural
+status: ready
+execution:
+  mode: phase-checkpoints
+owner: maintainer
+review_by: 2026-11-27
+relates: []
+# relates: `agent-config roadmap:context` on 2026-08-27 — scanned 3 PRs,
+# 784 roadmap file(s) across active/later/stubs/archive, 349 remote branch(es),
+# 3 live session record(s), 0 inbox file name(s). No sibling roadmap on the
+# topic. One soft overlap to declare rather than hide: open PR #1682 edits
+# `src/config/gate-coverage.yml`, which Phase 4 of this roadmap would also
+# touch if it registers a check — a cited-path overlap, not a file conflict,
+# and Phase 4 is gated behind a kill criterion that may cancel it. The probe's
+# fingerprint is its own digest of the inputs it read; a later run whose
+# fingerprint differs has seen a changed estate. Fingerprint b1cce950ff54fb2e,
+# base 612b817e7.
+estate_offset_exempt: "No disposal is available in this change: the dashboard reports the active estate mid-flight with three completion PRs open (#1675, #1679, #1682), so nothing is archivable from here, and parking this would grow the later_roadmaps floor instead of the active one. It folds into no sibling — grepping every active, parked and stub roadmap for `undeclared`, `obligation_frequency` and `check_enforcement_coverage` returns six files, and each owns a different slice: `stubs/road-to-kernel-instruction-only-migration.md` owns exactly one kernel rule's `enforced_by` value, `later/road-to-mixed-trigger-activation-cost.md` owns activation cost, and `archive/road-to-obligation-carrier-audit.md` built the instrument and closed while explicitly leaving this cohort unmeasured. The cohort itself has no owner."
+---
+# Road to disposing the undeclared 82 — the instrument has been printing the number for months and nobody has read it
+
+> **Source:** the adversarial-review findings on PR #1681 (merged `612b817`) and
+> the reconciliation that followed it. Two survivors of a twelve-repository
+> external harvest — "the agent has no mirror for its own prose output" and "the
+> output-shaping obligations are scattered" — were traced to their real cause
+> here rather than taken at face value, and the cause is not a missing skill.
+> It is that **82 of 120 rules declare no enforcement at all**, four of the
+> scattered output rules are in that cohort, and the instrument that reports it
+> has been green while reporting it.
+
+## Goal
+
+Every rule in `src/rules/` carries a disposition for how it is enforced —
+including the honest `instruction-only` with a reason — or is on a written list
+of those that structurally cannot, with the structural reason named. When this
+is finished, `check_enforcement_coverage`'s `undeclared` count is a number
+somebody decided rather than a number nobody read, and a proposal to build a new
+mechanism for an unenforced obligation has to say first why the existing
+disposition is wrong.
+
+## Context — three counts, two instruments, one cohort nobody owns
+
+`check_enforcement_coverage` reports, on 2026-08-27 at `612b817`:
+
+```
+enforcement coverage · 15/120 rules (12.5%) have a backstop that fails a CI build
+  declared 38 · local-only 0 · observer 10 · unwired 0 · missing 0 · undeclared 82
+  frequency: 9 gap · 9 unclassified (kernel — block_kernel_rule_writes denies the field)
+```
+
+**The 82 is confirmed by a second, independent instrument.**
+`grep -L 'enforced_by\|instruction-only' src/rules/*.md` returns exactly 82
+files. Two different readers, same number — so the cohort is a fact about the
+tree, not an artefact of one script's parse.
+
+**Nobody owns it, and that is recorded.** `archive/road-to-obligation-carrier-audit.md`
+built this instrument and closed. Its own disposition table has a row reading
+"Model-carried by design, no claim either way — the 85 undeclared in the
+baseline — **unmeasured**", and step 2 notes "some of the 85 undeclared rules are
+likely this shape". It named the cohort and shipped without dispositioning it.
+The number has since moved 85 → 82 through incidental work, never through a
+decision.
+
+**Why this is the right home for the two harvest survivors.** The external
+analysis proposed a slop-resistant prose skill and an output-shaping contract.
+Checked against the tree: `communication-through-line`, `direct-answers`,
+`no-cheap-questions` and `user-interaction` are all **inside the undeclared 82**.
+So the diagnosis "these obligations are unenforced" is right, and the remedy
+"add a mechanism" skips the step that decides whether one is warranted. That
+step is this roadmap.
+
+## What already exists — read this before proposing a mechanism
+
+- `src/scripts/check_enforcement_coverage.ts` — the instrument. Resolves
+  declaration to a **reachable** carrier, counts `observer` separately from
+  `validator`, and treats `none` as a legal counted value. Do not rebuild it.
+- `src/scripts/probe_session_canary.ts`, `src/scripts/probe_promissory_closing.ts` —
+  the per-obligation transcript-probe pattern, already twice instantiated,
+  exit-0-always, each stating its own honest bound. A new probe is a third
+  instance of a shipped pattern, never a new kind of thing.
+- `stubs/road-to-kernel-instruction-only-migration.md` — owns the one kernel rule
+  whose `enforced_by: none` cannot be retired by an agent write. This roadmap
+  must not touch a kernel rule; `block_kernel_rule_writes` denies it anyway.
+- `docs/contracts/hook-architecture-v1.md` § Stop-event capability tiers — the
+  per-host answer to what a `stop`-slot verdict can do. Any mechanism proposal
+  reads this before claiming enforcement.
+
+## Phase 1 — Disposition the cohort, without building anything
+
+- [ ] **1.1 Emit the list.** Produce the 82 file names with, per rule, its
+      `type`, its trigger kind and whether any script, hook or test mentions it.
+      This is a report, not a change.
+      verify: the list is written to `agents/evidence/analysis/`, its count
+      matches `check_enforcement_coverage`'s `undeclared` exactly, and a
+      mismatch is reported rather than reconciled by hand.
+- [ ] **1.2 Sort into four buckets, one pass, no mechanism design.**
+      `already-carried` (a carrier exists and the declaration is merely missing) ·
+      `cheaply-probeable` (the transcript-probe pattern would fit) ·
+      `instruction-only-by-nature` (the obligation is a pre-action reasoning step
+      nothing can observe) · `structurally-blocked` (kernel).
+      verify: every one of the 82 lands in exactly one bucket, the counts sum to
+      82, and each `already-carried` row names the carrier with a file path.
+- [ ] **1.3 Land the free half.** Every `already-carried` rule gets its
+      declaration written; every `instruction-only-by-nature` rule gets
+      `instruction-only: <reason>` with the reason stated at the rule.
+      verify: `check_enforcement_coverage`'s `undeclared` count drops by exactly
+      the size of those two buckets, and the run is quoted before and after. No
+      kernel rule is touched.
+
+## Phase 2 — Decide the cheaply-probeable bucket on evidence
+
+- [ ] **2.1 Rank it by measured failure, not by feel.** For each
+      `cheaply-probeable` rule, record whether a measured failure rate exists
+      anywhere in the tree, and cite it. Two already do:
+      `src/rules/session-canary.md:105` records the opening canary dropped on
+      **24 of 29** task starts with the honesty clause firing **0** times, and
+      `src/rules/user-interaction.md:75` records that **no gate ships** for the
+      malformed-ask class because the existing checker "scans exactly the surface
+      that did not fail".
+      verify: the table separates rules with a cited measurement from rules with
+      none, and the second group is the larger one or the claim is wrong.
+- [ ] **2.2 Build at most one probe, for the top-ranked rule only.** A third
+      instance of the shipped pattern: reads the transcript store, exits 0
+      always, states its own bound, and reports a rate.
+      verify: the probe runs, prints a rate and a denominator, and a
+      deliberately malformed fixture turn is detected — an instrument never seen
+      fire has unknown sensitivity.
+- [ ] **2.3 Stop after one.** No second probe is built in this roadmap whatever
+      2.2 finds.
+      verify: the roadmap closes with one probe or none. A batch of probes is the
+      roadmap-explosion failure this whole line of work exists to refuse.
+
+## Phase 3 — Write down what cannot be dispositioned, and why
+
+- [ ] **3.1 State the kernel exception as a list, not as a shrug.** Name the
+      nine rules `check_enforcement_coverage` reports as `unclassified`, and for
+      each say whether it would be `instruction-only` if the field could be
+      written.
+      verify: the list has nine entries and cites
+      `block_kernel_rule_writes` as the reason the write is impossible, with the
+      stub that owns the one live case.
+- [ ] **3.2 Record the residual honestly.** Whatever remains undeclared after
+      Phase 1 is stated as a number with a reason per rule.
+      verify: the residual count plus the four bucket counts equals 82.
+
+## Phase 4 — A gate, only if Phase 1 earned one
+
+- [ ] **4.1 Ratchet the count, do not block a rule.** If and only if the
+      residual from 3.2 is small enough to hold, register the `undeclared` count
+      as a ratcheted metric so it cannot silently grow, with a `reportScanned`
+      count and a `--self-test`.
+      verify: the gate is green on the current tree and its canary — a newly
+      added rule file carrying no declaration, enumerated with the
+      others-listing form of `ls-files` — is reported, so a diff-scoped check is
+      not silently blind. Coordinate with open PR #1682, which also edits
+      `src/config/gate-coverage.yml`.
+
+## Blockers
+
+### is-a-declaration-worth-anything
+
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** Phase 4 only. Phases 1 to 3 land regardless and are the deliverable.
+- **What to do:** pick exactly one — (a) a declaration is worth ratcheting, so
+  the count becomes a gated metric; (b) it is documentation only, so the count
+  stays a report nobody gates; or (c) decide after Phase 1 has produced the four
+  bucket counts, when the question is answerable against a distribution instead
+  of against an intention.
+- **Resolved when:** the answer is recorded in this roadmap, and for (a) the gate
+  is registered in `src/config/gate-coverage.yml`.
+- **Recommendation:** (c). The whole argument for a ratchet depends on how big
+  the `instruction-only-by-nature` bucket turns out to be — if most of the 82 are
+  genuinely unobservable, a ratchet gates a number that cannot improve, which is
+  a gate on a constant.
+- **If you do nothing:** Phases 1 to 3 still convert 82 undeclared rules into 82
+  decided ones, which is the entire value. Phase 4 is the optional half.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-08-27 | reviewer: claude/host -->
+
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | The bucketing becomes 82 rubber stamps | product | `instruction-only` is the cheap answer for every row, and a pass that writes it 82 times converts an honest unknown into a false settled state — strictly worse than the current gap, because the count then reads as dispositioned | 1.2 forces exactly one bucket per rule with the `already-carried` rows naming a file path, and 2.1 forces the probeable bucket to be ranked by a cited measurement rather than by judgement; a bucket that swallows everything is visible in the sums | Phase 1 — Disposition the cohort, without building anything |
+| 2 | Phase 2 turns into a probe factory | product | Once the pattern is instantiated a third time, the marginal cost of a fourth looks near zero, and the estate acquires N probes measuring N rates nobody reads | 2.3 caps the roadmap at one probe as an explicit step rather than as restraint, and the cap is an acceptance criterion | Phase 2 — Decide the cheaply-probeable bucket on evidence |
+| 3 | A declaration is mistaken for enforcement | implementation | Writing `enforced_by:` on a rule changes the count without changing what happens at runtime; a later reader sees coverage improve and concludes the obligations got safer | 1.3 splits the free half into carrier-exists and nature-is-unobservable, and the instrument already separates `observer` from `validator`, so a declaration cannot upgrade a rule that only instruments | Phase 1 — Disposition the cohort, without building anything |
+| 4 | The kernel nine are treated as a defect to fix | implementation | They are unclassifiable because a guard denies the write, and an attempt to route around that guard is a kernel-rule edit under a slow-rollout contract this roadmap has no mandate for | 3.1 makes the kernel list an output rather than a target, and the roadmap states in Phase 1 that no kernel rule is touched | Phase 3 — Write down what cannot be dispositioned, and why |
+| 5 | The count moves under the roadmap | implementation | Three completion PRs are open; incidental work has already moved this number 85 → 82 without a decision, so a plan written against 82 can be measuring a different cohort by the time it runs | 1.1 requires the emitted list's count to match the instrument's on the same run and to report a mismatch rather than reconcile it, and 3.2 closes on sums rather than on the original 82 | Phase 1 — Disposition the cohort, without building anything |
+
+## Acceptance Criteria
+
+- [ ] AC-1 — The 82 undeclared rules each carry exactly one bucket, the four
+      bucket counts sum to the instrument's own `undeclared` reading taken on the
+      same run, and every `already-carried` row names its carrier by file path.
+- [ ] AC-2 — `check_enforcement_coverage`'s `undeclared` count is quoted before
+      and after Phase 1, and the drop equals the size of the two buckets Phase 1.3
+      addresses. No kernel rule appears in the diff.
+- [ ] AC-3 — The probeable bucket is ranked with a cited measurement per rule
+      that has one, and the rules with no measurement are the larger group —
+      stated as counts, so the claim is falsifiable.
+- [ ] AC-4 — At most one probe exists at the end of this roadmap, and it has been
+      seen to fire on a deliberately malformed fixture.
+- [ ] AC-5 — The nine kernel rules are listed with the reason the field cannot be
+      written and the stub that owns the live case, and the residual undeclared
+      count is stated with a per-rule reason.
+- [ ] AC-6 — No new mechanism is proposed anywhere in this roadmap for an
+      obligation whose bucket is `instruction-only-by-nature`. An unobservable
+      obligation does not get a gate because it would be nice if it did.

--- a/agents/roadmaps/road-to-undeclared-obligation-disposition.md
+++ b/agents/roadmaps/road-to-undeclared-obligation-disposition.md
@@ -16,6 +16,7 @@ relates: []
 # fingerprint is its own digest of the inputs it read; a later run whose
 # fingerprint differs has seen a changed estate. Fingerprint b1cce950ff54fb2e,
 # base 612b817e7.
+estate_growth_exempt: "open_blockers 42 -> 44, and the rise is a CORRECTION rather than growth — a distinction this gate has no field for, so it is stated here. Both blockers already existed and were invisible to `update_roadmap_progress.ts:439`, whose `BLOCKER_HEADING_RE` requires a literal `blocker:` prefix that neither heading carried: this roadmap's own, and `road-to-composition-before-creation.md`'s, which landed unparsed in PR #1681. Repairing the two headings is what made them countable; nothing new was added to the backlog. Four further instances across three files are recorded in `stubs/road-to-blocker-parse-visibility.md` and deliberately not repaired here — one is being archived by open PR #1682, and two sit in drafts with open owner decisions. The gate defect behind it is also recorded there: `lint_roadmap_blockers` reported this file blocker-contract-clean while its blocker parsed to nothing."
 estate_offset_exempt: "No disposal is available in this change: the dashboard reports the active estate mid-flight with three completion PRs open (#1675, #1679, #1682), so nothing is archivable from here, and parking this would grow the later_roadmaps floor instead of the active one. It folds into no sibling — grepping every active, parked and stub roadmap for `undeclared`, `obligation_frequency` and `check_enforcement_coverage` returns six files, and each owns a different slice: `stubs/road-to-kernel-instruction-only-migration.md` owns exactly one kernel rule's `enforced_by` value, `later/road-to-mixed-trigger-activation-cost.md` owns activation cost, and `archive/road-to-obligation-carrier-audit.md` built the instrument and closed while explicitly leaving this cohort unmeasured. The cohort itself has no owner."
 ---
 # Road to disposing the undeclared 82 — the instrument has been printing the number for months and nobody has read it
@@ -158,7 +159,7 @@ step is this roadmap.
 
 ## Blockers
 
-### is-a-declaration-worth-anything
+### blocker: is-a-declaration-worth-anything
 
 - **Status:** open
 - **Owner:** maintainer

--- a/agents/roadmaps/stubs/road-to-blocker-parse-visibility.md
+++ b/agents/roadmaps/stubs/road-to-blocker-parse-visibility.md
@@ -1,0 +1,80 @@
+---
+complexity: lightweight
+review_by: 2026-12-27
+---
+
+# Stub: road to a blocker the parser can actually see
+
+> **Stub — not active work.** Found 2026-08-27 while landing
+> `road-to-undeclared-obligation-disposition`, when the dashboard reported that
+> roadmap's blocker column as `0` and the roadmap plainly had a blocker. Two of
+> the six instances were repaired in that change because they were its own; the
+> rest and the gate defect behind them are recorded here rather than fixed
+> drive-by.
+
+## The defect
+
+`update_roadmap_progress.ts:439` reads blocker headings with
+
+```
+BLOCKER_HEADING_RE = /^###[ \t]+blocker:[ \t]*(.+?)[ \t]*$/gim
+```
+
+The literal `blocker:` prefix is **required**. A section written as
+`### <id>` under a correct `## Blockers` heading parses to nothing — the
+roadmap reports zero blockers, and every consumer downstream of the parser
+agrees with it.
+
+## Three consequences, in rising order of cost
+
+1. **The dashboard under-reports.** A roadmap with real, open, owner-assigned
+   blockers shows `0` in the blockers column and no anchor section.
+2. **`check_estate_count`'s `open_blockers` metric is an undercount**, and it is
+   a **ratcheted** metric measured against an exact base-ref floor. The gate's
+   own header notes that a quality anchor is phrased on it. A ratchet running on
+   a number that silently omits an unknown share of the population is measuring
+   something other than what it claims.
+3. **`lint_roadmap_blockers` reports the affected file clean.** It validates the
+   per-blocker contract for each blocker it parses; a file whose blockers all
+   parse to nothing has zero to validate and passes vacuously. Verified
+   2026-08-27: the linter printed `blocker-contract-clean` for
+   `road-to-undeclared-obligation-disposition.md` while that roadmap's blocker
+   was invisible. This is the "a gate that scans nothing exits green" shape this
+   tree has recorded before, arriving through the blocker door.
+
+## Measured instances at `612b817`
+
+`grep -rn '^### ' agents/roadmaps/*.md | grep -v '### blocker:'` returns six
+headings that sit under a `## Blockers` section without the prefix, across five
+files:
+
+| File | Heading | Disposition |
+|---|---|---|
+| `road-to-composition-before-creation.md` | `disposition-vocabulary-authority` | **repaired 2026-08-27** — own file, in the same change |
+| `road-to-undeclared-obligation-disposition.md` | `is-a-declaration-worth-anything` | **repaired 2026-08-27** — own file, in the same change |
+| `road-to-consolidation-lineage-integrity.md` | `lineage-check-enforcement-surface` | **not touched** — open PR #1682 completes and archives this file; editing it here would conflict with a run already under way |
+| `road-to-governed-harness-evolution.md` | `merge-authority` | not touched — `status: draft`, and drafts are excluded from `collect()` so the metric is unaffected today; it becomes a live undercount the moment the file is promoted |
+| `road-to-experience-loop-broadening.md` | `runtime-consumption-of-experience`, `experience-retention-policy` | same, two headings |
+
+Other `### ` headings in the estate (`Council convergence`, phase sub-headings)
+are outside a `## Blockers` section and are not instances.
+
+## What would close this
+
+- Repair the remaining four headings, each in a change that already touches its
+  file — never as a sweep across roadmaps with open owner decisions.
+- Make `lint_roadmap_blockers` refuse a vacuous pass: a file carrying a
+  `## Blockers` section whose parsed blocker count is zero is a finding, not a
+  clean bill. That is the half worth building, because it turns a silent class
+  into a reported one and it is the only change here that prevents recurrence.
+- Decide whether `open_blockers`' floor should be re-measured after the repairs.
+  It will rise, and the rise is a correction rather than growth — which is a
+  distinction the estate gate has no way to express today, so it needs a stated
+  reason in whatever change lands it.
+
+## What this stub deliberately does not do
+
+Propose loosening the regex to accept a bare `### <id>`. Every `###` heading
+inside `## Blockers` would then be a blocker, including prose sub-headings, and
+the failure would invert from silent-undercount to silent-overcount. The prefix
+is a reasonable contract; the defect is that nothing reports its violation.


### PR DESCRIPTION
PR #1681 merged (`612b817`) carrying **two blocking-advisory findings from its
own review gate**, and a reconciliation followed it naming three survivors of
the external harvest. This answers the findings against the tree and emits one
roadmap out of the three.

## The two blocking findings

**`74007388aa70` (high) — "Headline 70% ownership claim lacks denominator."**
Correct, and the percentage is **withdrawn rather than recomputed**. It was
never taken against a stated set. The countable version: the source program
carries **47** numbered sub-items, the record checked **16**, and of those
**4** are owned outright — **31 sub-items were never checked at all**. A
per-track percentage would additionally need a weighting nobody chose, since
the tracks differ in size (8 sub-items in one, 4 in another).

The ownership count fell from 5 to 4 *during this pass*, when one row's
`already-fixed` verdict was re-examined and did not hold. A count that moves
when a row is re-read is the argument for withdrawing the percentage rather
than restating it.

**`45e24dabfed9` (critical) — "Authorization defect depends on a single
evidence file."** Correct as written; it rested on two prose lines in one
narrative record. Two independent legs now:

- **The host's own record.** A `<task-notification>` is stored as
  `"type":"user","message":{"role":"user"}` — **561 occurrences across 92 of
  167** session transcripts. It is not *treated* as a prompt by one hook; it
  **is** a user turn.
- **The writer.** `git_authorization_hook.ts:468-513` returns early only on
  empty prompt text, then rebuilds and writes the ledger. Nothing in the path
  reads origin.

Verifying it produced two things the roadmap did not have. The **discriminator**
Phase 1 was written to go hunting for is the literal `<task-notification>`
element, present in all 561 measured turns — so the "no field differs, stop
here" branch does not fire, and Phase 1 becomes confirmation rather than
discovery. And a **second instance in the same function**: `takePending`
(`:427`, called `:499`) removes the pending-refusal file at `:440` before any
affirmative or origin check, so a notification arriving between a refusal and
the user's "ja" deletes the record the affirmative would have confirmed. Step
3.2's sibling sweep now starts from one confirmed instance instead of zero.

Four advisory findings are answered too: the step-3 classification (the step
succeeded, the answer was partial — `diverged` was the wrong label), the
`tmp.old` sanitization premise (the folder is gitignored and was never
committed; the half that does hold is recorded with what discharged it), the
composition roadmap's kill criterion (its detector must be checked in both
directions before the count is read), and its fingerprint and
authority-citation gaps.

## One roadmap out of three survivors

The reconciliation named three items as unowned. Each was checked before
anything was written.

**Slop-resistant surfaces — half right, and the remedy does not follow.** The
drain marked this `already-fixed` citing `humanizer`; that verdict does not
survive inspection — `humanizer` is scoped to *deliverable* prose, sits under
`gtm-marketing` with no `default_install` and `workspaces: [gtm, founder]`, so
an engineering install never receives it. But tracing further: the four rules
carrying the obligation — `communication-through-line`, `direct-answers`,
`no-cheap-questions`, `user-interaction` — are all inside
`check_enforcement_coverage`'s **undeclared 82**. The gap is not a missing
skill.

**`road-to-undeclared-obligation-disposition`** is the resulting roadmap.
**82 of 120 rules declare no enforcement at all**, confirmed by two instruments
that agree exactly (the gate's own count, and `grep -L` over `src/rules/*.md`).
The archived audit that *built* the instrument closed while calling the cohort
"unmeasured, no claim either way"; the number has since moved 85 → 82 through
incidental work, never through a decision. Phases 1–3 convert it into buckets
and land the free half; a gate is Phase 4 and is blocked on whether a
declaration is worth ratcheting at all — ratcheting a count that cannot improve
is a gate on a constant. At most one probe is built, as a step rather than as
restraint.

**Output-shaping contract** and **runtime load-order** are both real gaps with
**no observed failure**, so neither gets a roadmap. Recorded as candidates. One
claimed anchor was checked and is closed: `lint_hidden_unicode` now runs a
second pass over 8,462 tracked text files, so the `src/scripts/` blind spot a
prior measurement recorded no longer exists.

## A finding this change made rather than answered

The dashboard reported the new roadmap's blocker column as `0` while the
roadmap plainly had a blocker.

`BLOCKER_HEADING_RE` (`update_roadmap_progress.ts:439`) requires a literal
`blocker:` prefix. A section written `### <id>` parses to nothing, and every
consumer agrees with the parser. Three consequences, rising in cost:

1. the dashboard under-reports;
2. **`open_blockers` is a ratcheted metric running on the undercount**;
3. `lint_roadmap_blockers` printed `blocker-contract-clean` for the affected
   file — it validates each blocker it parses, so zero parsed blockers pass
   vacuously.

Six instances across five roadmaps. **Two repaired** (this line of work's own,
including one that landed unparsed in #1681); **four recorded** in
`stubs/road-to-blocker-parse-visibility.md` rather than swept — one file is
being archived by open PR #1682, and two are drafts with open owner decisions
where a drive-by edit would collide with whoever resolves them. The stub also
declines the obvious fix of loosening the regex, which would invert a silent
undercount into a silent overcount.

## Estate

`active_roadmaps` 10 → 11 on an offset exemption. `open_blockers` 42 → 44 on a
growth claim that states the rise is a **correction, not growth**: both
blockers already existed and were unparseable. The gate has no field for that
distinction, so the reason carries it.

## Gates

`check_estate_count`, `check_roadmap_trackable` (7 against a baseline of 9),
`lint_roadmap_blockers`, `lint_plan_risk_register`, `check_references`,
`check_no_external_sources`, `lint_evidence_artifacts`,
`check_completion_review`, `npm run typecheck`. All green locally.
