### PR TITLE
fix(gate): the supervision pattern matched a denial, and six more review findings

### DIFF
--- a/agents/evidence/drain-run-summary.md
+++ b/agents/evidence/drain-run-summary.md
@@ -459,3 +459,52 @@ Its window is extended to 2026-11-23 with the reason in the file. It was **not**
 promoted to `stable`: `STABILITY.md` reserves that for contracts settled through
 a major release, and this one's surface changed as recently as `e5e4c48d6`.
 Promotion is a maintainer review this run is not entitled to make.
+
+## Post-hoc: a neutral code review, and it found an inversion
+
+The stop-hook flagged that the session had mutated ~98 non-doc lines with no
+neutral review. A council round was run over the **whole** code delta — every
+change under `src/scripts/` and `tests/scripts/`, scope not chosen by the author
+— with a prompt stating no expected outcome, per `evaluator-independence`. The prompt and the exact diff it reviewed are committed at
+`agents/evidence/reviews/runtime-governance-code.review-input/` — that path
+rather than `agents/runtime/council/questions/`, which is gitignored and would
+have made the prompt unrecoverable. A recorded verdict whose prompt nobody can
+read is not evidence.
+
+**Verdict: "do not merge as written."** It was right.
+
+The worst finding **inverted the gate this run had just built**:
+`SUPERVISION_CLAIM_RE` matched `The resident process is **not** supervised.` —
+`not` was absorbed by the 0-to-3-word gap — so `check_supervision_claim_atomicity`
+would have **refused a truthful denial** of the capability while the false claim
+it exists to catch reads identically minus one word. The test suite claimed to
+cover "negative statements" and tested a different grammatical form. Both seats
+found it independently; neither was told what to look for.
+
+Six more, every one reproduced before being fixed:
+
+| Finding | Was |
+|---|---|
+| markdown emphasis escapes | `**supervised**` never matched — `\b` does not match inside `**`, i.e. a false negative on the formatting a README actually uses |
+| type coercion in evidence | `cases_run: "abc"` passed every comparison and read as **sufficient evidence**; `"12"` was refused for a wrong reason by lexicographic compare |
+| negative counts | `cases_run: -5` accepted as a count |
+| blank suite name | `suite: "   "` accepted as named |
+| `## Not reopened` too loose | accepted `###`, and accepted an **empty** section — both forbidden by the check's own error message |
+| malformed `date:` | bought the grandfathered warning instead of failing to the error |
+| self-test over-advertised | the docstring named a mocked-process negative the case list did not contain |
+
+All closed with regression cases. Self-test **4/4 → 7/7, 5 rejecting**, including
+a `denial needs no evidence` accepting control. 141 unit cases across the three
+touched test files.
+
+A **§ Known limits** section was added rather than the pattern widened — one
+physical line at a time, copula-only so active voice escapes, no grammatical
+subject resolution, no markdown-structure awareness, a bounded-window negation
+heuristic. The gate is a **floor, not a proof**.
+
+**The lesson is about the run, not the regex.** Everything else in this run was
+verified against gates and measurements, and the gates all passed on the broken
+code — the self-test was green at 4/4 while the pattern was inverted, because a
+self-test only proves the cases someone thought to write. Nothing in the run's
+own discipline would have caught it. The neutral read did, and it was prompted by
+a hook rather than by the plan.

--- a/agents/evidence/reviews/runtime-governance-code.review-input/diff.patch
+++ b/agents/evidence/reviews/runtime-governance-code.review-input/diff.patch
@@ -1,0 +1,882 @@
+diff --git a/src/scripts/check_adr_frontmatter.ts b/src/scripts/check_adr_frontmatter.ts
+index 2d6b55c6a..2b15ec8d2 100644
+--- a/src/scripts/check_adr_frontmatter.ts
++++ b/src/scripts/check_adr_frontmatter.ts
+@@ -60,6 +60,20 @@ const ADR_DIR = path.join(REPO_ROOT, 'docs', 'decisions');
+  */
+ export const REVIEW_TRIGGER_SINCE = '2026-07-25';
+ 
++/**
++ * Staging date for the `## Not reopened` obligation on a scoped supersession
++ * (road-to-runtime-governance-flip step 1.4). Same shape and same reason as
++ * `REVIEW_TRIGGER_SINCE`: a new structural requirement is an error on records
++ * written after it and a warning on records written before, so the gate does
++ * not retroactively red the corpus it is being added to.
++ *
++ * Two records predate it and warn: `ADR-124` (2026-07-23) and `ADR-209`
++ * (2026-08-03). Both carry a real `supersedes_scope` and neither states its
++ * remainder in a section — measured, not assumed, and left visible as a warning
++ * rather than silenced with a baseline file.
++ */
++export const SCOPED_SUPERSESSION_SINCE = '2026-08-27';
++
+ /** Fields every ADR must carry — the shape that already exists in practice. */
+ const REQUIRED = ['adr', 'status', 'date', 'decision'] as const;
+ 
+@@ -264,6 +278,7 @@ export function check_one(rel: string, text: string): AdrFinding[] {
+     }
+     check_reopen_authority(rel, fm, findings);
+     check_amendment_shape(rel, fm, findings);
++    check_scoped_supersession(rel, fm, text, findings);
+     const parsed = readAdrFrontmatter(text);
+     if (parsed !== null) check_descriptive_axes(rel, parsed, findings);
+     return findings;
+@@ -552,6 +567,79 @@ export function check_amendment_shape(
+     }
+ }
+ 
++/**
++ * Validate a SCOPED supersession — the `supersedes_scope` / `superseded_scope`
++ * pair documented at `docs/contracts/adr-layout.md:59-60, 105-117`.
++ *
++ * Two invariants, both decidable from one file, both taken from that contract's
++ * own text rather than invented here:
++ *
++ * 1. **A scope with no refs is not a supersession.** The contract says so
++ *    literally — "A scope with no refs is not a supersession and renders as
++ *    `—`" — and `regenerate_index.ts` → `supersessionCell` silently drops the
++ *    scope in that case, so the author's intent disappears with no signal.
++ * 2. **A scoped supersession names what it did NOT reopen.** Narrowing a
++ *    prohibition to one row is precisely when a reader needs the boundary
++ *    stated, and a `## Not reopened` section is where this corpus states it.
++ *    Without the section, "supersedes ADR-NNN, partially" is an assertion with
++ *    no stated remainder, and the remainder is the whole content of a partial
++ *    supersession.
++ *
++ * **What this deliberately does NOT check**, because it is not observable: it
++ * cannot require a scope wherever partial supersession was *intended*. Intent
++ * is not in the file. A whole-document supersession that should have been
++ * scoped passes this check, and closing that gap needs stable section
++ * identifiers rather than prose scopes — recorded as the known limit rather
++ * than implied away.
++ *
++ * road-to-runtime-governance-flip step 1.4, which asked for exactly one thing:
++ * make the required section enforceable, or drop the word "required".
++ */
++export function check_scoped_supersession(
++    rel: string,
++    fm: Record<string, string>,
++    text: string,
++    findings: AdrFinding[],
++): void {
++    const placeholder = (v: string | undefined): boolean =>
++        v === undefined || v.trim() === '' || v.trim() === '—' || v.trim() === '-';
++
++    for (const [scopeKey, refKey] of [
++        ['supersedes_scope', 'supersedes'],
++        ['superseded_scope', 'superseded_by'],
++    ] as const) {
++        if (placeholder(fm[scopeKey])) continue;
++        if (placeholder(fm[refKey])) {
++            findings.push({
++                file: rel,
++                level: 'error',
++                message:
++                    `\`${scopeKey}\` is set but \`${refKey}\` names no ADR. A scope with no refs ` +
++                    'is not a supersession (adr-layout § Frontmatter) — the index renders it as ' +
++                    '`—` and the scope text is lost. Name the record, or drop the scope.',
++            });
++        }
++    }
++
++    // The "Not reopened" obligation is on the record that PERFORMS the scoped
++    // supersession, never on the one that receives it: the successor is what
++    // has to state the remainder.
++    if (placeholder(fm['supersedes_scope'])) return;
++    if (!/^#{2,3}\s+Not reopened\s*$/im.test(text)) {
++        const date = fm['date'] ?? '';
++        const staged = date !== '' && date < SCOPED_SUPERSESSION_SINCE;
++        findings.push({
++            file: rel,
++            level: staged ? 'warn' : 'error',
++            message:
++                'a scoped supersession (`supersedes_scope`) must carry a `## Not reopened` ' +
++                'section naming what the narrowing leaves standing. Partially superseding a ' +
++                'record without stating the remainder reads as a general relaxation, which is ' +
++                'the reading a safety floor cannot survive.',
++        });
++    }
++}
++
+ /**
+  * Corpus-level check: every `amends:` has its reciprocal `amended_by:` and vice
+  * versa. Its absence for the `supersedes:` / `superseded_by:` pair is exactly
+diff --git a/src/scripts/check_claims.ts b/src/scripts/check_claims.ts
+index 38493e5e9..c911b17f7 100644
+--- a/src/scripts/check_claims.ts
++++ b/src/scripts/check_claims.ts
+@@ -178,6 +178,19 @@ export interface LedgerEntry {
+      * ledger exists to make impossible.
+      */
+     superseded_by: string;
++    /**
++     * REQUIRED on a `withdrawn` entry: the decision record that retired the
++     * claim. Empty everywhere else.
++     *
++     * `road-to-runtime-governance-flip` Phase 2, on an AI council ruling
++     * (2026-08-27, 4/4 across two rounds). `withdrawn` is the ledger's third
++     * closure — a claim that was true and asserted, and that the package decided
++     * to stop having. The status alone does not say WHOSE decision, and a
++     * withdrawal nobody can trace to a record is an unexplained deletion wearing
++     * a status. Requiring the pointer is what keeps the fourth status from
++     * becoming the dumping ground both council rounds warned about.
++     */
++    retired_by: string;
+     /**
+      * Optional: the build a quantitative measurement describes, when that is not
+      * the current one.
+@@ -256,6 +269,7 @@ function load_ledger(): Map<string, LedgerEntry> {
+                 status: cur.status ?? '',
+                 last_verified: cur.last_verified ?? '',
+                 superseded_by: cur.superseded_by ?? '',
++                retired_by: cur.retired_by ?? '',
+                 measured_on: cur.measured_on ?? '',
+                 non_inference: cur.non_inference ?? '',
+             });
+@@ -275,7 +289,7 @@ function load_ledger(): Map<string, LedgerEntry> {
+         // would have silently ignored the second and dropped whichever field
+         // came from the other branch. One union, both fields.
+         const field = line.match(
+-            /^-\s+(claim|kind|evidence|status|last_verified|superseded_by|measured_on|non_inference):\s*(.*)$/,
++            /^-\s+(claim|kind|evidence|status|last_verified|superseded_by|retired_by|measured_on|non_inference):\s*(.*)$/,
+         );
+         if (field) {
+             const key = field[1] as keyof LedgerEntry;
+@@ -431,13 +445,19 @@ function main(argv: string[] = process.argv.slice(2)): number {
+     //     reader arriving at a `resolved-null` learns the question was reopened
+     //     by a different mechanism — a dangling id would send them nowhere, and
+     //     the field on a live entry would claim a closure that never happened.
++    //
++    //     `withdrawn` joins `resolved-null` as a closure that may carry a
++    //     successor (road-to-runtime-governance-flip Phase 2). The two are
++    //     different closures — one is "we measured and the threshold was missed",
++    //     the other is "we decided to stop having the property" — but both are
++    //     closed, and both leave a reader who needs the forward link.
+     for (const entry of ledger.values()) {
+         if (!entry.superseded_by) continue;
+-        if (entry.status !== 'resolved-null') {
++        if (entry.status !== 'resolved-null' && entry.status !== 'withdrawn') {
+             findings.push({
+                 id: entry.id,
+                 file: LEDGER_REL,
+-                reason: `superseded_by is only meaningful on a resolved-null entry (status: ${entry.status || 'missing'})`,
++                reason: `superseded_by is only meaningful on a closed entry — resolved-null or withdrawn (status: ${entry.status || 'missing'})`,
+             });
+             continue;
+         }
+@@ -456,6 +476,31 @@ function main(argv: string[] = process.argv.slice(2)): number {
+         }
+     }
+ 
++    // 2c. A withdrawal names the decision that retired it. Without the pointer
++    //     `withdrawn` says only "this closed for a reason that was not a
++    //     measurement", which is the half of the statement a reader can already
++    //     infer from the absence of `resolved-null`.
++    for (const entry of ledger.values()) {
++        if (entry.status !== 'withdrawn') continue;
++        if (!entry.retired_by) {
++            findings.push({
++                id: entry.id,
++                file: LEDGER_REL,
++                reason: 'status is withdrawn but no `retired_by` names the decision that retired it',
++            });
++        }
++        continue;
++    }
++    for (const entry of ledger.values()) {
++        if (entry.retired_by && entry.status !== 'withdrawn') {
++            findings.push({
++                id: entry.id,
++                file: LEDGER_REL,
++                reason: `retired_by is only meaningful on a withdrawn entry (status: ${entry.status || 'missing'})`,
++            });
++        }
++    }
++
+     // 3. Witness sweep (road-to-opt-subagent-harvest P1.2): a QUANTIFIED
+     //    capability claim on a marketing-class surface must be witnessed — a
+     //    `<!-- claim:ID -->` marker on the same line, or an explicit
+diff --git a/src/scripts/check_supervision_claim_atomicity.ts b/src/scripts/check_supervision_claim_atomicity.ts
+new file mode 100644
+index 000000000..065a0803c
+--- /dev/null
++++ b/src/scripts/check_supervision_claim_atomicity.ts
+@@ -0,0 +1,339 @@
++/**
++ * A present-tense supervision claim on a public surface must be backed by a
++ * lifecycle result from THIS revision, or it does not ship.
++ *
++ * `road-to-runtime-governance-flip` step 3.4. ADR-249 permits a supervised
++ * resident process in core and deliberately does **not** assert that one behaves
++ * as described — nothing supervised has shipped. The gap between "we adopted
++ * this policy" and "this property holds" is exactly where an unproven capability
++ * claim lands on a public page, and the roadmap's Phase 3 exists because the
++ * first draft would have let it.
++ *
++ * **What the gate refuses.** A public surface asserting, in the present tense,
++ * that a resident process IS supervised / bounded / isolated / auto-restarted /
++ * lifecycle-managed — while no lifecycle evidence for the current revision
++ * exists. The policy statement ADR-249 authorises is not a claim of this kind
++ * and is not matched: "resident processes are permitted only under the
++ * supervision contract" names an adopted rule, and the patterns below are
++ * written to require a copula plus a property, not a permission.
++ *
++ * **Why a file-presence check is not enough.** A council seat named this
++ * directly: "a file-presence check can masquerade as evidence". So the evidence
++ * artifact must establish four separate things, and each is a distinct refusal:
++ *
++ * 1. the named suite exists at all;
++ * 2. it ran on **this** revision (`revision` equals `git rev-parse HEAD`);
++ * 3. it exercised **real processes** (`processes_exercised: true`);
++ * 4. its result was neither empty nor skipped (`cases_run > 0`, and
++ *    `cases_run > cases_skipped`).
++ *
++ * A suite that ran on a parent commit, a suite with every case skipped, and a
++ * suite that mocked the process layer are three different lies, and a gate that
++ * collapses them into "the file is there" catches none of them.
++ *
++ * **Today it passes vacuously, and says so.** No public surface carries a
++ * supervision claim, so the evidence side is never reached. That is the correct
++ * state — but a gate that scans a corpus and finds nothing is indistinguishable
++ * from a blind one, which is why `--self-test` plants all three seeded negatives
++ * and asserts each one reds.
++ */
++
++import { execFileSync } from 'node:child_process';
++import fs from 'node:fs';
++import path from 'node:path';
++import { fileURLToPath, pathToFileURL } from 'node:url';
++
++import { GateLedger } from './_lib/gate_ledger.js';
++import { runGateCli, runSelfTest, type SelfTestCase } from './_lib/gate_self_test.js';
++import { reportScanned } from './_lib/scan_scope.js';
++
++/** Public surfaces a reader of this project actually lands on. */
++export const PUBLIC_SURFACES = [
++    'README.md',
++    'docs/comparison.yaml',
++    'docs/positioning-evidence.md',
++    'docs/proof.md',
++    'docs/us-vs-the-category.md',
++    'docs/getting-started-by-role.md',
++    'docs/governance-advantage.md',
++    'docs/featured-skills.md',
++] as const;
++
++/** Where the dependent roadmap's lifecycle suite writes its result. */
++export const EVIDENCE_REL = path.join('internal', 'reports', 'supervision-lifecycle.json');
++
++/**
++ * A present-tense assertion that a resident process HAS a runtime property.
++ *
++ * The subject is a process noun, the verb is a copula, and the object is a
++ * property word. All three are required together, which is what keeps the
++ * adopted-policy sentence out: "resident processes **are permitted** only under
++ * the supervision contract" carries no property word, and "the supervision
++ * contract ADR-249 **establishes**" has no copula binding a property to a
++ * process.
++ */
++const PROCESS = String.raw`(?:resident process(?:es)?|daemon|background (?:process|worker)|collector|supervisor)`;
++const COPULA = String.raw`(?:is|are|stays?|remains?|runs?)`;
++const PROPERTY = String.raw`(?:supervised|bounded|isolated|sandboxed|auto-restarted|restart(?:ed|s)? automatically|lifecycle-managed|always (?:up|available)|crash-safe|self-healing)`;
++
++export const SUPERVISION_CLAIM_RE = new RegExp(
++    String.raw`\b${PROCESS}\b[^.\n]{0,60}?\b${COPULA}\b\s+(?:\w+\s+){0,3}?\b${PROPERTY}\b`,
++    'i',
++);
++
++export interface Finding {
++    readonly file: string;
++    readonly line: number;
++    readonly text: string;
++    readonly reason: string;
++}
++
++export interface LifecycleEvidence {
++    readonly suite?: string;
++    readonly revision?: string;
++    readonly processes_exercised?: boolean;
++    readonly cases_run?: number;
++    readonly cases_skipped?: number;
++}
++
++/**
++ * The four evidence conditions, each returning its own refusal.
++ *
++ * Returns `null` when the evidence is sufficient. Separated from I/O so the
++ * self-test can drive it with literal objects.
++ */
++export function evidenceRefusal(ev: LifecycleEvidence | null, headRevision: string): string | null {
++    if (ev === null) {
++        return `no lifecycle evidence at ${EVIDENCE_REL} — the suite that would back this claim does not exist`;
++    }
++    if (!ev.suite) {
++        return `${EVIDENCE_REL} names no \`suite\` — an unnamed suite cannot be re-run by a reader`;
++    }
++    if (ev.revision !== headRevision) {
++        return (
++            `${EVIDENCE_REL} records revision ${ev.revision ?? '(none)'}, but HEAD is ${headRevision} — ` +
++            'a result from another revision says nothing about the code being shipped'
++        );
++    }
++    if (ev.processes_exercised !== true) {
++        return `${EVIDENCE_REL} does not record \`processes_exercised: true\` — a suite that mocked the process layer did not test supervision`;
++    }
++    const run = ev.cases_run ?? 0;
++    const skipped = ev.cases_skipped ?? 0;
++    if (run <= 0) {
++        return `${EVIDENCE_REL} records ${String(run)} cases run — an empty suite is not evidence`;
++    }
++    if (run <= skipped) {
++        return `${EVIDENCE_REL} records ${String(run)} run against ${String(skipped)} skipped — a suite that skipped at least as much as it ran is not evidence`;
++    }
++    return null;
++}
++
++/** Read the evidence artifact, or `null` when it is absent or unparsable. */
++export function readEvidence(root: string): LifecycleEvidence | null {
++    const p = path.join(root, EVIDENCE_REL);
++    if (!fs.existsSync(p)) return null;
++    try {
++        return JSON.parse(fs.readFileSync(p, 'utf8')) as LifecycleEvidence;
++    } catch {
++        return null;
++    }
++}
++
++/** Scan the public surfaces. Pure over an explicit file list. */
++export function scan(
++    root: string,
++    files: readonly string[],
++    headRevision: string,
++    ledger?: GateLedger,
++): Finding[] {
++    const findings: Finding[] = [];
++    let refusal: string | null | undefined;
++
++    for (const rel of files) {
++        const abs = path.join(root, rel);
++        // Plan BEFORE resolving, always. Resolving an unplanned target is a
++        // ledger usage error, and it only shows up where a surface is missing —
++        // never on the real tree, where all eight exist. Found by the self-test's
++        // positive control, whose fixture repo has README.md and nothing else.
++        ledger?.plan(rel);
++        if (!fs.existsSync(abs)) {
++            ledger?.skip(rel, 'dead_scan_root');
++            continue;
++        }
++        const lines = fs.readFileSync(abs, 'utf8').split('\n');
++        let failedHere = '';
++        for (const [i, line] of lines.entries()) {
++            if (!SUPERVISION_CLAIM_RE.test(line)) continue;
++            // Resolve the evidence once, and only when a claim is actually
++            // found: an absent artifact is not a finding on its own, because
++            // the correct state today is "no claim, no evidence, no gate".
++            if (refusal === undefined) refusal = evidenceRefusal(readEvidence(root), headRevision);
++            if (refusal === null) continue;
++            findings.push({
++                file: rel,
++                line: i + 1,
++                text: line.trim().slice(0, 160),
++                reason: refusal,
++            });
++            if (failedHere === '') failedHere = `${rel}:${String(i + 1)} — ${refusal}`;
++        }
++        if (failedHere === '') ledger?.complete(rel);
++        else ledger?.fail(rel, failedHere);
++    }
++    return findings;
++}
++
++function headRevisionOf(root: string): string {
++    try {
++        return execFileSync('git', ['-C', root, 'rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
++    } catch {
++        return '';
++    }
++}
++
++/**
++ * Three seeded negatives and one positive control, each driving the REAL CLI.
++ *
++ * Step 3.4 required the seeded negatives to be OBSERVED red rather than
++ * asserted, and the three are separate on purpose: a suite that ran on a parent
++ * commit, a suite that skipped every case, and a suite that mocked the process
++ * layer are three different lies, and a file-presence check catches none of
++ * them. The positive control is what stops the suite passing by rejecting
++ * everything.
++ *
++ * Shelling out through {@link runGateCli} rather than calling `scan()` is the
++ * point of the harness: the thing under test is the binary a contributor runs,
++ * argv parsing and entry guard included.
++ */
++const SELF_TEST_MIN_CASES = 4;
++const SELF_TEST_MIN_REJECTING = 3;
++
++function selfTest(): number {
++    const repoRoot = process.cwd();
++    const rel = path.join('src', 'scripts', 'check_supervision_claim_atomicity.ts');
++    const CLAIM = 'The resident process is supervised and auto-restarted.\n';
++
++    /** Build a throwaway repo whose HEAD is real, so the revision check is meaningful. */
++    const fixture = (evidence: LifecycleEvidence | null): { dir: string; head: string } => {
++        const dir = fs.mkdtempSync(path.join(fs.realpathSync(process.env.TMPDIR ?? '/tmp'), 'supclaim-'));
++        fs.writeFileSync(path.join(dir, 'README.md'), CLAIM);
++        const git = (...a: string[]): void => {
++            execFileSync('git', ['-C', dir, ...a], { stdio: 'ignore' });
++        };
++        git('init', '-q');
++        git('config', 'user.email', 'selftest@example.com');
++        git('config', 'user.name', 'self test');
++        git('add', 'README.md');
++        git('commit', '-q', '-m', 'fixture');
++        const head = execFileSync('git', ['-C', dir, 'rev-parse', 'HEAD'], { encoding: 'utf8' }).trim();
++        if (evidence !== null) {
++            const abs = path.join(dir, EVIDENCE_REL);
++            fs.mkdirSync(path.dirname(abs), { recursive: true });
++            fs.writeFileSync(abs, JSON.stringify({ ...evidence, revision: evidence.revision ?? head }));
++        }
++        return { dir, head };
++    };
++
++    const run = (evidence: LifecycleEvidence | null): number => {
++        const { dir } = fixture(evidence);
++        try {
++            return runGateCli(repoRoot, rel, [], dir);
++        } finally {
++            fs.rmSync(dir, { recursive: true, force: true });
++        }
++    };
++
++    const cases: SelfTestCase[] = [
++        {
++            name: 'a seeded supervision claim with no lifecycle evidence at all',
++            expect: 'reject',
++            run: () => run(null),
++        },
++        {
++            name: 'an emptied suite — every case skipped, none run',
++            expect: 'reject',
++            run: () =>
++                run({ suite: 'supervision-lifecycle', processes_exercised: true, cases_run: 0, cases_skipped: 12 }),
++        },
++        {
++            name: 'a result recorded against a different revision',
++            expect: 'reject',
++            run: () =>
++                run({
++                    suite: 'supervision-lifecycle',
++                    revision: 'b'.repeat(40),
++                    processes_exercised: true,
++                    cases_run: 12,
++                    cases_skipped: 0,
++                }),
++        },
++        {
++            name: 'sufficient evidence on this revision lets the same claim through',
++            expect: 'accept',
++            run: () =>
++                run({ suite: 'supervision-lifecycle', processes_exercised: true, cases_run: 12, cases_skipped: 1 }),
++        },
++    ];
++
++    return runSelfTest({
++        gate: 'check_supervision_claim_atomicity',
++        cases,
++        minCases: SELF_TEST_MIN_CASES,
++        minRejectCases: SELF_TEST_MIN_REJECTING,
++    });
++}
++
++export function main(argv: readonly string[]): number {
++    const root = process.cwd();
++    if (argv.includes('--self-test')) return selfTest();
++
++    const ledger = new GateLedger('check_supervision_claim_atomicity');
++    const findings = scan(root, PUBLIC_SURFACES, headRevisionOf(root), ledger);
++    ledger.report();
++    reportScanned({
++        gate: 'check_supervision_claim_atomicity',
++        scanned: PUBLIC_SURFACES.filter((f) => fs.existsSync(path.join(root, f))).length,
++        units: 'public surfaces',
++        roots: ['README.md', 'docs/'],
++    });
++
++    if (findings.length > 0) {
++        for (const f of findings) {
++            process.stderr.write(`    ❌ ${f.file}:${String(f.line)} — ${f.text}\n       ${f.reason}\n`);
++        }
++        process.stderr.write(
++            `❌  check_supervision_claim_atomicity: ${String(findings.length)} present-tense supervision claim(s) ` +
++                'on a public surface without lifecycle evidence for this revision.\n' +
++                '    ADR-249 permits a supervised resident process; it does not assert that one behaves as described.\n' +
++                '    State the adopted policy, or land the evidence first.\n',
++        );
++        return 1;
++    }
++    process.stdout.write(
++        '✅  check_supervision_claim_atomicity: no unbacked present-tense supervision claim on a public surface.\n',
++    );
++    return 0;
++}
++
++const _HERE = fileURLToPath(import.meta.url);
++function _isCliEntry(): boolean {
++    if (process.argv[1] === undefined) {
++        return false;
++    }
++    const argvUrl = pathToFileURL(path.resolve(process.argv[1])).href;
++    if (import.meta.url === argvUrl) {
++        return true;
++    }
++    try {
++        const here = fs.realpathSync(fileURLToPath(import.meta.url));
++        const argv = fs.realpathSync(path.resolve(process.argv[1]));
++        return here === argv;
++    } catch {
++        return false;
++    }
++}
++
++if (_isCliEntry() || process.argv[1] === _HERE) {
++    process.exit(main(process.argv.slice(2)));
++}
+diff --git a/tests/scripts/check_adr_frontmatter.test.ts b/tests/scripts/check_adr_frontmatter.test.ts
+index a369b360e..5f57a0688 100644
+--- a/tests/scripts/check_adr_frontmatter.test.ts
++++ b/tests/scripts/check_adr_frontmatter.test.ts
+@@ -7,6 +7,7 @@ import {
+     check_amendment_shape,
+     check_one,
+     check_reopen_authority,
++    check_scoped_supersession,
+     check_supersession_links,
+     parse_adr_refs,
+     split_dimensions,
+@@ -590,3 +591,104 @@ describe('reciprocal links — per-area numbers never collide with flat ADR numb
+         expect(f.some((x) => x.kind === 'supersession_link')).toBe(true);
+     });
+ });
++
++/**
++ * Scoped supersession — `supersedes_scope` / `superseded_scope`, the pair
++ * `docs/contracts/adr-layout.md:59-60, 105-117` documents and nothing validated
++ * until road-to-runtime-governance-flip step 1.4.
++ *
++ * Sensitivity: each case below was seen red before the check existed, and the
++ * staging case is the one that matters most — without it the check retroactively
++ * reds ADR-124 and ADR-209, two accepted records that predate the requirement.
++ */
++describe('check_scoped_supersession', () => {
++    const body = (extra = ''): string =>
++        [
++            '# ADR-900 — a title',
++            '',
++            '## Decision',
++            '',
++            'Something.',
++            extra,
++        ].join('\n');
++
++    const fm = (over: Record<string, string> = {}): Record<string, string> => ({
++        adr: '900',
++        status: 'accepted',
++        date: '2026-09-01',
++        decision: 'a-slug',
++        review_trigger: 'Reopen when the measured condition below stops holding.',
++        ...over,
++    });
++
++    it('errors when a scope names no refs — a scope with no refs is not a supersession', () => {
++        const findings: AdrFinding[] = [];
++        check_scoped_supersession(
++            'docs/decisions/ADR-900-x.md',
++            fm({ supersedes: '—', supersedes_scope: 'the Class-B row only' }),
++            body('\n## Not reopened\n\nEverything else.\n'),
++            findings,
++        );
++        expect(findings.length).toBe(1);
++        expect(findings[0]?.level).toBe('error');
++        expect(findings[0]?.message).toContain('names no ADR');
++    });
++
++    it('errors on a scoped supersession with no `## Not reopened` section', () => {
++        const findings: AdrFinding[] = [];
++        check_scoped_supersession(
++            'docs/decisions/ADR-900-x.md',
++            fm({ supersedes: 'ADR-124', supersedes_scope: 'the Class-B row only' }),
++            body(),
++            findings,
++        );
++        expect(findings.length).toBe(1);
++        expect(findings[0]?.level).toBe('error');
++        expect(findings[0]?.message).toContain('Not reopened');
++    });
++
++    it('accepts a scoped supersession that states its remainder', () => {
++        const findings: AdrFinding[] = [];
++        check_scoped_supersession(
++            'docs/decisions/ADR-900-x.md',
++            fm({ supersedes: 'ADR-124', supersedes_scope: 'the Class-B row only' }),
++            body('\n## Not reopened\n\nADR-094 stands.\n'),
++            findings,
++        );
++        expect(findings).toEqual([]);
++    });
++
++    it('WARNS rather than errors on a record predating the staging date', () => {
++        const findings: AdrFinding[] = [];
++        check_scoped_supersession(
++            'docs/decisions/ADR-124-embedded-engine-doctrine.md',
++            fm({ date: '2026-07-23', supersedes: 'ADR-088', supersedes_scope: 'engine-adoption interpretation only' }),
++            body(),
++            findings,
++        );
++        expect(findings.length).toBe(1);
++        expect(findings[0]?.level).toBe('warn');
++    });
++
++    it('is silent when no scope is claimed at all', () => {
++        const findings: AdrFinding[] = [];
++        check_scoped_supersession(
++            'docs/decisions/ADR-900-x.md',
++            fm({ supersedes: 'ADR-124' }),
++            body(),
++            findings,
++        );
++        expect(findings).toEqual([]);
++    });
++
++    it('puts the `## Not reopened` duty on the successor, never on the superseded record', () => {
++        const findings: AdrFinding[] = [];
++        check_scoped_supersession(
++            'docs/decisions/ADR-124-embedded-engine-doctrine.md',
++            fm({ superseded_by: 'ADR-249', superseded_scope: 'the Class-B row only' }),
++            body(),
++            findings,
++        );
++        expect(findings).toEqual([]);
++    });
++});
+diff --git a/tests/scripts/check_claims.test.ts b/tests/scripts/check_claims.test.ts
+index a26746eff..bbd4a8781 100644
+--- a/tests/scripts/check_claims.test.ts
++++ b/tests/scripts/check_claims.test.ts
+@@ -275,7 +275,10 @@ describe('check_claims — mechanism', () => {
+         write('README.md', 'No markers here.\n');
+         const r = run();
+         expect(r.code).toBe(2);
+-        expect(r.stderr).toContain('only meaningful on a resolved-null entry');
++        // Wording widened when `withdrawn` joined `resolved-null` as a closure
++        // that may carry a successor. The BEHAVIOUR under test is unchanged:
++        // a `backed` entry still may not point at one.
++        expect(r.stderr).toContain('only meaningful on a closed entry');
+     });
+ 
+     it('rejects a successor pointer at its own entry', () => {
+@@ -287,4 +290,71 @@ describe('check_claims — mechanism', () => {
+         expect(r.stderr).toContain('points at its own entry');
+     });
+ 
++    // road-to-runtime-governance-flip Phase 2 — `withdrawn`, the ledger's third
++    // closure. A claim that was TRUE and was retired by a decision fits neither
++    // `unbacked` (debt somebody should discharge) nor `resolved-null` (a
++    // pre-registered threshold was missed), and the status column in
++    // `docs/proof.md` is what a reader scans.
++    function withdrawnLedger(fields: string, status = 'withdrawn'): string {
++        return [
++            '# Claims Ledger',
++            '',
++            '### claim: retired',
++            '- claim: A property the package decided to stop having.',
++            '- kind: qual',
++            '- evidence: docs/evidence.md#ANCHOR',
++            `- status: ${status}`,
++            '- last_verified: 2026-07-04',
++            fields,
++            '',
++            '### claim: successor',
++            '- claim: The policy that replaced it.',
++            '- kind: qual',
++            '- evidence: docs/evidence.md#ANCHOR',
++            '- status: unbacked',
++            '- last_verified: 2026-08-27',
++            '',
++        ].join('\n');
++    }
++
++    it('accepts a withdrawn entry that names its decision and its successor', () => {
++        write('docs/evidence.md', 'ANCHOR\n');
++        write(
++            'docs/CLAIMS.md',
++            withdrawnLedger('- retired_by: ADR-249\n- superseded_by: successor'),
++        );
++        write('README.md', 'No markers here.\n');
++        expect(run().code).toBe(0);
++    });
++
++    it('rejects a withdrawal that cannot name the decision that retired it', () => {
++        write('docs/evidence.md', 'ANCHOR\n');
++        write('docs/CLAIMS.md', withdrawnLedger('- superseded_by: successor'));
++        write('README.md', 'No markers here.\n');
++        const r = run();
++        expect(r.code).toBe(2);
++        expect(r.stderr).toContain('no `retired_by` names the decision');
++    });
++
++    it('rejects retired_by on an entry that is not withdrawn', () => {
++        write('docs/evidence.md', 'ANCHOR\n');
++        write('docs/CLAIMS.md', withdrawnLedger('- retired_by: ADR-249', 'unbacked'));
++        write('README.md', 'No markers here.\n');
++        const r = run();
++        expect(r.code).toBe(2);
++        expect(r.stderr).toContain('retired_by is only meaningful on a withdrawn entry');
++    });
++
++    it('still refuses a marker in public prose for a withdrawn claim', () => {
++        write('docs/evidence.md', 'ANCHOR\n');
++        write(
++            'docs/CLAIMS.md',
++            withdrawnLedger('- retired_by: ADR-249\n- superseded_by: successor'),
++        );
++        write('README.md', 'We have no daemon.<!-- claim:retired -->\n');
++        const r = run();
++        expect(r.code).toBe(2);
++        expect(r.stderr).toContain("ledger status is 'withdrawn', not 'backed'");
++    });
++
+ });
+diff --git a/tests/scripts/check_supervision_claim_atomicity.test.ts b/tests/scripts/check_supervision_claim_atomicity.test.ts
+new file mode 100644
+index 000000000..86ef3ce85
+--- /dev/null
++++ b/tests/scripts/check_supervision_claim_atomicity.test.ts
+@@ -0,0 +1,118 @@
++import { describe, expect, it } from 'vitest';
++
++import {
++    EVIDENCE_REL,
++    type LifecycleEvidence,
++    SUPERVISION_CLAIM_RE,
++    evidenceRefusal,
++} from '../../src/scripts/check_supervision_claim_atomicity.js';
++
++/**
++ * `road-to-runtime-governance-flip` step 3.4.
++ *
++ * The gate's own `--self-test` proves the CLI reds on three seeded negatives and
++ * passes its positive control. These cases cover the half a self-test cannot
++ * reach cheaply: the DISCRIMINATION of the pattern — which sentences are
++ * capability claims and which are the adopted policy ADR-249 authorises.
++ *
++ * That boundary is the whole point of the step. A pattern that also matched the
++ * policy statement would make the gate refuse the very sentence Phase 3 was
++ * written to publish, and one that matched neither would be decorative.
++ */
++describe('SUPERVISION_CLAIM_RE — capability claim vs adopted policy', () => {
++    const MUST_MATCH = [
++        'The resident process is supervised and auto-restarted.',
++        'Our daemon is bounded and isolated.',
++        'The collector runs sandboxed.',
++        'The background worker stays crash-safe under load.',
++        'Every resident process is always available.',
++        'The supervisor is lifecycle-managed by the host.',
++    ];
++
++    const MUST_NOT_MATCH = [
++        // The sentence Phase 3.1 actually publishes. If this ever matches, the
++        // gate refuses the policy statement it exists to permit.
++        'Resident processes are permitted only under the supervision contract ADR-249 establishes.',
++        'ADR-249 establishes a supervision contract for resident processes.',
++        'A supervised resident process is permitted in core under four governance conditions.',
++        // Historical and negative statements are not present-tense property claims.
++        'This package shipped no daemon before 2026-08-27.',
++        'Swarm-runtime tools ship a background process by design.',
++        // Adjacent vocabulary with no process subject.
++        'The build is sandboxed.',
++        'Every claim is machine-checked.',
++    ];
++
++    it.each(MUST_MATCH)('matches a present-tense property claim: %s', (line) => {
++        expect(SUPERVISION_CLAIM_RE.test(line)).toBe(true);
++    });
++
++    it.each(MUST_NOT_MATCH)('does not match: %s', (line) => {
++        expect(SUPERVISION_CLAIM_RE.test(line)).toBe(false);
++    });
++});
++
++/**
++ * Four evidence conditions, four distinct refusals. They are separate because a
++ * suite that ran on a parent commit, a suite that skipped everything, and a
++ * suite that mocked the process layer are three different lies — and a gate
++ * that collapses them into "the file is there" catches none of them.
++ */
++describe('evidenceRefusal', () => {
++    const HEAD = 'a'.repeat(40);
++    const sufficient: LifecycleEvidence = {
++        suite: 'supervision-lifecycle',
++        revision: HEAD,
++        processes_exercised: true,
++        cases_run: 12,
++        cases_skipped: 1,
++    };
++
++    it('accepts sufficient evidence', () => {
++        expect(evidenceRefusal(sufficient, HEAD)).toBeNull();
++    });
++
++    it('refuses an absent artifact', () => {
++        expect(evidenceRefusal(null, HEAD)).toContain('does not exist');
++    });
++
++    it('refuses an unnamed suite', () => {
++        // Built by omission rather than `suite: undefined` — `exactOptionalPropertyTypes`
++        // makes those two different types, and the real artifact omits the key.
++        const { suite: _dropped, ...withoutSuite } = sufficient;
++        const r = evidenceRefusal(withoutSuite, HEAD);
++        expect(r).toContain('names no');
++    });
++
++    it('refuses a result from another revision', () => {
++        const r = evidenceRefusal({ ...sufficient, revision: 'b'.repeat(40) }, HEAD);
++        expect(r).toContain('says nothing about the code being shipped');
++    });
++
++    it('refuses a suite that did not exercise real processes', () => {
++        const r = evidenceRefusal({ ...sufficient, processes_exercised: false }, HEAD);
++        expect(r).toContain('mocked the process layer');
++    });
++
++    it('refuses an empty suite', () => {
++        const r = evidenceRefusal({ ...sufficient, cases_run: 0, cases_skipped: 0 }, HEAD);
++        expect(r).toContain('empty suite is not evidence');
++    });
++
++    it('refuses a suite that skipped at least as much as it ran', () => {
++        const r = evidenceRefusal({ ...sufficient, cases_run: 4, cases_skipped: 4 }, HEAD);
++        expect(r).toContain('skipped at least as much as it ran');
++    });
++
++    it('names the artifact path in every refusal it can', () => {
++        const { suite: _dropped, ...withoutSuite } = sufficient;
++        for (const ev of [
++            withoutSuite,
++            { ...sufficient, revision: 'c'.repeat(40) },
++            { ...sufficient, processes_exercised: false },
++            { ...sufficient, cases_run: 0 },
++        ]) {
++            expect(evidenceRefusal(ev, HEAD)).toContain(EVIDENCE_REL);
++        }
++    });
++});

--- a/agents/evidence/reviews/runtime-governance-code.review-input/prompt.md
+++ b/agents/evidence/reviews/runtime-governance-code.review-input/prompt.md
@@ -1,0 +1,65 @@
+# Neutral review of the code delta from PR #1700
+
+Review the TypeScript delta below. It was written in a single autonomous run by
+the same agent commissioning this review, so this is a self-commissioned review
+and the prompt is recorded with the verdict.
+
+**Scope is the whole code delta, not a subset chosen by the author:** every
+change under `src/scripts/` and `tests/scripts/` on the branch, `git diff
+origin/main...HEAD`. Three files changed, three test files changed. 845
+insertions across the branch, of which this diff is the executable part.
+
+Report what you find. Do not calibrate to any expected number of findings.
+
+## What the code is supposed to do
+
+**`check_supervision_claim_atomicity.ts` (new).** ADR-249 permits a supervised
+resident process in core and asserts nothing about one behaving as described.
+This gate refuses a *present-tense supervision claim* on a public surface while
+no lifecycle evidence exists for the current git revision. It must NOT match the
+adopted-policy sentence the README now publishes ("Resident processes are
+permitted only under the supervision contract ADR-249 establishes"), and it must
+match a capability claim ("The resident process is supervised and
+auto-restarted"). Evidence sufficiency is four separate refusals: unnamed suite,
+foreign revision, `processes_exercised != true`, and a run that was empty or
+skipped at least as much as it ran.
+
+**`check_adr_frontmatter.ts` (added `check_scoped_supersession`).** Enforces two
+invariants on the `supersedes_scope` / `superseded_scope` pair: a scope with no
+refs is invalid, and a scoped supersession must carry a `## Not reopened`
+section. Staged by `SCOPED_SUPERSESSION_SINCE` so it warns rather than errors on
+two accepted records that predate it.
+
+**`check_claims.ts`.** Adds a fourth ledger status `withdrawn` (a claim that was
+true and was retired by decision, distinct from `unbacked` debt and from
+`resolved-null` measurement failure), a required `retired_by` on it, and widens
+`superseded_by` from resolved-null-only to closed entries.
+
+## Specific things worth attacking
+
+1. **`SUPERVISION_CLAIM_RE`.** It composes three fragments — a process noun, a
+   copula, a property word — with `[^.\n]{0,60}?` and `(?:\w+\s+){0,3}?` between
+   them. Is it exploitable in either direction? False negatives that let a real
+   capability claim through, or false positives on ordinary prose, both matter.
+   Note it has no `g` flag and is used with `.test()` in a loop.
+2. **The `refusal` cache in `scan()`.** It is computed once on the first match
+   and reused for every subsequent file. Is that correct, or does it hide a
+   per-file distinction?
+3. **The GateLedger contract.** `plan()` must precede any terminal call. One
+   ordering bug was already found by the self-test's positive control (skip
+   before plan, which only fires when a surface is missing). Are there others?
+4. **`evidenceRefusal` ordering.** The checks run in a fixed order and return the
+   first refusal. Does any earlier check mask a later, more serious one?
+5. **The `withdrawn` status in `check_claims.ts`.** Two separate loops iterate
+   the ledger for the two new invariants; one contains a `continue` as its last
+   statement. Is the logic right, and is anything reachable that should not be?
+6. **Staging by date.** `SCOPED_SUPERSESSION_SINCE` uses a string comparison on
+   `fm['date']`. What happens on a malformed, absent, or backdated `date:`?
+7. **The self-test.** It builds a real git repo per case via `execFileSync` and
+   shells out to the gate through `runGateCli`. Does it actually prove what it
+   claims, or can it pass while the gate is broken? Is the positive control a
+
+> **The diff follows in the original prompt and is omitted here**: it is
+> `git diff origin/main...HEAD -- src/scripts/ tests/scripts/` at the branch tip
+> before the review fixes, i.e. commit `0de0522c9`. Reproduce it with that
+> command rather than trusting a copy.

--- a/agents/roadmaps/archive/road-to-runtime-governance-flip.md
+++ b/agents/roadmaps/archive/road-to-runtime-governance-flip.md
@@ -458,6 +458,27 @@ is *being established*.
       carries such a claim. That is the correct state and the reason the
       self-test exists — a gate that scans a corpus and finds nothing is
       indistinguishable from a blind one.
+      **Corrected after a neutral council review of the code, same run.** The
+      gate shipped with a defect that INVERTED it: `SUPERVISION_CLAIM_RE` matched
+      `The resident process is **not** supervised.` — `not` was absorbed by the
+      0-to-3-word gap — so it would have refused a truthful DENIAL of the
+      capability while the claim it exists to catch reads identically minus one
+      word. The test suite claimed to cover "negative statements" and tested a
+      different grammatical form. Both council seats found it independently.
+      Six further findings, all reproduced before being fixed: markdown emphasis
+      (`**supervised**`) escaped the pattern entirely; `cases_run: "abc"` passed
+      every comparison and read as sufficient evidence; a negative count and a
+      whitespace-only suite name likewise; the `## Not reopened` check accepted
+      `###` and an empty section, both of which its own message forbids; a
+      malformed `date:` bought the grandfathered warning; and the self-test's
+      docstring advertised a mocked-process negative the case list did not
+      contain. All closed with regression cases — self-test **7/7, 5 rejecting**;
+      141 unit cases across the three touched test files.
+      A **§ Known limits** section was added rather than the pattern widened: one
+      physical line at a time, copula-only so active voice escapes, no
+      grammatical subject resolution, no markdown-structure awareness, and a
+      bounded-window negation heuristic. The gate is a **floor, not a proof**, and
+      saying so is cheaper than a regex that pretends otherwise.
 - [-] **3.5 Correct the stale figure only if the rewritten argument uses it.**
       `docs/positioning-evidence.md` states "261 skills, 93 rules"; the measured
       count is 299 (`find src/skills -name SKILL.md | wc -l`). The first draft

--- a/src/config/gate-coverage.yml
+++ b/src/config/gate-coverage.yml
@@ -1816,14 +1816,21 @@ gates:
       `check_no_automerge_key` and `check_condensation`.
       Discrimination is proven instead by the gate's own `--self-test`, which is
       the step that created it: road-to-runtime-governance-flip 3.4 required
-      three seeded negatives to be OBSERVED red, not asserted. It plants a
-      supervision claim with (1) no evidence at all, (2) an emptied suite whose
-      cases all skipped, and (3) a result recorded against a different revision,
-      and asserts a distinct refusal for each — then plants sufficient evidence
-      as a positive control and asserts the same claim passes. 4/4. The three
-      refusals are separate because a suite that ran on a parent commit, a suite
-      that skipped everything, and a suite that mocked the process layer are
-      three different lies, and a file-presence check catches none of them.
+      seeded negatives to be OBSERVED red, not asserted. **7/7, 5 rejecting**,
+      each building a throwaway git repo so the revision check is real and each
+      driving the real CLI. The rejecting cases: no evidence at all; an emptied
+      suite whose cases all skipped; a result recorded against a different
+      revision; a suite that did not exercise real processes; and a non-integer
+      case count. Two accepting controls: sufficient evidence lets the claim
+      through, and a DENIAL of supervision needs no evidence at all.
+      The refusals are separate because a suite that ran on a parent commit, one
+      that skipped everything, and one that mocked the process layer are three
+      different lies, and a file-presence check catches none of them.
+      **Grown from 4/4 by a neutral council review of the code**, which found the
+      docstring advertising a mocked-process negative the case list did not
+      contain, and — worse — that the pattern matched `is NOT supervised`, so the
+      gate would have refused a truthful denial. Both are closed with regression
+      cases; the second is the `denial` accepting control above.
   - id: check_score_contract
     argv: ["--quiet"]
     min_scanned: 20

--- a/src/scripts/check_adr_frontmatter.ts
+++ b/src/scripts/check_adr_frontmatter.ts
@@ -595,6 +595,34 @@ export function check_amendment_shape(
  * road-to-runtime-governance-flip step 1.4, which asked for exactly one thing:
  * make the required section enforceable, or drop the word "required".
  */
+/**
+ * Is there a `## Not reopened` section WITH content under it?
+ *
+ * Two corrections a neutral review made to the first version, both real:
+ *
+ * 1. **The level is exactly `##`.** The first pattern was `#{2,3}`, so a `###`
+ *    subsection satisfied a contract and a diagnostic that both say `##`. A gate
+ *    accepting a shape its own message forbids teaches the message is decorative.
+ * 2. **The section must say something.** Matching the heading alone let an empty
+ *    section pass while the error text promises one "naming what the narrowing
+ *    leaves standing". A heading with nothing under it is the absence the check
+ *    exists to catch, wearing the right title.
+ *
+ * "Content" is deliberately weak — one non-blank, non-heading line. No gate can
+ * judge whether the prose is true, and pretending otherwise would be the
+ * masquerade the sibling gate's docstring warns about.
+ */
+export function hasNotReopenedSection(text: string): boolean {
+    const lines = text.split('\n');
+    const start = lines.findIndex((l) => /^##\s+Not reopened\s*$/i.test(l));
+    if (start === -1) return false;
+    for (const line of lines.slice(start + 1)) {
+        if (/^#{1,6}\s/.test(line)) break;
+        if (line.trim() !== '') return true;
+    }
+    return false;
+}
+
 export function check_scoped_supersession(
     rel: string,
     fm: Record<string, string>,
@@ -625,9 +653,13 @@ export function check_scoped_supersession(
     // supersession, never on the one that receives it: the successor is what
     // has to state the remainder.
     if (placeholder(fm['supersedes_scope'])) return;
-    if (!/^#{2,3}\s+Not reopened\s*$/im.test(text)) {
+    if (!hasNotReopenedSection(text)) {
+        // A well-formed ISO date, or no grandfathering. A malformed `date:`
+        // sorts unpredictably against the staging constant, and the safe
+        // direction for an unreadable date is the error, not the warning.
         const date = fm['date'] ?? '';
-        const staged = date !== '' && date < SCOPED_SUPERSESSION_SINCE;
+        const wellFormed = /^\d{4}-\d{2}-\d{2}$/.test(date);
+        const staged = wellFormed && date < SCOPED_SUPERSESSION_SINCE;
         findings.push({
             file: rel,
             level: staged ? 'warn' : 'error',

--- a/src/scripts/check_claims.ts
+++ b/src/scripts/check_claims.ts
@@ -489,7 +489,6 @@ function main(argv: string[] = process.argv.slice(2)): number {
                 reason: 'status is withdrawn but no `retired_by` names the decision that retired it',
             });
         }
-        continue;
     }
     for (const entry of ledger.values()) {
         if (entry.retired_by && entry.status !== 'withdrawn') {

--- a/src/scripts/check_supervision_claim_atomicity.ts
+++ b/src/scripts/check_supervision_claim_atomicity.ts
@@ -34,8 +34,33 @@
  * **Today it passes vacuously, and says so.** No public surface carries a
  * supervision claim, so the evidence side is never reached. That is the correct
  * state — but a gate that scans a corpus and finds nothing is indistinguishable
- * from a blind one, which is why `--self-test` plants all three seeded negatives
- * and asserts each one reds.
+ * from a blind one, which is why `--self-test` plants the seeded negatives and
+ * asserts each one reds.
+ *
+ * ## Known limits — what a line-based pattern cannot do
+ *
+ * Written after a neutral review, and kept because the alternative is a reader
+ * assuming coverage this does not have. None of these is a bug to be fixed by
+ * widening the regex; each is a property of the approach.
+ *
+ * - **One physical line at a time.** A claim wrapped across two lines
+ *   (`The resident process` / `is supervised.`) is not seen. Markdown reflow can
+ *   therefore hide a claim from the gate.
+ * - **Copula-only.** Active voice escapes: `We supervise the resident process`
+ *   asserts the property and does not match. Narrowing to a copula is what keeps
+ *   the adopted-policy sentence out, so widening trades one error for the other.
+ * - **No grammatical subject resolution.** The 60-character window between the
+ *   process noun and the copula can cross a clause boundary, so a property
+ *   belonging to a different subject can be attributed to the first process noun
+ *   on the line. Bounded distance is not ownership.
+ * - **No markdown structure awareness.** A claim quoted inside a fenced block or
+ *   a historical excerpt is scanned like any other line.
+ * - **The negation guard is a heuristic.** It reads the captured gap plus a
+ *   24-character determiner window; a negator further away is not seen.
+ *
+ * The gate is therefore a **floor, not a proof**: it catches the plain forms of
+ * the claim it names. The obligation not to publish an unproven capability stays
+ * with the author, as it did before this file existed.
  */
 
 import { execFileSync } from 'node:child_process';
@@ -76,10 +101,71 @@ const PROCESS = String.raw`(?:resident process(?:es)?|daemon|background (?:proce
 const COPULA = String.raw`(?:is|are|stays?|remains?|runs?)`;
 const PROPERTY = String.raw`(?:supervised|bounded|isolated|sandboxed|auto-restarted|restart(?:ed|s)? automatically|lifecycle-managed|always (?:up|available)|crash-safe|self-healing)`;
 
+/**
+ * Words that INVERT the assertion. Their presence between the copula and the
+ * property means the sentence denies the property rather than asserting it.
+ *
+ * **This guard is the fix for the worst defect a neutral review found**, and it
+ * is worth stating what the bug was rather than only that it is closed. The
+ * first version matched `The resident process is **not** supervised.` — `not`
+ * was absorbed by the 0-to-3-word gap, and the gate would have refused a
+ * TRUTHFUL DENIAL of the capability while the sentence it exists to catch reads
+ * identically minus one word. That is an inversion, not a false positive: the
+ * gate would have pushed authors away from the honest statement.
+ *
+ * The test suite claimed to cover "historical and negative statements" and
+ * tested only `shipped no daemon before …` — a different grammatical form. The
+ * direct negation was untested and broken. Both council seats found it
+ * independently.
+ */
+const NEGATOR_RE = /\b(?:not|never|no|non|without|cannot|can't|won't|isn't|aren't|neither|nor|un\w+)\b/i;
+
+/** The gap between the copula and the property, captured so it can be inspected. */
 export const SUPERVISION_CLAIM_RE = new RegExp(
-    String.raw`\b${PROCESS}\b[^.\n]{0,60}?\b${COPULA}\b\s+(?:\w+\s+){0,3}?\b${PROPERTY}\b`,
+    String.raw`\b${PROCESS}\b[^.\n]{0,60}?\b${COPULA}\b(\s+(?:\w+[\s-]+){0,3}?)\b${PROPERTY}\b`,
     'i',
 );
+
+/**
+ * Strip markdown emphasis before matching.
+ *
+ * `\b` does not match inside `**bold**`, so `The resident process is
+ * **supervised**.` escaped the pattern entirely — a false negative on exactly
+ * the formatting a README uses for the words that matter. Also found by review.
+ */
+export function normaliseLine(line: string): string {
+    return line.replace(/[*_`]+/g, '');
+}
+
+/**
+ * Does this line assert — rather than deny — a supervision property?
+ *
+ * Two steps, deliberately separate so each is testable: the shape must match,
+ * and the gap between copula and property must carry no negator.
+ */
+export function assertsSupervision(rawLine: string): boolean {
+    const line = normaliseLine(rawLine);
+    const m = SUPERVISION_CLAIM_RE.exec(line);
+    if (m === null) return false;
+    // Two negation slots, and both were found by review rather than by design.
+    // AFTER the copula: "the resident process is **not** supervised".
+    // BEFORE the subject, in the determiner: "**No** resident process is
+    // supervised here". The second is why this reads a bounded window ahead of
+    // the match instead of only the captured gap.
+    const lead = line.slice(Math.max(0, m.index - NEGATOR_LOOKBEHIND), m.index);
+    return !NEGATOR_RE.test(lead) && !NEGATOR_RE.test(m[1] ?? '');
+}
+
+/**
+ * How far back the determiner slot is inspected for a negator.
+ *
+ * Bounded rather than whole-line on purpose: a negator early in a DIFFERENT
+ * clause ("the daemon is not the concern; the collector is supervised") must
+ * not suppress a real claim later in the same line. 24 characters covers
+ * "No ", "Never a ", "There is no " and the like without reaching a previous
+ * clause. This is a heuristic and is named as one — see § Known limits.
+ */
+const NEGATOR_LOOKBEHIND = 24;
 
 export interface Finding {
     readonly file: string;
@@ -102,11 +188,23 @@ export interface LifecycleEvidence {
  * Returns `null` when the evidence is sufficient. Separated from I/O so the
  * self-test can drive it with literal objects.
  */
-export function evidenceRefusal(ev: LifecycleEvidence | null, headRevision: string): string | null {
+export function evidenceRefusal(
+    ev: LifecycleEvidence | null | 'malformed',
+    headRevision: string,
+): string | null {
     if (ev === null) {
         return `no lifecycle evidence at ${EVIDENCE_REL} — the suite that would back this claim does not exist`;
     }
-    if (!ev.suite) {
+    if (ev === 'malformed') {
+        return `${EVIDENCE_REL} exists but does not parse as a JSON object — a broken artifact is not weaker evidence than a missing one, it is a different problem`;
+    }
+    // A revision the gate could not read is not a revision that matched. Review
+    // found this reporting `HEAD is ` with an empty string, which reads as a
+    // mismatch rather than as a failure to determine anything.
+    if (headRevision === '') {
+        return 'could not determine HEAD (`git rev-parse HEAD` failed) — the same-revision condition cannot be checked, so it is not treated as met';
+    }
+    if (typeof ev.suite !== 'string' || ev.suite.trim() === '') {
         return `${EVIDENCE_REL} names no \`suite\` — an unnamed suite cannot be re-run by a reader`;
     }
     if (ev.revision !== headRevision) {
@@ -118,8 +216,21 @@ export function evidenceRefusal(ev: LifecycleEvidence | null, headRevision: stri
     if (ev.processes_exercised !== true) {
         return `${EVIDENCE_REL} does not record \`processes_exercised: true\` — a suite that mocked the process layer did not test supervision`;
     }
+    // Typed, not coerced. Review found `cases_run: "abc"` passing every
+    // comparison — `"abc" <= 0` and `"abc" <= 0` are both false, so an
+    // unparsable count read as sufficient evidence. A string `"12"` was worse
+    // than useless in the other direction: `"12" <= "2"` is TRUE
+    // lexicographically, so valid-looking data was refused for a wrong reason.
+    // The artifact is machine-written; a non-integer in it is a broken producer,
+    // and the gate says so instead of guessing.
     const run = ev.cases_run ?? 0;
     const skipped = ev.cases_skipped ?? 0;
+    if (!Number.isInteger(run) || !Number.isInteger(skipped)) {
+        return `${EVIDENCE_REL} records a non-integer case count (run: ${JSON.stringify(ev.cases_run)}, skipped: ${JSON.stringify(ev.cases_skipped)}) — the artifact is machine-written, so this is a broken producer rather than a low count`;
+    }
+    if (run < 0 || skipped < 0) {
+        return `${EVIDENCE_REL} records a negative case count (run: ${String(run)}, skipped: ${String(skipped)}) — not a possible measurement`;
+    }
     if (run <= 0) {
         return `${EVIDENCE_REL} records ${String(run)} cases run — an empty suite is not evidence`;
     }
@@ -129,14 +240,23 @@ export function evidenceRefusal(ev: LifecycleEvidence | null, headRevision: stri
     return null;
 }
 
-/** Read the evidence artifact, or `null` when it is absent or unparsable. */
-export function readEvidence(root: string): LifecycleEvidence | null {
+/**
+ * Read the evidence artifact.
+ *
+ * Returns `null` when it is ABSENT and the string `'malformed'` when it exists
+ * and does not parse. Review flagged that collapsing the two reported unparsable
+ * JSON as "the suite does not exist" — both fail closed, but they need
+ * different remediation and a reader deserves to know which one they have.
+ */
+export function readEvidence(root: string): LifecycleEvidence | null | 'malformed' {
     const p = path.join(root, EVIDENCE_REL);
     if (!fs.existsSync(p)) return null;
     try {
-        return JSON.parse(fs.readFileSync(p, 'utf8')) as LifecycleEvidence;
+        const parsed: unknown = JSON.parse(fs.readFileSync(p, 'utf8'));
+        if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return 'malformed';
+        return parsed as LifecycleEvidence;
     } catch {
-        return null;
+        return 'malformed';
     }
 }
 
@@ -164,7 +284,7 @@ export function scan(
         const lines = fs.readFileSync(abs, 'utf8').split('\n');
         let failedHere = '';
         for (const [i, line] of lines.entries()) {
-            if (!SUPERVISION_CLAIM_RE.test(line)) continue;
+            if (!assertsSupervision(line)) continue;
             // Resolve the evidence once, and only when a claim is actually
             // found: an absent artifact is not a finding on its own, because
             // the correct state today is "no claim, no evidence, no gate".
@@ -206,8 +326,8 @@ function headRevisionOf(root: string): string {
  * point of the harness: the thing under test is the binary a contributor runs,
  * argv parsing and entry guard included.
  */
-const SELF_TEST_MIN_CASES = 4;
-const SELF_TEST_MIN_REJECTING = 3;
+const SELF_TEST_MIN_CASES = 7;
+const SELF_TEST_MIN_REJECTING = 5;
 
 function selfTest(): number {
     const repoRoot = process.cwd();
@@ -215,9 +335,12 @@ function selfTest(): number {
     const CLAIM = 'The resident process is supervised and auto-restarted.\n';
 
     /** Build a throwaway repo whose HEAD is real, so the revision check is meaningful. */
-    const fixture = (evidence: LifecycleEvidence | null): { dir: string; head: string } => {
+    const fixture = (
+        evidence: LifecycleEvidence | null,
+        line: string = CLAIM,
+    ): { dir: string; head: string } => {
         const dir = fs.mkdtempSync(path.join(fs.realpathSync(process.env.TMPDIR ?? '/tmp'), 'supclaim-'));
-        fs.writeFileSync(path.join(dir, 'README.md'), CLAIM);
+        fs.writeFileSync(path.join(dir, 'README.md'), line);
         const git = (...a: string[]): void => {
             execFileSync('git', ['-C', dir, ...a], { stdio: 'ignore' });
         };
@@ -235,14 +358,15 @@ function selfTest(): number {
         return { dir, head };
     };
 
-    const run = (evidence: LifecycleEvidence | null): number => {
-        const { dir } = fixture(evidence);
+    const runWithLine = (line: string, evidence: LifecycleEvidence | null): number => {
+        const { dir } = fixture(evidence, line);
         try {
             return runGateCli(repoRoot, rel, [], dir);
         } finally {
             fs.rmSync(dir, { recursive: true, force: true });
         }
     };
+    const run = (evidence: LifecycleEvidence | null): number => runWithLine(CLAIM, evidence);
 
     const cases: SelfTestCase[] = [
         {
@@ -267,6 +391,41 @@ function selfTest(): number {
                     cases_run: 12,
                     cases_skipped: 0,
                 }),
+        },
+        {
+            // Advertised by the docstring from the first version and ABSENT from
+            // the case list until a neutral review counted them. The doc said
+            // three negatives and named a mocked-process one; the code had two
+            // plus a foreign revision. A self-test that describes a case it does
+            // not run is the shape it exists to prevent.
+            name: 'a suite that did not exercise real processes',
+            expect: 'reject',
+            run: () =>
+                run({
+                    suite: 'supervision-lifecycle',
+                    processes_exercised: false,
+                    cases_run: 12,
+                    cases_skipped: 0,
+                }),
+        },
+        {
+            name: 'a non-integer case count — a broken producer, not a low count',
+            expect: 'reject',
+            run: () =>
+                run({
+                    suite: 'supervision-lifecycle',
+                    processes_exercised: true,
+                    cases_run: 'twelve' as unknown as number,
+                    cases_skipped: 0,
+                }),
+        },
+        {
+            // The inversion control. Without the negation guard this line
+            // matched, and the gate would have refused a TRUTHFUL DENIAL while
+            // no evidence existed. It must pass with no evidence at all.
+            name: 'a DENIAL of supervision is not a claim, and needs no evidence',
+            expect: 'accept',
+            run: () => runWithLine('The resident process is not supervised.\n', null),
         },
         {
             name: 'sufficient evidence on this revision lets the same claim through',

--- a/tests/scripts/check_adr_frontmatter.test.ts
+++ b/tests/scripts/check_adr_frontmatter.test.ts
@@ -8,6 +8,7 @@ import {
     check_one,
     check_reopen_authority,
     check_scoped_supersession,
+    hasNotReopenedSection,
     check_supersession_links,
     parse_adr_refs,
     split_dimensions,
@@ -690,5 +691,58 @@ describe('check_scoped_supersession', () => {
             findings,
         );
         expect(findings).toEqual([]);
+    });
+});
+
+/**
+ * `hasNotReopenedSection` — two corrections a neutral review made to the
+ * scoped-supersession check, both of which let a shape through that the
+ * check's own error message forbids.
+ */
+describe('hasNotReopenedSection', () => {
+    const doc = (body: string): string => ['# ADR-900 — a title', '', body].join('\n');
+
+    it('accepts a `## Not reopened` section with content', () => {
+        expect(hasNotReopenedSection(doc('## Not reopened\n\nADR-094 stands.\n'))).toBe(true);
+    });
+
+    it('rejects a `###` subsection — the contract and the message both say `##`', () => {
+        expect(hasNotReopenedSection(doc('### Not reopened\n\nADR-094 stands.\n'))).toBe(false);
+    });
+
+    it('rejects an EMPTY section — a heading is not a statement of the remainder', () => {
+        expect(hasNotReopenedSection(doc('## Not reopened\n\n## Consequences\n\nSomething.\n'))).toBe(
+            false,
+        );
+    });
+
+    it('rejects the section being absent entirely', () => {
+        expect(hasNotReopenedSection(doc('## Decision\n\nSomething.\n'))).toBe(false);
+    });
+});
+
+/**
+ * A malformed `date:` sorts unpredictably against the staging constant, so it
+ * must not buy the grandfathered warning. The safe direction for an unreadable
+ * date is the error.
+ */
+describe('check_scoped_supersession — staging on a malformed date', () => {
+    it('errors rather than warns when `date` is not an ISO date', () => {
+        const findings: AdrFinding[] = [];
+        check_scoped_supersession(
+            'docs/decisions/ADR-900-x.md',
+            {
+                adr: '900',
+                status: 'accepted',
+                date: '2026-8-3',
+                decision: 'a-slug',
+                supersedes: 'ADR-124',
+                supersedes_scope: 'the Class-B row only',
+            },
+            '# ADR-900\n\n## Decision\n\nSomething.\n',
+            findings,
+        );
+        expect(findings.length).toBe(1);
+        expect(findings[0]?.level).toBe('error');
     });
 });

--- a/tests/scripts/check_supervision_claim_atomicity.test.ts
+++ b/tests/scripts/check_supervision_claim_atomicity.test.ts
@@ -3,8 +3,9 @@ import { describe, expect, it } from 'vitest';
 import {
     EVIDENCE_REL,
     type LifecycleEvidence,
-    SUPERVISION_CLAIM_RE,
+    assertsSupervision,
     evidenceRefusal,
+    normaliseLine,
 } from '../../src/scripts/check_supervision_claim_atomicity.js';
 
 /**
@@ -19,7 +20,7 @@ import {
  * policy statement would make the gate refuse the very sentence Phase 3 was
  * written to publish, and one that matched neither would be decorative.
  */
-describe('SUPERVISION_CLAIM_RE — capability claim vs adopted policy', () => {
+describe('assertsSupervision — capability claim vs adopted policy vs denial', () => {
     const MUST_MATCH = [
         'The resident process is supervised and auto-restarted.',
         'Our daemon is bounded and isolated.',
@@ -27,6 +28,11 @@ describe('SUPERVISION_CLAIM_RE — capability claim vs adopted policy', () => {
         'The background worker stays crash-safe under load.',
         'Every resident process is always available.',
         'The supervisor is lifecycle-managed by the host.',
+        // Emphasis is stripped before matching: `\b` does not match inside `**`,
+        // so this escaped the first version entirely — a false negative on
+        // exactly the formatting a README uses for the words that matter.
+        'The resident process is **supervised**.',
+        'The `daemon` is _bounded_.',
     ];
 
     const MUST_NOT_MATCH = [
@@ -41,14 +47,23 @@ describe('SUPERVISION_CLAIM_RE — capability claim vs adopted policy', () => {
         // Adjacent vocabulary with no process subject.
         'The build is sandboxed.',
         'Every claim is machine-checked.',
+        // DENIALS. The first version matched every one of these, and would have
+        // refused a truthful statement that the property does NOT hold — an
+        // inversion, not a false positive. Both council seats found it
+        // independently; these rows are the regression.
+        'The resident process is not supervised.',
+        'The daemon is never supervised.',
+        'No resident process is supervised here.',
+        'There is no daemon that is supervised.',
+        'The collector is not bounded.',
     ];
 
     it.each(MUST_MATCH)('matches a present-tense property claim: %s', (line) => {
-        expect(SUPERVISION_CLAIM_RE.test(line)).toBe(true);
+        expect(assertsSupervision(line)).toBe(true);
     });
 
     it.each(MUST_NOT_MATCH)('does not match: %s', (line) => {
-        expect(SUPERVISION_CLAIM_RE.test(line)).toBe(false);
+        expect(assertsSupervision(line)).toBe(false);
     });
 });
 
@@ -114,5 +129,81 @@ describe('evidenceRefusal', () => {
         ]) {
             expect(evidenceRefusal(ev, HEAD)).toContain(EVIDENCE_REL);
         }
+    });
+});
+
+/**
+ * The negation guard, tested as its own unit rather than only through the
+ * corpus rows above — because it is the fix for the one defect in this file
+ * that inverted the gate's meaning rather than merely widening or narrowing it.
+ */
+describe('negation guard', () => {
+    it('strips markdown emphasis before matching', () => {
+        expect(normaliseLine('The **resident process** is _supervised_.')).toBe(
+            'The resident process is supervised.',
+        );
+    });
+
+    it('reads the determiner slot, not only the copula-to-property gap', () => {
+        // "not" sits AFTER the copula; "No" sits BEFORE the subject. Two
+        // different slots, both of which invert the sentence.
+        expect(assertsSupervision('The resident process is not supervised.')).toBe(false);
+        expect(assertsSupervision('No resident process is supervised.')).toBe(false);
+    });
+
+    it('does not let a negator in a previous clause suppress a real claim', () => {
+        // The lookbehind is bounded at 24 chars for exactly this: a denial about
+        // one subject must not excuse an assertion about another on the same line.
+        expect(
+            assertsSupervision(
+                'That claim is not the point here, and yet the resident process is supervised.',
+            ),
+        ).toBe(true);
+    });
+});
+
+/**
+ * Evidence values are TYPED, not coerced. Review found `cases_run: "abc"`
+ * passing every comparison — `"abc" <= 0` is false — so an unparsable count read
+ * as sufficient evidence.
+ */
+describe('evidenceRefusal — type discipline', () => {
+    const HEAD = 'a'.repeat(40);
+    const base = {
+        suite: 'supervision-lifecycle',
+        revision: HEAD,
+        processes_exercised: true,
+        cases_run: 12,
+        cases_skipped: 1,
+    };
+
+    it('refuses a non-integer case count instead of coercing it', () => {
+        const r = evidenceRefusal({ ...base, cases_run: 'abc' as unknown as number }, HEAD);
+        expect(r).toContain('non-integer');
+    });
+
+    it('refuses a numeric string, which the first version compared lexicographically', () => {
+        const r = evidenceRefusal({ ...base, cases_run: '12' as unknown as number }, HEAD);
+        expect(r).toContain('non-integer');
+    });
+
+    it('refuses a negative case count', () => {
+        const r = evidenceRefusal({ ...base, cases_run: -5, cases_skipped: -9 }, HEAD);
+        expect(r).toContain('negative');
+    });
+
+    it('refuses a whitespace-only suite name', () => {
+        const r = evidenceRefusal({ ...base, suite: '   ' }, HEAD);
+        expect(r).toContain('names no');
+    });
+
+    it('distinguishes a malformed artifact from an absent one', () => {
+        expect(evidenceRefusal('malformed', HEAD)).toContain('does not parse');
+        expect(evidenceRefusal(null, HEAD)).toContain('does not exist');
+    });
+
+    it('fails closed when HEAD cannot be determined, rather than reporting a mismatch', () => {
+        const r = evidenceRefusal(base, '');
+        expect(r).toContain('could not determine HEAD');
     });
 });


### PR DESCRIPTION
Fixes seven defects in the gates PR #1700 landed, found by a **neutral council
review of the code delta** run after that PR merged. The worst one inverted the
gate's meaning.

The prompt and the exact diff reviewed are committed at
`agents/evidence/reviews/runtime-governance-code.review-input/` — a recorded
verdict whose prompt nobody can read is not evidence, and
`agents/runtime/council/questions/` is gitignored.

## The inversion

`check_supervision_claim_atomicity` exists to refuse a **present-tense
supervision claim** on a public surface with no lifecycle evidence. As shipped,
`SUPERVISION_CLAIM_RE` also matched:

```
The resident process is not supervised.
The daemon is never supervised.
No resident process is supervised here.
```

`not` was absorbed by the `(?:\w+\s+){0,3}?` gap between copula and property. So
the gate would have **refused a truthful denial** of the capability — pushing
authors away from the honest sentence — while the false claim it exists to catch
reads identically minus one word.

The test suite claimed to cover *"Historical and negative statements are not
present-tense property claims"* and tested only
`This package shipped no daemon before 2026-08-27` — a different grammatical
form. **The direct negation was untested and broken.** Both council seats found
it independently; neither was told what to look for.

Reproduced before fixing:

```
MATCH  The resident process is not supervised.
MATCH  The daemon is never supervised.
```

**Fix:** `assertsSupervision()` splits shape-matching from polarity. The captured
copula-to-property gap and a bounded 24-character determiner window are both
checked for a negator — two slots, because `is **not** supervised` and
`**No** resident process is supervised` invert in different places. The window is
bounded rather than whole-line so a denial about one subject cannot excuse an
assertion about another on the same line; that case is a test.

## The other six

| Finding | Was | Now |
|---|---|---|
| markdown emphasis | `**supervised**` never matched — `\b` does not match inside `**`, a false negative on exactly the formatting a README uses | emphasis stripped before matching (`normaliseLine`) |
| type coercion | `cases_run: "abc"` passed every comparison and read as **sufficient evidence** (`"abc" <= 0` is false); `"12"` was refused for a *wrong* reason by lexicographic compare | `Number.isInteger` on both counts, with a message naming a broken producer rather than a low count |
| negative counts | `cases_run: -5` accepted | refused as "not a possible measurement" |
| blank suite | `suite: "   "` accepted as named | trimmed non-empty string required |
| `## Not reopened` | accepted `###`, and accepted an **empty** section — both forbidden by the check's own error message | exactly `##`, plus one non-blank non-heading line under it |
| malformed `date:` | `2026-8-3` sorts unpredictably and bought the grandfathered *warning* | a well-formed ISO date is required for grandfathering; otherwise the error |
| self-test over-advertised | the docstring named a mocked-process negative the case list did not contain | that case exists, plus a non-integer-count case and a denial control |

Two further robustness fixes the review asked for: `readEvidence` now
distinguishes a **malformed** artifact from an **absent** one (both fail closed,
but they need different remediation), and a failure of `git rev-parse HEAD` now
returns *"could not determine HEAD"* instead of reporting `HEAD is ` — an empty
string that read as a revision mismatch.

## § Known limits — added rather than papering over

The review named several gaps that are properties of a line-based pattern, not
bugs to widen the regex for. They are now documented in the gate's docstring, and
the gate is described as a **floor, not a proof**:

- one physical line at a time — a claim wrapped across two lines is not seen;
- copula-only, so active voice (`We supervise the resident process`) escapes —
  narrowing to a copula is what keeps the adopted-policy sentence out, so
  widening trades one error for the other;
- no grammatical subject resolution — the 60-char window can cross a clause;
- no markdown-structure awareness — a quoted claim in a fenced block is scanned;
- the negation guard is a bounded heuristic.

## Verification

```
check_supervision_claim_atomicity --self-test: 7/7 case(s) behaved (5 rejecting, floor 7)
```

Up from 4/4. The five rejecting cases: no evidence; an emptied suite; a foreign
revision; a suite that did not exercise real processes; a non-integer count. Two
accepting controls: sufficient evidence passes, **and a denial needs no evidence
at all** — the regression for the inversion.

**141 unit tests** across the three touched files (was 120), including a
13-case discrimination corpus that pins both directions: the capability claims
that must match, and the policy sentence + five denials that must not.

`check_gate_coverage` · `check_estate_count` · `check_references` ·
`lint_evidence_artifacts` · `check_adr_frontmatter` · `check_claims` — all green.
`tsc -p tsconfig.scripts.json` clean.

The `gate-coverage.yml` `no_canary_reason` and the archived roadmap's step-3.4
verify are both updated to the new counts, and both record what the review found
rather than only that the numbers moved.

## What this says about the run that produced it

Every gate passed on the broken code. The self-test was green at 4/4 **while the
pattern was inverted**, because a self-test only proves the cases someone thought
to write. Nothing in the original run's own discipline would have caught this —
the neutral read did, and it was prompted by a stop-hook rather than by the plan.
That is recorded in `agents/evidence/drain-run-summary.md` § Post-hoc.
