### PR TITLE
fix(contracts): the two value contracts lapsed yesterday and blocked every PR

### DIFF
--- a/docs/contracts/value-dashboard-spec.md
+++ b/docs/contracts/value-dashboard-spec.md
@@ -1,6 +1,29 @@
 ---
 stability: beta
-keep-beta-until: 2026-08-28
+keep-beta-until: 2026-09-30
+keep-beta-reason: >-
+  Extended 2026-08-29, on a review performed rather than deferred. The window
+  lapsed by one day and blocked every open pull request, so the three
+  dispositions were evaluated against the tree: `docs/value.md`,
+  `_lib/value_report.ts` and `render_value_md.ts` all exist and the contracts
+  are referenced from `render_value_md.ts` and `value_ladder.ts`, so these are
+  shipped-and-wired rather than aspirational; and every commit touching either
+  file since 2026-06 is cosmetic (dead-link repair, path repoint, slug-only
+  mentions, an English-prose sweep), so neither has churned semantically.
+  `superseded` is therefore false — nothing replaced them.
+  .
+  That leaves promote-or-extend, and PROMOTION IS NOT THIS RUN'S TO MAKE:
+  `stability: stable` on `value-v1` is a parser-visible JSON shape whose
+  consumers would then be entitled to rely on it, which is a compatibility
+  commitment, and `decision-revisit-gate`'s owner-reserved table assigns
+  "creates a compatibility commitment" to the owner. An autonomous run may not
+  issue one on the owner's behalf.
+  .
+  So this is an extension with a named decision, not a rolling one: the review
+  is DONE and its finding is "ready on the merits, blocked only on an owner
+  commitment". The new date is deliberately near-term so it forces that
+  decision rather than burying it, and a second extension on the same reasoning
+  would be the decoration failure the gate exists to catch.
 ---
 
 # Value Dashboard Spec — what the package costs and what it saves

--- a/docs/contracts/value-report-schema.md
+++ b/docs/contracts/value-report-schema.md
@@ -1,6 +1,29 @@
 ---
 stability: beta
-keep-beta-until: 2026-08-28
+keep-beta-until: 2026-09-30
+keep-beta-reason: >-
+  Extended 2026-08-29, on a review performed rather than deferred. The window
+  lapsed by one day and blocked every open pull request, so the three
+  dispositions were evaluated against the tree: `docs/value.md`,
+  `_lib/value_report.ts` and `render_value_md.ts` all exist and the contracts
+  are referenced from `render_value_md.ts` and `value_ladder.ts`, so these are
+  shipped-and-wired rather than aspirational; and every commit touching either
+  file since 2026-06 is cosmetic (dead-link repair, path repoint, slug-only
+  mentions, an English-prose sweep), so neither has churned semantically.
+  `superseded` is therefore false — nothing replaced them.
+  .
+  That leaves promote-or-extend, and PROMOTION IS NOT THIS RUN'S TO MAKE:
+  `stability: stable` on `value-v1` is a parser-visible JSON shape whose
+  consumers would then be entitled to rely on it, which is a compatibility
+  commitment, and `decision-revisit-gate`'s owner-reserved table assigns
+  "creates a compatibility commitment" to the owner. An autonomous run may not
+  issue one on the owner's behalf.
+  .
+  So this is an extension with a named decision, not a rolling one: the review
+  is DONE and its finding is "ready on the merits, blocked only on an owner
+  commitment". The new date is deliberately near-term so it forces that
+  decision rather than burying it, and a second extension on the same reasoning
+  would be the decoration failure the gate exists to catch.
 ---
 
 # Value Report Schema (`value-v1`)


### PR DESCRIPTION
`check_beta_review_markers` went red on **every open pull request**, including ones touching neither contract. `value-dashboard-spec.md` and `value-report-schema.md` both carried `keep-beta-until: 2026-08-28`, which lapsed one day ago. The frozen baseline **may not grow**, so suppression was not available — the gate offers promote / extend-with-a-reason / superseded, and one had to be chosen.

## The review was performed, not deferred

Recorded in the files themselves, so the next reader inherits the finding rather than the question:

- **Shipped and wired, not aspirational** — `docs/value.md`, `_lib/value_report.ts` and `render_value_md.ts` all exist, and the contracts are referenced from `render_value_md.ts` and `value_ladder.ts`.
- **No semantic churn** — every commit touching either file since 2026-06 is cosmetic: dead-link repair, path repoint, slug-only mentions, an English-prose sweep.
- **`superseded` is therefore false.** Nothing replaced them.

## Why extend rather than promote

**Promotion is not an autonomous run's to make.** `stability: stable` on `value-v1` is a parser-visible JSON shape whose consumers would then be entitled to rely on it — a **compatibility commitment**, which `decision-revisit-gate`'s owner-reserved table assigns to the **owner**.

So this is an extension with a **named decision attached**, not a rolling one: the review is done and its finding is *"ready on the merits, blocked only on an owner commitment"*. The new date (2026-09-30) is deliberately near-term so it forces that decision rather than burying it, and the reason in each file says a second extension on this same reasoning would be the decoration failure the gate exists to catch.

**@matze4u — the actual question for you: promote both to `stable`, or keep them beta for a reason I could not see?**

## Result

The gate now exits **0** — zero FRESH lapses. The other 84 are inherited, sit in the frozen 2026-08-25 baseline, clear by 2026-11-23, and are warnings rather than failures. Untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
