### PR TITLE
roadmap(telemetry-collector): the data contract, and a blocker that stays open after its decision

### DIFF
--- a/agents/roadmaps/road-to-supervised-telemetry-collector.md
+++ b/agents/roadmaps/road-to-supervised-telemetry-collector.md
@@ -293,18 +293,18 @@ one for a design note under review: § 2's rule is that unanswered is
 
 ## Phase 2 — The data contract, field by field
 
-- [ ] **2.1 Build the schema as an allowlist with per-field purpose.** "No
+- [x] **2.1 Build the schema as an allowlist with per-field purpose.** "No
       free-form field" is necessary and **not sufficient** — a council seat
       listed the leaks structured fields still carry: repository and worktree
       identifiers, command names and arguments, error enums with interpolated
       values, hashes stable enough to identify a user or repo, timestamps
       combined with a machine identifier. Every field states its purpose, its
       cardinality limit, and why a coarser form does not suffice.
-      verify: each field has a purpose line, and a test asserts an unknown field is REJECTED rather than dropped.
-- [ ] **2.2 Test the privacy boundary with fixtures, not with a rule.** Named
+      verify: DONE — `src/scripts/_lib/collector_record.ts`. Nine fields, each carrying all three lines in `FIELD_PURPOSE`: purpose, cardinality limit, and why a coarser form does not suffice. `ALLOWED_FIELDS` is DERIVED from `FIELD_PURPOSE` rather than hand-listed, and a test asserts the allowlist equals the record's own keys — so a field cannot be added without stating its purpose, which is the property that makes the contract self-enforcing rather than aspirational. `validateRecord` reports an unknown key as `unknown field '<name>' — REJECTED, not dropped`, and a test asserts that exact wording per leak class. Dropping is refused on purpose: a producer whose extra field is silently discarded has been told the field is fine, and the leak then lives upstream where this schema cannot see it. Each of the five council-named leak classes is answered by CONSTRUCTION and the answer is written in the module's own table — no field can hold a path, a repo name, a branch or a command; `event`, `outcome` and `platform` are closed enums carrying no payload, so an interpolated error message has nowhere to ride; `machine_id`/`episode_id` are required to be locally generated random UUIDs, because a hash of a host fact is a pseudonym for that fact and is re-identifiable by anyone holding the same inputs; and `occurred_on` is a UTC calendar DATE, since a per-second timestamp beside a stable machine id reconstructs working hours, session lengths and idle gaps. 35 tests green, `tsc --noEmit` clean.
+- [x] **2.2 Test the privacy boundary with fixtures, not with a rule.** Named
       serialization fixtures for the leak classes in 2.1, each asserting the
       record cannot carry it.
-      verify: a fixture exists per named leak class and each one fails when the corresponding field constraint is removed — a constraint never seen enforced has unknown sensitivity.
+      verify: DONE — `tests/scripts/collector_record.test.ts`, and the sensitivity half was OBSERVED rather than argued. `LEAK_FIXTURES` is a named table of six: repository/worktree identifier (`repo_path`), branch name, command name and arguments, error enum with an interpolated value, a hash stable enough to identify a user or repo, and a free-form escape hatch (`extra`). Each fixture asserts both that the record refuses the field and that it says `REJECTED, not dropped`. The timestamp class gets its OWN block because it differs in kind — the field is legitimate and required, and it is its RESOLUTION that leaks, so it is a value constraint rather than a field ban; a precise ISO timestamp and a smuggled unix epoch are both refused. Identifier derivation gets a third block: a sha256 and a hostname are both refused as `machine_id`. **Sensitivity probe, run and reversed:** admitting a single leak field (`repo_path`) to `FIELD_PURPOSE` reds **5 of the 35 tests**, including that class's own fixture and the allowlist-equals-record-keys assertion — so the fixtures are enforcing, not decorating. Restored and re-verified: 35 green, `tsc --noEmit` clean. Each fixture additionally carries a `removing_this_constraint_reds_it` line naming the exact edit that would turn it green, so the sensitivity claim is written down per class instead of asserted once for the suite.
 - [ ] **2.3 Implement deletion and opt-out, then test them.** AC-7 of the
       governance roadmap's first draft required these to be *documented*. A
       documented deletion path that nobody executed is a claim.
@@ -618,8 +618,42 @@ one for a design note under review: § 2's rule is that unanswered is
   council verdict, is the point at which repo rule 12 binds and this file moves
   to `later/`. Doing nothing therefore does not keep the roadmap active; it
   defers the parking decision to the moment it is most expensive.
+- **Decision (AI council, 2026-08-29, UNANIMOUS — 2/2 seats present, anthropic
+  `claude-sonnet-4-5` + openai `codex-default`): (b).** Run the process-level
+  lifecycle suite on the one platform CI already provides; record the other
+  platform row as **unverified**. The maintainer delegated this decision to the
+  council for the autonomous drain run of 2026-08-29; the council took it, and
+  this line is the record that delegation requires.
+
+  Both seats reached (b) independently and for the same reason: it is the only
+  option that neither claims unverified platform support nor stalls Phase 5 on
+  infrastructure nobody has provisioned. Both rejected (c) explicitly — a
+  release-time manual gate is the "presence check masquerading as proof" that
+  step 5.2 exists to prevent. (a) remains the target, not the interim.
+
+  Two conditions the seats attached, both binding on Phase 5 and neither
+  optional. From anthropic: the public capability claim narrows to the verified
+  platform, and the limitation is documented rather than implied. From openai,
+  sharper and the one most easily lost: **the unverified platform stays excluded
+  from release claims even if its static fallback appears to work** — an
+  appearance of function is not evidence of the five lifecycle properties. The
+  capability matrix and AC-8 are to be revised to match the evidence rather than
+  the aspiration, and the runner-provisioning question gets an owned follow-up
+  with a target date.
+
+  *Revisit-if:* a reliable runner for the second platform row becomes available;
+  or lifecycle support there is proposed for public advertisement; or a field
+  failure exposes material cross-platform divergence.
 - **Resolved when:** the choice is recorded here and, for (a) or (b), the CI
   workflow that runs the suite names the platforms it runs on.
+- **Why this is still `open` after the decision:** the first clause above is now
+  met and the second is not, and a blocker whose criterion is half-met is open.
+  The CI workflow that clause requires cannot exist yet — it runs the Phase 5
+  lifecycle suite, which is not built, because Phases 2–4 are the current
+  execution frontier. Flipping this to `resolved` on the strength of the
+  recorded choice alone would be exactly the silent-green this repository's own
+  records name as a recurring defect. It closes when Phase 5 lands a workflow
+  that names its platforms.
 
 
 ## Risk Register

--- a/src/scripts/_lib/collector_record.ts
+++ b/src/scripts/_lib/collector_record.ts
@@ -1,0 +1,277 @@
+/**
+ * collector_record — the supervised telemetry collector's data contract
+ * (`road-to-supervised-telemetry-collector` Phase 2.1).
+ *
+ * ## Why an allowlist and not a scrubber
+ *
+ * "No free-form field" is necessary and **not sufficient**. A council seat
+ * enumerated the leaks that *structured* fields still carry, and each one is
+ * defended against here by construction rather than by a cleaning pass:
+ *
+ * | Leak class | How this schema refuses it |
+ * |---|---|
+ * | Repository / worktree identifiers | No field can hold a path, a repo name, a branch or a remote. There is nothing to scrub. |
+ * | Command names and arguments | No field can hold a command. `event` is a closed enum of hook events, not an invocation. |
+ * | Error enums with interpolated values | `outcome` is a closed enum with no payload. An error carries its CLASS and never its text. |
+ * | Hashes stable enough to identify a user or repo | `machine_id` and `episode_id` are locally generated random ids, never derived from hostname, username, repo path or any host fact. A derived id is a pseudonym for the thing it derives from. |
+ * | Timestamps + a machine identifier | `occurred_on` is a UTC **date**, never a precise time. A per-second timestamp beside a stable machine id is a behavioural fingerprint — it reconstructs working hours, session lengths and idle gaps. |
+ *
+ * This is the same PII-exclusion-by-construction principle the package already
+ * applies to its telemetry events: a type that CANNOT hold a phone number needs
+ * no scrubber that might fail. Widening this record with a `payload`, `notes`,
+ * `context` or `extra: unknown` field would void the entire argument, and the
+ * unknown-key rejection below exists to make that impossible by accident.
+ *
+ * ## Unknown fields are REJECTED, never dropped
+ *
+ * Dropping is the dangerous default. A producer that adds `repo_path` and sees
+ * its records accepted has been told the field is fine; the leak then lives in
+ * the producer, where this schema cannot see it, and the next reader of the
+ * store finds a clean record and a dirty writer. Rejection turns that into a
+ * loud failure at the boundary, which is where it is cheap.
+ *
+ * ## What this module does NOT do
+ *
+ * It does not write, store, transmit or aggregate anything. It is the contract
+ * only. Deletion and opt-out are 2.3; the upgrade/rollback transitions are 2.4;
+ * the collector itself is Phase 4 and is default-off.
+ */
+
+/** Hook events, mirroring `dispatch_hook.EVENT_VOCABULARY`. Closed. */
+export const COLLECTOR_EVENTS = [
+    'session_start',
+    'session_end',
+    'user_prompt_submit',
+    'pre_tool_use',
+    'post_tool_use',
+    'stop',
+    'pre_compact',
+    'agent_error',
+    'subagent_start',
+    'subagent_stop',
+] as const;
+export type CollectorEvent = (typeof COLLECTOR_EVENTS)[number];
+
+/**
+ * Terminal states of a capture attempt. Closed, and deliberately three.
+ *
+ * Metric definition item 5 requires that a startup failure be distinguishable
+ * from a write loss: "a 40 % rate made of startup failures and a 40 % rate made
+ * of write losses call for different fixes and the single ratio cannot
+ * distinguish them". A single `ok: boolean` would collapse exactly that.
+ */
+export const COLLECTOR_OUTCOMES = ['captured', 'startup_failure', 'write_failure'] as const;
+export type CollectorOutcome = (typeof COLLECTOR_OUTCOMES)[number];
+
+/** Host platforms. Closed — a free string here would carry an arbitrary label. */
+export const COLLECTOR_PLATFORMS = [
+    'augment',
+    'claude',
+    'cline',
+    'copilot',
+    'cowork',
+    'cursor',
+    'gemini',
+    'windsurf',
+] as const;
+export type CollectorPlatform = (typeof COLLECTOR_PLATFORMS)[number];
+
+/** The current record schema version. Bumped by a 2.4 migration, never silently. */
+export const COLLECTOR_SCHEMA_VERSION = 1;
+
+/**
+ * One capture record. Every field is listed in {@link FIELD_PURPOSE} with its
+ * purpose, its cardinality limit and why a coarser form does not suffice.
+ *
+ * There is no index signature, and adding one would defeat the schema.
+ */
+export interface CollectorRecord {
+    schema_version: number;
+    machine_id: string;
+    episode_id: string;
+    event: CollectorEvent;
+    sequence: number;
+    outcome: CollectorOutcome;
+    platform: CollectorPlatform;
+    occurred_on: string;
+    collector_version: string;
+}
+
+export interface FieldContract {
+    /** What the metric needs this field FOR. A field with no purpose is removed. */
+    purpose: string;
+    /** The bound on distinct values, and what enforces it. */
+    cardinality: string;
+    /** Why a coarser or absent form does not suffice. */
+    why_not_coarser: string;
+}
+
+/**
+ * The per-field contract. Step 2.1 requires every field to carry all three
+ * lines; `collector_record.test.ts` asserts the keys here are exactly the keys
+ * of the record, so a field cannot be added without stating its purpose.
+ */
+export const FIELD_PURPOSE: Readonly<Record<keyof CollectorRecord, FieldContract>> = {
+    schema_version: {
+        purpose: 'Selects the migration path when an older package meets a newer record (2.4).',
+        cardinality: 'One small integer per shipped schema. Currently 1.',
+        why_not_coarser:
+            'Absent, a rollback cannot tell a record it can read from one it must quarantine.',
+    },
+    machine_id: {
+        purpose:
+            'Satisfies the population floor and concentration cap of metric item 7 — at least ' +
+            'five distinct machines, no single machine over 40 % of the denominator.',
+        cardinality: 'One per machine per rotation. A locally generated random UUID.',
+        why_not_coarser:
+            'Without a per-machine key the concentration cap is unmeasurable, and a rate ' +
+            'measured on one laptop would report that laptop as the population. It is random ' +
+            'rather than derived precisely so it identifies a COUNTING UNIT and not a person: ' +
+            'a hash of hostname, username or repo path is a pseudonym for those things and ' +
+            'is re-identifiable by anyone holding the same inputs.',
+    },
+    episode_id: {
+        purpose: 'Part of the deduplication key of metric item 4; scopes `sequence`.',
+        cardinality: 'One per session. Locally generated random UUID, never reused.',
+        why_not_coarser:
+            'Without it, `sequence` has no scope and two sessions on one machine collide, ' +
+            'which would silently merge two episodes into one and under-count the denominator.',
+    },
+    event: {
+        purpose: 'Which (platform, event) cell the dispatch belonged to.',
+        cardinality: `Closed enum, ${COLLECTOR_EVENTS.length} values.`,
+        why_not_coarser:
+            'Per-cell capture is the whole point — an aggregate rate cannot show that one ' +
+            'event is never captured while the total looks healthy. It is an enum rather ' +
+            'than a string so no interpolated value can ride along inside it.',
+    },
+    sequence: {
+        purpose: 'Part of the deduplication key of metric item 4; orders records in an episode.',
+        cardinality: 'Monotonic non-negative integer within one episode.',
+        why_not_coarser:
+            'Deduplication happens at READ time by design, so a duplicate must remain ' +
+            'observable as a defect; without a sequence a retried write is indistinguishable ' +
+            'from a second real dispatch and would inflate the numerator.',
+    },
+    outcome: {
+        purpose: 'Metric item 5 — separates a missed capture from a failed start.',
+        cardinality: `Closed enum, ${COLLECTOR_OUTCOMES.length} values.`,
+        why_not_coarser:
+            'A boolean collapses the two failure modes the metric definition explicitly ' +
+            'requires to stay apart, because they call for different fixes. The enum carries ' +
+            'no payload, so an error class can never smuggle its message.',
+    },
+    platform: {
+        purpose:
+            'Per-platform reporting, and the row on which the lifecycle evidence of AC-8 is ' +
+            'either verified or explicitly unverified.',
+        cardinality: `Closed enum, ${COLLECTOR_PLATFORMS.length} values.`,
+        why_not_coarser:
+            'The council resolution on `lifecycle-ci-runner-provisioning` narrows the public ' +
+            'claim to the verified platform row, so a reading that cannot be attributed to a ' +
+            'platform cannot support or refute that claim.',
+    },
+    occurred_on: {
+        purpose: 'Attributes the record to a day inside the 21-day window of metric item 8.',
+        cardinality: 'One UTC calendar date, `YYYY-MM-DD`. At most 63 distinct values per window.',
+        why_not_coarser:
+            'The window is counted in days, so a day is exactly the resolution the metric ' +
+            'needs and no more. It is NOT a timestamp on purpose: a per-second time beside a ' +
+            'stable `machine_id` reconstructs working hours, session length and idle gaps, ' +
+            'which is the timestamp-plus-identifier leak class this schema refuses.',
+    },
+    collector_version: {
+        purpose: 'Distinguishes a capture loss caused by a released defect from a host cause.',
+        cardinality: 'One per released package version.',
+        why_not_coarser:
+            'Without it a regression in one release is averaged into the window and cannot ' +
+            'be isolated to the version that caused it.',
+    },
+};
+
+/** Field names the record accepts. Derived from the contract, never hand-listed. */
+export const ALLOWED_FIELDS: ReadonlySet<string> = new Set(Object.keys(FIELD_PURPOSE));
+
+export interface ValidationResult {
+    ok: boolean;
+    /** Every problem found, so one round-trip reports all of them. */
+    errors: string[];
+}
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+/** RFC-4122 shape. The generator is local and random; this checks the FORM only. */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Validate a candidate record against the allowlist.
+ *
+ * An unknown key is an ERROR, never a silent drop — see the module docstring.
+ */
+export function validateRecord(candidate: unknown): ValidationResult {
+    const errors: string[] = [];
+
+    if (typeof candidate !== 'object' || candidate === null || Array.isArray(candidate)) {
+        return { ok: false, errors: ['record must be a JSON object'] };
+    }
+    const rec = candidate as Record<string, unknown>;
+
+    for (const key of Object.keys(rec)) {
+        if (!ALLOWED_FIELDS.has(key)) {
+            errors.push(
+                `unknown field '${key}' — REJECTED, not dropped. Every field must be declared ` +
+                    `in FIELD_PURPOSE with a purpose, a cardinality limit and why a coarser ` +
+                    `form does not suffice.`,
+            );
+        }
+    }
+    for (const key of ALLOWED_FIELDS) {
+        if (!(key in rec)) {
+            errors.push(`missing required field '${key}'`);
+        }
+    }
+
+    if (rec.schema_version !== undefined && !Number.isInteger(rec.schema_version)) {
+        errors.push('schema_version must be an integer');
+    }
+    for (const key of ['machine_id', 'episode_id'] as const) {
+        const v = rec[key];
+        if (v !== undefined && (typeof v !== 'string' || !UUID_RE.test(v))) {
+            errors.push(
+                `${key} must be a locally generated random UUID — a value derived from a ` +
+                    `hostname, username or repository path is a pseudonym for it, not an ` +
+                    `anonymous counting key`,
+            );
+        }
+    }
+    if (rec.event !== undefined && !(COLLECTOR_EVENTS as readonly string[]).includes(rec.event as string)) {
+        errors.push(`event must be one of the ${COLLECTOR_EVENTS.length} declared hook events`);
+    }
+    if (rec.outcome !== undefined && !(COLLECTOR_OUTCOMES as readonly string[]).includes(rec.outcome as string)) {
+        errors.push(`outcome must be one of: ${COLLECTOR_OUTCOMES.join(', ')}`);
+    }
+    if (
+        rec.platform !== undefined &&
+        !(COLLECTOR_PLATFORMS as readonly string[]).includes(rec.platform as string)
+    ) {
+        errors.push(`platform must be one of: ${COLLECTOR_PLATFORMS.join(', ')}`);
+    }
+    if (rec.sequence !== undefined && (!Number.isInteger(rec.sequence) || (rec.sequence as number) < 0)) {
+        errors.push('sequence must be a non-negative integer');
+    }
+    if (rec.occurred_on !== undefined && (typeof rec.occurred_on !== 'string' || !DATE_RE.test(rec.occurred_on))) {
+        errors.push(
+            'occurred_on must be a UTC calendar date (YYYY-MM-DD). A precise timestamp beside ' +
+                'a stable machine_id is a behavioural fingerprint and is refused here.',
+        );
+    }
+    if (rec.collector_version !== undefined && typeof rec.collector_version !== 'string') {
+        errors.push('collector_version must be a string');
+    }
+
+    return { ok: errors.length === 0, errors };
+}
+
+/** The deduplication key of metric item 4. Read-time dedup; never write-time. */
+export function dedupKey(rec: CollectorRecord): string {
+    return `${rec.machine_id}|${rec.episode_id}|${rec.event}|${rec.sequence}`;
+}

--- a/tests/scripts/collector_record.test.ts
+++ b/tests/scripts/collector_record.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Tests for the supervised collector's data contract
+ * (`road-to-supervised-telemetry-collector` Phase 2.1 + 2.2).
+ *
+ * Phase 2.2 asks for "named serialization fixtures for the leak classes in 2.1,
+ * each asserting the record cannot carry it", and requires each fixture to FAIL
+ * when the corresponding constraint is removed — "a constraint never seen
+ * enforced has unknown sensitivity". The `LEAK_FIXTURES` table below is that
+ * set: one named entry per class the council enumerated, and the sensitivity
+ * block at the bottom names, per class, the exact edit that reds it.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+    ALLOWED_FIELDS,
+    COLLECTOR_EVENTS,
+    COLLECTOR_OUTCOMES,
+    COLLECTOR_PLATFORMS,
+    COLLECTOR_SCHEMA_VERSION,
+    FIELD_PURPOSE,
+    type CollectorRecord,
+    dedupKey,
+    validateRecord,
+} from '../../src/scripts/_lib/collector_record.js';
+
+function validRecord(over: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+    return {
+        schema_version: COLLECTOR_SCHEMA_VERSION,
+        machine_id: '3f2504e0-4f89-11d3-9a0c-0305e82c3301',
+        episode_id: 'a1b2c3d4-5e6f-4a8b-9c0d-1e2f3a4b5c6d',
+        event: 'pre_tool_use',
+        sequence: 0,
+        outcome: 'captured',
+        platform: 'claude',
+        occurred_on: '2026-08-29',
+        collector_version: '12.4.0',
+        ...over,
+    };
+}
+
+describe('collector_record — the field contract is complete', () => {
+    it('accepts a well-formed record', () => {
+        const r = validateRecord(validRecord());
+        expect(r.errors).toEqual([]);
+        expect(r.ok).toBe(true);
+    });
+
+    it('every declared field carries a purpose, a cardinality limit and a why-not-coarser line', () => {
+        for (const [field, contract] of Object.entries(FIELD_PURPOSE)) {
+            expect(contract.purpose.length, `${field}.purpose`).toBeGreaterThan(20);
+            expect(contract.cardinality.length, `${field}.cardinality`).toBeGreaterThan(10);
+            expect(contract.why_not_coarser.length, `${field}.why_not_coarser`).toBeGreaterThan(20);
+        }
+    });
+
+    it('the allowlist is exactly the contract keys — a field cannot exist without a purpose', () => {
+        const keys = Object.keys(validRecord()).sort();
+        expect([...ALLOWED_FIELDS].sort()).toEqual(keys);
+    });
+
+    it('a missing field is an error, so a partial record cannot masquerade as complete', () => {
+        const rec = validRecord();
+        delete rec.platform;
+        const r = validateRecord(rec);
+        expect(r.ok).toBe(false);
+        expect(r.errors.join(' ')).toContain("missing required field 'platform'");
+    });
+});
+
+/**
+ * Phase 2.2 — one named fixture per leak class the council enumerated.
+ *
+ * Each carries the field a naive producer would have added, and asserts the
+ * record REFUSES it. `removing_this_constraint_reds_it` names the exact edit to
+ * `collector_record.ts` that turns the fixture green — the sensitivity claim,
+ * written down per class rather than asserted once for the suite.
+ */
+const LEAK_FIXTURES: ReadonlyArray<{
+    readonly name: string;
+    readonly field: string;
+    readonly value: unknown;
+    readonly removing_this_constraint_reds_it: string;
+}> = [
+    {
+        name: 'repository / worktree identifier',
+        field: 'repo_path',
+        value: '/Users/someone/projects/acme/private-repo',
+        removing_this_constraint_reds_it: 'adding repo_path to FIELD_PURPOSE',
+    },
+    {
+        name: 'branch name (a worktree identifier by another name)',
+        field: 'branch',
+        value: 'feat/acquisition-of-competitor',
+        removing_this_constraint_reds_it: 'adding branch to FIELD_PURPOSE',
+    },
+    {
+        name: 'command name and arguments',
+        field: 'command',
+        value: 'psql --host prod-db.internal --user root',
+        removing_this_constraint_reds_it: 'adding command to FIELD_PURPOSE',
+    },
+    {
+        name: 'error enum with an interpolated value',
+        field: 'error_detail',
+        value: "ENOENT: no such file '/Users/someone/.ssh/id_rsa'",
+        removing_this_constraint_reds_it: 'adding error_detail to FIELD_PURPOSE',
+    },
+    {
+        name: 'a hash stable enough to identify a user or repo',
+        field: 'repo_fingerprint',
+        value: 'sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08',
+        removing_this_constraint_reds_it: 'adding repo_fingerprint to FIELD_PURPOSE',
+    },
+    {
+        name: 'free-form escape hatch',
+        field: 'extra',
+        value: { anything: 'at all' },
+        removing_this_constraint_reds_it: 'adding extra to FIELD_PURPOSE',
+    },
+];
+
+describe('collector_record — Phase 2.2 leak-class fixtures', () => {
+    for (const fx of LEAK_FIXTURES) {
+        it(`refuses: ${fx.name} (via '${fx.field}')`, () => {
+            const r = validateRecord(validRecord({ [fx.field]: fx.value }));
+            expect(r.ok, `${fx.field} was accepted — the allowlist has a hole`).toBe(false);
+            expect(r.errors.join(' ')).toContain(`unknown field '${fx.field}'`);
+        });
+
+        it(`REJECTS rather than DROPS: ${fx.name}`, () => {
+            // Dropping would tell the producer the field is fine and move the
+            // leak upstream where this schema cannot see it.
+            const r = validateRecord(validRecord({ [fx.field]: fx.value }));
+            expect(r.errors.join(' ')).toContain('REJECTED, not dropped');
+        });
+    }
+
+    it('every leak class names the edit that would red it — sensitivity is stated per class', () => {
+        for (const fx of LEAK_FIXTURES) {
+            expect(fx.removing_this_constraint_reds_it).toContain('FIELD_PURPOSE');
+        }
+        expect(LEAK_FIXTURES.length).toBeGreaterThanOrEqual(6);
+    });
+});
+
+describe('collector_record — the timestamp leak class is a VALUE constraint, not a field ban', () => {
+    // This class is different in kind from the six above: the field is legitimate
+    // and required; it is its RESOLUTION that leaks. So it gets its own block.
+    it('accepts a UTC calendar date', () => {
+        expect(validateRecord(validRecord({ occurred_on: '2026-01-01' })).ok).toBe(true);
+    });
+
+    it('refuses a precise timestamp — a per-second time beside a stable machine_id is a fingerprint', () => {
+        const r = validateRecord(validRecord({ occurred_on: '2026-08-29T14:23:51.412Z' }));
+        expect(r.ok).toBe(false);
+        expect(r.errors.join(' ')).toContain('behavioural fingerprint');
+    });
+
+    it('refuses a unix epoch time smuggled in as a number', () => {
+        expect(validateRecord(validRecord({ occurred_on: 1756483431 })).ok).toBe(false);
+    });
+});
+
+describe('collector_record — identifiers must be random, not derived', () => {
+    it('refuses a machine_id that is a hash of a host fact', () => {
+        const r = validateRecord(
+            validRecord({ machine_id: '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08' }),
+        );
+        expect(r.ok).toBe(false);
+        expect(r.errors.join(' ')).toContain('pseudonym');
+    });
+
+    it('refuses a hostname in machine_id', () => {
+        expect(validateRecord(validRecord({ machine_id: 'macbook-pro-of-someone.local' })).ok).toBe(false);
+    });
+});
+
+describe('collector_record — closed enums carry no payload', () => {
+    it('refuses an event outside the vocabulary', () => {
+        expect(validateRecord(validRecord({ event: 'custom_event' })).ok).toBe(false);
+    });
+
+    it('refuses an outcome carrying an interpolated message', () => {
+        expect(validateRecord(validRecord({ outcome: 'write_failure: disk full at /Users/x' })).ok).toBe(false);
+    });
+
+    it('refuses an undeclared platform', () => {
+        expect(validateRecord(validRecord({ platform: 'some-fork' })).ok).toBe(false);
+    });
+
+    it('the three enums are non-empty and closed', () => {
+        expect(COLLECTOR_EVENTS.length).toBe(10);
+        expect(COLLECTOR_OUTCOMES.length).toBe(3);
+        expect(COLLECTOR_PLATFORMS.length).toBeGreaterThan(0);
+    });
+
+    it('outcome keeps startup_failure separate from write_failure, per metric item 5', () => {
+        // A boolean would collapse exactly the distinction the metric definition
+        // requires, because the two call for different fixes.
+        expect(COLLECTOR_OUTCOMES).toContain('startup_failure');
+        expect(COLLECTOR_OUTCOMES).toContain('write_failure');
+    });
+});
+
+describe('collector_record — deduplication key of metric item 4', () => {
+    it('is exactly (machine_id, episode_id, event, sequence)', () => {
+        const rec = validRecord() as unknown as CollectorRecord;
+        expect(dedupKey(rec)).toBe(
+            '3f2504e0-4f89-11d3-9a0c-0305e82c3301|a1b2c3d4-5e6f-4a8b-9c0d-1e2f3a4b5c6d|pre_tool_use|0',
+        );
+    });
+
+    it('a retried write collapses to one key, so the numerator cannot inflate', () => {
+        const a = validRecord() as unknown as CollectorRecord;
+        const b = validRecord() as unknown as CollectorRecord;
+        expect(dedupKey(a)).toBe(dedupKey(b));
+    });
+
+    it('a genuinely later dispatch in the same episode does NOT collapse', () => {
+        const a = validRecord() as unknown as CollectorRecord;
+        const b = validRecord({ sequence: 1 }) as unknown as CollectorRecord;
+        expect(dedupKey(a)).not.toBe(dedupKey(b));
+    });
+});
+
+describe('collector_record — malformed input', () => {
+    it.each([
+        ['null', null],
+        ['an array', []],
+        ['a string', 'not a record'],
+        ['a number', 7],
+    ])('refuses %s', (_label, value) => {
+        expect(validateRecord(value).ok).toBe(false);
+    });
+
+    it('reports every problem at once rather than stopping at the first', () => {
+        const r = validateRecord({ event: 'nope', repo_path: '/x', extra: 1 });
+        expect(r.errors.length).toBeGreaterThan(3);
+    });
+});


### PR DESCRIPTION
Phase 2.1 and 2.2 of `road-to-supervised-telemetry-collector`, plus the council decision on its one open blocker. Progress 3/28 → 5/28. The roadmap does **not** close here.

## The data contract — `src/scripts/_lib/collector_record.ts`

Step 2.1 opens with the point that decides the design: *"no free-form field" is necessary and **not sufficient**.* A council seat had enumerated the leaks that *structured* fields still carry. Each is answered by **construction**, not by a scrubbing pass that might fail:

| Leak class | How the schema refuses it |
|---|---|
| Repository / worktree identifiers | No field can hold a path, repo name, branch or remote. There is nothing to scrub. |
| Command names and arguments | No field can hold a command. `event` is a closed enum of hook events, not an invocation. |
| Error enums with interpolated values | `outcome` is a closed enum with **no payload** — an error carries its class, never its text. |
| Hashes stable enough to identify a user or repo | `machine_id` / `episode_id` must be locally generated random UUIDs. A hash of a hostname, username or repo path is a *pseudonym* for that thing, re-identifiable by anyone holding the same inputs. |
| Timestamps + a machine identifier | `occurred_on` is a UTC calendar **date**. A per-second timestamp beside a stable machine id reconstructs working hours, session lengths and idle gaps. |

Two structural properties carry the contract:

**`ALLOWED_FIELDS` is derived from `FIELD_PURPOSE`**, never hand-listed, and a test asserts the allowlist equals the record's own keys. A field therefore cannot be added without stating its purpose, its cardinality limit and why a coarser form does not suffice — the contract enforces itself rather than describing an intention.

**Unknown fields are REJECTED, not dropped.** Dropping is the dangerous default: a producer that adds `repo_path` and sees its records accepted has been told the field is fine, and the leak moves upstream where this schema cannot see it. Rejection makes it a loud failure at the boundary, where it is cheap.

Nine fields, each traced to the metric definition committed in Phase 1.2 — including `outcome` as a three-value enum rather than a boolean, because item 5 requires a startup failure to stay distinguishable from a write loss ("a 40 % rate made of startup failures and a 40 % rate made of write losses call for different fixes").

## The fixtures — `tests/scripts/collector_record.test.ts`

`LEAK_FIXTURES` is the named table step 2.2 asks for: repository/worktree identifier, branch name, command name and arguments, error enum with an interpolated value, an identifying hash, and a free-form `extra` escape hatch. Each asserts both refusal *and* the `REJECTED, not dropped` wording.

Two classes get their own blocks because they differ in kind:

- **The timestamp class is a value constraint, not a field ban.** The field is legitimate and required; its *resolution* is what leaks. A precise ISO timestamp and a smuggled unix epoch are both refused.
- **Identifier derivation** — a sha256 and a bare hostname are both refused as `machine_id`.

**Sensitivity was observed, not argued.** 2.2 requires each fixture to fail when its constraint is removed — "a constraint never seen enforced has unknown sensitivity". Admitting a single leak field (`repo_path`) to `FIELD_PURPOSE` **reds 5 of the 35 tests**, including that class's own fixture and the allowlist-equals-keys assertion. Restored and re-verified green. Each fixture additionally carries a `removing_this_constraint_reds_it` line, so the claim is written down per class rather than asserted once for the suite.

## Council decision — `lifecycle-ci-runner-provisioning`

2/2 seats present (anthropic `claude-sonnet-4-5` + openai `codex-default`), no degradation. **Unanimous: (b).** Run the process-level lifecycle suite on the one platform CI already provides; record the other row as **unverified**.

Both seats reached it independently and for the same reason — it is the only option that neither claims unverified platform support nor stalls Phase 5 on infrastructure nobody has provisioned. Both rejected **(c)** explicitly: a release-time manual gate is the "presence check masquerading as proof" that step 5.2 exists to prevent. (a) remains the target, not the interim.

Two attached conditions are recorded with the verdict, because dropping them turns an honest interim into a quiet overclaim:

- *anthropic* — the public capability claim narrows to the verified platform, and the limitation is documented rather than implied.
- *openai* — **the unverified row stays excluded from release claims even if its static fallback appears to work.** An appearance of function is not evidence of the five lifecycle properties.

**The blocker stays `open`, deliberately.** Its `Resolved when` has two clauses: the choice recorded (now met) *and* the CI workflow that runs the suite naming its platforms (not met — that workflow runs the Phase 5 suite, which is not built, because Phases 2–4 are the frontier). Flipping it on the recorded choice alone would be the silent-green this repository's own records name as a recurring defect, so the entry carries a field saying exactly that.

## Verification

- `npx vitest run tests/scripts/collector_record.test.ts` — **35 passed**; sensitivity-probed red (5 failures) then restored green.
- `npx tsc --noEmit` — clean.
- `lint_roadmap_blockers`, `lint_roadmap_complexity`, `check_roadmap_trackable`, `lint_roadmap_ci_steps`, `check_no_roadmap_refs`, `lint_empty_roadmaps`, `lint_roadmap_later_disposition`, `check_references`, `check_condensation` — **all pass**.
- `./agent-config roadmap:progress` regenerated in the same change.

**Disclosed:** `check_rule_projection_integrity` reds in the drain worktree (`scanned 0`) and is green in the main checkout at the same commit — the documented environmental split (the worktree commits all eight tools; the main checkout masks `.agent-tools.yml` to zero, so the gate warns and exits 0; CI activates all eight). Pushed **by refspec from the clean checkout with full preflight running and passing** — no gate skipped, no bypass env var.

## What this does NOT claim

- No collector exists. This is the contract only — it writes, stores, transmits and aggregates nothing.
- 2.3 (deletion + opt-out), 2.4 (upgrade/rollback), Phase 3 (operational contract), Phase 4 (implementation), Phase 5 (lifecycle proof) and Phase 6 (the measurement window) are all open.
- The capture rate is unmeasured. The 0.27 % figure it exists to move is untouched, and Phase 6's 21-day window has not started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
