### PR TITLE
fix(drain): six defects a neutral review found in code that had just merged green

### DIFF
--- a/src/scripts/_lib/collector_record.ts
+++ b/src/scripts/_lib/collector_record.ts
@@ -199,6 +199,20 @@ export interface ValidationResult {
 }
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * A date must be REAL, not merely date-SHAPED. `2026-99-99` matches the regex
+ * above and is not a day; letting it through would put a record in no window at
+ * all while looking well-formed. Round-tripping through `Date` is what
+ * distinguishes the two — `2026-02-30` normalises to March and fails to match.
+ */
+function isRealDate(value: string): boolean {
+    if (!DATE_RE.test(value)) {
+        return false;
+    }
+    const d = new Date(`${value}T00:00:00Z`);
+    return !Number.isNaN(d.getTime()) && d.toISOString().slice(0, 10) === value;
+}
 /** RFC-4122 shape. The generator is local and random; this checks the FORM only. */
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -225,7 +239,11 @@ export function validateRecord(candidate: unknown): ValidationResult {
         }
     }
     for (const key of ALLOWED_FIELDS) {
-        if (!(key in rec)) {
+        // `key in rec` is TRUE for a key present with an `undefined` value, and
+        // every type guard below is `!== undefined`-gated — so testing presence
+        // alone let `{ platform: undefined }` through with no constraint applied
+        // at all. Explicit-undefined is treated as missing, which is what it is.
+        if (!(key in rec) || rec[key] === undefined) {
             errors.push(`missing required field '${key}'`);
         }
     }
@@ -258,7 +276,7 @@ export function validateRecord(candidate: unknown): ValidationResult {
     if (rec.sequence !== undefined && (!Number.isInteger(rec.sequence) || (rec.sequence as number) < 0)) {
         errors.push('sequence must be a non-negative integer');
     }
-    if (rec.occurred_on !== undefined && (typeof rec.occurred_on !== 'string' || !DATE_RE.test(rec.occurred_on))) {
+    if (rec.occurred_on !== undefined && (typeof rec.occurred_on !== 'string' || !isRealDate(rec.occurred_on))) {
         errors.push(
             'occurred_on must be a UTC calendar date (YYYY-MM-DD). A precise timestamp beside ' +
                 'a stable machine_id is a behavioural fingerprint and is refused here.',

--- a/src/scripts/_lib/collector_record.ts
+++ b/src/scripts/_lib/collector_record.ts
@@ -213,8 +213,23 @@ function isRealDate(value: string): boolean {
     const d = new Date(`${value}T00:00:00Z`);
     return !Number.isNaN(d.getTime()) && d.toISOString().slice(0, 10) === value;
 }
-/** RFC-4122 shape. The generator is local and random; this checks the FORM only. */
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+/**
+ * RFC-4122 **version 4** shape. The version nibble is pinned deliberately: a v1
+ * UUID embeds a MAC address and a timestamp, and a v5 UUID is a HASH of a name
+ * in a namespace — both are derived identifiers wearing a UUID's clothes, which
+ * is exactly the leak class `machine_id` exists to avoid.
+ *
+ * Stated honestly, because a review raised it and the answer is a real limit:
+ * **syntax cannot establish randomness.** A v4-shaped value can still be
+ * produced deterministically. What this check buys is the elimination of the
+ * two derived forms that are *identifiable by construction*; the remaining
+ * guarantee has to come from the generator being trusted code, and that is a
+ * property of the (not yet written) collector, not of this validator.
+ */
+const UUID_V4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/** A package version. Bounded and shaped so the field cannot carry prose. */
+const VERSION_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]{1,32})?$/;
 
 /**
  * Validate a candidate record against the allowlist.
@@ -226,6 +241,21 @@ export function validateRecord(candidate: unknown): ValidationResult {
 
     if (typeof candidate !== 'object' || candidate === null || Array.isArray(candidate)) {
         return { ok: false, errors: ['record must be a JSON object'] };
+    }
+    // Reject anything that is not a PLAIN object. `Object.keys` sees only own
+    // keys while `in` and property reads see inherited ones, so an object whose
+    // PROTOTYPE carries `repo_path` would pass the unknown-key sweep below and
+    // still read that value downstream. Pinning the prototype closes the gap at
+    // the boundary rather than trying to out-think it field by field.
+    const proto = Object.getPrototypeOf(candidate) as unknown;
+    if (proto !== Object.prototype && proto !== null) {
+        return {
+            ok: false,
+            errors: [
+                'record must be a plain object — a prototype can carry fields the ' +
+                    'own-key scan cannot see',
+            ],
+        };
     }
     const rec = candidate as Record<string, unknown>;
 
@@ -248,12 +278,18 @@ export function validateRecord(candidate: unknown): ValidationResult {
         }
     }
 
-    if (rec.schema_version !== undefined && !Number.isInteger(rec.schema_version)) {
-        errors.push('schema_version must be an integer');
+    if (rec.schema_version !== undefined && rec.schema_version !== COLLECTOR_SCHEMA_VERSION) {
+        // Any-integer was too weak: -50 and 999999 both passed, and a record
+        // claiming an unshipped version is a migration decision, not a datum.
+        errors.push(
+            `schema_version must be ${COLLECTOR_SCHEMA_VERSION} — the only shipped schema. ` +
+                `A record naming another version is handled by the 2.4 migration path, ` +
+                `not accepted here.`,
+        );
     }
     for (const key of ['machine_id', 'episode_id'] as const) {
         const v = rec[key];
-        if (v !== undefined && (typeof v !== 'string' || !UUID_RE.test(v))) {
+        if (v !== undefined && (typeof v !== 'string' || !UUID_V4_RE.test(v))) {
             errors.push(
                 `${key} must be a locally generated random UUID — a value derived from a ` +
                     `hostname, username or repository path is a pseudonym for it, not an ` +
@@ -282,8 +318,17 @@ export function validateRecord(candidate: unknown): ValidationResult {
                 'a stable machine_id is a behavioural fingerprint and is refused here.',
         );
     }
-    if (rec.collector_version !== undefined && typeof rec.collector_version !== 'string') {
-        errors.push('collector_version must be a string');
+    if (
+        rec.collector_version !== undefined &&
+        (typeof rec.collector_version !== 'string' || !VERSION_RE.test(rec.collector_version))
+    ) {
+        // `typeof === 'string'` was an unrestricted leak channel in a schema
+        // whose entire claim is that no field can hold free-form content: a
+        // path, a command line or a paragraph all passed it.
+        errors.push(
+            'collector_version must be a bounded semver-shaped string — an unconstrained ' +
+                'string is a free-form field, which is the thing this schema refuses',
+        );
     }
 
     return { ok: errors.length === 0, errors };

--- a/src/scripts/_lib/source_redact.ts
+++ b/src/scripts/_lib/source_redact.ts
@@ -50,18 +50,31 @@
  * - It does not redact SHAPE findings (a speaking `**Source:**` header, a
  *   quoted `agents/tmp/<name>/` path). Those are heuristics with a measured
  *   false-positive tail, and redacting on a heuristic silently corrupts a diff
- *   a reviewer has to read. The deny set is an exact-match list; a hit on it is
- *   a name, not a guess.
+ *   a reviewer has to read. A deny entry names a source; a shape match guesses
+ *   at one.
+ * - **The deny entries are REGEXES, not literals, and that is deliberate.** A
+ *   cross-model review recommended escaping their metacharacters to make them
+ *   exact-match. Measured before acting: 13 of the 65 shipped entries use `\b`
+ *   word boundaries, so escaping would turn a working boundary assertion into a
+ *   literal backslash-b and those 13 would stop matching entirely. More
+ *   importantly the GATE compiles them as regexes too, so escaping here would
+ *   make the redactor MISS tokens the gate still catches — a file that fails
+ *   the gate and that this module declined to clean. Matching the gate exactly
+ *   is the invariant; an earlier version of this docstring called the set
+ *   "exact-match", which was simply wrong.
  * - It does not preserve length or reversibility. The marker is deliberately
  *   fixed-width and opaque: a length-preserving redaction leaks the length.
  *
  * ## The evidence chain stays intact
  *
- * Redaction is line-local and leaves every surrounding byte alone, so a
- * reviewer reading `diff.patch` sees the same hunks, the same paths and the
- * same context; only the token is gone. The count of redactions performed is
- * returned so a caller can record it in the snapshot header rather than
- * silently changing what it wrote.
+ * Redaction is **token-local**: it replaces matched spans and leaves every other
+ * byte alone, so a reviewer reading `diff.patch` sees the same hunks, the same
+ * paths and the same context. It is NOT *line*-local — an earlier docstring
+ * claimed that, and it was false: the matcher runs over the whole string, and a
+ * deny pattern permitting `\s` could span a newline. Nothing in the shipped set
+ * does today, but the guarantee is written to match the code rather than the
+ * intention. The count of redactions is returned so a caller can record it
+ * rather than silently changing what it wrote.
  */
 
 import fs from 'node:fs';
@@ -90,8 +103,39 @@ export function loadDenyPatterns(configPath: string = CONFIG): RegExp[] {
     if (!data.deny || data.deny.length === 0) {
         throw new Error('source_redact: empty deny list');
     }
-    // `g` so every occurrence on a line is replaced, `i` to match the gate.
-    return data.deny.map((p) => new RegExp(p, 'gi'));
+    // Longest source first. Applying patterns SEQUENTIALLY lets a shorter one
+    // consume the head of a longer token and leave its tail in the clear: a
+    // `\b`-bounded entry can fire INSIDE a longer hyphenated entry, because a
+    // hyphen is a word boundary, so the naive order emits
+    // `[REDACTED:src-conf]-<tail>` — a partial disclosure that still names the
+    // source. **Two such pairs exist in the shipped set today** (verified by
+    // scanning the config; the pairs are deliberately not quoted here, because
+    // naming them is the disclosure this module exists to prevent). This is a
+    // live defect, not a hypothetical. Ordering feeds the alternation below,
+    // where
+    // JS picks the first alternative that matches at a position, so
+    // longest-first approximates longest-match.
+    //
+    // `g` so every occurrence is replaced, `i` to match the gate.
+    return [...data.deny]
+        .sort((a, b) => b.length - a.length)
+        .map((p) => new RegExp(p, 'gi'));
+}
+
+/**
+ * Combine the patterns into ONE alternation, preserving their order.
+ *
+ * Sequential application is what produces the partial-exposure defect above:
+ * each pass rewrites the output of the last, so an earlier pattern can destroy
+ * a later one's match. A single alternation makes every position decided once,
+ * against all patterns at the same time.
+ *
+ * Safe here because no shipped entry is anchored (`^`/`$`) — checked, 0 of 65 —
+ * and none carries a capturing group, so joining cannot change what any
+ * individual pattern means or shift a group index.
+ */
+function combine(patterns: RegExp[]): RegExp {
+    return new RegExp(patterns.map((rx) => `(?:${rx.source})`).join('|'), 'gi');
 }
 
 export interface RedactionResult {
@@ -107,17 +151,18 @@ export interface RedactionResult {
  * Pure: takes text, returns text. The caller decides what to do with the count.
  */
 export function redactSourceTokens(text: string, patterns: RegExp[]): RedactionResult {
-    let out = text;
-    let count = 0;
-    for (const rx of patterns) {
-        // A `g` RegExp carries lastIndex across calls; reset before each use so
-        // the same compiled pattern can be reused for many files.
-        rx.lastIndex = 0;
-        out = out.replace(rx, () => {
-            count += 1;
-            return REDACTION_MARKER;
-        });
+    if (patterns.length === 0) {
+        return { text, count: 0 };
     }
+    const rx = combine(patterns);
+    // A `g` RegExp carries lastIndex across calls; reset before use so the same
+    // compiled set can be reused across many files.
+    rx.lastIndex = 0;
+    let count = 0;
+    const out = text.replace(rx, () => {
+        count += 1;
+        return REDACTION_MARKER;
+    });
     return { text: out, count };
 }
 

--- a/tests/scripts/collector_record.test.ts
+++ b/tests/scripts/collector_record.test.ts
@@ -26,7 +26,7 @@ import {
 function validRecord(over: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
     return {
         schema_version: COLLECTOR_SCHEMA_VERSION,
-        machine_id: '3f2504e0-4f89-11d3-9a0c-0305e82c3301',
+        machine_id: '3f2504e0-4f89-4d3a-9a0c-0305e82c3301',
         episode_id: 'a1b2c3d4-5e6f-4a8b-9c0d-1e2f3a4b5c6d',
         event: 'pre_tool_use',
         sequence: 0,
@@ -135,9 +135,14 @@ describe('collector_record — Phase 2.2 leak-class fixtures', () => {
         });
     }
 
-    it('every leak class names the edit that would red it — sensitivity is stated per class', () => {
+    // A review called the previous version of this test documentary: it asserted
+    // a string contains 'FIELD_PURPOSE', which proves nothing about the code.
+    // The probative version checks the property the table exists for — that
+    // every fixture field is genuinely absent from the allowlist, so no entry
+    // has quietly become a declared field while its test still reads as a leak.
+    it('no leak-fixture field is in the allowlist — the table cannot go stale silently', () => {
         for (const fx of LEAK_FIXTURES) {
-            expect(fx.removing_this_constraint_reds_it).toContain('FIELD_PURPOSE');
+            expect(ALLOWED_FIELDS.has(fx.field), `${fx.field} became a declared field`).toBe(false);
         }
         expect(LEAK_FIXTURES.length).toBeGreaterThanOrEqual(6);
     });
@@ -206,7 +211,7 @@ describe('collector_record — deduplication key of metric item 4', () => {
     it('is exactly (machine_id, episode_id, event, sequence)', () => {
         const rec = validRecord() as unknown as CollectorRecord;
         expect(dedupKey(rec)).toBe(
-            '3f2504e0-4f89-11d3-9a0c-0305e82c3301|a1b2c3d4-5e6f-4a8b-9c0d-1e2f3a4b5c6d|pre_tool_use|0',
+            '3f2504e0-4f89-4d3a-9a0c-0305e82c3301|a1b2c3d4-5e6f-4a8b-9c0d-1e2f3a4b5c6d|pre_tool_use|0',
         );
     });
 
@@ -249,6 +254,59 @@ describe('collector_record — regressions found by adversarial probe, not by th
 
     it.each(['2026-02-28', '2024-02-29', '2026-12-31'])('accepts the real date %s', (value) => {
         expect(validateRecord(validRecord({ occurred_on: value })).ok).toBe(true);
+    });
+});
+
+describe('collector_record — findings from the neutral cross-model review', () => {
+    it('refuses an object whose PROTOTYPE carries a leak field', () => {
+        // Object.keys sees own keys only, while `in` and property reads see
+        // inherited ones — so a prototype-borne repo_path passed the unknown-key
+        // sweep and was still readable downstream.
+        const carrier = Object.create({ repo_path: '/Users/someone/private-repo' }) as Record<
+            string,
+            unknown
+        >;
+        Object.assign(carrier, validRecord());
+        const r = validateRecord(carrier);
+        expect(r.ok).toBe(false);
+        expect(r.errors.join(' ')).toContain('plain object');
+    });
+
+    it('refuses an inherited required field masquerading as present', () => {
+        const partial = validRecord();
+        delete partial.platform;
+        const carrier = Object.create({ platform: 'claude' }) as Record<string, unknown>;
+        Object.assign(carrier, partial);
+        expect(validateRecord(carrier).ok).toBe(false);
+    });
+
+    it.each([-50, 0, 2, 999999])('refuses schema_version %s — only the shipped one', (v) => {
+        expect(validateRecord(validRecord({ schema_version: v })).ok).toBe(false);
+    });
+
+    it.each([
+        '/Users/alice/repo',
+        'psql --host prod-db.internal',
+        'a whole sentence of prose that should never be in a telemetry record',
+        '',
+    ])('refuses collector_version %j — an unbounded string is a free-form field', (v) => {
+        expect(validateRecord(validRecord({ collector_version: v })).ok).toBe(false);
+    });
+
+    it.each(['12.4.0', '1.0.0', '12.4.0-rc.1'])('accepts the version-shaped %s', (v) => {
+        expect(validateRecord(validRecord({ collector_version: v })).ok).toBe(true);
+    });
+
+    it('refuses a UUIDv1 machine_id — it embeds a MAC address and a timestamp', () => {
+        expect(
+            validateRecord(validRecord({ machine_id: '3f2504e0-4f89-11d3-9a0c-0305e82c3301' })).ok,
+        ).toBe(false);
+    });
+
+    it('refuses a UUIDv5 machine_id — it is a hash of a name in a namespace', () => {
+        expect(
+            validateRecord(validRecord({ machine_id: '886313e1-3b8a-5372-9b90-0c9aee199e5d' })).ok,
+        ).toBe(false);
     });
 });
 

--- a/tests/scripts/collector_record.test.ts
+++ b/tests/scripts/collector_record.test.ts
@@ -223,6 +223,35 @@ describe('collector_record — deduplication key of metric item 4', () => {
     });
 });
 
+describe('collector_record — regressions found by adversarial probe, not by the happy path', () => {
+    // Both were found by probing the validator directly AFTER the first 35 tests
+    // were green. The suite passed and the validator was wrong, which is the
+    // reason a passing suite is not evidence on its own.
+
+    it.each(['platform', 'event', 'outcome', 'machine_id'])(
+        'a required field present with an explicit `undefined` is MISSING, not valid (%s)',
+        (field) => {
+            // `key in rec` is true here, and every type guard is
+            // `!== undefined`-gated — so presence-only checking applied NO
+            // constraint at all and the record validated clean.
+            const r = validateRecord(validRecord({ [field]: undefined }));
+            expect(r.ok, `${field}: undefined was accepted`).toBe(false);
+            expect(r.errors.join(' ')).toContain(`missing required field '${field}'`);
+        },
+    );
+
+    it.each(['2026-99-99', '2026-02-30', '2026-13-01', '2026-00-10'])(
+        'occurred_on must be a REAL date, not merely date-shaped (%s)',
+        (value) => {
+            expect(validateRecord(validRecord({ occurred_on: value })).ok).toBe(false);
+        },
+    );
+
+    it.each(['2026-02-28', '2024-02-29', '2026-12-31'])('accepts the real date %s', (value) => {
+        expect(validateRecord(validRecord({ occurred_on: value })).ok).toBe(true);
+    });
+});
+
 describe('collector_record — malformed input', () => {
     it.each([
         ['null', null],

--- a/tests/scripts/source_redact.test.ts
+++ b/tests/scripts/source_redact.test.ts
@@ -88,25 +88,62 @@ describe('source_redact — redactSourceTokens', () => {
         expect(lines[5]).toBe('+new line');
     });
 
-    it('a reused compiled pattern does not skip hits — lastIndex is reset per call', () => {
-        // A `g` RegExp carries lastIndex across .replace calls. Reusing one
-        // compiled set over many files is the intended usage, so this is the
-        // bug the reset guards against.
+    it('a reused compiled pattern set does not skip hits across many files', () => {
+        // The review noted that global String.replace resets regex state on its
+        // own, so this does not prove the explicit lastIndex reset is load
+        // bearing — it is belt-and-braces, and the test is kept for the
+        // property that actually matters: reusing one compiled set over many
+        // files is the intended usage and must be stable.
         const pats = patterns();
-        const first = redactSourceTokens('example-denied-slug', pats);
-        const second = redactSourceTokens('example-denied-slug', pats);
-        expect(first.count).toBe(1);
-        expect(second.count).toBe(1);
+        for (let i = 0; i < 5; i += 1) {
+            expect(redactSourceTokens('example-denied-slug', pats).count).toBe(1);
+        }
     });
 
-    // SENSITIVITY PROBE. If the matcher were neutralised — the deny list empty,
-    // the pattern never compiled — every assertion above would still pass on
-    // clean input. This one fails in that case, so the suite can tell "nothing
-    // to redact" from "redaction is broken".
-    it('SENSITIVITY: a token absent from the deny set is NOT redacted', () => {
-        const r = redactSourceTokens('a-token-that-is-not-denied', patterns());
-        expect(r.count).toBe(0);
-        expect(r.text).toBe('a-token-that-is-not-denied');
+    // A cross-model review correctly called the previous version of this test
+    // BACKWARDS: it asserted that a non-denied token survives, which a totally
+    // neutered matcher also satisfies. It proved nothing about sensitivity. The
+    // real discriminator is a paired assertion — the denied token must go AND
+    // the neighbouring one must stay — because no single broken implementation
+    // satisfies both.
+    it('discriminates: the denied token goes, the non-denied neighbour stays', () => {
+        const r = redactSourceTokens('example-denied-slug and a-token-that-is-not-denied', patterns());
+        expect(r.count).toBe(1);
+        expect(r.text).toBe(`${REDACTION_MARKER} and a-token-that-is-not-denied`);
+    });
+});
+
+describe('source_redact — overlapping patterns cannot partially expose a token', () => {
+    // This is a LIVE defect class, not a hypothetical: two pairs in the shipped
+    // denylist have this shape, where a `\b`-bounded entry matches inside a
+    // longer hyphenated entry because a hyphen is a word boundary. Applying
+    // patterns sequentially let the short one consume the head and leave the
+    // tail in the clear, emitting `[REDACTED:src-conf]-<tail>` — which still
+    // names the source. The real pairs are NOT quoted here: this repo's own
+    // step 2.2 had to fix a gate test that published real names, and repeating
+    // it inside the redactor's own suite would be the same defect. The fixture
+    // below reproduces the shape with invented tokens.
+    const overlapping = () =>
+        loadDenyPatterns(fixtureConfig(['\\bexample-denied\\b', 'example-denied-labs']));
+
+    it('redacts the WHOLE longer token, not just its head', () => {
+        const r = redactSourceTokens('see example-denied-labs for details', overlapping());
+        expect(r.text).toBe(`see ${REDACTION_MARKER} for details`);
+        expect(r.text).not.toContain('-labs');
+    });
+
+    it('still redacts the shorter token when it stands alone', () => {
+        const r = redactSourceTokens('see example-denied for details', overlapping());
+        expect(r.text).toBe(`see ${REDACTION_MARKER} for details`);
+    });
+
+    it('order in the config file does not change the outcome', () => {
+        const reversed = loadDenyPatterns(
+            fixtureConfig(['example-denied-labs', '\\bexample-denied\\b']),
+        );
+        expect(redactSourceTokens('x example-denied-labs y', reversed).text).toBe(
+            `x ${REDACTION_MARKER} y`,
+        );
     });
 });
 


### PR DESCRIPTION
Six defects in code merged an hour ago by #1720 and #1721. **None was found by the 46 tests that were green when those PRs shipped.** Two came from probing the validator directly after the suite passed; four from a neutral cross-model review of the whole session delta, which both seats returned as *"do not approve as complete"*.

This is the follow-up because both PRs merged while the review was still running.

## The security defect — a shorter deny entry left the tail of a longer one

`_lib/source_redact.ts` applied deny patterns **sequentially**, each pass rewriting the last one's output. A `\b`-bounded entry matches *inside* a longer hyphenated entry, because a hyphen is a word boundary — so the short one consumed the head and left the tail in the clear:

```
[REDACTED:src-conf]-<tail>
```

which still names the source. **Two pairs of that shape are in the shipped denylist today** — verified by scanning the config, not hypothesised. The pairs are deliberately not quoted here or in the code, for the obvious reason.

**Fix:** one alternation, patterns ordered longest-source-first, so every position is decided once against all patterns simultaneously. Safe to join because **0 of 65** entries are anchored and **none** carries a capturing group — both checked before relying on it.

### One review recommendation rejected, with the measurement

Both seats recommended escaping the deny entries' metacharacters to make them literal exact-matches. **Rejected:**

- **13 of the 65** shipped entries use `\b`. Escaping turns a working boundary assertion into a literal backslash-b, and those 13 stop matching entirely.
- The **gate** compiles them as regexes too. Escaping here would make the redactor *miss* tokens the gate still catches — producing a file that fails CI and that this module declined to clean.

The actual error was my docstring calling the set "exact-match". That is corrected. Matching the gate exactly is the invariant.

## The privacy defects — `collector_record.ts`

| # | Defect | Why it mattered |
|---|---|---|
| 1 | A required field present with an explicit `undefined` **validated clean** | `key in rec` is true for such a key and every type guard is `!== undefined`-gated, so **no constraint applied at all**. `{ platform: undefined }` passed. |
| 2 | `occurred_on` accepted any date-*shaped* string | `2026-99-99` and `2026-02-30` passed. A record in no observation window, looking well-formed. |
| 3 | **Prototype-borne fields were invisible** | `Object.keys` sees own keys; `in` and property reads see inherited ones. An object whose *prototype* carried `repo_path` passed the unknown-key sweep and stayed readable downstream. |
| 4 | `schema_version` accepted any integer | `-50` and `999999` both passed. |
| 5 | `collector_version` was `typeof === 'string'` and nothing else | An **unrestricted free-form channel** in a schema whose entire claim is that no field can hold free-form content. A path, a command line and a paragraph all passed. |
| 6 | `machine_id` accepted any UUID shape | A **v1** UUID embeds a MAC address and a timestamp; a **v5** UUID is a hash of a name in a namespace. Both are derived identifiers wearing a UUID's clothes — the exact leak class the field exists to avoid. |

On (6): **the test fixture itself was a UUIDv1.** That is how the contradiction reached the suite unnoticed, and enforcing v4 is what surfaced it.

The docstring now states the real limit instead of implying more than it has: **syntax cannot establish randomness.** Pinning v4 removes the two forms that are identifiable *by construction*; the rest must come from the generator being trusted code, which is a property of a collector that does not exist yet.

## Two tests rewritten because they proved nothing

- The one named **`SENSITIVITY`** asserted that a *non-denied* token survives — which a totally neutered matcher also satisfies. It now asserts the denied token goes **and** the neighbour stays; no single broken implementation passes both.
- A meta-test asserted a string contained `'FIELD_PURPOSE'`. It now checks the property the table exists for: that no leak-fixture field has quietly become a declared field.

The `lastIndex` test is kept but its comment now says honestly that global `String.replace` resets regex state on its own, so the explicit reset is belt-and-braces rather than load-bearing.

## Verification

- **75 tests pass** across both suites (46 → 61 collector, 11 → 14 redactor).
- **Every fix sensitivity-probed, then restored:** neutralising the four collector constraints reds **12 of 61**; reverting the redactor to sequential application reds the overlap test; reverting only the `undefined`/date fix (keeping the new tests) reds **8 of 46**.
- `npx tsc --noEmit` clean · `check_no_external_sources` **exit 0** · `check_review_prompt_binding` passes.

## One thing worth saying plainly

While writing the comment that explains the overlap fix, I pasted **four real source names** into it. The gate caught them — the exact defect this module exists to prevent, committed inside its own repair. Scrubbed before the commit: the shape is described, the names are not.

That is also the honest summary of this PR. A green suite is not evidence; the review and the probes are what found these, and the suite that missed all six had passed 46 assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
