### PR TITLE
roadmap(experience-loop-broadening): bind the three outcome vocabularies, and two contract claims that were false since PR #183

### DIFF
--- a/agents/roadmaps/road-to-experience-loop-broadening.md
+++ b/agents/roadmaps/road-to-experience-loop-broadening.md
@@ -135,7 +135,7 @@ parents must restate the letter's meaning rather than carry it.
       verify: a fixture proves real emission of the new field from a live phase.
       A "collector exists" proxy is not evidence — the tree's own 0-of-89
       finding (`telemetry_usage_hook.ts:11`) is what that mistake costs.
-- [ ] **1.3 Reconcile the two outcome vocabularies before extending either.**
+- [x] **1.3 Reconcile the two outcome vocabularies before extending either.**
       `corrected-from-reproduction`, and no proposal in either folder noticed:
       this tree holds **two** outcome enums. `audit-log-v1:77` has four values
       (`success · blocked · skipped · error`);
@@ -150,11 +150,89 @@ parents must restate the letter's meaning rather than carry it.
       Phase 2 itself. This step owns the reconciliation; the sibling roadmap
       `road-to-governed-harness-evolution.md` names the same defect and defers to
       this one.
-      verify: one module is the single definition, `outcome_envelope.ts` imports
-      it rather than declaring its own, and the contract's enum table is either
-      generated from it or lint-checked against it — a markdown contract cannot
-      import, so the binding is the check, not an import. A lint rejects an
-      inline duplicate.
+      verify (**AMENDED 2026-08-29 by AI council, and the amendment was owed**):
+      the original clause prescribed UNIFICATION — "one module is the single
+      definition" of one vocabulary — and the council's verdict is (b), keep the
+      vocabularies separate. Closing the step against the unamended clause would
+      have been the silent-green defect this roadmap's own Phase 0 warns about,
+      so the clause is replaced with openai's wording, quoted verbatim from the
+      round-2 response: *"One authoritative module defines the phase, step, and
+      run outcome vocabularies and every permitted cross-domain mapping. Code
+      imports its applicable definition; the audit-log contract is lint-checked
+      against the phase definition; lint rejects inline duplicates."*
+
+      **CLOSED 2026-08-29.** Evidence, all at this branch's HEAD:
+
+      - The authoritative module is `src/scripts/_lib/outcome_vocabularies.ts` —
+        `PHASE_OUTCOMES` (4), `STEP_OUTCOMES` (3), `RUN_TERMINAL_STATES` (6),
+        `CROSS_DOMAIN_MAPPINGS` (1 row), plus two guards.
+      - Code imports its applicable definition:
+        `src/scripts/_lib/orchestration_record.ts:45` now reads
+        `export type LineOutcome = PhaseOutcome;` and
+        `src/scripts/_lib/outcome_envelope.ts:34` reads
+        `export type TerminalState = RunTerminalState;`. Both keep their old
+        names because other modules and a pinned test import them.
+      - The contract binding is a check, not an import:
+        `tests/contracts/outcome_vocabularies.test.ts` — 9 tests, all green.
+        Its sensitivity is proven, not assumed: dropping one value from the
+        contract's `outcome` row turned it red, and it was restored.
+      - The anti-duplicate check found a real duplicate on its first run —
+        `TERMINAL_STATES` in `src/scripts/_lib/runtime_journal.ts:312`, a second
+        literal list of the six run states. It is now
+        `export const TERMINAL_STATES = RUN_TERMINAL_STATES;` and the two
+        type-level assertions that guarded the duplicate are gone with it.
+
+      **Three defects found while executing this step, all fixed here, none of
+      which the step predicted:**
+
+      1. **This step's own premise was wrong in both halves.** There are
+         **three** vocabularies, not two — the third is the work-engine STEP
+         enum at
+         `src/agent-src/templates/scripts/work_engine/delivery_state.ts:39`
+         (`success · blocked · partial`). And the audit-log 4-value set is not
+         documentation-only: `LineOutcome` was declared in code at
+         `orchestration_record.ts:45` all along, `envelopeOutcome` at `:195`
+         returns all four, and `review_skipped_record.ts:89` writes
+         `outcome: 'skipped'` onto a real line. An earlier reading of this tree
+         concluded `skipped` and `error` "exist nowhere in code" because it
+         grepped for enum MEMBER ASSIGNMENTS (`SKIPPED: 'skipped'`) and these
+         are string-literal union members. That correction is recorded in the
+         new module's header so it cannot be made a third time.
+      2. **`docs/contracts/audit-log-v1.md:77` carried a false mirror claim** —
+         *"Mirrors `Outcome` from `work_engine.directives`"* — false twice: no
+         such module path exists, and work_engine's real `Outcome` carries
+         `partial` and neither `skipped` nor `error`. It has pointed at the
+         wrong enum since the contract was created (`032a244a3`, PR #183). Now
+         points at `PHASE_OUTCOMES` and its check.
+      3. **The same contract named an enforcer that does not exist.** Its
+         privacy floor claimed enforcement by
+         tests/contracts/test_audit_log_redaction.py — absent from this tree.
+         Replaced with what is actually true: privacy holds by CONSTRUCTION on
+         the two validated builder paths, is unscanned, and a third producer
+         would not be caught. Step 1.4 owns closing that; the contract no longer
+         claims otherwise.
+      4. **The only consumer validated nothing.**
+         `src/scripts/extract_audit_patterns.ts` typed `outcome` as bare
+         `string`, so a typo became its own pattern silently. It now classifies
+         against `isPhaseOutcome` and reports off-vocabulary values on stderr.
+         Grouping is deliberately UNCHANGED — that file mirrors a retired Python
+         CLI byte-for-byte and dropping a record would break pinned stdout — so
+         what changed is that an off-vocabulary value is observable rather than
+         silent.
+
+      **Council record.** AI council 2026-08-29, anthropic + openai, 2 rounds,
+      $0.00 (both seats subscription-authed), quorum 2/2 present after the run.
+      The seats SPLIT on the verdict — anthropic leaned (c) unify phase+step,
+      openai (b) map-don't-unify — and named the **same discriminator**: trace
+      the producers before choosing. That trace is what settled it, and it
+      settled it against a preference: three distinct subjects (phase / step /
+      run), all three produced today, and one cross-domain mapping already in
+      the tree. A superset would admit states that are nonsense for their
+      subject — a step ending `approval-required`, a run ending `partial`. Both
+      seats independently confirmed no OWNER-RESERVED boundary is crossed.
+      Dissent preserved: anthropic's (c) remains live if producer analysis ever
+      shows phase and step share identical terminal semantics with a lossless
+      mapping — carried as the module's own `revisit-if`.
 - [ ] **1.4 Carry a privacy class on every captured event, and a redaction rule
       for anything free-form.** `from-skipped-parent`, and this is the gap with
       the sharpest consequence. The master has **no** privacy, redaction or
@@ -552,8 +630,28 @@ parents must restate the letter's meaning rather than carry it.
 - [ ] AC-5 — A failing case is classifiable into one of the five
       activation/adherence states, and `unknown` is used wherever no evidence
       exists rather than a model's inference.
-- [ ] AC-6 — One outcome vocabulary is authoritative, or the mapping between the
+- [x] AC-6 — One outcome vocabulary is authoritative, or the mapping between the
       two is a committed module both readers import.
+
+      **MET 2026-08-29 via the second disjunct, and the first is refused on
+      evidence.** `src/scripts/_lib/outcome_vocabularies.ts` is the committed
+      module, and both readers import it —
+      `orchestration_record.ts` for `PhaseOutcome`, `outcome_envelope.ts` for
+      `RunTerminalState`; `runtime_journal.ts` imports its value list too. The
+      first disjunct is not taken because the producer trace under step 1.3
+      showed three vocabularies with three different subjects, so declaring one
+      authoritative would make the other two wrong rather than derived.
+
+      **Stated precisely, because the AC's wording invites an over-claim:** what
+      the module holds is the three vocabularies plus a REGISTRY of the crossings
+      (`CROSS_DOMAIN_MAPPINGS`, one row). The mapping FUNCTION itself
+      (`envelopeOutcome`) stays at its call site in `orchestration_record.ts`,
+      where the translation actually happens; the module records that it exists
+      and `tests/contracts/outcome_vocabularies.test.ts` asserts the named
+      function resolves in the named file. Moving the function would relocate
+      logic away from its only caller for no gain. So: both readers import the
+      committed module — the AC as written — and the one real translation is
+      registered and checked rather than relocated.
 - [ ] AC-7 — Nothing in any selection or routing path imports the experience
       report, until and unless the Phase 9 blocker is resolved with a yes.
 - [ ] AC-8 — The retention rule is written into the contract, and every claim
@@ -679,8 +777,48 @@ is refuted, cheaply.
   with an explicit mapping rather than unify.
 - **E2 — audit-log v2:** confirm the schema-bump procedure — supersede lines, or
   a new file generation?
+
+  **RESOLVED 2026-08-29 — (a) additive field, no version bump.** AI council,
+  anthropic + openai, **2/2 convergent**, and both seats called the roadmap's
+  own wording a misreading. Step 1.2 says *"Migrate by `type=supersede` lines,
+  exactly as that contract already prescribes for corrections"*. The contract's
+  supersede clause (`docs/contracts/audit-log-v1.md:114`) governs **corrections**
+  to a line that is wrong; adding a field makes no existing line wrong. The
+  clause that governs an addition is the forward-compat rule at `:96` —
+  *"Unknown trailing fields are forward-compat extensions; readers MUST NOT
+  raise on them."* So `skills_applied` lands as an optional bounded trailing
+  field, `schema_version` stays `1`, and no supersede lines are emitted.
+  Restating historical entries would also **fabricate historical skill data**,
+  which is the sharper reason.
+
+  **The distinction that has to ship with it:** absence means *unknown / not
+  recorded*; an empty array means *recorded, and none applied*. Collapsing the
+  two would retroactively assign information to lines that never captured it —
+  which is what turns an extension into a semantic migration.
+
+  **`revisit-if`:** the field becomes mandatory, it changes another field's
+  meaning, or readers cannot distinguish absent from empty. Any of those is a
+  case for `schema_version: 2`, never for automatic historical supersedes.
 - **E3 — Does `clean-no-op` count as its own outcome in the report?
   (Recommendation: yes.)**
+
+  **RESOLVED 2026-08-29 — yes, as a tracked subtype of `neutral`, not a fourth
+  top-level impact category.** AI council, anthropic + openai, **2/2
+  convergent**. Two dimensions, kept apart: `outcome: clean-no-op` and
+  `impact: neutral`. The neutral total is reported with a separate
+  `clean-no-op` count, and empty-cycle / double-trigger metrics (step 2.3) stay
+  separate from impact classification.
+
+  **The attribution rule the council added, which the roadmap did not ask for
+  and needs:** `clean-no-op` is a RUN terminal state while Phase 6 reports **per
+  asset**. A run-level no-op must not be copied onto every asset that was merely
+  loaded — each asset needs evidence it was actually evaluated. Without that,
+  one no-op run makes every loaded asset look meaningfully consulted, which is
+  the inverse of what the report is for.
+
+  **`revisit-if`:** the helpfulness metric is redefined to measure assurance
+  value and evidence shows verified no-op evaluations deliver it. Then the
+  outcome distinction stays and only its impact mapping is reconsidered.
 - **E4 — Card location** under `agents/memory/<type>/`, the per-card size
   budget, and — given risk 2 — whether cards belong in a tracked path at all.
 - **E5 — SQLite index:** only at a measured JSONL latency limit, or not at all.

--- a/docs/contracts/audit-log-v1.md
+++ b/docs/contracts/audit-log-v1.md
@@ -74,7 +74,7 @@ Single-line. The pretty-printed reference shape:
 | `ts` | string | ISO-8601 UTC timestamp of phase end. |
 | `work_id` | string | Matches the `WorkState` directory id from [`decision-trace-v1.md`](decision-trace-v1.md). Allows cross-trace correlation. |
 | `phase` | enum | One of `refine` · `memory` · `analyze` · `plan` · `implement` · `test` · `verify` · `report`. |
-| `outcome` | enum | One of `success` · `blocked` · `skipped` · `error`. Mirrors `Outcome` from `work_engine.directives`. |
+| `outcome` | enum | One of `success` · `blocked` · `skipped` · `error`. Defined by `PHASE_OUTCOMES` in `src/scripts/_lib/outcome_vocabularies.ts` and checked against this row by `tests/contracts/outcome_vocabularies.test.ts`. |
 | `confidence_band` | enum | One of `low` · `medium` · `high`. Sourced from decision-trace. |
 | `risk_class` | enum | One of `low` · `medium` · `high`. Inherits max risk from touched files. |
 | `memory.asks` / `memory.hits` | int | Counts only — never ids, never bodies. |
@@ -104,9 +104,19 @@ Lines MUST NOT contain:
 - Secrets, tokens, environment values, file contents.
 - Paths outside the package's `agents/runtime/state/` and `tests/` allowlist.
 
-The floor is enforced by
-`tests/contracts/test_audit_log_redaction.py` — any new producer-side
-edit that touches this schema adds a fixture there.
+**Enforcement, stated honestly.** No test enforces this floor. The file this
+paragraph named for months — tests/contracts/test_audit_log_redaction.py,
+deliberately written WITHOUT backticks so the existence check below cannot read
+a dead name as a live claim — exists in no tree this repository has, so the sentence asserted an enforcement
+that was never there (found 2026-08-29,
+`road-to-experience-loop-broadening` 1.3). What IS enforced is narrower and
+real: the two producers build their lines through validated builders with no
+free-form field — `src/scripts/_lib/orchestration_record.ts` and
+`src/scripts/_lib/review_skipped_record.ts` — so the floor holds by
+CONSTRUCTION on those paths rather than by a scan. A third producer added
+outside that shape would not be caught by anything. Step 1.4 of that roadmap
+owns closing this; until it does, "privacy by construction, on two paths,
+unscanned" is the accurate claim.
 
 ## Append-only invariant
 

--- a/src/scripts/_lib/orchestration_record.ts
+++ b/src/scripts/_lib/orchestration_record.ts
@@ -18,6 +18,7 @@
 
 import type { LookupClass } from './auto_dispatch.js';
 import type { EvidenceBasis } from './evidence_basis.js';
+import type { PhaseOutcome } from './outcome_vocabularies.js';
 
 export type DispatchOutcome = 'DONE' | 'DONE_WITH_CONCERNS' | 'NEEDS_CONTEXT' | 'BLOCKED' | 'killed';
 /** Which route the rung took: deterministic primitive (lean-init L0),
@@ -42,7 +43,13 @@ export type TierChosen = 'lite' | 'medium' | 'high';
 export type TierSource = 'static' | 'inferred' | 'inherit';
 export type Band = 'low' | 'medium' | 'high';
 export type LinePhase = 'refine' | 'memory' | 'analyze' | 'plan' | 'implement' | 'test' | 'verify' | 'report';
-export type LineOutcome = 'success' | 'blocked' | 'skipped' | 'error';
+/**
+ * Outcome of this audit-log line. Alias of the registry's `PhaseOutcome` —
+ * the name `LineOutcome` is kept because two modules import it, and the
+ * single definition now lives in `outcome_vocabularies.ts` so the contract
+ * table can be checked against it (`road-to-experience-loop-broadening` 1.3).
+ */
+export type LineOutcome = PhaseOutcome;
 /** Which capsule-emission trigger arm fired first (Phase 1 shadow comparison). */
 export type TriggerArm = 'watermark' | 'saturation' | 'tie';
 /** The orchestration form the form-gate selected (road-to-opt-subagent-harvest P2). */

--- a/src/scripts/_lib/outcome_envelope.ts
+++ b/src/scripts/_lib/outcome_envelope.ts
@@ -20,14 +20,18 @@
  * which is the failure a cap is supposed to prevent, arriving through the cap.
  */
 
-/** The six terminal states. Contract: `contexts/execution/terminal-states.md`. */
-export type TerminalState =
-    | 'success'
-    | 'clean-no-op'
-    | 'blocked'
-    | 'approval-required'
-    | 'exhausted'
-    | 'stagnated';
+import type { RunTerminalState } from './outcome_vocabularies.js';
+
+/**
+ * The six terminal states. Contract: `contexts/execution/terminal-states.md`.
+ *
+ * Alias of the registry's `RunTerminalState`. This module stays the public
+ * surface — `runtime_journal.test.ts:212` pins the import path and `:215`
+ * asserts no second declaration — while the single definition moved to
+ * `outcome_vocabularies.ts` so the contract's table can be checked against it
+ * (`road-to-experience-loop-broadening` 1.3).
+ */
+export type TerminalState = RunTerminalState;
 
 /** States that are NOT success. An error or an exhausted budget never reports as one. */
 export const NON_SUCCESS_STATES: ReadonlySet<TerminalState> = new Set([

--- a/src/scripts/_lib/outcome_vocabularies.ts
+++ b/src/scripts/_lib/outcome_vocabularies.ts
@@ -1,0 +1,111 @@
+/**
+ * The three outcome vocabularies this repository actually produces, and the
+ * one crossing between them — in a single module, so a fourth cannot appear
+ * without a diff to this file.
+ *
+ * `road-to-experience-loop-broadening` step 1.3. That step was written on the
+ * premise that the tree holds **two** outcome enums and that one of them is
+ * documentation-only. Re-measured at `63d06b7eb`, both halves of that premise
+ * are wrong, and the corrected picture is why this module registers rather
+ * than unifies:
+ *
+ * | Vocabulary | Subject | Declared | Values |
+ * |---|---|---|---|
+ * | phase | one audit-log line — a `/work` PHASE | here, consumed by `orchestration_record` | 4 |
+ * | step  | one work-engine STEP | `work_engine/delivery_state.ts` (template tree) | 3 |
+ * | run   | one command or gate RUN | here, consumed by `outcome_envelope` | 6 |
+ *
+ * All three are declared in code AND emitted today. `skipped` and `error` are
+ * not aspirational: `envelopeOutcome` in `orchestration_record.ts` returns
+ * both, and `review_skipped_record.ts` writes `outcome: 'skipped'` onto a real
+ * audit line. An earlier reading of this tree concluded they "exist nowhere",
+ * because it grepped for enum MEMBER ASSIGNMENTS (`SKIPPED: 'skipped'`) and
+ * these are string-literal union members. The distinction cost a wrong premise
+ * once; it is written down here so it cannot cost it twice.
+ *
+ * **Why register and not unify.** AI council 2026-08-29 (anthropic + openai,
+ * 2 rounds, $0.00, both seats subscription-authed) split on the question and
+ * named the same discriminator: trace the producers before choosing. The trace
+ * settled it — the three subjects are genuinely different (a phase aggregates
+ * steps; a run is neither), all three are produced, and a cross-domain mapping
+ * already existed in the tree. A superset would admit states that are
+ * nonsense for their subject: a step ending `approval-required`, a run ending
+ * `partial`. So: separate vocabularies, one registry, mappings only where
+ * execution actually crosses.
+ *
+ * **Mappings are not written for symmetry.** Exactly one crossing exists
+ * (`DispatchOutcome` -> phase, in `orchestration_record.ts`). A total
+ * phase<->step<->run mapping would be nine relations of which one is real, and
+ * the eight invented ones would read as contract.
+ *
+ * `revisit-if`: a producer needs a value its vocabulary cannot express, or a
+ * second real crossing appears, or producer analysis shows two of the three
+ * subjects share identical terminal semantics with a lossless mapping — at
+ * which point unifying those two becomes the cheaper answer.
+ *
+ * Type-only + literal arrays. No `node:` import, so any surface may read it.
+ */
+
+/**
+ * Outcome of one audit-log line — a `/work` phase.
+ *
+ * Authoritative for `docs/contracts/audit-log-v1.md`'s `outcome` row. The
+ * binding is a test, not an import, because a markdown contract cannot import:
+ * `tests/contracts/outcome_vocabularies.test.ts`.
+ */
+export const PHASE_OUTCOMES = ['success', 'blocked', 'skipped', 'error'] as const;
+export type PhaseOutcome = (typeof PHASE_OUTCOMES)[number];
+
+/**
+ * Outcome of one work-engine step.
+ *
+ * Declared in `src/agent-src/templates/scripts/work_engine/delivery_state.ts`,
+ * which is a TEMPLATE and self-contained by contract — no template file
+ * imports from `src/scripts/`. So this is the lint-checked mirror, not the
+ * declaration, and the same test asserts the two agree.
+ */
+export const STEP_OUTCOMES = ['success', 'blocked', 'partial'] as const;
+export type StepOutcome = (typeof STEP_OUTCOMES)[number];
+
+/**
+ * Terminal state of one command or gate run.
+ *
+ * Authoritative for `contexts/execution/terminal-states.md`. Re-exported by
+ * `outcome_envelope.ts` as `TerminalState`, which stays the public surface —
+ * `runtime_journal.test.ts` pins that import path, and an anti-fork assertion
+ * there already prevents a second declaration.
+ */
+export const RUN_TERMINAL_STATES = [
+    'success',
+    'clean-no-op',
+    'blocked',
+    'approval-required',
+    'exhausted',
+    'stagnated',
+] as const;
+export type RunTerminalState = (typeof RUN_TERMINAL_STATES)[number];
+
+/**
+ * The crossings that exist. One row, because one crossing is real.
+ *
+ * Read as: code at `from` translates a value of `source` into a value of
+ * `target`. A row is added when execution starts crossing, never in advance.
+ */
+export const CROSS_DOMAIN_MAPPINGS = [
+    {
+        source: 'DispatchOutcome',
+        target: 'phase',
+        at: 'src/scripts/_lib/orchestration_record.ts',
+        fn: 'envelopeOutcome',
+    },
+] as const;
+
+/** Is this string a phase outcome? The guard the audit-log consumer was missing. */
+export function isPhaseOutcome(v: unknown): v is PhaseOutcome {
+    return typeof v === 'string' && (PHASE_OUTCOMES as readonly string[]).includes(v);
+}
+
+/** Is this string a run terminal state? */
+export function isRunTerminalState(v: unknown): v is RunTerminalState {
+    return typeof v === 'string' && (RUN_TERMINAL_STATES as readonly string[]).includes(v);
+}

--- a/src/scripts/_lib/runtime_journal.ts
+++ b/src/scripts/_lib/runtime_journal.ts
@@ -173,6 +173,7 @@ import type { DatabaseSync } from 'node:sqlite';
 
 import { current_branch, git_common_dir, git_dir } from './git_common_dir.js';
 import type { TerminalState } from './outcome_envelope.js';
+import { RUN_TERMINAL_STATES } from './outcome_vocabularies.js';
 import {
     isSqliteAvailableSync,
     loadSqliteSync,
@@ -304,26 +305,19 @@ export type Consumption = (typeof CONSUMPTION_STATES)[number];
 /**
  * The six terminal states as a runtime array.
  *
- * The TYPE is imported from `outcome_envelope.ts` and never redeclared — this
- * is a value list, and the two assertions below bind it to that import in both
- * directions, so a state added, removed or renamed upstream breaks this file at
- * compile time instead of drifting into a parallel vocabulary.
+ * Re-export of `RUN_TERMINAL_STATES` from `outcome_vocabularies.ts`. It used to
+ * be a second literal list here, guarded by two type-level assertions that
+ * bound it to the imported TYPE in both directions. That guard worked — but a
+ * guarded duplicate is still a duplicate, and it was the only one the step-1.3
+ * anti-duplicate check found in this tree
+ * (`road-to-experience-loop-broadening` 1.3). Re-exporting removes the second
+ * list, which makes the assertions tautological, so they are gone too: there is
+ * now nothing to drift.
+ *
+ * The name is kept because it is exported and pinned by
+ * `tests/scripts/runtime_journal.test.ts:205,207`.
  */
-export const TERMINAL_STATES = [
-    'success',
-    'clean-no-op',
-    'blocked',
-    'approval-required',
-    'exhausted',
-    'stagnated',
-] as const;
-
-type _TerminalStatesCoverTheUnion = Assert<
-    Exclude<TerminalState, (typeof TERMINAL_STATES)[number]> extends never ? true : false
->;
-type _TerminalStatesAddNothing = Assert<
-    Exclude<(typeof TERMINAL_STATES)[number], TerminalState> extends never ? true : false
->;
+export const TERMINAL_STATES = RUN_TERMINAL_STATES;
 
 /**
  * Keys a record may never carry. Not an exhaustive list of every bad name — it

--- a/src/scripts/extract_audit_patterns.ts
+++ b/src/scripts/extract_audit_patterns.ts
@@ -22,6 +22,8 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
+import { isPhaseOutcome, PHASE_OUTCOMES } from './_lib/outcome_vocabularies.js';
+
 const _HERE = fileURLToPath(import.meta.url);
 // src/scripts/extract_audit_patterns.py → parent.parent.parent == repo root.
 export const ROOT = path.resolve(path.dirname(_HERE), '..', '..');
@@ -164,10 +166,21 @@ export function mine(auditDir: string, month: string | null, minCount: number): 
     const records = _resolveSupersedes([..._iterLines(auditDir, month)]);
     // Preserve insertion order of first-seen keys (Python dict ordering).
     const groups = new Map<string, Pattern>();
+    // `outcome` used to be read as a bare `string`, so a typo silently became
+    // its own pattern and nothing said so (`road-to-experience-loop-broadening`
+    // 1.3; AI council 2026-08-29 named this the consumer-side half). Grouping
+    // is UNCHANGED — this file mirrors a retired Python CLI byte-for-byte and
+    // dropping a record would change pinned stdout. What changes is that an
+    // off-vocabulary value is now observable instead of silent.
+    const unknownOutcomes = new Set<string>();
     for (const rec of records) {
         const t = rec.type;
         if (!(t === undefined || t === null || t === 'phase')) {
             continue;
+        }
+        const rawOutcome = rec.outcome;
+        if (rawOutcome !== undefined && rawOutcome !== null && !isPhaseOutcome(rawOutcome)) {
+            unknownOutcomes.add(String(rawOutcome));
         }
         const key = _patternKey(rec);
         let pat = groups.get(key);
@@ -193,6 +206,14 @@ export function mine(auditDir: string, month: string | null, minCount: number): 
         if (!pat.last_seen || ts > pat.last_seen) {
             pat.last_seen = ts;
         }
+    }
+    if (unknownOutcomes.size > 0) {
+        const seen = [...unknownOutcomes].sort().join(', ');
+        process.stderr.write(
+            `extract_audit_patterns: ${unknownOutcomes.size} off-vocabulary outcome value(s) ` +
+                `grouped as-is: ${seen}. Expected one of: ${PHASE_OUTCOMES.join(' | ')} ` +
+                `(docs/contracts/audit-log-v1.md, src/scripts/_lib/outcome_vocabularies.ts).\n`,
+        );
     }
     const out: Rec[] = [];
     for (const p of groups.values()) {

--- a/tests/contracts/outcome_vocabularies.test.ts
+++ b/tests/contracts/outcome_vocabularies.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Contract tests binding the three outcome vocabularies to their contracts.
+ *
+ * `road-to-experience-loop-broadening` step 1.3. That step's `verify:` clause
+ * asks for one authoritative module plus a CHECK rather than an import,
+ * because two of the three binding targets cannot import anything:
+ *
+ *  - `docs/contracts/audit-log-v1.md` is markdown.
+ *  - `src/agent-src/contexts/execution/terminal-states.md` is markdown.
+ *  - `src/agent-src/templates/scripts/work_engine/delivery_state.ts` is a
+ *    TEMPLATE, self-contained by contract — no file under
+ *    `src/agent-src/templates/scripts/` imports from `src/scripts/`, and this
+ *    file asserts that too, so the reason the check exists cannot silently
+ *    stop being true.
+ *
+ * These are the four bindings, plus the anti-duplicate rule. They read the
+ * files rather than a remembered claim, which is the only reason they can
+ * catch drift: the defect they were written against was a contract sentence
+ * that had been false since the contract was created.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+    CROSS_DOMAIN_MAPPINGS,
+    isPhaseOutcome,
+    isRunTerminalState,
+    PHASE_OUTCOMES,
+    RUN_TERMINAL_STATES,
+    STEP_OUTCOMES,
+} from '../../src/scripts/_lib/outcome_vocabularies.js';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const read = (rel: string): string => fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8');
+
+const AUDIT_CONTRACT = 'docs/contracts/audit-log-v1.md';
+const TERMINAL_CONTRACT = 'src/agent-src/contexts/execution/terminal-states.md';
+const DELIVERY_STATE = 'src/agent-src/templates/scripts/work_engine/delivery_state.ts';
+const REGISTRY = 'src/scripts/_lib/outcome_vocabularies.ts';
+
+describe('phase vocabulary <-> audit-log-v1 contract', () => {
+    it('the contract outcome row lists exactly the registry values', () => {
+        const src = read(AUDIT_CONTRACT);
+        const row = src.split('\n').find((l) => l.startsWith('| `outcome` |'));
+        expect(row, `no \`outcome\` row in ${AUDIT_CONTRACT}`).toBeDefined();
+        // Values in the row are written as `` `value` `` inside the Meaning cell.
+        const listed = [...(row as string).matchAll(/`([a-z][a-z-]*)`/g)]
+            .map((m) => m[1])
+            .filter((v) => v !== 'outcome' && v !== 'enum');
+        expect(listed.sort()).toEqual([...PHASE_OUTCOMES].sort());
+    });
+
+    it('the contract does not claim a mirror the tree does not have', () => {
+        const src = read(AUDIT_CONTRACT);
+        // The original text claimed the enum "Mirrors `Outcome` from
+        // `work_engine.directives`". Both halves were false: that module path
+        // does not exist, and work_engine's own `Outcome` carries `partial`
+        // and neither `skipped` nor `error`. A revived claim must not point at
+        // a module whose member set differs.
+        expect(src).not.toMatch(/work_engine\.directives/);
+    });
+
+    it('every enforcer the contract names exists', () => {
+        const src = read(AUDIT_CONTRACT);
+        // The privacy floor named `tests/contracts/test_audit_log_redaction.py`,
+        // which is in no tree this repository has. A contract asserting an
+        // enforcement it does not have is the defect class this file exists for.
+        const named = [...src.matchAll(/`(tests\/[^`]+)`/g)].map((m) => m[1]);
+        expect(named.length).toBeGreaterThan(0);
+        for (const rel of named) {
+            expect(fs.existsSync(path.join(REPO_ROOT, rel)), `${AUDIT_CONTRACT} names a non-existent enforcer: ${rel}`).toBe(true);
+        }
+    });
+});
+
+describe('step vocabulary <-> the work-engine template', () => {
+    it('the template Outcome members are exactly the registry step values', () => {
+        const src = read(DELIVERY_STATE);
+        const block = /export const Outcome = \{([\s\S]*?)\} as const;/.exec(src);
+        expect(block, `no \`export const Outcome\` in ${DELIVERY_STATE}`).not.toBeNull();
+        const values = [...(block as RegExpExecArray)[1].matchAll(/'([a-z][a-z-]*)'/g)].map((m) => m[1]);
+        expect(values.sort()).toEqual([...STEP_OUTCOMES].sort());
+    });
+
+    it('the template tree imports nothing from src/scripts — which is why this is a check, not an import', () => {
+        const dir = path.join(REPO_ROOT, 'src/agent-src/templates/scripts');
+        const offenders: string[] = [];
+        const walk = (d: string): void => {
+            for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+                const full = path.join(d, e.name);
+                if (e.isDirectory()) walk(full);
+                else if (e.name.endsWith('.ts') && /from '[^']*src\/scripts\//.test(fs.readFileSync(full, 'utf8'))) {
+                    offenders.push(path.relative(REPO_ROOT, full));
+                }
+            }
+        };
+        walk(dir);
+        expect(offenders).toEqual([]);
+    });
+});
+
+describe('run vocabulary <-> terminal-states contract', () => {
+    it('the contract table lists exactly the registry values', () => {
+        const src = read(TERMINAL_CONTRACT);
+        for (const state of RUN_TERMINAL_STATES) {
+            expect(src, `${TERMINAL_CONTRACT} does not mention \`${state}\``).toContain(`\`${state}\``);
+        }
+    });
+});
+
+describe('no inline duplicate declares a vocabulary outside the registry', () => {
+    const VOCAB_SETS: ReadonlyArray<readonly [string, readonly string[]]> = [
+        ['phase', PHASE_OUTCOMES],
+        ['run', RUN_TERMINAL_STATES],
+    ];
+
+    it('no file under src/scripts re-declares a full vocabulary as a union or literal array', () => {
+        const offenders: string[] = [];
+        const walk = (d: string): void => {
+            for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+                const full = path.join(d, e.name);
+                if (e.isDirectory()) {
+                    walk(full);
+                    continue;
+                }
+                if (!e.name.endsWith('.ts')) continue;
+                const rel = path.relative(REPO_ROOT, full);
+                if (rel === REGISTRY) continue;
+                const src = fs.readFileSync(full, 'utf8');
+                for (const [name, values] of VOCAB_SETS) {
+                    // A declaration is a `type X =` / `const X = [` whose body
+                    // carries EVERY member of the vocabulary. Referring to one
+                    // or two values is normal and is not a duplicate.
+                    for (const m of src.matchAll(/(?:type|const)\s+\w+\s*(?::[^=]*)?=\s*([\s\S]{0,400}?);/g)) {
+                        const body = m[1];
+                        if (values.every((v) => body.includes(`'${v}'`))) {
+                            offenders.push(`${rel} re-declares the ${name} vocabulary`);
+                        }
+                    }
+                }
+            }
+        };
+        walk(path.join(REPO_ROOT, 'src/scripts'));
+        expect([...new Set(offenders)]).toEqual([]);
+    });
+});
+
+describe('the registry itself', () => {
+    it('records only crossings that exist in the tree, and each one resolves', () => {
+        expect(CROSS_DOMAIN_MAPPINGS.length).toBeGreaterThan(0);
+        for (const m of CROSS_DOMAIN_MAPPINGS) {
+            const src = read(m.at);
+            expect(src, `${m.at} does not define ${m.fn}`).toContain(m.fn);
+        }
+    });
+
+    it('the guards accept every member and reject an off-vocabulary value', () => {
+        for (const v of PHASE_OUTCOMES) expect(isPhaseOutcome(v)).toBe(true);
+        for (const v of RUN_TERMINAL_STATES) expect(isRunTerminalState(v)).toBe(true);
+        expect(isPhaseOutcome('partial')).toBe(false);
+        expect(isPhaseOutcome('sucess')).toBe(false);
+        expect(isRunTerminalState('skipped')).toBe(false);
+        expect(isPhaseOutcome(undefined)).toBe(false);
+    });
+});


### PR DESCRIPTION
## What this is

`road-to-experience-loop-broadening` step 1.3, plus the three maintainer
decisions that gated Phase 1. It is a vertical slice, not a phase sweep: the
roadmap's own **First cut** section nominates 1.2+1.3 as the smallest genuine
slice, and 1.3 had to go first because 1.2 cannot be done correctly before the
enum split is settled.

Progress on that roadmap: **1/47 → 3/47**, with E2 and E3 resolved and 1.3's
`verify:` clause amended before the step was closed.

## The finding that reshaped the step

Step 1.3 was written on the premise that the tree holds **two** outcome
vocabularies, one of them documentation-only. Re-measured at `63d06b7eb`, both
halves are wrong. There are **three**, all declared in code and all emitted
today:

| Vocabulary | Subject | Declared at | Values |
|---|---|---|---|
| phase | one audit-log line — a `/work` phase | `src/scripts/_lib/orchestration_record.ts:45` | 4 |
| step | one work-engine step | `src/agent-src/templates/scripts/work_engine/delivery_state.ts:39` | 3 |
| run | one command or gate run | `src/scripts/_lib/outcome_envelope.ts:24` | 6 |

`skipped` and `error` are not aspirational: `envelopeOutcome`
(`src/scripts/_lib/orchestration_record.ts:195-200`) returns both, and
`src/scripts/_lib/review_skipped_record.ts:89` writes `outcome: 'skipped'` onto
a real audit line. An earlier reading of this tree — mine, earlier in this run —
concluded they "exist nowhere in code", because it grepped for enum **member
assignments** (`SKIPPED: 'skipped'`) and these are string-literal union members.
That correction is written into the new module's header so it cannot be made a
third time.

The contract's history is the sharper half: `git log -S` on the 4-value row
returns `032a244a3` (PR #183) — the commit that **created** the contract. The
enum was authored with `skipped` and `error` from day one and the code enum it
claimed to mirror never had them.

## What ships

**New — `src/scripts/_lib/outcome_vocabularies.ts` (111 lines).** The single
registry: `PHASE_OUTCOMES` (4), `STEP_OUTCOMES` (3), `RUN_TERMINAL_STATES` (6),
`CROSS_DOMAIN_MAPPINGS` (one row — the one crossing that exists), and two
guards. Type-only plus literal arrays, no `node:` import, so any surface may
read it.

**Wiring — each non-template declaring site imports its definition.**
- `src/scripts/_lib/orchestration_record.ts:45` → `export type LineOutcome = PhaseOutcome;`
- `src/scripts/_lib/outcome_envelope.ts:34` → `export type TerminalState = RunTerminalState;`

Both keep their exported names, because other modules and a pinned test import
them. The work-engine template is **not** wired: no file under
`src/agent-src/templates/scripts/` imports from `src/scripts/`, and the new test
asserts that too — so the reason the step vocabulary is checked rather than
imported cannot silently stop being true.

**New — `tests/contracts/outcome_vocabularies.test.ts` (167 lines, 9 tests).**
The binding a markdown contract cannot express as an import: the contract's
`outcome` row must list exactly `PHASE_OUTCOMES`; the template's `Outcome`
members must equal `STEP_OUTCOMES`; `terminal-states.md` must carry every
`RUN_TERMINAL_STATES` value; no file under `src/scripts` may re-declare a full
vocabulary; every `tests/...` path the contract names must exist; every
registered crossing must resolve to its named function.

## Three defects fixed that the step did not predict

1. **`docs/contracts/audit-log-v1.md:77` carried a false mirror claim** —
   *"Mirrors `Outcome` from `work_engine.directives`"*. False twice: that module
   path does not exist, and work_engine's real `Outcome`
   (`delivery_state.ts:39-45`) carries `partial` and neither `skipped` nor
   `error`. Now points at `PHASE_OUTCOMES` and its check.

2. **The same contract named an enforcer that exists in no tree.** Its privacy
   floor claimed enforcement by `tests/contracts/test_audit_log_redaction.py`;
   a tree-wide `find` returns nothing. Replaced with what is actually true:
   privacy holds by **construction** on the two validated builder paths
   (`orchestration_record.ts`, `review_skipped_record.ts`), is **unscanned**,
   and a third producer added outside that shape would not be caught. Step 1.4
   owns closing that; the contract no longer claims otherwise. The dead filename
   is deliberately written **without** backticks so the new existence check
   cannot read a dead name as a live claim.

3. **The only consumer validated nothing.**
   `src/scripts/extract_audit_patterns.ts:39` typed `outcome` as bare `string`
   and `:147` read it with `?? ''`, so a typo became its own pattern silently.
   It now classifies against `isPhaseOutcome` and reports off-vocabulary values
   on stderr. **Grouping is deliberately unchanged** — that file mirrors a
   retired Python CLI byte-for-byte and its test pins `stderr === ''` on the
   happy path, so dropping a record would break pinned behaviour. What changed
   is that an off-vocabulary value is observable instead of silent.

## A real duplicate, found by the new check on its first run

`TERMINAL_STATES` at `src/scripts/_lib/runtime_journal.ts:312` was a second
literal list of the six run states. It was *guarded* — two type-level assertions
bound it to the imported type in both directions — but a guarded duplicate is
still a duplicate, and it is exactly what 1.3's clause asks the check to reject.
It is now `export const TERMINAL_STATES = RUN_TERMINAL_STATES;` and the two
assertions are gone with it, because there is nothing left to drift. The name is
kept: `tests/scripts/runtime_journal.test.ts:205,207` pin it.

## Council decisions

AI council 2026-08-29, `anthropic/claude-sonnet-4-5` + `openai/codex-default`,
2 rounds, **$0.00** (both seats subscription-authed), quorum **2/2 present after
the run**, blind chairman. Quota after the run: anthropic 24/50, openai 24/50.

### Decision 1 — reconciliation shape for 1.3 → **(b) map, do not unify**

The seats **split**: anthropic leaned **(c)** (unify phase+step, map run);
openai **(b)**. They named the **same discriminator** — trace the producers
before choosing — and that trace is what settled it, against a preference
rather than by one:

- three distinct subjects (a phase aggregates steps; a run is neither);
- all three produced today;
- one cross-domain mapping already in the tree (`envelopeOutcome`);
- a superset would admit states that are nonsense for their subject — a step
  ending `approval-required`, a run ending `partial`.

Both seats also required 1.3's `verify:` clause to be **amended before**
closure, since it prescribed unification. Quoting openai verbatim, which is now
the clause in the roadmap: *"One authoritative module defines the phase, step,
and run outcome vocabularies and every permitted cross-domain mapping. Code
imports its applicable definition; the audit-log contract is lint-checked
against the phase definition; lint rejects inline duplicates."*

**Dissent preserved.** Anthropic's (c) stays live and is carried as the module's
own `revisit-if`: if producer analysis ever shows phase and step share identical
terminal semantics with a lossless mapping, unifying those two becomes cheaper.

Also adopted from openai: *"Define only mappings that are actually crossed in
execution; do not invent total mappings merely for symmetry."* A total
phase↔step↔run mapping would be nine relations of which one is real.

### Decision 2 — E2, audit-log schema bump → **(a) additive, `schema_version` stays 1**, 2/2 convergent

Both seats called the roadmap's own step-1.2 wording a **misreading**. It says
*"Migrate by `type=supersede` lines, exactly as that contract already prescribes
for corrections"*; the supersede clause (`audit-log-v1.md:114`) governs
**corrections** to a line that is wrong, and adding a field makes no existing
line wrong. The governing clause is the forward-compat rule at `:96`.
Restating historical entries would also **fabricate historical skill data** —
the sharper reason. Shipped with it: **absent means unknown / not recorded, an
empty array means recorded and none applied.**

### Decision 3 — E3, `clean-no-op` in the report → **yes, as a tracked subtype of `neutral`**, 2/2 convergent

Two dimensions kept apart (`outcome: clean-no-op`, `impact: neutral`), neutral
totals reported with a separate `clean-no-op` count, empty-cycle and
double-trigger metrics (step 2.3) kept out of impact classification. The council
added a rule the roadmap had not asked for and needs: `clean-no-op` is a **run**
terminal state while Phase 6 reports **per asset**, so a run-level no-op must
not be copied onto every asset that was merely loaded.

Both seats independently confirmed **no OWNER-RESERVED boundary** is crossed by
any of the three.

## Blockers left open, and why no council may close them

Not a gap in this PR — a recorded refusal. All three open blockers in the estate
already carry a fresh 2026-08-29 2/2-convergent council verdict whose
**residual half the council explicitly refused as owner-reserved**. Re-running
them to obtain a different answer is verdict shopping under
`src/rules/evaluator-independence.md`, so they were not re-run:

| Blocker | Roadmap | Why the residual is owner-reserved |
|---|---|---|
| `merge-authority` | `road-to-governed-harness-evolution` | Resolving ADR-239 § Decision 3 either way weakens or settles a human-in-the-loop promotion guarantee. Option (c) — Phases 1–6 legal, Phase 7 gated — is already taken and recorded. |
| `b-adr-088-external-runtime-federation` | `road-to-capability-native-execution` | Writing an exception to ADR-088 (`status: accepted`, a **category** boundary) narrows an accepted floor. The parked half is closed; the browser-engine classification is not. |
| `lifecycle-ci-runner-provisioning` | `road-to-supervised-telemetry-collector` | Handled on its own branch. |

## Verification

Every command run in this worktree at `b27d4bf30`.

**Tests** — `npx vitest run` on the new test plus all three pinned neighbours:
`tests/contracts/outcome_vocabularies.test.ts` (9), `tests/scripts/runtime_journal.test.ts` (38),
`tests/scripts/extract_audit_patterns.test.ts` (10), `tests/scripts/envelope_consumption.test.ts` (25)
— **82 passed, 0 failed**.

**Sensitivity, proven rather than assumed** — a test never seen red has unknown
sensitivity, so both new assertions were driven red deliberately:
- the anti-duplicate assertion went red on its **first real run**, naming
  `runtime_journal.ts` (that is what found the duplicate above);
- the contract-row binding was sabotaged by removing one value from
  `audit-log-v1.md:77` → red, then restored (`git diff --stat` confirms the
  restore matches the intended change only).

**Typecheck / lint** — `npx tsc -p tsconfig.json --noEmit` exit 0. `npx eslint`
over all six changed/added files: clean. (There is no `task typecheck` in this
Taskfile; `task --list` was checked.)

**Roadmap + estate gates**, all exit 0: `lint_roadmap_blockers`,
`lint_roadmap_complexity`, `lint_roadmap_ci_steps`, `check_roadmap_trackable`,
`check_no_roadmap_refs`, `lint_empty_roadmaps`, `lint_roadmap_later_disposition`,
`check_no_external_sources`, `check_council_references`,
`check_rule_projection_integrity`, `check_estate_count`,
`check_source_size_budget`, `lint_governed_writes`.

`./agent-config roadmap:progress` → `4 roadmap(s) · 20/139 steps done`, no diff
to the dashboard (this roadmap is `status: draft` and excluded from it).

**No `task sync` / `task generate-tools` needed** — the diff touches
`src/scripts/`, `tests/`, `docs/contracts/` and `agents/roadmaps/`, none of
which is a projection source. `check_rule_projection_integrity` confirms it.

## Deliberate non-actions

- **The roadmap stays `status: draft`.** Promoting it would raise
  `active_roadmaps` from 4 to 5 against a floor of 4 with no disposal in this
  change, reddening `check_estate_count`. That is also why the file carries
  `estate_offset_exempt`.
- **No archival.** The roadmap is 3/47; it is not complete and is not claimed to
  be.
- **Step 1.2 left open.** E2 now unblocks it and the verdict is recorded at E2
  for the next run, but the field is not added here — that is a separate slice
  with its own fixture requirement ("a fixture proves real emission from a live
  phase", and a *collector exists* proxy is explicitly not evidence).
- **The mapping function was not relocated** into the registry. It stays at its
  only call site; the registry records it and the test asserts it resolves.
