### PR TITLE
roadmap(capability-native-execution): close 0.4, and a stale blocker field that was holding lint_roadmap_blockers green

### DIFF
--- a/agents/roadmaps/road-to-capability-native-execution.md
+++ b/agents/roadmaps/road-to-capability-native-execution.md
@@ -190,7 +190,7 @@ Merge-blocking. Nothing in Phases 1-9 is authored before this phase closes.
       verify asked for *at least one* property, and it has one; it does not have
       the three it went looking for.
 
-- [ ] **0.4 Map existing runtime-routing primitives and forbid a second
+- [x] **0.4 Map existing runtime-routing primitives and forbid a second
       router.** Read `tool_probe.ts`, `reach_doctor.ts`, `judgment_ladder.ts`,
       `tier_budget_routing.ts`, missing-tool handling and missing-skill
       recovery. Every proposed code path either extends one of them or states
@@ -199,6 +199,34 @@ Merge-blocking. Nothing in Phases 1-9 is authored before this phase closes.
       extend-or-not with a reason; no new module duplicates
       `ToolProbeStatus`/`ChannelStatus` or re-implements a priority-ordered
       resolver.
+
+      **CLOSED 2026-08-29.** All six read at this branch's HEAD. Line numbers
+      are citations, not recollections.
+
+      | Primitive | File | Decision | Reason |
+      |---|---|---|---|
+      | `ToolProbeStatus` (`ok · missing · broken · timeout · error`), `ToolProbeDescriptor`, `ToolProbeResult`, `probeTool` | `src/scripts/_lib/tool_probe.ts:59,70,88,266` | **EXTEND** | This IS the cheap static availability probe Phase 2.2 asks for. A new status enum next to it is the duplication this step forbids. |
+      | `ChannelStatus` (`ToolProbeStatus \| 'removed' \| 'not-ready'`), `ChannelRow`, `runDeepProbe`, `ReachDoctorPayload` | `src/scripts/reach_doctor.ts:110,204,425,219` | **EXTEND** | Phase 2.3 already says so. The load-bearing detail is HOW: `:110` adds two states by **composing** `ToolProbeStatus`, never by restating it. Phase 2.3's `dispatchable` state is added the same way or not at all. |
+      | `LadderRung`, `LadderVerdict`, `classifyLadder`, `explainLadder`, `RungStatus` (`taken · rejected · not-reached`) | `src/scripts/_lib/judgment_ladder.ts:40,42,342,499,467` | **DO NOT extend the resolver; IMPORT the reason-code shape** | Different input and different domain: the ladder classifies TASK TEXT to pick a fixed delegation rung; the Phase 4 selector filters ADAPTERS by capability coverage against a host-dependent set. Merging them would give one module two unrelated input types and two unrelated rung sets. But `explainLadder`'s per-rung `taken / rejected / not-reached` is exactly what 4.5 and AC-7 need, so the selector imports `RungStatus`-shaped reason codes rather than inventing a parallel vocabulary. **This is the closest thing in the tree to the second router 0.4 warns about, and it is named here so Phase 4 cannot drift into one unnoticed.** |
+      | `BudgetTier`, `TIER_ORDER`, cooldown read/write | `src/scripts/_lib/tier_budget_routing.ts:32,35,37,49` | **DO NOT extend; adopt the shape** | It routes MODEL tiers under a spend budget with cooldowns — nothing about capability coverage, and an adapter is not a price tier. What transfers is `TIER_ORDER`: a fixed ordered array with no numeric weight, which is the existing precedent for AC-7. |
+      | `missing-tool-handling` (ask before working around a missing CLI; never install silently) | `src/rules/missing-tool-handling.md`, routing to `guideline:agent-infra/missing-tool-handling` | **ROUTE INTO IT** | When no adapter is dispatchable the terminal behaviour already exists. The selector must hand off to it, not grow its own install-or-workaround path. |
+      | `rank()` — keyword scoring over skill frontmatter, returns `[name, score, tags]` | `src/scripts/skill_tools/score_skill_relevance.ts:247,249` | **DO NOT extend — cite as the ANTI-precedent** | `RankRow` carries a NUMERIC score, and AC-7 forbids numeric weight anywhere in selection. This is the one place the tree ranks numerically; reusing it for adapters would violate AC-7 by construction. Recorded so a future step cannot reach for it as the obvious ready-made ranker. |
+
+      **The negative half is a CHECK, not a promise.** At Phase 0 "no new module
+      duplicates `ToolProbeStatus`/`ChannelStatus`" is trivially true because no
+      adapter code exists — which is precisely when the assurance is worthless.
+      `tests/contracts/runtime_routing_primitives.test.ts` (4 tests, green)
+      asserts each vocabulary is declared exactly once, that no other module
+      re-lists a full member set, and that `ChannelStatus` still composes rather
+      than forks. Sensitivity proven: a temporary second `ToolProbeStatus`
+      declaration turned 2 of the 4 red, and it was removed.
+
+      **What the check deliberately does NOT cover:** *"re-implements a
+      priority-ordered resolver"* is not decidable from a file's text — a
+      resolver is recognisable by what it does, and a pattern guess would either
+      miss the real case or fire on every `sort`. That half stays model-carried
+      and is carried into Phase 4's exit criteria, with `explainLadder` named
+      above as the specific thing Phase 4 must import from rather than mirror.
 
 - [ ] **0.5 Freeze the browser benchmark fixtures.** Minimum set: project
       Playwright available; playwright-cli only; MCP only; CLI + MCP; backend
@@ -768,7 +796,8 @@ Do not expand because capability names are cheap to invent.
   *both* halves — "records the deterministic class as outside the boundary with
   its reason, **and** the two parked classes as gated on a named federation
   ADR". One half is owner-reserved by its own subject matter. Amended below.
-- **Resolved when (AMENDED 2026-08-29):** the parked half is already recorded
+- **Resolved when:** *(AMENDED 2026-08-29 — the marker moved inside the value on
+  purpose; see the note under this field.)* the parked half is already recorded
   above. The blocker closes when the owner either (i) confirms in ADR-088 or a
   clarifying ADR that deterministic, local browser engines were never within
   "external tool runtimes", or (ii) states that they are within it, at which
@@ -793,9 +822,24 @@ Do not expand because capability names are cheap to invent.
 - **If you do nothing:** a `semantic-single-step` adapter lands as
   "experimental" and the category boundary is crossed without the ADR ADR-088
   requires.
-- **Resolved when:** a disposition records the deterministic class as outside the
-  boundary with its reason, and the two parked classes as gated on a named
-  federation ADR that does not yet exist.
+
+  **Why this field had a stale twin until 2026-08-29, and why removing it was
+  not a formatting fix.** The 2026-08-29 amendment added a second
+  `Resolved when` and left the original in place, three fields below, stating
+  the opposite: that the blocker closes when *"a disposition records the
+  deterministic class as outside the boundary"* — the very thing the amendment
+  had just established no council may do. Two contradictory closure conditions
+  on one blocker, and `lint_roadmap_blockers` was green throughout.
+
+  It was green **because of** the stale line. Its check is
+  `/^-[ \t]*\*\*Resolved when:\*\*/im`
+  (`src/scripts/lint_roadmap_blockers.ts:52`) — a literal label. The amendment
+  had written `**Resolved when (AMENDED 2026-08-29):**`, which does not match,
+  so the field the reader was meant to follow did not satisfy the five-field
+  contract at all, and the contradictory line was the only thing keeping this
+  blocker legal. Deleting the stale line first would have turned the gate red;
+  renaming the amended one first makes the deletion safe. Both are done here, in
+  that order, which is why the marker now sits inside the value.
 
 ## Risk Register
 <!-- risk-review: v1 | reviewed: 2026-08-24 | reviewer: claude/host -->

--- a/tests/contracts/runtime_routing_primitives.test.ts
+++ b/tests/contracts/runtime_routing_primitives.test.ts
@@ -1,0 +1,97 @@
+/**
+ * The negative half of `road-to-capability-native-execution` step 0.4.
+ *
+ * That step's `verify:` clause has two halves: a table naming each existing
+ * runtime-routing primitive with an extend-or-not decision (in the roadmap),
+ * and a property — *"no new module duplicates `ToolProbeStatus`/`ChannelStatus`
+ * or re-implements a priority-ordered resolver"*. At Phase 0 the property is
+ * trivially true because no adapter or resolver code exists yet, which is
+ * exactly when a promise is cheapest to make and least worth anything.
+ *
+ * So it is a check instead. These tests fail the moment a second module
+ * declares either status vocabulary, which is the failure 0.4 exists to
+ * prevent and the one a table alone cannot catch.
+ *
+ * What this does NOT check, stated because the gap matters: "re-implements a
+ * priority-ordered resolver" is not decidable from a file's text. A resolver is
+ * recognisable by what it does, not by a token, and a check that guessed at it
+ * would either miss the real case or fire on every `find`/`sort`. That half
+ * stays model-carried and is carried into Phase 4's exit criteria rather than
+ * asserted here.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+/** The one legal home of each status vocabulary. */
+const OWNERS: Readonly<Record<string, string>> = {
+    ToolProbeStatus: 'src/scripts/_lib/tool_probe.ts',
+    ChannelStatus: 'src/scripts/reach_doctor.ts',
+};
+
+/** The member sets, read from their owning file rather than restated here. */
+function ownedUnion(name: string): string[] {
+    const src = fs.readFileSync(path.join(REPO_ROOT, OWNERS[name]), 'utf8');
+    const m = new RegExp(`export type ${name} =([^;]+);`).exec(src);
+    expect(m, `${OWNERS[name]} no longer declares ${name}`).not.toBeNull();
+    return [...(m as RegExpExecArray)[1].matchAll(/'([a-z][a-z-]*)'/g)].map((x) => x[1]);
+}
+
+function tsFiles(root: string): string[] {
+    const out: string[] = [];
+    const walk = (d: string): void => {
+        for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+            const full = path.join(d, e.name);
+            if (e.isDirectory()) walk(full);
+            else if (e.name.endsWith('.ts')) out.push(path.relative(REPO_ROOT, full));
+        }
+    };
+    walk(path.join(REPO_ROOT, root));
+    return out;
+}
+
+describe('step 0.4 — no second declaration of a status vocabulary', () => {
+    it('ToolProbeStatus is declared exactly once, in tool_probe.ts', () => {
+        const offenders = tsFiles('src').filter(
+            (rel) => rel !== OWNERS.ToolProbeStatus && /export type ToolProbeStatus\s*=/.test(fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8')),
+        );
+        expect(offenders).toEqual([]);
+    });
+
+    it('ChannelStatus is declared exactly once, in reach_doctor.ts', () => {
+        const offenders = tsFiles('src').filter(
+            (rel) => rel !== OWNERS.ChannelStatus && /export type ChannelStatus\s*=/.test(fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8')),
+        );
+        expect(offenders).toEqual([]);
+    });
+
+    it('no module outside the owners re-lists a full status member set', () => {
+        const sets = Object.keys(OWNERS).map((n) => [n, ownedUnion(n)] as const);
+        const owners = new Set(Object.values(OWNERS));
+        const offenders: string[] = [];
+        for (const rel of tsFiles('src')) {
+            if (owners.has(rel)) continue;
+            const src = fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8');
+            for (const [name, values] of sets) {
+                if (values.length === 0) continue;
+                for (const m of src.matchAll(/(?:type|const)\s+\w+\s*(?::[^=]*)?=\s*([\s\S]{0,300}?);/g)) {
+                    if (values.every((v) => m[1].includes(`'${v}'`))) {
+                        offenders.push(`${rel} re-lists the ${name} member set`);
+                    }
+                }
+            }
+        }
+        expect([...new Set(offenders)]).toEqual([]);
+    });
+
+    it('ChannelStatus still COMPOSES ToolProbeStatus rather than restating it', () => {
+        // The precedent 0.4's table rests on: a third state set is added by
+        // composition, never by forking. If this ever becomes a flat union the
+        // extend-not-fork argument in the roadmap has silently expired.
+        const src = fs.readFileSync(path.join(REPO_ROOT, OWNERS.ChannelStatus), 'utf8');
+        expect(src).toMatch(/export type ChannelStatus = ToolProbeStatus \|/);
+    });
+});


### PR DESCRIPTION
## What this is

`road-to-capability-native-execution` step **0.4** — the Phase 0 step that maps
the existing runtime-routing primitives and forbids a second router — plus a
blocker-contract defect found while reading that roadmap's `## Blockers`
section, which no step predicted.

Progress: **2/54 → 3/54**. The roadmap stays `status: draft`; nothing here
claims it is complete.

## Step 0.4 — the table, with citations rather than recollections

All six primitives read at this branch's HEAD. Verdicts:

| Primitive | File | Decision |
|---|---|---|
| `ToolProbeStatus`, `ToolProbeDescriptor`, `ToolProbeResult`, `probeTool` | `src/scripts/_lib/tool_probe.ts:59,70,88,266` | **EXTEND** — this already *is* the cheap static availability probe Phase 2.2 asks for |
| `ChannelStatus`, `ChannelRow`, `runDeepProbe`, `ReachDoctorPayload` | `src/scripts/reach_doctor.ts:110,204,425,219` | **EXTEND** — and the load-bearing detail is *how*: `:110` adds two states by **composing** `ToolProbeStatus`, never restating it |
| `LadderRung`, `classifyLadder`, `explainLadder`, `RungStatus` | `src/scripts/_lib/judgment_ladder.ts:40,342,499,467` | **Do not extend the resolver; import the reason-code shape** |
| `BudgetTier`, `TIER_ORDER`, cooldowns | `src/scripts/_lib/tier_budget_routing.ts:32,35,37,49` | **Do not extend; adopt the shape** — `TIER_ORDER` is the existing fixed-order, no-numeric-weight precedent for AC-7 |
| `missing-tool-handling` | `src/rules/missing-tool-handling.md` | **Route into it** — the no-dispatchable-adapter terminal behaviour already exists |
| `rank()` → `[name, score, tags]` | `src/scripts/skill_tools/score_skill_relevance.ts:247,249` | **Do not extend — the ANTI-precedent** |

Two rows are the useful ones.

**`explainLadder` is the closest thing in the tree to the second router 0.4
warns about.** It is a priority-ordered resolver that emits per-rung
`taken / rejected / not-reached` — exactly what step 4.5 and AC-7 need. It is
named in the roadmap so Phase 4 imports that reason-code shape rather than
mirroring it, and so the drift cannot happen quietly. It is *not* extended as
the resolver, because its input is task text and its rungs are fixed delegation
tiers, while the Phase 4 selector filters adapters by capability coverage over
a host-dependent set; merging would give one module two unrelated input types
and two unrelated rung sets.

**`rank()` is recorded as the anti-precedent, which the step did not ask for.**
`RankRow` carries a **numeric** score, and AC-7 forbids numeric weight anywhere
in selection. It is the one place this tree ranks numerically, so it is the
obvious ready-made ranker a future step would reach for — and using it would
violate AC-7 by construction. Better recorded now than discovered in Phase 4.

## The negative half is a check, not a promise

0.4's clause also requires that *"no new module duplicates
`ToolProbeStatus`/`ChannelStatus`"*. At Phase 0 that is trivially true because
no adapter code exists — which is precisely when the assurance is worth
nothing. So it ships as
`tests/contracts/runtime_routing_primitives.test.ts` (4 tests, green): each
vocabulary declared exactly once in its owning file, no other module re-listing
a full member set, and `ChannelStatus` still composing rather than forking.

**Sensitivity proven, not assumed** — a temporary second `ToolProbeStatus`
declaration turned **2 of the 4** red (both intended detectors), then was
removed.

**What the check deliberately does not cover**, said rather than implied:
*"re-implements a priority-ordered resolver"* is not decidable from a file's
text. A resolver is recognisable by what it does, and a pattern guess would
either miss the real case or fire on every `sort`. That half stays
model-carried and is carried into Phase 4's exit criteria, with `explainLadder`
named as the specific thing to import from.

## The defect: a stale blocker field that was holding the gate green

Found while reading `## Blockers`, predicted by no step.

Blocker `b-adr-088-external-runtime-federation` carried **two `Resolved when`
fields with opposite closure conditions.** The 2026-08-29 amendment added one
and left the original three fields below, stating the blocker closes when *"a
disposition records the deterministic class as outside the boundary"* — the
exact act that same amendment had just established **no council may perform**,
because writing an exception to ADR-088 (`status: accepted`, a *category*
boundary) narrows an accepted floor.

`lint_roadmap_blockers` was green throughout — and green **because of** the
stale line. Its check is a literal label match:

```
['Resolved when', /^-[ \t]*\*\*Resolved when:\*\*/im]   // lint_roadmap_blockers.ts:52
```

The amendment had written `**Resolved when (AMENDED 2026-08-29):**`, which does
not match. So the field a reader was meant to follow **never satisfied the
five-field contract at all**, and the contradictory line was the only thing
keeping the blocker legal. Deleting the stale line on its own — the obvious
tidy-up — would have turned the gate red.

Fixed in the order that keeps it green: rename first (marker moved inside the
value), then delete. **Verified in both directions:**

- after the fix → `7 roadmap(s) blocker-contract-clean`
- with the mislabelled field and the twin gone →
  `line 760: blocker 'b-adr-088-external-runtime-federation' missing required field(s): Resolved when`

The second reading is the one that proves the claim written into the roadmap,
so it was produced rather than reasoned about, then restored.

**A gate gap this exposes, reported and not fixed here.** `lint_roadmap_blockers`
cannot see a *duplicate* field, and its literal-label check silently ignores a
renamed one — so an amendment that renames a field converts a required field
into prose without any signal. Widening that linter is a separate change with
its own baseline implications; this PR fixes the data defect and names the gap.

## Blockers not touched, and why no council may close them

`b-adr-088`'s residual half and `merge-authority` on the sibling roadmap already
carry fresh 2026-08-29 2/2-convergent council verdicts that **explicitly refuse
that residual as owner-reserved** (narrowing an accepted floor; settling a
human-in-the-loop promotion guarantee). Re-running the council to obtain a
different answer is verdict shopping under
`src/rules/evaluator-independence.md`, so they were not re-run. Phases 0–5 and
7–9 are declared legal by those same verdicts, which is what makes this Phase 0
work legitimate.

## Verification

At `b5f890464`, every command run in this worktree.

- `npx vitest run tests/contracts/runtime_routing_primitives.test.ts` — **4 passed**
- `npx tsc -p tsconfig.json --noEmit` — exit **0**
- `npx eslint` on the new test — clean
- Gates, all exit 0: `lint_roadmap_blockers`, `lint_roadmap_complexity`,
  `lint_roadmap_ci_steps`, `check_roadmap_trackable`, `check_no_roadmap_refs`,
  `lint_empty_roadmaps`, `lint_roadmap_later_disposition`,
  `check_no_external_sources`, `check_council_references`,
  `check_estate_count`, `check_source_size_budget`
- `./agent-config roadmap:progress` → `4 roadmap(s) · 20/139 steps done`, no
  dashboard diff (this roadmap is `status: draft` and excluded)

No `task sync` / `task generate-tools` needed — the diff touches `tests/` and
`agents/roadmaps/` only.

## Deliberate non-actions

- **Steps 0.5 and 0.6 left open.** Both require their commit to *precede* any
  resolver or adapter code. That ordering is preserved by not doing them in the
  same PR as a step that reasons about resolver design — they are cheap and
  belong in their own commit, immediately before Phase 1.
- **No archival, no promotion to `ready`.** The roadmap is 3/54, and promoting
  it would raise `active_roadmaps` past its floor with no disposal here.
- **`lint_roadmap_blockers` not widened** — named above as a gap, out of scope.
