### PR TITLE
roadmap(governed-harness-evolution): close 1.4 as a reference, not a gate — the E1 ownership matrix discharged

### DIFF
--- a/agents/roadmaps/road-to-governed-harness-evolution.md
+++ b/agents/roadmaps/road-to-governed-harness-evolution.md
@@ -195,7 +195,7 @@ once.
       `type=supersede` lines as that contract already prescribes.
       verify: the contract's schema table carries the new field and the
       append-only migration note; no new path under `agents/runtime/state/`.
-- [ ] **1.4 Reconcile the two outcome vocabularies before extending either.**
+- [x] **1.4 Reconcile the two outcome vocabularies before extending either.**
       `corrected-from-reproduction`, and no proposal in either folder noticed:
       this tree holds **two** outcome enums — `audit-log-v1:77` has four values
       (`success · blocked · skipped · error`) and
@@ -233,6 +233,49 @@ once.
       anti-duplication lint are asserted by `experience-loop-broadening` 1.3 and not
       here, and any translation emitted by this roadmap carries `canonical: false`
       with its source version.
+
+      **CLOSED 2026-08-29, and the accounting is per conjunct, because two of the
+      three are satisfiable in different ways and the third is vacuous.**
+
+      1. *"this step declares no reconciliation complete"* — **met.** The step
+         performs nothing and claims nothing. The old owner-style `verify:` that
+         could have declared the mechanism complete was already removed by the
+         2026-08-29 re-scoping above; this closure does not restore it.
+      2. *"the enum module and its anti-duplication lint are asserted by
+         `experience-loop-broadening` 1.3 and not here"* — **met.** That step is
+         now closed and its assertions exist:
+         `src/scripts/_lib/outcome_vocabularies.ts` is the registry and
+         `tests/contracts/outcome_vocabularies.test.ts` is the anti-duplicate
+         check, both authored under 1.3, neither under this roadmap. Read
+         precisely, this conjunct is a claim about **where the assertion lives**,
+         not about whether it has merged — which is the reading the clause
+         requires, because the paragraph above forbids sibling completion from
+         becoming an entry or exit criterion here. Landing on the sibling's
+         branch, not this one.
+      3. *"any translation emitted by this roadmap carries `canonical: false`
+         with its source version"* — **VACUOUS, and recorded as vacuous rather
+         than as met.** This roadmap emits no cross-vocabulary translation
+         today, so the conjunct quantifies over an empty set. A check would scan
+         nothing and exit green, which is worse than no check: it would look
+         like coverage. The obligation is therefore carried into the exit
+         criteria of the first phase that actually emits a translation, where
+         the set is non-empty and the provenance fields (source snapshot or
+         version, adapter version, `canonical: false`) can be asserted against
+         a real artefact.
+
+      **What this closure buys, since the step builds nothing:** it discharges
+      the E1 ownership matrix. Before this, both roadmaps carried a step for the
+      same mechanism and either could have declared it complete — the duplicate
+      completion claim the matrix prohibits. Now exactly one does, and this side
+      records the dependency without gating on it. The corrected FACTS from the
+      owner's side also land here: there are **three** vocabularies, not the two
+      this step's prose names — the third is the work-engine STEP enum at
+      `src/agent-src/templates/scripts/work_engine/delivery_state.ts:39`
+      (`success · blocked · partial`) — and the four audit-log values are not
+      documentation-only, since `LineOutcome` is declared in code and
+      `envelopeOutcome` returns all four. The prose above is left as written
+      because it is the record of what was believed when the step was authored;
+      the correction is here rather than as a silent edit to it.
 
 ## Phase 2 — Trigger corpus: census first, coverage second
 


### PR DESCRIPTION
## What this is

`road-to-governed-harness-evolution` step **1.4** — the *non-owner* side of the
outcome-vocabulary reconciliation. It builds nothing, and that is the point.

Progress: **0/58 → 1/58**. `status: draft` unchanged.

## Why a step that builds nothing is worth closing

The E1 ownership matrix (recorded on the sibling roadmap, council 2/2,
2026-08-29) assigns outcome-vocabulary reconciliation to
`road-to-experience-loop-broadening` **step 1.3**, on the criterion of
**acceptance authority** — the vocabulary governs captured outcomes, subagent
returns, delayed amendments and episode integrity, and this harness *consumes*
those semantics rather than originating their lifecycle.

Before the 2026-08-29 re-scoping, this step carried the **owner's** acceptance
test (*"one module exports the enum both readers import, and a lint rejects an
inline duplicate"*), which meant either roadmap could declare the mechanism
complete — the duplicate completion claim the matrix prohibits. 1.3 is now
closed with a real registry module and a real anti-duplicate check
(sibling PR), so this side closes as what the re-scoping made it: **a reference
that records the dependency and does not gate on it.**

## Per-conjunct accounting, because the three are not satisfied the same way

The step's `verify:` has three conjuncts and closing them as one would hide the
interesting part.

1. **"declares no reconciliation complete"** — **met.** Nothing is performed and
   nothing is claimed; the owner-style clause removed by the re-scoping is not
   restored.

2. **"the enum module and its anti-duplication lint are asserted by
   `experience-loop-broadening` 1.3 and not here"** — **met.**
   `src/scripts/_lib/outcome_vocabularies.ts` and
   `tests/contracts/outcome_vocabularies.test.ts` were authored under 1.3,
   neither under this roadmap.

   Read precisely, this is a claim about **where the assertion lives**, not
   about whether it has merged — and that reading is *required*, not
   convenient: the paragraph directly above it forbids sibling completion from
   becoming an entry or exit criterion for this phase. Waiting for the sibling
   to merge before closing this step would turn the reference into exactly the
   hidden gate the clause prohibits.

3. **"any translation emitted by this roadmap carries `canonical: false` with
   its source version"** — **VACUOUS, and recorded as vacuous rather than as
   met.** This roadmap emits no cross-vocabulary translation today, so the
   conjunct quantifies over an empty set. A check for it would scan nothing and
   exit green, which is worse than no check — it would look like coverage. The
   obligation is carried into the exit criteria of the first phase that actually
   emits a translation, where the set is non-empty and the provenance fields can
   be asserted against a real artefact.

## Corrected facts carried over from the owner's side

This step's prose says the tree holds **two** outcome enums, one of them
documentation-only. Executing 1.3 showed both halves are wrong:

- There are **three**. The third is the work-engine STEP enum at
  `src/agent-src/templates/scripts/work_engine/delivery_state.ts:39`
  (`success · blocked · partial`).
- The four audit-log values are **not** documentation-only: `LineOutcome` is
  declared in code at `src/scripts/_lib/orchestration_record.ts:45`,
  `envelopeOutcome` at `:195-200` returns all four, and
  `src/scripts/_lib/review_skipped_record.ts:89` writes `outcome: 'skipped'`
  onto a real audit line.

**The original prose is deliberately left as written**, with the correction
appended beneath it, because it is the record of what was believed when the step
was authored. Silently editing it would erase the fact that the premise was
wrong — which is the more useful thing to keep.

## Verification

At this branch's HEAD, in this worktree.

Gates, all exit 0: `lint_roadmap_blockers` (`7 roadmap(s)
blocker-contract-clean`), `lint_roadmap_complexity`, `lint_roadmap_ci_steps`,
`check_roadmap_trackable`, `check_no_roadmap_refs`, `lint_empty_roadmaps`,
`lint_roadmap_later_disposition`, `check_no_external_sources`,
`check_council_references`, `check_estate_count`.

`./agent-config roadmap:progress` → `4 roadmap(s) · 20/139 steps done`, no
dashboard diff (draft roadmaps are excluded from it).

Markdown-only diff — one file — so no `task sync` / `task generate-tools` and no
typecheck surface.

## Deliberate non-actions

- **`merge-authority` not re-run past the council.** It already carries a fresh
  2026-08-29 2/2-convergent verdict taking option (c) — Phases 1–6 legal, Phase
  7 gated — and explicitly refusing (a) and (b) as owner-reserved, because
  either resolves ADR-239 § Decision 3 and touches a human-in-the-loop
  promotion guarantee. Re-running it for a different answer is verdict shopping
  under `src/rules/evaluator-independence.md`. Step 0.8 stays `[~]` for the same
  reason.
- **Step 0.1 left open.** Its second conjunct — *"every later phase names a row
  in it"* — is not satisfiable by writing the matrix alone; it needs edits
  across every later phase, which is a separate change.
- **No promotion to `ready`, no archival.** 1/58.
