### PR TITLE
roadmap(inbox-2026-08-g): three roadmaps from five bundles, and the one that dropped in full

### DIFF
--- a/agents/roadmaps/road-to-concern-admission-ratchet.md
+++ b/agents/roadmaps/road-to-concern-admission-ratchet.md
@@ -1,0 +1,160 @@
+---
+complexity: lightweight
+status: ready
+execution:
+  mode: phase-checkpoints
+research_pin: "agent-config @ 6e37584a1 (main, 2026-08-30, v14.12.0). Concern series reproduced at six pins in an isolated worktree; no network, no writes outside agents/roadmaps/."
+estate_offset_exempt: "The one-in-one-out half fires on every added agents/roadmaps/road-to-*.md whatever its status, and this run archived nothing, so there is no offset to point at. The addition is sanctioned on its own terms: a tree-wide grep over agents/roadmaps/*.md, later/*.md and stubs/*.md for `concern` combined with `ratchet`/`admission` returns no file that owns the hook-concern growth axis, so no active, parked or stubbed roadmap covers the subject."
+estate_growth_exempt: "Lands as status: ready rather than draft because the finding is measured, not proposed — the growth series is reproduced at six pins and the absent mechanism is a file that does not exist. A draft would repeat the exact failure this roadmap records: the same recommendation was already made once, in a consumed inbox file, and left no durable trace."
+---
+# Road to concern admission ratchet
+
+> **Source:** intake round `inbox-2026-08-g`, set E — the round's status-update
+> artefact, § 2. Consumed by the `/analyze:inbox` run of 2026-08-30.
+> **Second occurrence** — the preceding round's status update already named the
+> concern axis the next ratchet candidate at 68→69, and the item was never
+> recorded anywhere durable. Routed through `src/rules/recurring-criticism.md`;
+> the broken assumption is named in § Why this is here twice. True source paths
+> are recorded encrypted in the round's intake note per
+> `src/rules/source-confidentiality.md`.
+
+## Goal
+
+The hook-concern count is governed by the same two mechanisms that froze the
+skill count: a forward-only admission ledger in which every added concern
+carries a recorded answer and a refusal is a first-class row, and a ratcheted
+count a change may only raise with a reason read from its own diff. When this
+is finished, adding the 72nd concern either carries its record or fails a
+gate — and `check_estate_count` reports the concern axis the same way it
+reports `skill_count`.
+
+## Why this is here twice
+
+The recommendation was right; the **record** failed. It was written in an
+untracked inbox file, that file was consumed, and nothing in
+`agents/roadmaps/` — active, `later/` or `stubs/` — inherited it. Of the three
+outcomes `recurring-criticism` names, this is **"right, never recorded"**: the
+disposition was not wrong and it was not unreachable, it was never made
+durable. The learning that constrains the next run is Phase 3.
+
+## Measured state (reproduced at `6e37584a1`)
+
+| Pin | `7c6a71d` | `1dba34c8` | `40791536` | `0f7c26ee9` | `2bcefb8b1` | `6e37584a1` |
+|---|---|---|---|---|---|---|
+| Concerns | 63 | 65 | 65 | 68 | 69 | **71** |
+
+`git show "<pin>:src/scripts/hook_manifest.yaml" | grep -cE '^  [a-z][a-z0-9_-]*:$'`
+— +8 over the series, and the only axis in the source's four-row table still
+climbing. Skills held at 299 across the last three pins, rules at 120, tier-2
+at 81.
+
+What exists today and why it does not catch this:
+`src/scripts/lint_hook_concern_budget.ts` caps concerns **per (platform,
+event)** at `DEFAULT_MAX_PER_EVENT = 8` and ships `DEFAULT_HARD_FAIL = false`.
+A per-event cap is blind to total growth by construction — eight new concerns
+spread across eight events violate nothing — and warn-only means even the
+per-event finding does not stop a merge unless `--strict` is passed. There is
+no concern-count budget file, and `check_estate_count.ts` measures roadmaps and
+skills only.
+
+## Phase 1 — Measure the axis where the other axes are measured
+
+- [ ] **1.1 Add a concern-count metric to `check_estate_count.ts`.** Count
+      concerns at HEAD and at the base ref with the *same* function, the way
+      `_lib/skill_estate.ts` already does for skills — one parser shared by
+      both sides, never two readings. The manifest is a single file at
+      `src/scripts/hook_manifest.yaml`, so the existing `materialiseSubtree`
+      call needs a second prefix or a single-file `git cat-file` read; state
+      which in the implementation note.
+      verify: `./scripts-run src/scripts/check_estate_count --base <a pin
+      carrying 69 concerns>` prints the concern floor and the HEAD count, and
+      exits non-zero when HEAD is higher with no claim in the diff.
+- [ ] **1.2 Extend the `estate_growth_exempt` claim path to the new metric.**
+      No new allowance key: the metric joins `skill_count` in taking the claim
+      path or nothing, for the reason the estate budget file already records
+      for skills — an allowance reopens the gaming path the dimension exists
+      to close.
+      verify: a fixture branch adding one concern without a claim fails; the
+      same branch with `estate_growth_exempt` in a touched roadmap's
+      frontmatter passes, and the reason is printed.
+- [ ] **1.3 Register the metric in `src/config/estate-count-budget.json`.**
+      Document the basis, the reproduce command, and the measured value 71 —
+      in the shape the `skill_count` entry uses, including the rejected
+      candidates measured rather than argued.
+      verify: `check_estate_count`'s own self-test covers the concern branch,
+      and the gate-coverage row for the script names the new scanned path.
+
+## Phase 2 — Record the answers, and the refusals
+
+- [ ] **2.1 Mirror `check_skill_admissions.ts` for hook concerns.** Same
+      shape, same reasons: forward-only against the base ref so the 71 already
+      in the tree are grandfathered by construction, `decision: rejected` a
+      first-class state, and a rejected row forbidden from naming a concern
+      that exists. Ledger at `agents/decisions/concern-admissions.jsonl`.
+      The questions a new concern must answer are not the skill questions —
+      derive them from `docs/contracts/hook-architecture-v1.md`: which slot,
+      which hosts actually bind it, what it does where the host ignores a deny,
+      why an existing concern cannot carry it, and its per-event budget impact.
+      verify: a fixture adding a concern with no ledger row fails; with a row,
+      passes; a `rejected` row naming a live concern fails.
+- [ ] **2.2 Write the questions where the author will meet them.**
+      `hook_manifest.yaml`'s header already lists what to update when adding a
+      concern; the questions belong in that list and in the hook-architecture
+      contract, not only in the gate.
+      verify: the header names the ledger, and `check_references` stays green.
+- [ ] **2.3 Register both gates in the gate-coverage ledger** with `scanned`
+      and a self-test, per this repository's gate-authoring contract.
+      verify: the coverage gate is green and the two new rows carry a
+      non-empty `scanned` field.
+
+## Phase 3 — Close the recurrence, not just the finding
+
+- [ ] **3.1 Record the disposition so a third occurrence is impossible.**
+      One `agents/decisions/` entry or an ADR stating that the concern axis is
+      ratcheted as of this roadmap, with the six-pin series as its basis and a
+      `revisit-if` naming the condition that would reopen it — a measured case
+      where the ratchet blocks a concern the repository needed.
+      verify: the record exists, is citable by path, and names the series.
+- [ ] **3.2 State the intake learning.** An inbox status-update prediction
+      naming a concrete mechanism becomes a stub or a roadmap in the same run,
+      never a line in a file about to be consumed. Add it to the
+      `/analyze:inbox` command's Phase 4c or to `recurring-criticism`'s failure
+      list — whichever the overlap scan says already owns the surface — as one
+      sentence, not a new artefact.
+      verify: the sentence exists in exactly one of the two files, and the
+      other links to it rather than repeating it.
+
+## Blockers
+
+None. Every step is inside this repository and needs no host capability, no
+network, no spend and no owner decision. The one judgement call — whether the
+count metric belongs in `check_estate_count` or in its own gate — is
+implementation shape, not authority, and 1.1 decides it by placing it where
+`skill_count` already lives.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-08-30 | reviewer: claude/host -->
+
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | The ratchet fires on legitimate hook work and the reflex becomes a boilerplate claim | product | `estate_growth_exempt` is unbounded by design, so a concern that genuinely must ship is one line away. The failure is not a blocked merge, it is a claim reason nobody reads — the erosion the per-event cap already suffers by shipping warn-only | Phase 2's ledger makes the answer the artefact rather than the claim string: the row names slot, hosts, deny behaviour and why no existing concern carries it, and a reviewer can check each. 3.1's revisit-if names the measured condition that reopens the decision | Phase 2 — Record the answers, and the refusals |
+| 2 | The floor side reads a different manifest than the live side | implementation | The roadmap and skill metrics both materialise a subtree; the manifest is a single file at a different prefix, and a second materialise call or a bare cat-file read is exactly where a base ref with no manifest silently reads zero — a floor of zero passes every possible tree | 1.1 shares one parser between both sides; 1.3's self-test covers the missing-manifest branch explicitly, failing rather than skipping, on the precedent the budget file already records for a base ref with no src/skills | Phase 1 — Measure the axis where the other axes are measured |
+| 3 | Two gates where one would do | implementation | The count metric and the admission ledger both guard growth; shipping both reads as the composition this repository's marginal-cost principle warns about | They answer different questions, and the skill axis needed both for the same reason: the count catches growth, the ledger catches growth without a recorded decision, and a count alone is satisfiable by a merge that says nothing | Phase 1 — Measure the axis where the other axes are measured |
+
+## Acceptance Criteria
+
+- [ ] AC-1 — Adding a 72nd concern with no recorded reason fails a gate that
+      runs in `task ci`. Demonstrated on a fixture, seen red before it is seen
+      green.
+- [ ] AC-2 — `agents/decisions/concern-admissions.jsonl` exists and can hold a
+      `rejected` row; a rejected row naming a concern present in the manifest
+      is refused.
+- [ ] AC-3 — `check_estate_count` reports the concern axis alongside
+      `skill_count`, measured at the base ref with the same function it
+      measures HEAD with, and fails rather than skips when the base ref carries
+      no manifest.
+- [ ] AC-4 — A citable record states the concern axis is ratcheted, names the
+      six-pin series as its basis, and carries a `revisit-if`.
+- [ ] AC-5 — The intake learning from § Why this is here twice is written in
+      exactly one file, so a third occurrence of this prediction lands as a
+      tracked artefact rather than as prose in a consumed bundle.

--- a/agents/roadmaps/road-to-gates-that-do-not-run.md
+++ b/agents/roadmaps/road-to-gates-that-do-not-run.md
@@ -1,0 +1,161 @@
+---
+complexity: lightweight
+status: ready
+execution:
+  mode: phase-checkpoints
+research_pin: "agent-config @ 6e37584a1 (main, 2026-08-30, v14.12.0). The reachability set was computed in an isolated worktree with `task ci --summary` and a grep over .github/workflows/; no network, no writes outside agents/roadmaps/."
+estate_offset_exempt: "The one-in-one-out half fires on every added agents/roadmaps/road-to-*.md whatever its status, and this run archived nothing, so there is no offset to point at. Sanctioned on its own terms: a grep over agents/roadmaps/*.md, later/*.md and stubs/*.md finds no file owning gate REACHABILITY — the closest, road-to-gate-council-auto-dispatch, is about who decides a gate's verdict, not about whether the gate is invoked at all."
+estate_growth_exempt: "Lands as status: ready rather than draft because a named gate is red in the tree right now and has been unreachable from every CI entry point since it was written, while the roadmap that closed it recorded it as CI-wired. A draft would file a live red behind a proposal."
+---
+# Road to gates that do not run
+
+> **Source:** intake round `inbox-2026-08-g`, sets A and C, consumed by the
+> `/analyze:inbox` run of 2026-08-30. Neither set found this: set A planned a
+> *new* detector for a defect a shipped detector already reports, and set C
+> found the shipped detector but read its scope as one target. The class was
+> found by reproducing set A's proposed step against the tree. True source
+> paths are recorded encrypted in the round's intake note per
+> `src/rules/source-confidentiality.md`.
+
+## Goal
+
+Every gate this repository ships is either reachable from an entry point CI
+actually runs, or is recorded as deliberately manual with the reason stated —
+and a target that is neither cannot be added silently. Finished means: the 32
+gate-shaped task targets currently unreachable from both `task ci` and every
+workflow are each classified, the ones that should run are wired, and a check
+fails when a new gate target joins the unreachable set without a recorded
+reason.
+
+## The lead instance, and why it is a class
+
+`lint_positioning.ts` exits **1** on the tree at `6e37584a1`. It reports two
+publish surfaces that have drifted from the canonical README anchor:
+
+```
+- package.json.description missing canonical anchor
+- .github/about.yml description missing canonical anchor
+```
+
+Both carry the phrase `"zero runtime daemon"` — a claim `docs/CLAIMS.md:143-151`
+marks `status: withdrawn`, `retired_by: ADR-249`. So a live red is sitting on
+the two most public surfaces the package has, and nothing has reported it.
+
+It is not run. `lint-positioning` is defined at `taskfiles/ci-fast.yml:1631`
+and referenced only from `visibility-check` at `:1643`. Reproduce:
+
+```
+task ci --summary | grep -oE 'Task: [a-z0-9:_-]+' | sed 's/Task: //' | sort -u
+```
+
+277 targets; neither `visibility-check` nor `lint-positioning` is among them,
+and no file under `.github/workflows/` names either.
+
+And the record says otherwise. `agents/roadmaps/archive/strategic-visibility-mcp-topics-positioning.md:99`
+carries `- [x] task visibility-check runs the three linters above as one
+command, **used in CI**`. A closed step whose check could never have gone red —
+the failure class this repository's own drain runs have been naming all month,
+here found in an archived roadmap rather than in a fresh one.
+
+Subtracting the 277 reachable targets and every `task <name>` a workflow
+invokes from the 480 defined across `taskfiles/`, **32 gate-shaped targets
+(`lint-*`, `check-*`, `verify-*`) are reachable from neither**. Not all 32 are
+defects: several are output-format variants of a reachable target
+(`lint-skills-json`, `lint-skills-report`) and several are plausibly manual by
+design (`check-media-deps`, `lint-originality-shingles`, which writes into the
+tracked tree). Which is which is Phase 1's job and is not asserted here.
+
+## Phase 1 — Classify the 32, do not wire them
+
+- [ ] **1.1 Produce the reachable set as a committed artefact, not a grep.**
+      A script that resolves `task ci`'s transitive closure plus every
+      `task <name>` invoked from `.github/workflows/`, and diffs it against the
+      targets defined under `taskfiles/`. The two-command version above is what
+      found this; a committed one is what keeps finding it.
+      verify: the script prints 32 on this tree, and its output is stable
+      across two runs.
+- [ ] **1.2 Give every one of the 32 a class and a reason.** Three classes:
+      `should-run` (a gate whose absence from CI is a hole), `variant` (a
+      different output shape of a target that is reachable — name it), and
+      `manual` (deliberately human-invoked — say why, and what would make it
+      run). A class with no reason is not a class.
+      verify: a table with 32 rows, every row carrying a class and a
+      non-empty reason, committed under `agents/evidence/`.
+- [ ] **1.3 Do not act on the classification in this phase.** Wiring a gate
+      that has never run in CI is how a green pipeline goes red for reasons
+      nobody scheduled; Phase 2 does it deliberately and one at a time.
+      verify: the diff of this phase touches no taskfile and no workflow.
+
+## Phase 2 — Wire the `should-run` set, red first
+
+- [ ] **2.1 Fix the two publish strings and wire `lint-positioning`.**
+      `package.json:5` and `.github/about.yml:13` take the canonical README
+      anchor, which does not carry the withdrawn claim. Then add the target to
+      an entry point CI runs.
+      verify: `./scripts-run src/scripts/lint_positioning` exits 0; the string
+      `zero runtime daemon` appears in neither file; the target appears in
+      the Phase 1.1 script's reachable set.
+- [ ] **2.2 Wire the rest of the `should-run` set one target per commit,
+      each seen red or explained.** A gate that has never run in CI has an
+      unknown baseline: run it locally first, and if it is green, say so in
+      the commit — a gate wired while already green is wired on an unverified
+      sensitivity claim.
+      verify: for each target, either a recorded red-then-green, or a stated
+      reason why it was green on arrival and what a red would look like.
+- [ ] **2.3 Correct the archived record.** The closed step at
+      `strategic-visibility-mcp-topics-positioning.md:99` asserts CI wiring
+      that never existed. Annotate it in place — do not silently rewrite a
+      closed roadmap — with what was actually true and when it was found.
+      verify: the annotation names the date, the finding, and this roadmap;
+      the original text is still readable.
+
+## Phase 3 — Make the class un-reintroducible
+
+- [ ] **3.1 Turn the Phase 1.1 script into a gate.** A new gate-shaped target
+      that is reachable from neither `task ci` nor a workflow fails, unless it
+      carries a `manual:` reason in the taskfile beside its definition. The
+      classification from 1.2 seeds the allowed set at its measured size — the
+      ratchet shape this repository uses everywhere a strict gate would
+      otherwise red the whole backlog on day one.
+      verify: a fixture adding an unreachable, unreasoned gate target fails;
+      the same target with a `manual:` reason passes. Seen red before green.
+- [ ] **3.2 Register the gate** in the gate-coverage ledger with `scanned`
+      and a self-test, per this repository's gate-authoring contract.
+      verify: the coverage gate is green and the new row's `scanned` field is
+      non-empty.
+
+## Blockers
+
+None. Phase 1 is read-only classification, Phase 2 acts one target at a time
+with a recorded baseline, and Phase 3 ratchets at the measured size. No step
+needs a host capability, a network call, spend, or an owner decision — the one
+judgement Phase 1.2 makes is per-target and is recorded rather than assumed.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-08-30 | reviewer: claude/host -->
+
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | Wiring a long-unrun gate turns the pipeline red for unrelated pre-existing debt | implementation | A gate that has never run in CI has an unmeasured baseline. Wiring several at once produces a red nobody can attribute, and the recovery move — muting them again — leaves the tree worse than before | 2.2 wires one target per commit with its local baseline recorded first, and 1.3 forbids acting during classification. A gate found already-green is wired with a stated reason, not silently | Phase 2 — Wire the `should-run` set, red first |
+| 2 | `manual:` becomes the universal escape and the ratchet measures nothing | product | An unbounded reason field is one line away from turning every new gate into a documented non-gate, which is the erosion this repository already records for its warn-only budgets | 1.2 forces a reason that says *what would make it run*, so a `manual:` row carries its own reopening condition rather than a justification for permanence | Phase 3 — Make the class un-reintroducible |
+| 3 | The reachability computation is wrong and the 32 is an artefact of the method | implementation | `task ci --summary` resolves a static closure; a target invoked dynamically, from a composite action, or from a workflow the grep's pattern misses would be counted unreachable while it runs | 1.1 makes the computation a committed script with a stable output rather than a one-off grep, and 1.2's per-target reason forces a human read of each — a target that actually runs will be found at classification, not after wiring | Phase 1 — Classify the 32, do not wire them |
+| 4 | Annotating a closed archived roadmap reads as rewriting history | product | Editing a 100 %-closed archive entry is exactly the move the archive exists to prevent, and a reader who sees the edit without its reason cannot tell correction from revision | 2.3 annotates in place with date, finding and this roadmap's name, and leaves the original text readable — the same in-place correction shape the tree's own roadmap headers already use | Phase 2 — Wire the `should-run` set, red first |
+
+## Acceptance Criteria
+
+- [ ] AC-1 — A committed script computes the set of gate-shaped task targets
+      reachable from neither `task ci` nor any workflow, and its output is
+      reproducible across two runs on an unchanged tree.
+- [ ] AC-2 — Every target in that set carries a class and a non-empty reason
+      in a committed table; no row is unclassified.
+- [ ] AC-3 — `lint_positioning` exits 0 on the tree and is reachable from an
+      entry point CI runs; the phrase `zero runtime daemon` appears in neither
+      `package.json` nor `.github/about.yml`.
+- [ ] AC-4 — Every target wired in Phase 2 carries either a recorded
+      red-then-green or a stated reason why it arrived green and what a red
+      would look like.
+- [ ] AC-5 — A new unreachable, unreasoned gate target fails a gate, and the
+      red was observed before the green.
+- [ ] AC-6 — The archived step that claimed CI wiring carries an in-place
+      annotation naming the date, the finding, and this roadmap, with its
+      original text still readable.

--- a/agents/roadmaps/road-to-retired-claims-stay-retired.md
+++ b/agents/roadmaps/road-to-retired-claims-stay-retired.md
@@ -1,0 +1,158 @@
+---
+complexity: lightweight
+status: ready
+execution:
+  mode: phase-checkpoints
+research_pin: "agent-config @ 6e37584a1 (main, 2026-08-30, v14.12.0). Every figure re-derived in an isolated worktree at that commit; no network, no writes outside agents/roadmaps/."
+estate_offset_exempt: "The one-in-one-out half fires on every added agents/roadmaps/road-to-*.md whatever its status, and this run archived nothing, so there is no offset to point at. Sanctioned on its own terms: the two roadmaps that previously closed the adjacent defect class are archived at 19/19 and 21/21 closed, so neither is a live carrier, and no active, parked or stubbed roadmap names retired-claim reachability or rule provenance."
+estate_growth_exempt: "Lands as status: ready rather than draft because the gap is structural and verified: retiring a claim in the ledger changes nothing about where its wording is still published, and no gate in the tree connects the two. A draft would leave that design hole filed as an opinion."
+---
+# Road to retired claims stay retired
+
+> **Source:** intake round `inbox-2026-08-g`, sets A, B and C, consumed by the
+> `/analyze:inbox` run of 2026-08-30. The sets found the *instance*; the
+> structural half below was found by checking what the existing gates actually
+> read. True source paths are recorded encrypted in the round's intake note per
+> `src/rules/source-confidentiality.md`.
+
+## Goal
+
+Retiring a claim in the ledger has a consequence outside the ledger: its
+wording can no longer be published. Finished means a `withdrawn` or
+`resolved-null` entry carries the phrasings it retires, a gate refuses those
+phrasings on any surface the package publishes, and the normative content of a
+rule either names where it came from or is recorded as having no external
+source.
+
+## The gap, stated precisely
+
+Three separate things are true at `6e37584a1`, and none of them closes the
+loop:
+
+| | What it does | What it cannot see |
+|---|---|---|
+| `check_claims.ts` | Validates a ledger entry's own shape — a `withdrawn` entry must carry `retired_by` (`:484-489`); `SURFACE_ROOTS = ['README.md', 'docs']` (`:56`) | Whether the retired claim's **text** is still published. `package.json` and `.github/about.yml` are in neither the surface set nor the witness set |
+| `lint_positioning.ts` | Enforces that `README.md`, `package.json.description` and `.github/about.yml` share the canonical anchor | The ledger. It reads **0** lines of `docs/CLAIMS.md`. Three surfaces agreeing on a retired claim pass it |
+| The ledger itself | 60 `backed` · 29 `unbacked` · 6 `resolved-null` · 1 `withdrawn` | Nothing downstream. A row's `status` has no consumer that looks outward |
+
+So retirement is a bookkeeping act with no reach. The live instance — the
+withdrawn `no-runtime-daemon` claim still advertised on two publish surfaces —
+is being fixed as a red in `road-to-gates-that-do-not-run` Phase 2.1. **This
+roadmap deliberately does not fix that string**; it fixes the reason a second
+one can appear tomorrow without anything noticing.
+
+## Prior disposition — closed twice, each time scoped to a surface list
+
+`agents/roadmaps/archive/road-to-number-truth.md` (2026-07-25, 19/19 closed)
+found three published numbers wrong and named the cause: *"the ledger checks
+that a pointer exists, never that its number is true."*
+`agents/roadmaps/archive/road-to-published-number-truth.md` (2026-08-24, 21/21
+closed) found the resulting witness sweep watched the right file in the wrong
+shapes, and widened the shapes.
+
+Both closes were correct. Both were about **numbers on a listed surface**.
+Neither reached a *qualitative* claim, and neither questioned the list. That
+the same class arrives a third time on a third axis is the finding — routed
+through `src/rules/recurring-criticism.md`, where the broken assumption is
+that a surface list plus a shape list is a closure. It is a snapshot of what
+was published when the list was written.
+
+## Phase 1 — Give a retired claim something to retire
+
+- [ ] **1.1 Add a `retires_phrasings:` field to closed ledger entries.** On a
+      `withdrawn` or `resolved-null` row, a short list of the literal phrasings
+      that claim was published as. The list lives on the row so that retiring a
+      claim and forbidding its wording are one edit — a separate deny-list is a
+      second file, and the second file is the one nobody updates.
+      verify: `check_claims` accepts a closed entry with the field and one
+      without; a `withdrawn` entry whose field is present but empty fails.
+- [ ] **1.2 Populate it for the four closed entries that have published
+      phrasings.** One `withdrawn` and six `resolved-null` rows exist; read
+      each and record the phrasings it actually shipped under, or record that
+      it never appeared outside the ledger.
+      verify: every closed row carries either a non-empty list or a stated
+      never-published note.
+- [ ] **1.3 Name the publish-surface set once, with the rule for extending
+      it.** Both prior closes fixed an instance and left a list. State the
+      decision rule instead: any file whose content is rendered by a
+      distribution channel the package publishes to. Record it where the
+      surface set is defined, not in a roadmap.
+      verify: a reader can apply the rule to a channel not yet listed — a
+      registry page, a marketplace manifest — and get an answer without asking.
+
+## Phase 2 — Refuse a retired phrasing on any publish surface
+
+- [ ] **2.1 Extend `check_claims` to scan the publish-surface set for
+      `retires_phrasings`.** Extend rather than add a sibling gate: the
+      withdrawn/retired axis is already modelled there and a second gate needs
+      its own copy of the ledger parser. The surface set comes from 1.3.
+      verify: a fixture whose `package.json` description carries a retired
+      phrasing fails; the same fixture with the current wording passes. Seen
+      red before green.
+- [ ] **2.2 Prove the gate on the case that motivated it.** Re-introduce the
+      exact historical string in a fixture — not a synthetic near-miss — and
+      watch it fail. A gate never seen red on the real instance has unknown
+      sensitivity.
+      verify: the fixture carries the literal historical wording; the red and
+      the restored green are both recorded.
+- [ ] **2.3 Register the widened gate** in the gate-coverage ledger with the
+      new `scanned` paths and a self-test.
+      verify: the coverage gate is green and the row names every surface added.
+
+## Phase 3 — Say where a rule's content came from, and what it was when it left
+
+- [ ] **3.1 Add an optional `evidence:` frontmatter block to the rule schema.**
+      Fields: `source_type`, `source_urls` (ENC1 tokens where the source is
+      confidential, per `source-confidentiality`), `verified_on`,
+      `normative_level`. Optional on day one — **0 of 120** rules carry any
+      provenance field today, and holding all 120 at once is the
+      strict-gate-fires-on-everything failure this repository has recorded
+      before. The blocker linter's own decidability fields are the ratchet
+      precedent.
+      verify: `validate_frontmatter` accepts a rule with the block and one
+      without; a malformed block fails.
+- [ ] **3.2 Populate ten rules and register the ratchet.** Pick the ten whose
+      normative content most plausibly came from outside — the security and
+      safety floors — because an unsourced normative claim costs most there.
+      verify: ten rules carry a populated block; the ratchet baseline is the
+      measured ten, and an eleventh rule added without one fails.
+- [ ] **3.3 Create `docs/removed-rules.md` as a tombstone register.** One row
+      per removed rule: name, what it required, when it went, why. A rule that
+      vanishes without a row is indistinguishable from one that never existed,
+      which is how a removed obligation returns as a fresh proposal.
+      verify: the file exists, accounts for every rule removed in the two
+      releases preceding this roadmap's landing as read from `git log`, and
+      `check_references` stays green.
+
+## Blockers
+
+None. Every step is inside this repository and needs no host capability, no
+network, no spend and no owner decision. Phase 1.3 makes a scoping decision,
+but it records a rule rather than choosing a policy — the surfaces it admits
+are the ones the package already publishes to.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-08-30 | reviewer: claude/host -->
+
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | The surface list grows by one again and the class recurs a fourth time | product | Both prior closes fixed an instance and left the list a list. Adding two files and stopping is the identical move, and the next channel — a registry page, a marketplace manifest, a generated badge — is outside it again | 1.3 makes the decision rule the deliverable rather than the entries, so a new channel is answerable without a fourth roadmap. The rule is recorded where the set is defined, not in this file, which will be archived | Phase 1 — Give a retired claim something to retire |
+| 2 | `retires_phrasings` collects paraphrases and the gate becomes a false-positive machine | implementation | A retired claim has many near wordings; a list that tries to cover them all will match prose that is not the claim, and a gate that fires on legitimate text is muted within a release | 1.2 records only phrasings the claim was **actually published under**, read from history rather than imagined, and 2.2 proves the gate on the real historical string. A paraphrase nobody shipped is not in scope | Phase 2 — Refuse a retired phrasing on any publish surface |
+| 3 | `evidence:` becomes a field authors fill with the nearest plausible URL | product | An unratcheted optional provenance field collects sources that look right, and a wrong provenance is worse than none because it survives review while being false | 3.2 populates only ten rules, by hand, on the highest-cost surfaces, and `normative_level` forces the author to state how binding the source is rather than only that one exists | Phase 3 — Say where a rule's content came from |
+| 4 | Overlap with a concurrent re-opening of the archived number-truth roadmap | implementation | That roadmap touches `check_claims.ts` in the same region; two branches widening one gate is a conflict in the single file both need | The axes are separable — numeric witness shapes there, closed-status reach here — and 2.1 adds a scan rather than editing the witness sweep. If both land, the second rebases onto the first rather than re-deciding scope | Phase 2 — Refuse a retired phrasing on any publish surface |
+
+## Acceptance Criteria
+
+- [ ] AC-1 — Every closed ledger entry carries either a non-empty
+      `retires_phrasings` list or a stated note that the claim never appeared
+      outside the ledger.
+- [ ] AC-2 — A fixture publishing a retired phrasing on any surface in the
+      declared set fails `check_claims`, and the red was observed on the literal
+      historical wording before the green.
+- [ ] AC-3 — The publish-surface set carries, where it is defined, a stated rule
+      for deciding whether a channel belongs — applicable by a reader to a
+      channel not yet listed.
+- [ ] AC-4 — The rule schema accepts an `evidence:` block, at least ten rules
+      carry a populated one, and an eleventh added without it fails a ratchet.
+- [ ] AC-5 — `docs/removed-rules.md` exists and accounts for every rule removed
+      in the two releases preceding this roadmap's landing.


### PR DESCRIPTION
Intake round `inbox-2026-08-g` — five bundles, consumed by `/analyze:inbox` in an isolated worktree at `6e37584a1`. Every claim was re-derived against the tree rather than inherited; **eleven of the bundles' own figures did not survive that pass** and are recorded as corrections, not carried forward.

## What landed

**`road-to-concern-admission-ratchet`** — the hook-concern count grew **63 → 65 → 65 → 68 → 69 → 71** across six pins while skills, rules and tier-2 all held, and nothing objects. `lint_hook_concern_budget.ts` caps concerns *per (platform, event)* at 8 and ships `DEFAULT_HARD_FAIL = false`, so it is blind to total growth by construction. The skill axis got both an admission ledger and a count ratchet; the concern axis got neither.

Second occurrence: the preceding round predicted exactly this at 68 → 69, the file was consumed, and no roadmap, stub or parked file inherited it. Routed through `recurring-criticism`; the outcome is **"right, never recorded"**, and Phase 3 is what makes a third occurrence impossible.

**`road-to-gates-that-do-not-run`** — `lint_positioning.ts` **exits 1 on this tree right now**, reporting that `package.json:5` and `.github/about.yml:13` both advertise `"zero runtime daemon"` — a claim `docs/CLAIMS.md:143-151` marks `status: withdrawn`, `retired_by: ADR-249`.

It is reachable from neither `task ci` (277 targets, reproducible with `task ci --summary`) nor any workflow. And `agents/roadmaps/archive/strategic-visibility-mcp-topics-positioning.md:99` carries `- [x] task visibility-check … used in CI`. A closed step whose check could never have gone red.

Subtracting the reachable closure and every workflow-invoked target from the 480 defined under `taskfiles/`, **32 gate-shaped targets are reachable from neither entry point**. Not all 32 are defects — some are output variants, some are plausibly manual — which is why Phase 1 classifies and explicitly forbids wiring.

**`road-to-retired-claims-stay-retired`** — retiring a claim in the ledger reaches nothing outside it. `check_claims.ts` validates a `withdrawn` entry's own shape (`:484-489`) over `SURFACE_ROOTS = ['README.md', 'docs']` (`:56`); `lint_positioning.ts` reads **zero** lines of `CLAIMS.md`, so three surfaces agreeing on a retired claim pass it. This is the third arrival of a class closed twice — `road-to-number-truth` (19/19) and `road-to-published-number-truth` (21/21) — each time scoped to a surface list plus a shape list. That the list itself is the snapshot is the finding.

The two false strings are fixed by the *other* roadmap, as the live red they are. This one fixes the reason a second one can appear tomorrow.

## What did not land

**One bundle dropped in full.** Its lead item proposes projecting a compressed skill index into the consumer surface to fix reach. `check_preamble_payload_budget` reports `preloaded skills catalog 14,851 tok` — the index already preloads on every spawn — and the consumer thin-root sits at **2,499 chars against a `fail_at` of 2,500**. One character. The premise is falsified and the remedy is arithmetically closed; the residue folds into `road-to-governed-harness-evolution` Phase 6, which already owns that substrate.

Also prevented rather than planned: a second claim detector (a shipped one already reports the defect), an eval-coverage ratchet (`skill_eval_coverage --check` is green and `backed`), a per-skill activation counter (`report_skill_activation.ts` exists and publishes 2.1 %), and a broad outcome-benchmark campaign (three `backed`, placebo-controlled outcome claims already exist). Six named fold-target roadmaps two bundles planned against **have never existed in any commit**.

## Estate

`check_estate_count` green: `active_roadmaps 4 (floor 1, +3)`, all three claimed. Every other axis `+0`. All roadmap gates, `check_references`, `check_no_external_sources` and `check_md_language` pass.

Bundles moved to `agents/tmp.old/inbox-2026-08-g/set-{a..e}` with the source mapping recorded encrypted in that round's `INTAKE.md` — roadmaps cite the round id and set letter only.
