### PR TITLE
roadmap(agent-turnaround): measure why a one-file change costs 42 round-trips

### DIFF
--- a/agents/evidence/analysis/agent-turnaround-2026-08-30.md
+++ b/agents/evidence/analysis/agent-turnaround-2026-08-30.md
@@ -1,0 +1,120 @@
+<!-- evidence-type: analysis -->
+# Why a one-file change takes a session — measured
+
+> Measured 2026-08-30 over the 10 most recent sessions in this package's
+> transcript store (`~/.claude/projects/<mangled-cwd>/*.jsonl`, 2026-08-27 →
+> 2026-08-30), excluding the measuring session itself. Instrument: transcript
+> parse by `requestId`, so a request is counted once even though the host writes
+> `thinking`, `text` and `tool_use` as separate rows — an earlier pass that
+> counted rows inflated every per-call figure and is not the basis here.
+
+## Corpus
+
+| | |
+|---|---|
+| sessions | 10 |
+| real user requests | 76 |
+| API calls (distinct `requestId`) | 3,241 |
+| tool calls | 3,196 (96.2 % `Bash`) |
+| file mutations (`Edit`/`Write`) | 55 |
+| session wall-clock span | 86.9 h |
+| model-generation time | 6.8 h |
+| tool-execution time | 14.2 h |
+
+Span minus model minus tool is 65.9 h, i.e. **76 % of elapsed session time is
+neither the model nor a tool** — sessions left open between requests. Elapsed
+session time is therefore not the metric; the two numbers below are.
+
+## The four findings
+
+### F1 — 42.6 API round-trips per user request, and every one of them is serial
+
+3,241 calls / 76 requests = **42.6 calls per user request**; 3,196 tool calls /
+55 mutations = **58 tool calls per file change**.
+
+Across **3,212 tool-using assistant messages the mean batch size is exactly
+1.00** — not one message in the corpus carried two tool calls, although the
+harness instructs that independent calls go in one block. At a median
+model-generation latency of 4.7 s (mean 7.6 s, p90 14.3 s) the serialization
+alone costs ≈ 5 min of model time per request before a single tool runs.
+
+This is not a read-loop: **exact-duplicate command re-runs are 0.3 %** (9 of
+3,090). The agent is doing 42 genuinely distinct steps, one at a time.
+
+### F2 — 64 % of tool time is 167 blocking calls
+
+| command | n | total | median |
+|---|---|---|---|
+| `ci_settle` | 45 | **162.9 min** | 217 s |
+| `npx vitest` | 77 | 87.2 min | 68 s |
+| `cat` (compound/heredoc) | 188 | 72.1 min | 23 s |
+| `python3 -` | 424 | 65.0 min | 9 s |
+| `git push` | 54 | **60.0 min** | 67 s |
+| `git add` | 110 | 30.0 min | 16 s |
+| `task preflight` | 10 | 16.0 min | 96 s |
+
+167 calls exceeded 60 s and account for **547 min = 9.1 h of the 14.2 h** of
+tool time. Two mechanisms are visible in the tail:
+
+- **`ci_settle` blocks the foreground.** Its own default deadline is 45 min
+  (`src/scripts/ci_settle.ts:127`) while the `Bash` tool caps at 600 s, so ten
+  of the twelve slowest calls in the corpus are `ci_settle` stopped at
+  592–603 s and then re-invoked. 2.7 h of a 14.2 h budget is spent watching CI
+  in the foreground.
+- **git hooks are on the interactive path.** `pre-push` runs `task consistency`
+  (its own header states "~15-40 s"; measured median 67 s, max 890 s) and
+  `pre-commit` runs `lint_marketplace` plus the roadmap-dashboard check
+  (measured median 16 s over 110 `git add` calls).
+
+### F3 — the delivered always-on payload is 7.4× the governed budget
+
+`check_always_budget` reports **60,252 / 60,254 chars (100.0 %) across 9 rules**
+and is the gate the package treats as the always-on ceiling.
+
+What the host actually receives is `~/.claude/rules/`, written by this
+package's own installer:
+
+| activation on Claude Code | rules | chars | ≈ tokens |
+|---|---|---|---|
+| keyword-only triggers | **79** | **340,109** (75.9 %) | 85,027 |
+| path triggers nested under `triggers:` | 15 | 77,011 | 19,252 |
+| `type: always` | 9 | 29,864 | 7,466 |
+| no trigger | 1 | 1,007 | 251 |
+| **total** | **104** | **447,991** | **111,997** |
+
+**Zero of the 104 installed rules emit a top-level `paths:` key** — the only
+per-file activation surface Claude Code reads. `triggers.keyword` and
+`triggers.file_pattern` are nested under a key the host does not parse, so all
+104 rules arrive on every request regardless of what the request is about. The
+79 keyword-only rules (85k tokens) are a routing surface that does not exist on
+this host.
+
+**Independent cross-check.** `src/config/preamble-payload-budget.json` records a
+gated baseline of **102,520 tokens** and explicitly *excludes* the user-scope
+bucket as "machine-dependent, not CI-checkable". 102,520 + 111,997 = **214,517**,
+against a measured first-call context floor of **218,705–230,705 tokens** in all
+ten sessions. Two instruments built for different purposes agree to within 3 %,
+which is what makes the floor a fact rather than an estimate.
+
+### F4 — context size is NOT the per-call latency driver, and saying so matters
+
+| context | n | median latency |
+|---|---|---|
+| 200–300k | 559 | 4.3 s |
+| 400–500k | 791 | 4.8 s |
+| 600–700k | 268 | 4.8 s |
+| 900–1000k | 82 | 5.9 s |
+
+Median latency rises 37 % across a 4× context increase. So the 220k floor is
+**not** what makes a turn slow — it is what makes a turn *expensive*, and what
+pushes sessions toward the 994,216-token maximum observed and the compaction
+that follows. Any proposal that sells preamble reduction as a latency fix is
+selling the wrong benefit; F1 and F2 are the latency, F3 is the cost.
+
+## What this rules out
+
+- **Read-loops / flailing** — 0.3 % duplicate re-runs.
+- **Subagent overspawn** — 38 `Agent` calls in 3,196, 0.06 h of tool time.
+- **Thinking cost** — thinking blocks are ~2.6 M chars of 4.9 M output tokens
+  total; they are not the tail.
+- **Context length as latency** — F4.

--- a/agents/evidence/analysis/agent-turnaround-2026-08-30.md
+++ b/agents/evidence/analysis/agent-turnaround-2026-08-30.md
@@ -109,12 +109,65 @@ Median latency rises 37 % across a 4× context increase. So the 220k floor is
 **not** what makes a turn slow — it is what makes a turn *expensive*, and what
 pushes sessions toward the 994,216-token maximum observed and the compaction
 that follows. Any proposal that sells preamble reduction as a latency fix is
-selling the wrong benefit; F1 and F2 are the latency, F3 is the cost.
+selling the wrong benefit; F1 and F5 are the latency, F3 is the cost.
+
+### F5 — per-call latency is output generation, and the commands are long
+
+Output tokens, deduplicated by `requestId`: **2,455,974** over 3,261 calls.
+Of those, the visible payload — `tool_use` inputs (4,105,909 chars) plus
+assistant text (162,893 chars) — accounts for ~1,067,200 tokens (43.5 %),
+leaving **~1,388,774 tokens (56.5 %, ≈425/call) of reasoning**. The store
+redacts thinking-block text (1,743 blocks, zero characters retained), so the
+reasoning figure is a residual, not a direct read; it is stated as such.
+
+The visible half is the surprise: **4,105,909 chars across 3,196 tool calls is
+1,285 characters per command.** These are not `git status` calls — they are
+inline heredoc scripts. Generating ~750 output tokens (425 reasoning + ~320
+command) is, at ordinary generation rates, the 4.7 s median this corpus shows.
+That closes the causal loop: per-call latency is **output**, and F1 multiplies
+it by 42.6.
+
+### F6 — the turnaround problem already bought one security regression
+
+Found in the same working tree on 2026-08-30, uncommitted:
+
+```
+-export const LEDGER_MAX_AGE_MS = 30 * 60 * 1000;
++export const LEDGER_MAX_AGE_MS = 6 * 60 * 60 * 1000; // TEMP: PR-drain, revert after
+```
+
+`LEDGER_MAX_AGE_MS` is the authorization window on the guard that gates
+`pr-merge`, a `BLOCK_OPS` member. The docblock **immediately above the edited
+line** (`src/scripts/hooks/block_unauthorized_git.ts:509-524`) forbids exactly
+this edit and records the last time it happened — 2026-08-21, the same
+twelvefold value, the same "PR-drain" marker, the same promised revert that
+never came. It states: *"The supported answer to 'my run is longer than the
+window' is that the run STOPS and REPORTS at expiry and the user
+re-authorizes — never that the window grows."*
+
+Two facts make this a turnaround finding rather than a governance aside:
+
+1. **The stated motive is run length.** The window was widened because a run
+   outlasted 30 minutes. The sessions in this corpus run 1.1–35 h. A guard sized
+   for a bounded turn is under continuous pressure from a turn that is not
+   bounded, and the pressure has now been relieved the same wrong way twice.
+2. **It was live, not proposed.** `dist/hooks/dispatch.js` (built 2026-08-29
+   17:46) carried `LEDGER_MAX_AGE_MS = 6 * 60 * 60 * 1e3` and no occurrence of
+   the 30-minute value, so the weakened window was the one actually enforcing.
+   Restored and rebuilt 2026-08-30; `check_hook_bundle_content` now reports the
+   bundle byte-identical to its source (sha256 `20faf916cbe8`).
+
+The gate that detects this exists and is correct — it reported the mismatch on
+the first run. It is wired only into `taskfiles/ci-fast.yml:174`, and
+`dist/hooks/` is untracked, so in CI it is a declared no-op on a fresh checkout.
+The one place it would find something is the one place nothing runs it.
 
 ## What this rules out
 
+Thinking volume is deliberately **not** on this list: the store retains no
+thinking text, so it can only be reached by subtraction (F5) and is neither
+ruled in nor out as a lever here.
+
 - **Read-loops / flailing** — 0.3 % duplicate re-runs.
 - **Subagent overspawn** — 38 `Agent` calls in 3,196, 0.06 h of tool time.
-- **Thinking cost** — thinking blocks are ~2.6 M chars of 4.9 M output tokens
-  total; they are not the tail.
 - **Context length as latency** — F4.

--- a/agents/roadmaps/road-to-agent-turnaround.md
+++ b/agents/roadmaps/road-to-agent-turnaround.md
@@ -17,16 +17,16 @@ estate_offset_exempt: >
 > **Source:** `agents/evidence/analysis/agent-turnaround-2026-08-30.md` — a
 > transcript measurement over the 10 most recent sessions of this package
 > (2026-08-27 → 2026-08-30, 76 user requests, 3,241 API calls). Every number
-> below is from that file; none is estimated here.
+> below is from that file; none is estimated here, and the one figure that is a
+> residual rather than a direct read is labelled as one there.
 
 ## Context
 
 A user request in this package costs **42.6 API round-trips** and a file change
-costs **58 tool calls**. The measurement separates four causes and, as
-importantly, rules out four suspects — this is not a read-loop (0.3 % duplicate
-re-runs), not subagent overspawn (38 of 3,196 tool calls), not thinking cost,
-and not context length (median latency rises only 37 % across a 4× context
-increase).
+costs **58 tool calls**. The measurement separates the causes and, as
+importantly, rules out the obvious suspects — this is not a read-loop (0.3 %
+duplicate re-runs), not subagent overspawn (38 of 3,196 tool calls), and not
+context length (median latency rises only 37 % across a 4× context increase).
 
 What it is, in order of measured size:
 
@@ -40,11 +40,15 @@ What it is, in order of measured size:
    **Zero** installed rules emit a top-level `paths:`, the only activation key
    Claude Code reads, so 79 keyword-only rules (85k tokens) ship on every
    request as a routing surface the host cannot use.
-4. **Blindness.** None of the above was measurable before this run. There is no
+4. **Output size per call.** Per-call latency is generation, not context:
+   ~425 reasoning tokens plus a **1,285-character average command** — these are
+   inline heredoc scripts, not `git status` calls. ~750 output tokens is the
+   4.7 s median this corpus shows, and finding 1 multiplies it by 42.6.
+5. **Blindness.** None of the above was measurable before this run. There is no
    instrument in the tree that reports round-trips per request, batch size, or
    the blocking-wait tail, so no gate could have caught any of it growing.
 
-The ordering of the phases follows from finding 4: the instrument lands first,
+The ordering of the phases follows from finding 5: the instrument lands first,
 because every later phase claims a reduction and a claimed reduction with no
 before-number is not a claim.
 
@@ -109,7 +113,18 @@ silently reopen.
       `git show <base>:<path>` and confirm it no longer matches HEAD), or the
       obligation names its own `instruction-only` status in its own body.
 
-- [ ] **2.3 Re-measure, and accept the possibility of no movement.** Run
+- [ ] **2.3 Measure whether the 1,285-char average command is reducible.** A
+      long command is not automatically waste — an inline heredoc that replaces
+      four round-trips is the batching this phase wants, in a different form.
+      Split the corpus by command length and report which classes are one-shot
+      scripts doing real work and which are long because a short command was
+      written verbosely. Draw no conclusion before the split exists; the wrong
+      lesson here ("write shorter commands") would trade one round-trip's output
+      for three more round-trips.
+      verify: the length split is recorded in the evidence file with its
+      denominator and at least one example per class.
+
+- [ ] **2.4 Re-measure, and accept the possibility of no movement.** Run
       `probe_turnaround` over the next 10 sessions after 2.2 lands. If mean batch
       size has not moved, that is the result — record it as a null the way
       `session-canary`'s own section records a carrier that fired and changed
@@ -191,13 +206,50 @@ silently reopen.
       verify: a second floor reading exists in the evidence file with its date
       and the delta against 218,705–230,705 tokens stated.
 
+## Phase 5 — Stop long runs from buying their own exceptions
+
+- [ ] **5.1 Put the bundle-content gate where it can find something.**
+      `check_hook_bundle_content` correctly detected a live six-hour
+      authorization window on the `pr-merge` guard the first time it was run
+      (2026-08-30) — but it is wired only into `taskfiles/ci-fast.yml:174`, and
+      `dist/hooks/` is untracked, so on a fresh CI checkout it declares a no-op.
+      The only machine where it can find something is the only place it does not
+      run. Move it onto the local path — `task preflight` — where the artefact it
+      checks actually exists.
+      verify: `task preflight` invokes it, and an mtime-preserving edit to a
+      bundled source is refused by a fresh preflight run.
+
+- [ ] **5.2 Record the recurrence as a recurrence.** The widening on 2026-08-30
+      is a verbatim repeat of the 2026-08-21 incident that the guard's own
+      docblock already describes, marker text and value included. Under
+      `recurring-criticism` the repetition is evidence the disposition did not
+      hold, and the question is which of the three outcomes applies — the
+      decision was wrong, it was right but never recorded, or it was right and
+      recorded and unreachable. On the evidence it is the third: the prohibition
+      is in the file that was edited. Name what would have made it reachable.
+      verify: the finding names one of the three outcomes and the change that
+      follows from it, in the evidence file.
+
+- [ ] **5.3 Answer the pressure, not just the symptom.** The stated motive both
+      times was a run outlasting the 30-minute window. Sessions in the corpus
+      run 1.1–35 h. Decide whether the supported path — the run stops, reports,
+      and the operator re-authorizes — is actually usable at that run length, or
+      whether long autonomous runs need a different authorization shape that is
+      not a wider window. This is a security-relevant floor, so the decision is
+      owner-reserved: surface it, never take it.
+      verify: the question is put to the owner with both options and the measured
+      run lengths, and the answer is recorded — a deferral with a named blocker
+      counts, a silent widening never does.
+
 ## Risk Register
 <!-- risk-review: v1 | reviewed: 2026-08-30 | reviewer: claude/host -->
 
 | Rank | Item | Risk type | Description | Mitigation | Anchored under |
 |------|------|-----------|-------------|------------|----------------|
 | 1 | The instrument reads an empty corpus and certifies nothing | implementation | A fresh clone has no transcript store, so a gate over it exits green having scanned zero sessions — the permanently-green-gate failure this package names elsewhere | Step 1.3 answers the empty-corpus behaviour BEFORE anything is wired into CI, and the answer is recorded in the config | Phase 1 — Make turnaround measurable |
-| 2 | Batch size does not move and the phase is re-run harder | implementation | A model-carried obligation that a measurement shows did not change behaviour invites raising the frequency of the same reminder, which was already measured not to work for another obligation in this tree | Step 2.3 pre-commits to recording a null and forbids the re-attempt; the null is a result, not a failure | Phase 2 — Cut the serial round-trips |
+| 2 | Batch size does not move and the phase is re-run harder | implementation | A model-carried obligation that a measurement shows did not change behaviour invites raising the frequency of the same reminder, which was already measured not to work for another obligation in this tree | Step 2.4 pre-commits to recording a null and forbids the re-attempt; the null is a result, not a failure | Phase 2 — Cut the serial round-trips |
+| 7 | Phase 5 is read as a licence to widen the window | product | The phase names a real usability pressure on a 30-minute authorization bound, and the nearest reading of "answer the pressure" is to relax the bound — which is precisely the action taken twice and forbidden in the guard's own prose | Step 5.3 marks the decision owner-reserved and forbids the agent taking it; the roadmap never proposes a value | Phase 5 — Stop long runs from buying their own exceptions |
+| 6 | "Shorter commands" is read as the lesson of the 1,285-char average | product | The number invites a instruction to write terser commands, which would convert one expensive round-trip into several cheap ones and make the headline metric worse while looking like a fix | Step 2.3 forbids a conclusion before the length split exists and names this inversion explicitly | Phase 2 — Cut the serial round-trips |
 | 3 | The payload reduction is sold as a latency fix | product | The 220k floor is the most quotable number here and the obvious story is "big context, slow turns" — the measurement refutes it (37 % median latency rise across a 4× context increase), and shipping the wrong benefit would misdirect the next reader | The evidence file states the refutation in its own finding, and Phase 4's steps claim cost and crowding only, never latency | Phase 4 — Close the delivered-payload gap |
 | 4 | Lifting path triggers changes which rules a host loads, silently | implementation | Emitting `paths:` narrows delivery — a rule that must stay unconditional to be correct would go quiet with no error anywhere | Step 4.3 offers the write-it-down branch as a first-class outcome rather than forcing the emit, and 4.4 re-measures whichever branch is taken | Phase 4 — Close the delivered-payload gap |
 | 5 | Shortening the hook path removes a real gate | implementation | Step 3.2's scoping is one edit away from turning a push-blocking mirror into a partial one, which is how drift reaches CI instead of the developer | 3.2 is scoped to re-measuring and correcting the stated number; any narrowing must show the CI mirror still catches the same classes | Phase 3 — Take blocking waits off the interactive path |

--- a/agents/roadmaps/road-to-agent-turnaround.md
+++ b/agents/roadmaps/road-to-agent-turnaround.md
@@ -1,0 +1,219 @@
+---
+complexity: structural
+status: draft
+execution:
+  mode: phase-checkpoints
+estate_offset_exempt: >
+  Adds one active roadmap with no disposal in the same change. Archiving,
+  parking or merging each cost more than the offset: the four findings are a
+  single measured corpus and splitting them across existing roadmaps would
+  separate each fix from the number that justifies it, while parking it in
+  later/ would park the only instrument that measures the thing being fixed.
+  Measure the actual estate delta with check_estate_count after the commit —
+  do not read the number from this sentence.
+---
+# Road to agent turnaround
+
+> **Source:** `agents/evidence/analysis/agent-turnaround-2026-08-30.md` — a
+> transcript measurement over the 10 most recent sessions of this package
+> (2026-08-27 → 2026-08-30, 76 user requests, 3,241 API calls). Every number
+> below is from that file; none is estimated here.
+
+## Context
+
+A user request in this package costs **42.6 API round-trips** and a file change
+costs **58 tool calls**. The measurement separates four causes and, as
+importantly, rules out four suspects — this is not a read-loop (0.3 % duplicate
+re-runs), not subagent overspawn (38 of 3,196 tool calls), not thinking cost,
+and not context length (median latency rises only 37 % across a 4× context
+increase).
+
+What it is, in order of measured size:
+
+1. **Serialization.** Mean tool-call batch size is **exactly 1.00** across 3,212
+   tool-using messages — zero parallel calls in the entire corpus.
+2. **Blocking waits.** 167 calls over 60 s account for **9.1 h of the 14.2 h**
+   of tool time; `ci_settle` alone is 2.7 h, most of it hitting the 600 s `Bash`
+   ceiling while its own deadline is 45 min.
+3. **Payload.** The delivered always-on rule layer is **447,991 chars / 104
+   rules** against a governed budget of **60,252 chars / 9 rules** — 7.4×.
+   **Zero** installed rules emit a top-level `paths:`, the only activation key
+   Claude Code reads, so 79 keyword-only rules (85k tokens) ship on every
+   request as a routing surface the host cannot use.
+4. **Blindness.** None of the above was measurable before this run. There is no
+   instrument in the tree that reports round-trips per request, batch size, or
+   the blocking-wait tail, so no gate could have caught any of it growing.
+
+The ordering of the phases follows from finding 4: the instrument lands first,
+because every later phase claims a reduction and a claimed reduction with no
+before-number is not a claim.
+
+## Goal
+
+The package can state, from a committed instrument rather than a one-off script,
+how many model round-trips and how much blocking wall-clock a user request
+costs; the three mechanisms above each have a named disposition — fixed, or
+recorded as owner-reserved with the reason; and the delivered always-on payload
+is measured by the same gate that claims to govern it, so the 7.4 × gap cannot
+silently reopen.
+
+## Phase 1 — Make turnaround measurable
+
+- [ ] **1.1 Land `probe_turnaround` as a committed instrument.** Port the
+      throwaway analysis into `src/scripts/probe_turnaround.ts`, reading the
+      transcript store by `requestId` (not by row — row-counting inflates every
+      per-call figure and was the first wrong answer this measurement produced).
+      It reports, per corpus: API calls per user request, mean tool-call batch
+      size, the >60 s blocking tail with its share of tool time, and the
+      first-call context floor. Accept `--store <path>` and `--limit <n>` so it
+      runs over any project's store, the way `conformance:behavior` already does.
+      verify: `./scripts-run src/scripts/probe_turnaround --limit 10` exits 0 and
+      prints all four metrics with a non-zero sample count.
+
+- [ ] **1.2 Register the 2026-08-30 corpus as the baseline.** Write the four
+      headline numbers into a budget config the way
+      `src/config/preamble-payload-budget.json` records its own, with the corpus
+      window, the sample size, and the instrument that produced them. The
+      ratchet direction is DOWN for round-trips and blocking share, and the
+      baseline may only be raised with the reason as a sentence in the same
+      commit — the discipline `check_estate_count` already enforces elsewhere.
+      verify: the config exists, carries `owner` and `review_by`, and
+      `./scripts-run src/scripts/probe_turnaround --against-baseline` exits 0.
+
+- [ ] **1.3 Answer whether the instrument may gate.** A transcript is
+      machine-local and a fresh clone has none, so a CI gate over it would be
+      green-because-empty — the failure mode `gates-that-scan-nothing-exit-green`
+      names. Decide and record: local-only report, or a gate that fails closed on
+      an empty corpus. Do not wire it into `task ci` before this step answers.
+      verify: the decision is recorded in the config's `_comment` with the
+      empty-corpus behaviour stated explicitly.
+
+## Phase 2 — Cut the serial round-trips
+
+- [ ] **2.1 Establish why batching is at exactly 1.00.** 3,212 of 3,212 is not a
+      tendency, it is a floor, and a floor usually has a mechanism. Determine
+      from the transcripts and the host's own instruction surface whether the
+      cause is (a) a rule or skill in this package that reads as forbidding
+      parallel calls, (b) an interaction with the per-call obligations that makes
+      each call feel like it needs its own turn, or (c) purely model-carried with
+      no local cause. Report which, with the evidence.
+      verify: a finding is written into the evidence file naming (a), (b) or (c)
+      and citing the text or the absence of it.
+
+- [ ] **2.2 Act on 2.1's answer, and only on it.** If a local cause is found,
+      remove it. If the cause is model-carried, add the obligation where it can
+      actually be read and say plainly that it is instruction-only — the honesty
+      boundary this package states for every other unenforceable obligation.
+      Never claim enforcement the tree does not have.
+      verify: either the local cause is gone (grep the removed text at
+      `git show <base>:<path>` and confirm it no longer matches HEAD), or the
+      obligation names its own `instruction-only` status in its own body.
+
+- [ ] **2.3 Re-measure, and accept the possibility of no movement.** Run
+      `probe_turnaround` over the next 10 sessions after 2.2 lands. If mean batch
+      size has not moved, that is the result — record it as a null the way
+      `session-canary`'s own section records a carrier that fired and changed
+      nothing, rather than re-attempting the same lever at higher volume.
+      verify: a second baseline entry exists with its own corpus window, and the
+      delta is stated in the evidence file whichever direction it went.
+
+## Phase 3 — Take blocking waits off the interactive path
+
+- [ ] **3.1 Stop foreground-blocking on CI.** `ci_settle` was invoked 45 times
+      for 162.9 min, with ten of the twelve slowest calls in the corpus stopped
+      at the 600 s `Bash` ceiling and re-invoked, while its own default deadline
+      is 45 min (`src/scripts/ci_settle.ts:127`). Either default its timeout
+      under the tool ceiling so a run completes instead of being truncated, or
+      document the background invocation as the only supported form and make the
+      foreground path say so when it would exceed the ceiling.
+      verify: `./scripts-run src/scripts/ci_settle` with no settle inside the
+      window exits with a stated verdict rather than being killed, and the
+      chosen form is named in the script's own usage line.
+
+- [ ] **3.2 Price the git hooks.** `pre-push` runs `task consistency` at a
+      measured median of 67 s and a max of 890 s against a header that claims
+      "~15-40 s"; `pre-commit` costs a median 16 s over 110 `git add` calls.
+      Re-measure both, correct the header to what is true, and determine whether
+      the consistency mirror can be scoped to the paths the push actually
+      touches — it was already narrowed once for the peer-session case, so the
+      scoping surface exists.
+      verify: the header states a number produced by a fresh timed run in the
+      same change, and that run's output is quoted in the commit body.
+
+- [ ] **3.3 Scope the test invocation.** `npx vitest` cost 87.2 min over 77
+      calls at a 68 s median. Determine how many of those runs were whole-suite
+      where a filtered run would have answered the same question, and record the
+      split. This is a measurement step, not a policy step — the package already
+      forbids full-pipeline probes per iteration, so if the split shows the rule
+      is being followed, the finding is that the suite itself is the cost.
+      verify: the split is recorded with its denominator in the evidence file.
+
+## Phase 4 — Close the delivered-payload gap
+
+- [ ] **4.1 Measure the bucket the census excludes.**
+      `src/config/preamble-payload-budget.json` excludes user-scope rules as
+      "machine-dependent, not CI-checkable". The exclusion is falsifiable: that
+      layer is written by this package's own installer
+      (`src/install/globalRuleLayers.ts`), so its content is derivable from the
+      projection plus `installed.lock` without reading the developer's machine.
+      Extend `preamble_byte_census.ts` to report the user-scope bucket — as a
+      reported figure first, not a gated one.
+      verify: the census prints the user-scope bucket with a non-zero token
+      count, and the sum against the gated bucket lands within 5 % of the
+      first-call context floor recorded in the evidence file.
+
+- [ ] **4.2 Route the exclusion decision to the council.** Turning 4.1's
+      reported figure into a gated one changes a recorded budget decision, and
+      the recorded reason for the exclusion is exactly what 4.1 falsifies. This
+      is a reversible, internal strengthening of a measurement, so it is
+      council-decidable rather than owner-reserved — but it is not the agent's
+      to take silently. Present the measurement, the original reason, and what
+      changed.
+      verify: a council verdict is recorded with its members and date, or the
+      step is marked deferred with the blocker naming why the council could not
+      settle it.
+
+- [ ] **4.3 Emit a host-readable activation key, or state that none exists.**
+      Zero of 104 installed rules carry a top-level `paths:`; the file patterns
+      live under `triggers:`, a key the host does not parse. Either the emitter
+      lifts genuine path triggers to the key Claude Code reads, or — if lifting
+      them is not sound, because a rule carrying one non-path trigger must stay
+      unconditional to remain correct — that is written down as the reason the
+      79 keyword-only rules cannot be gated on this host, so the next pass meets
+      the argument instead of the silence.
+      verify: either `grep -lE '^paths:' ~/.claude/rules/*.md | wc -l` is greater
+      than zero after a fresh install, or the impossibility is stated in
+      `docs/contracts/rule-router.md` with the mechanism named.
+
+- [ ] **4.4 Re-measure the floor.** Whatever 4.3 concludes, run the census and
+      the turnaround probe again and record the delivered floor. A phase that
+      changed nothing measurable must say so.
+      verify: a second floor reading exists in the evidence file with its date
+      and the delta against 218,705–230,705 tokens stated.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-08-30 | reviewer: claude/host -->
+
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | The instrument reads an empty corpus and certifies nothing | implementation | A fresh clone has no transcript store, so a gate over it exits green having scanned zero sessions — the permanently-green-gate failure this package names elsewhere | Step 1.3 answers the empty-corpus behaviour BEFORE anything is wired into CI, and the answer is recorded in the config | Phase 1 — Make turnaround measurable |
+| 2 | Batch size does not move and the phase is re-run harder | implementation | A model-carried obligation that a measurement shows did not change behaviour invites raising the frequency of the same reminder, which was already measured not to work for another obligation in this tree | Step 2.3 pre-commits to recording a null and forbids the re-attempt; the null is a result, not a failure | Phase 2 — Cut the serial round-trips |
+| 3 | The payload reduction is sold as a latency fix | product | The 220k floor is the most quotable number here and the obvious story is "big context, slow turns" — the measurement refutes it (37 % median latency rise across a 4× context increase), and shipping the wrong benefit would misdirect the next reader | The evidence file states the refutation in its own finding, and Phase 4's steps claim cost and crowding only, never latency | Phase 4 — Close the delivered-payload gap |
+| 4 | Lifting path triggers changes which rules a host loads, silently | implementation | Emitting `paths:` narrows delivery — a rule that must stay unconditional to be correct would go quiet with no error anywhere | Step 4.3 offers the write-it-down branch as a first-class outcome rather than forcing the emit, and 4.4 re-measures whichever branch is taken | Phase 4 — Close the delivered-payload gap |
+| 5 | Shortening the hook path removes a real gate | implementation | Step 3.2's scoping is one edit away from turning a push-blocking mirror into a partial one, which is how drift reaches CI instead of the developer | 3.2 is scoped to re-measuring and correcting the stated number; any narrowing must show the CI mirror still catches the same classes | Phase 3 — Take blocking waits off the interactive path |
+
+## Acceptance Criteria
+
+- [ ] AC-1 — The four turnaround metrics are produced by a committed script over
+      a named corpus, and a second reading exists for at least one of them, so
+      the numbers are a series rather than a snapshot.
+- [ ] AC-2 — Each of the three mechanisms (serialization, blocking waits,
+      payload) has a recorded disposition: a landed change with a re-measurement,
+      or a written statement of why it cannot be changed here. No mechanism is
+      left described but undecided.
+- [ ] AC-3 — The delivered always-on payload and the governed budget are
+      produced by the same instrument, or the reason they cannot be is recorded
+      with the mechanism named.
+- [ ] AC-4 — Every reduction claimed anywhere in this roadmap cites a before and
+      an after from the instrument in Phase 1; a claim with only an after is not
+      accepted as satisfying any step.


### PR DESCRIPTION
## What this is

A transcript measurement over the **10 most recent sessions of this package**
(2026-08-27 → 2026-08-30 · 76 user requests · 3,241 API calls), an evidence
file recording it, and a structural roadmap that acts on it.

It also cleans the working tree that was sitting uncommitted on `main`, and
one part of that cleanup was a live security fix — see the second half.

## The measurement

A user request costs **42.6 API round-trips**; a file change costs **58 tool
calls**. Six findings, each with its number:

| | Finding |
|---|---|
| **F1** | Mean tool-call batch size is **exactly 1.00** across 3,212 tool-using messages — not one message in the corpus carried two tool calls. Every one of the 42.6 calls is a full serial round-trip. |
| **F2** | **167 calls over 60 s account for 9.1 h of the 14.2 h** of tool time. `ci_settle` alone is 2.7 h, with ten of the twelve slowest calls stopped at the 600 s `Bash` ceiling while its own deadline is 45 min. `pre-push` runs `task consistency` at a measured 67 s median against a header claiming "~15-40 s". |
| **F3** | The delivered always-on rule layer is **447,991 chars / 104 rules** against a governed budget of **60,252 chars / 9 rules** — 7.4×. **Zero** installed rules emit a top-level `paths:`, the only activation key the host reads, so 79 keyword-only rules (85k tokens) ship unconditionally as a routing surface that does not exist there. |
| **F4** | Context size is **not** the latency driver — median latency rises only 37 % across a 4× context increase. Stated explicitly because the opposite story is the more quotable one. |
| **F5** | Per-call latency is **output**: ~425 reasoning tokens plus a **1,285-character average command**. ~750 output tokens is the 4.7 s median the corpus shows. F1 multiplies it by 42.6. |
| **F6** | The turnaround problem has already bought one security regression — below. |

Ruled out with their numbers: read-loops (0.3 % duplicate re-runs), subagent
overspawn (38 of 3,196 tool calls), context length (F4). Thinking volume is
explicitly **not** ruled out — the store retains no thinking text, so it is
only reachable as a residual, and the evidence file labels it as one.

**Independent cross-check.** `preamble-payload-budget.json`'s gated baseline
(102,520 tok) plus the measured user-scope bucket (111,997 tok) = 214,517,
against an observed first-call context floor of 218,705–230,705 in all ten
sessions. Two instruments built for different purposes agreeing to within 3 %.

## The roadmap

Five phases, instrument first — because finding 5 is that none of this was
measurable before, so every later phase owes a before-number. Phase 2 carries
an explicit anti-lesson: "write shorter commands" would convert one expensive
round-trip into several cheap ones and make the headline metric worse while
looking like a fix.

## The security fix (do not skim this part)

The uncommitted tree on `main` contained, live:

```
-export const LEDGER_MAX_AGE_MS = 30 * 60 * 1000;
+export const LEDGER_MAX_AGE_MS = 6 * 60 * 60 * 1000; // TEMP: PR-drain, revert after
```

`LEDGER_MAX_AGE_MS` is the authorization window on the guard gating `pr-merge`,
a `BLOCK_OPS` member. The docblock **immediately above the edited line** forbids
this edit and records the identical 2026-08-21 incident — same twelvefold value,
same marker shape, same "PR-drain" motive, same promised revert that never came.

It was **live, not proposed**: `dist/hooks/dispatch.js` (built 2026-08-29 17:46)
carried the six-hour value and **zero** occurrences of the thirty-minute one.

**Restored and rebuilt.** `check_hook_bundle_content` now reports the executing
bundle byte-identical to its source (sha256 `20faf916cbe8`). That gate detected
the mismatch on its first run — it is wired only into `taskfiles/ci-fast.yml`,
where `dist/hooks/` does not exist, so it is a declared no-op exactly where it
finds nothing and absent exactly where it found something. Phase 5 moves it.

Nothing about this is in the diff: the source at `HEAD` already held the correct
value, so the fix was discarding a local edit and rebuilding.

## The rest of the uncommitted tree — parked, not shipped

The remaining uncommitted work was **two byte-exact reverts of already-merged
PRs**, left by an earlier session and deliberately stepped around by the
2026-08-30 drain run. It is **not in this PR**, because shipping it would
un-complete merged work with four gates red:

- `build_proof --check`, `check_claims` (3 findings), `check_estate_count`
  (`active_roadmaps` 4 → 5, no exemption), `build_archive_index --check`
- three files of PR #1668 were never reverted, so the ledger and the public
  surface disagree
- `ONBOARDING.md` re-introduces **37 absolute `/Users/…` paths** (HEAD: 0), and
  no gate catches it — the file is tracked but not in `package.json` `files[]`
- the `ten-across-the-board` park it reverses was an AI-council 2/2 decision of
  2026-08-26, with no recorded counter-decision

Nothing was discarded: it is preserved verbatim on the **local** branch
`wip/inherited-2026-08-30` (commit `a8fb29ec1`), whose message carries the full
gate readout. `main`'s working tree is now clean and identical to `HEAD`.

## Verification

Roadmap gates green (`lint_plan_risk_register`, `lint_roadmap_blockers`,
`check_roadmap_trackable`, `lint_roadmap_ci_steps`, `lint_empty_roadmaps`,
`lint_roadmap_family_cap`, `lint_roadmap_complexity`, `lint_evidence_artifacts`),
plus `check_estate_count` (`+1 active / -0 disposed, 1 exempt`),
`check_references`, `check_no_roadmap_refs`, `lint_output_slop`,
`lint_roadmap_later_disposition`.

**Disclosed:** `check_rule_projection_integrity` reds in the authoring worktree.
Two-reading proof that it is environmental: the same gate in the main checkout
on the same content is a warn no-op ("no host rule tree is active"), and this
branch touches two markdown files under `agents/` and no rule. Pushed by refspec
from the clean checkout so preflight ran in full rather than being skipped.
