### PR TITLE
roadmap: complete road-to-agent-turnaround (MERGE disposition, council 2/2)

### DIFF
--- a/agents/evidence/reviews/agent-turnaround-merge-closure.findings.md
+++ b/agents/evidence/reviews/agent-turnaround-merge-closure.findings.md
@@ -1,0 +1,3 @@
+# Completion review — agent-turnaround MERGE closure
+
+**Skipped:** no code surface for this completion — the diff is three markdown files: a roadmap moved to archive with two step glyphs and two blocker statuses rewritten, and a follow-up roadmap whose frontmatter had three false statements about the tree corrected, scope 2a4a5fdf7c7d017881c9680b6661ba2b66cfb10bf6d0c2cfc1c6f3af56a45b5b, declared 2026-08-30

--- a/agents/roadmaps/archive/road-to-agent-turnaround.md
+++ b/agents/roadmaps/archive/road-to-agent-turnaround.md
@@ -135,13 +135,27 @@ silently reopen.
       verify: the length split is recorded in the evidence file with its
       denominator and at least one example per class.
 
-- [~] **2.4 Re-measure, and accept the possibility of no movement <!-- blocked-by: post-change-window -->.** Run
+- [-] **2.4 Re-measure, and accept the possibility of no movement.** Run
       `probe_turnaround` over the next 10 sessions after 2.2 lands. If mean batch
       size has not moved, that is the result — record it as a null the way
       `session-canary`'s own section records a carrier that fired and changed
       nothing, rather than re-attempting the same lever at higher volume.
       verify: a second baseline entry exists with its own corpus window, and the
       delta is stated in the evidence file whichever direction it went.
+      **MERGED 2026-08-30 (outcome `transferred`, NOT cancelled) —
+      [`road-to-turnaround-followups.md`](../road-to-turnaround-followups.md)
+      Phase 1 step 1.1, which carries this criterion verbatim including its
+      pre-committed null.** Council 2/2, 2026-08-30, anthropic + openai: the
+      preservation test's CARRY branch requires a follow-up "created in the SAME
+      change" and this one was created in a prior change, so the lawful
+      disposition is the test's separate MERGE branch — *merge into existing
+      active work that already covers it* — not a CARRY. The criterion is
+      unchanged and stays live in the active estate; the glyph is `[-]` because
+      `update_roadmap_progress.ts:900` archives only at `deferred === 0`, and
+      `[-]`-with-a-transfer-note is this repository's existing shape for a
+      relocated obligation (`archive/road-to-context-fidelity.md:161`). The
+      dashboard will count it in its `cancelled` column; that column is a glyph
+      tally, and this note is the disposition.
 
 ## Phase 3 — Take blocking waits off the interactive path
 
@@ -241,7 +255,7 @@ silently reopen.
       verify: the finding names one of the three outcomes and the change that
       follows from it, in the evidence file.
 
-- [~] **5.3 Answer the pressure, not just the symptom <!-- blocked-by: authorization-shape-for-long-runs -->.** The stated motive both
+- [-] **5.3 Answer the pressure, not just the symptom.** The stated motive both
       times was a run outlasting the 30-minute window. Sessions in the corpus
       run 1.1–35 h. Decide whether the supported path — the run stops, reports,
       and the operator re-authorizes — is actually usable at that run length, or
@@ -251,13 +265,32 @@ silently reopen.
       verify: the question is put to the owner with both options and the measured
       run lengths, and the answer is recorded — a deferral with a named blocker
       counts, a silent widening never does.
+      **MERGED 2026-08-30 (outcome `transferred`, NOT cancelled) —
+      [`road-to-turnaround-followups.md`](../road-to-turnaround-followups.md)
+      Phase 2 step 2.1.** Council 2/2, 2026-08-30, anthropic + openai, on the
+      same MERGE-not-CARRY reasoning as 2.4, plus one bound both members stated
+      independently: **relocating an owner-reserved question is not answering
+      it.** The destination step keeps the owner (`user`), keeps Class 3, and
+      keeps the "the agent proposes no value for `LEDGER_MAX_AGE_MS` and does
+      not take the decision" clause verbatim. Nothing about the security floor
+      moved; only the file the question waits in did.
 
 ## Blockers
 
 ### blocker: post-change-window
 
-- **Status:** open — deferred, and deferred for a reason that cannot be
-  engineered away inside this change: step 2.2 landed the batching obligation
+- **Status:** resolved 2026-08-30 — **resolved FOR THIS ROADMAP BY MERGER, not
+  substantively.** The measurement itself is still outstanding; what closed is
+  this roadmap's disposition of it. Council 2/2 (anthropic + openai,
+  2026-08-30) ruled the CARRY branch of the preservation test unavailable —
+  it requires a follow-up "created in the SAME change" and
+  `road-to-turnaround-followups` was created in a prior change — and directed
+  the test's separate MERGE branch instead: *merge into existing active work
+  that already covers it*. Destination:
+  [`road-to-turnaround-followups.md`](../road-to-turnaround-followups.md) Phase 1
+  step 1.1, which carries the criterion below verbatim, including its
+  pre-committed null. Original deferral reason, unchanged and still true: step
+  2.2 landed the batching obligation
   minutes before 2.4 would measure its effect, so the ten post-change sessions
   the step names do not exist yet. Measuring the current window would be
   measuring the sessions that *preceded* the change and reporting it as an
@@ -292,7 +325,15 @@ silently reopen.
 
 ### blocker: authorization-shape-for-long-runs
 
-- **Status:** open — **OWNER-RESERVED, and deliberately not taken.** The
+- **Status:** resolved 2026-08-30 — **resolved FOR THIS ROADMAP BY MERGER, and
+  the decision itself is untouched.** Destination:
+  [`road-to-turnaround-followups.md`](../road-to-turnaround-followups.md) Phase 2
+  step 2.1, which keeps `Owner: user`, keeps Class 3, and keeps the "the agent
+  proposes no value and does not take the decision" bound verbatim. Council 2/2
+  (anthropic + openai, 2026-08-30) stated the boundary in both responses:
+  relocating an owner-reserved question is a disposition of WHERE it waits, not
+  an ANSWER to it, so the council may move it and may not settle it. **Still
+  OWNER-RESERVED, and still deliberately not taken.** The
   question is put here with both options and the measured run lengths, which is
   what step 5.3 asks for; the roadmap forbids the agent answering it, and
   `decision-revisit-gate`'s reserved table puts "lowers or removes a recorded

--- a/agents/roadmaps/road-to-turnaround-followups.md
+++ b/agents/roadmaps/road-to-turnaround-followups.md
@@ -1,32 +1,49 @@
 ---
 complexity: lightweight
-status: draft
+status: ready
 execution:
   mode: phase-checkpoints
 estate_growth_exempt: >
-  Grows active_roadmaps 5 -> 6, and the offset that would have paid for it is
-  not available: `road-to-agent-turnaround` cannot archive. It sits at 19/21
-  with two `[~]` items, and update_roadmap_progress archives only at
-  `deferred === 0` — by design, since Iron Law 3 exists to stop exactly the
-  silent burial of planned-for-later work. So this is a genuine +1, claimed
-  rather than disguised. What it buys: three items that provably could not
+  CORRECTED 2026-08-30 — the second sentence has since been falsified by the
+  change that carries this correction. It read "the offset that would have paid
+  for it is not available: road-to-agent-turnaround cannot archive", on the
+  ground that its two `[~]` items put it above update_roadmap_progress's
+  `deferred === 0` archive condition. That was true of the tree as it stood and
+  is no longer: a council (2/2, anthropic + openai, 2026-08-30) ruled the
+  preservation test's MERGE branch available for both items, they are now
+  `[-] MERGED (outcome transferred)` pointing at steps 1.1 and 2.1 here, and
+  that roadmap archives in this same change. The original +1 was claimed
+  honestly on the evidence available then; the offset exists now. What the
+  roadmap buys is unchanged: three items that provably could not
   close in the roadmap that found them — a re-measurement whose corpus does not
   exist yet, an owner-reserved security decision the agent is forbidden to take,
   and an installer change that would silently narrow three rules' activation
   from inside a measurement roadmap. Folding any of them into an existing
   roadmap would separate the work from the measurement that justifies it.
 estate_offset_exempt: >
-  Created in the same change that archives `road-to-agent-turnaround` at 19/21,
-  as the CARRY disposition for its two deferred items — the council-decidable
-  branch of the preservation test in roadmap-progress-sync, taken because both
-  criteria stay alive in the active estate rather than being weakened or
-  dropped. One in, one out. Measure the actual delta with check_estate_count
-  after the commit — do not read the number from this sentence.
+  CORRECTED 2026-08-30. The original line said this roadmap was "created in the
+  same change that archives road-to-agent-turnaround", as its CARRY disposition.
+  That was false in both halves: the archive did not happen in that change, and
+  a council (2/2, anthropic + openai, 2026-08-30) subsequently ruled the CARRY
+  branch of the preservation test unavailable precisely because this file was
+  created in a PRIOR change — the branch requires a follow-up created in the
+  SAME one. What actually applies is the test's separate MERGE branch, *merge
+  into existing active work that already covers it*, and that merge lands in the
+  change that archives `road-to-agent-turnaround`. So the offset is real and is
+  one-in-one-out, but this roadmap is the pre-existing destination of a merge
+  rather than the same-change product of a carry. Measure the actual delta with
+  check_estate_count after the commit — do not read the number from this
+  sentence.
 ---
 # Road to turnaround follow-ups
 
-> **Source:** the two `[~]` items and one recorded-but-unrepaired defect from
-> `agents/roadmaps/archive/road-to-agent-turnaround.md`, executed 2026-08-30.
+> **Source:** the two deferred items and one recorded-but-unrepaired defect from
+> `road-to-agent-turnaround`, executed 2026-08-30. Steps 1.1 and 2.1 below are
+> the destination of a MERGE disposition ruled by council 2/2 (anthropic +
+> openai, 2026-08-30); the source items are marked `[-] MERGED (outcome
+> transferred)` there, and the source roadmap archives in the same change.
+> **Step 2.1 stays owner-reserved:** relocating the question is not answering
+> it, which both council members stated independently.
 > Every number below is from
 > `agents/evidence/analysis/agent-turnaround-2026-08-30.md`; none is estimated
 > here.


### PR DESCRIPTION
Closes and archives `road-to-agent-turnaround`. Active estate 5 → 4, open blockers 32 → 30.

## Why it could not close before this PR

The roadmap sat at **19 done / 0 open / 2 deferred**, all four acceptance criteria checked. Two mechanisms held it in the active tree:

- `update_roadmap_progress.ts:900` archives only at `open_ === 0 && deferred === 0`. Two `[~]` items blocked it, by design — Iron Law 3 exists to stop exactly the silent burial of planned-for-later work.
- The archival sweep additionally refuses a roadmap carrying open blockers, and both of its blockers were open.

## The decision, and who took it

Neither deferred item was disposed of by the agent. Both went to the AI council — **2/2, anthropic + openai, 2026-08-30, converged on all three questions**, with the same reasoning arrived at independently.

### Q1 — is this a CARRY?

**No, and the council was explicit about it.** The preservation test's CARRY branch requires a follow-up *"created in the SAME change"*. `road-to-turnaround-followups` was created in a prior change and is already on `main`.

Both members gave the same textual argument without prompting: the preservation test lists *"merge into existing active work that already covers it"* as a **separate** branch. If "SAME change" merely meant "the destination is active", that second branch would be redundant. The separation is direct evidence that the clause is a literal constraint on CARRY, not a synonym for "immediately available".

So the lawful disposition is **MERGE**, not CARRY. One member added the sharper form: *"If you call this a CARRY, you're claiming to satisfy a constraint that the state demonstrably contradicts. That creates precedent for future agents to read 'SAME change' as 'exists somewhere' — which guts the requirement entirely."*

### Q2 — may the council move an owner-reserved question?

**Yes, and only move it.** Both members drew the same line: relocating **where** a decision waits is not **answering** it. No security floor moved; only the file the question sits in did.

The destination step keeps `Owner: user`, keeps `Class: 3`, and keeps the *"the agent proposes no value for `LEDGER_MAX_AGE_MS` and does not take the decision"* bound verbatim.

### Q3 — which glyph?

`[-]` **only with an explicit MERGED note.** Repository precedent is `agents/roadmaps/archive/road-to-context-fidelity.md:161`, which uses `[-]` with `TRANSFERRED (disposition B, outcome transferred)`. One member asked that the parser be checked before proceeding, in case `[-]` mechanically means cancellation — it was: `update_roadmap_progress.ts` counts the glyph into a `cancelled` column and nothing else reads it. **That column will read "cancelled" for two items that were transferred.** The note at each item is the disposition; the column is a glyph tally. Both are stated so a reader cannot mistake one for the other.

## What landed

| Item | Before | After | Destination |
|---|---|---|---|
| step 2.4 — re-measure mean batch size | `[~]` | `[-]` MERGED (outcome transferred) | `road-to-turnaround-followups.md` Phase 1 step 1.1 |
| step 5.3 — answer the authorization pressure | `[~]` | `[-]` MERGED (outcome transferred) | `road-to-turnaround-followups.md` Phase 2 step 2.1 |
| blocker `post-change-window` | open | resolved **by merger, not substantively** | same |
| blocker `authorization-shape-for-long-runs` | open | resolved **by merger; still OWNER-RESERVED** | same |

Both blocker statuses say *resolved FOR THIS ROADMAP BY MERGER* in those words. The batching measurement is still outstanding and the owner decision is still untaken — what closed is this roadmap's disposition of them, and the entries say so rather than implying the underlying work is done.

`road-to-agent-turnaround` moved to `agents/roadmaps/archive/`, and its four inbound links were re-depthed to `../road-to-turnaround-followups.md`. The archival sweep does not re-depth moved links; `check_references` would have caught it, and did not have to.

## Three false statements corrected

All three are claims about the tree rather than stale opinion, and the council flagged each one:

1. `estate_offset_exempt` claimed the follow-up was *"created in the same change that archives road-to-agent-turnaround, as the CARRY disposition for its two deferred items"*. **Neither half held** — no archive happened in that change, and the carry was unlawful for the reason in Q1.
2. `estate_growth_exempt` claimed *"road-to-agent-turnaround cannot archive"*. True when written; falsified by this PR. Corrected with the date and the mechanism rather than deleted.
3. The `> Source:` line pointed at `agents/roadmaps/archive/road-to-agent-turnaround.md` — **a path that did not exist until this commit.**

`road-to-turnaround-followups` promoted `draft` → `ready`. `roadmap:context` ran first and reported 0 open PRs, no roadmap-to-open-PR file overlap, and one stale remote branch carrying the slug with no PR behind it.

## Verification

Every gate run in the worktree at `596f6e8ee`, all green:

`lint_roadmap_blockers` · `lint_roadmap_complexity` · `lint_roadmap_ci_steps` · `check_roadmap_trackable` · `check_no_roadmap_refs` · `lint_empty_roadmaps` · `lint_roadmap_later_disposition` · `lint_roadmap_family_cap` · `check_references` (1785 scanned, 0 broken) · `check_md_language` · `check_completion_review` · `task preflight`

`check_estate_count`: `active_roadmaps 4 (floor 4, +0)` · `open_blockers 30 (floor 32, -2)`.

`check_completion_review` reported `missing-artifact` with its own count of **0 code paths across 3 changed files**. The diff carries no code surface, so the second commit declares a skip rather than a findings table — the two are mutually exclusive at `check_completion_review.ts:908`.

## What this PR does NOT claim

- **It does not answer the authorization question.** `LEDGER_MAX_AGE_MS` is untouched, no value is proposed, and the question is owner-reserved in its new home exactly as it was in its old one.
- **It does not measure the batching obligation.** The ten post-change sessions still do not exist. The criterion moved; the reading did not happen.
- **The dashboard's `cancelled` column now counts two transferred items.** Stated rather than worked around.
