### PR TITLE
fix(ci): exempt bot-generated body and commit text from the off-tree metadata gate

### DIFF
--- a/.github/workflows/pr-metadata-sources.yml
+++ b/.github/workflows/pr-metadata-sources.yml
@@ -75,19 +75,43 @@ jobs:
         shell: bash -euo pipefail {0}
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          # The MERGE BASE, not `base.sha`. `base.sha` is the base branch tip
-          # recorded on the event, so once the branch merges a newer `main` every
-          # base commit between the two enters the range and other authors'
-          # commits get gated as this change's own. Over-reporting only, but it
-          # makes a red job blame the wrong commits. Falls back to `base.sha` if
-          # the merge base cannot be computed, so the range is never empty.
-          BASE="$(git merge-base "${BASE_SHA}" "${HEAD_SHA}" 2>/dev/null || echo "${BASE_SHA}")"
-          ./scripts-run src/scripts/sweep_source_surfaces --gate-metadata \
-            --branch "${HEAD_REF}" \
-            --title "${PR_TITLE}" \
-            --body-file "${RUNNER_TEMP}/pr-body.txt" \
-            --commit-range "${BASE}..${HEAD_SHA}"
+          # Branch and title are gated for EVERY author, bots included: both are
+          # short, human-editable surfaces, and a dependabot branch name carries
+          # only the package group.
+          args=(--gate-metadata --branch "${HEAD_REF}" --title "${PR_TITLE}")
+
+          # Body and commit messages are NOT gated for dependabot, and the
+          # exemption is a category correction rather than a relaxation. This
+          # gate exists to stop AUTHORED source attribution from reaching a
+          # public, effectively immutable surface. A dependabot body is
+          # machine-generated upstream provenance — release notes, a changelog,
+          # compare links, a commit list — which the rule already carves out
+          # ("Recommending / integrating a tool or registry ... Naming the tool
+          # is fine"), and its owner set changes with every bump: measured on
+          # 2026-08-31, #1766 carried 23 hits from `nodeca` alone and #1767
+          # carried 102 across four owners. Allowlisting them is the broad
+          # allowlisting `source_shape.ts` warns against in the same breath as
+          # it keeps ALLOWED_OWNERS small.
+          #
+          # The local pre-push twin (hooks/prepush_metadata_sources.sh) is
+          # deliberately NOT given this carve-out: it gates a human pushing
+          # their own branch, which is exactly the case that stays covered.
+          if [ "${PR_AUTHOR}" != "dependabot[bot]" ]; then
+            # The MERGE BASE, not `base.sha`. `base.sha` is the base branch tip
+            # recorded on the event, so once the branch merges a newer `main`
+            # every base commit between the two enters the range and other
+            # authors' commits get gated as this change's own. Over-reporting
+            # only, but it makes a red job blame the wrong commits. Falls back
+            # to `base.sha` if the merge base cannot be computed, so the range
+            # is never empty.
+            BASE="$(git merge-base "${BASE_SHA}" "${HEAD_SHA}" 2>/dev/null || echo "${BASE_SHA}")"
+            args+=(--body-file "${RUNNER_TEMP}/pr-body.txt")
+            args+=(--commit-range "${BASE}..${HEAD_SHA}")
+          fi
+
+          ./scripts-run src/scripts/sweep_source_surfaces "${args[@]}"

--- a/docs/CLAIMS.md
+++ b/docs/CLAIMS.md
@@ -1056,7 +1056,10 @@ is the named exception in the claim itself.
 
   Off-tree surfaces are gated separately and are NOT covered by this pointer:
   `.github/workflows/pr-metadata-sources.yml` checks branch name, PR title, PR
-  body and the change's commit messages on `pull_request`, and
+  body and the change's commit messages on `pull_request` — with body and
+  commit messages exempt for `dependabot[bot]`, whose text is machine-generated
+  upstream provenance rather than authored attribution; branch and title stay
+  gated for every author. And
   `src/scripts/hooks/prepush_metadata_sources.sh` checks the local half before
   a push makes them public. `.github/workflows/source-surface-sweep.yml` runs
   the full five-surface census weekly so drift on the surfaces no per-PR gate


### PR DESCRIPTION
## Why

Every dependabot PR fails `gate off-tree metadata`, structurally rather than by accident — it was the **only** red check on both open dependabot PRs.

The gate flags any `github.com/<owner>/<repo>` URL whose owner is outside `ALLOWED_OWNERS` (`src/scripts/_lib/source_shape.ts`). A dependabot body is made of exactly those URLs: release notes, changelog, compare links, commit list. Measured 2026-08-31:

| PR | Owners in body | Hits |
|---|---|---|
| 1766 | `nodeca` | 23 incl. commit message |
| 1767 | four distinct owners | 102 |

The owner set changes with every bump, so allowlisting does not converge.

## What this is not

Not a relaxation — a category correction. The gate exists to stop **authored** source attribution from reaching a public, effectively immutable surface. Machine-generated upstream provenance is the case `source-confidentiality` already carves out ("Recommending / integrating a tool or registry ... Naming the tool is fine"), and growing the allowlist per upstream owner is the broad allowlisting `source_shape.ts` warns against in the same breath as it keeps its list deliberately small.

## Scope of the carve-out

- **Branch name and title stay gated for every author**, bots included — both are short, human-editable surfaces.
- Only `--body-file` and `--commit-range` are dropped, and only when the PR author is `dependabot[bot]`.
- The local pre-push twin (`src/scripts/hooks/prepush_metadata_sources.sh`) is deliberately **not** given this carve-out: it gates a human pushing their own branch, which stays fully covered.

## Verification

Both polarities executed through the real `run:` block, not argued:

- author `dependabot[bot]`, body containing an upstream URL → **passes** (2 surface units scanned)
- author human, same body → **still blocks** with the unchanged refusal text

`shellcheck -s bash --norc` clean on the extracted block. `check_claims` green; `docs/CLAIMS.md` updated in the same change so its unqualified claim no longer contradicts the code.

`actionlint` is not installed locally — CI is the authority for that one.
