### PR TITLE
roadmap: governed-harness-evolution 46/59 to 55/59 — the cascade wired, AC-3/AC-5/AC-6 closed, three measurements taken

### DIFF
--- a/agents/evidence/analysis/delivery-set-measurement-2026-08-31.json
+++ b/agents/evidence/analysis/delivery-set-measurement-2026-08-31.json
@@ -1,0 +1,102 @@
+{
+  "schema": 1,
+  "step": "6.4",
+  "roadmap": "road-to-governed-harness-evolution",
+  "preregistration": "agents/evidence/analysis/delivery-set-preregistration-2026-08-31.md",
+  "k": 5,
+  "bars": {
+    "recall_loss_ceiling_pp": 20,
+    "token_target": 500
+  },
+  "metrics": {
+    "precision_at_k": 82.508,
+    "recall_at_k": 64.599,
+    "recall_loss_pp": 35.401,
+    "ceiling_met": false,
+    "recall_curve_pp": {
+      "1": 44.703,
+      "3": 57.106,
+      "5": 64.599,
+      "10": 73.643,
+      "20": 80.62
+    },
+    "false_activation_at_k": 13.66,
+    "context_cost_tokens": 235.6,
+    "token_target_met": true,
+    "benefit_unconditional": 64.599,
+    "benefit_conditional_on_activation": 82.508,
+    "adjudicated_deliveries": 303,
+    "unadjudicated_deliveries": 3326,
+    "tie_decided_cut_pp": 78.796
+  },
+  "set_compatibility": {
+    "shared_prompts": 10,
+    "jointly_wrong_pairs_delivered_at_k": 0,
+    "pairs_delivered_at_k": [],
+    "jointly_wrong_pairs_in_corpus": 7,
+    "candidates": [
+      {
+        "prompt": "is this diff clean — naming, structure, conventions?",
+        "pair": [
+          "experiment-loop",
+          "verify-repair-loop"
+        ],
+        "jointlyDeliveredAtK": null
+      },
+      {
+        "prompt": "review my changes before I open the PR",
+        "pair": [
+          "experiment-loop",
+          "verify-repair-loop"
+        ],
+        "jointlyDeliveredAtK": null
+      },
+      {
+        "prompt": "run a security audit on the auth module",
+        "pair": [
+          "analysis-skill-router",
+          "forensics-report"
+        ],
+        "jointlyDeliveredAtK": null
+      },
+      {
+        "prompt": "threat-model this new payments endpoint before I build it",
+        "pair": [
+          "agent-security-review",
+          "ai-code-blindspots"
+        ],
+        "jointlyDeliveredAtK": null
+      },
+      {
+        "prompt": "threat-model this new payments endpoint before I build it",
+        "pair": [
+          "agent-security-review",
+          "security-audit"
+        ],
+        "jointlyDeliveredAtK": null
+      },
+      {
+        "prompt": "threat-model this new payments endpoint before I build it",
+        "pair": [
+          "ai-code-blindspots",
+          "security-audit"
+        ],
+        "jointlyDeliveredAtK": null
+      },
+      {
+        "prompt": "what chunk size and embedding model should I use for my RAG pipeline?",
+        "pair": [
+          "evaluate-llm-feature",
+          "prompt-engineering-patterns"
+        ],
+        "jointlyDeliveredAtK": null
+      }
+    ]
+  },
+  "corpus": {
+    "partition": "train",
+    "holdout_sealed": true,
+    "cases": 775,
+    "prompts": 764
+  }
+}

--- a/agents/evidence/analysis/delivery-set-measurement-2026-08-31.json
+++ b/agents/evidence/analysis/delivery-set-measurement-2026-08-31.json
@@ -4,6 +4,15 @@
   "roadmap": "road-to-governed-harness-evolution",
   "preregistration": "agents/evidence/analysis/delivery-set-preregistration-2026-08-31.md",
   "k": 5,
+  "index_input": {
+    "fields": [
+      "name",
+      "description"
+    ],
+    "derived_from": "5.1 verdict file, via _lib/routing_index_input.ts",
+    "verdict": "harmful",
+    "reason": "the 5.1 verdict is `harmful`, not `signal` — description-only"
+  },
   "bars": {
     "recall_loss_ceiling_pp": 20,
     "token_target": 500

--- a/agents/evidence/analysis/delivery-set-preregistration-2026-08-31.md
+++ b/agents/evidence/analysis/delivery-set-preregistration-2026-08-31.md
@@ -1,0 +1,111 @@
+<!-- evidence-type: analysis -->
+
+# Delivery-set pre-registration — loss ceiling, token target, set compatibility
+
+Registered 2026-08-31 · owner: maintainer ·
+`road-to-governed-harness-evolution` step **6.4**
+("Pre-register the loss ceiling, and measure set compatibility").
+
+**Written before the measurement module exists.** The step's `verify:` clause is
+*"the ceiling is committed before the run, and the corpus contains at least one
+jointly-wrong pair"*. The first half is an ordering claim, so it is discharged
+by the git history: this file is committed in a commit that adds no measurement
+module and runs nothing.
+
+## What is being decided
+
+A narrowed delivery — hand the model the top-k skills for a prompt instead of
+the whole catalogue — trades recall for context. The trade is only legible if
+the acceptable loss is named **first**. A ceiling picked after seeing the recall
+curve is a description of the curve.
+
+## The two numbers, fixed now
+
+```
+RECALL-LOSS CEILING   20.0 pp against the full-catalogue arm
+TOKEN TARGET          500 tokens of delivered skill description per prompt
+```
+
+**Recall-loss ceiling — 20.0 pp.** The full-catalogue arm delivers every skill,
+so its recall is 1.0 by construction and the loss is exactly `1 − recall@k`. The
+ceiling therefore reads: **recall@5 ≥ 80.0 %** of train positives. It is a
+stated default rather than a derived optimum, and it is deliberately set where
+the outcome is genuinely uncertain: the only comparable number this tree has
+published is `agents/evidence/metrics/skill-ranker-baseline.json`, whose
+incumbent `keyword-v1` scores `top3: 0.769` over a 26-prompt labelled corpus —
+a different corpus, a different k, and too small to predict this one.
+
+**Token target — 500 tokens.** The delivered set's summed description cost, at
+4 characters per token, averaged over prompts. Also a stated default.
+*Revisit-if:* the measured mean at k = 5 exceeds it by more than 2×, in which
+case k moves **before** the next run and never during one.
+
+**k = 5**, the same constant the 5.1 pre-registration fixes, so the two
+measurements are commensurable and neither can be re-tuned against the other.
+
+**Corpus.** Train partition only, by the frozen rule in
+`agents/evidence/analysis/trigger-corpus-holdout-2026-08-30.md`. The 18 holdout
+`evals/triggers.json` files are sealed and are not read.
+
+## The metric set — every field the step names, defined before the run
+
+| Metric | Definition |
+|---|---|
+| `precision_at_k` | over all (case, delivered skill) pairs: the fraction where the corpus records `trigger: true` for that skill on that prompt. Only pairs the corpus can adjudicate are counted; a delivered skill with no case for that prompt is `unadjudicated` and is reported separately rather than scored as either. |
+| `recall_at_k` | positives whose owning skill is in the delivered set, over all positives |
+| `false_activation_at_k` | negatives whose owning skill is in the delivered set, over all negatives |
+| `context_cost_tokens` | mean summed `name + description` length of the delivered set, divided by 4 |
+| `benefit_unconditional` | `recall_at_k` — the benefit counted over every positive, including those where the skill never activates |
+| `benefit_conditional_on_activation` | among **activations** (delivered, adjudicable pairs), the fraction that were wanted. The two differ exactly where delivery fails: an undelivered positive costs the unconditional figure and is invisible to the conditional one, which is why reporting only one of them is the failure this row exists to stop. |
+| `jointly_wrong_pairs` | see below |
+
+**`unadjudicated` is a first-class outcome, not a rounding error.** The corpus
+labels one skill per prompt; the delivered set holds five. Four of those five
+usually have no case for that prompt, and scoring them as false positives would
+manufacture a precision figure out of the corpus's silence. They are counted and
+reported as `unadjudicated`, and `precision_at_k` states its own denominator.
+
+## Set compatibility — the part that is not a per-artefact metric
+
+```
+THE QUESTION IS WHICH SET TO DELIVER TOGETHER, NOT ONLY WHICH ARTEFACT IS CLOSEST.
+TWO INDIVIDUALLY PLAUSIBLE SKILLS CAN BE JOINTLY WRONG.
+A METRIC THAT SCORES EACH DELIVERY ALONE CANNOT SEE THAT.
+```
+
+**Definition, fixed before the run.** A **jointly-wrong pair** for prompt *p* is
+an unordered pair of distinct skills `{A, B}` such that:
+
+1. both are in the delivered top-k for *p*; **and**
+2. the corpus adjudicates *both* on *p* — that is, *p* appears in A's corpus and
+   in B's corpus; **and**
+3. both records are `trigger: false`.
+
+Condition 2 is what makes the pair *observable*: only a prompt carried by two
+corpora can be jointly adjudicated, and this corpus has 15 such prompts. It is
+also the honest bound on the metric — the count is a **lower** bound on joint
+wrongness, never an estimate of it, because a pair whose members do not share a
+prompt cannot be evaluated at all.
+
+**Reported alongside:** `jointly_wrong_pairs` (count and the pairs), and
+`shared_prompts` (the denominator that makes them observable). The step's verify
+asks for **at least one** jointly-wrong pair in the corpus, and the run reports
+the count rather than asserting it.
+
+## The bar
+
+The ceiling is a **reporting** bar, not a gate on closing 6.4. Step 6.4's
+`verify:` asks that the ceiling be committed before the run and that the corpus
+carry a jointly-wrong pair; it does not ask that the ceiling be met. So:
+
+- ceiling met → the narrowed delivery is admissible at k = 5 on this corpus;
+- ceiling breached → **reported as breached, with the recall curve over k**, and
+  no narrowed delivery is promoted. A breach is a finding, not a failure of the
+  run.
+
+**No promotion claim is made from this run.** Per
+`internal/bench/council-topology-promotion-stats-PREREG.md`, a statement that
+changes what the suite does by default carries a trial count and a band. This
+run is a deterministic census over one corpus; it is published as an
+observation, and anything that would change delivery by default needs the band
+that prereg requires.

--- a/agents/evidence/analysis/delivery-set-result-2026-08-31.md
+++ b/agents/evidence/analysis/delivery-set-result-2026-08-31.md
@@ -1,0 +1,116 @@
+<!-- evidence-type: analysis -->
+
+# Delivery sets — the ceiling is breached, and 79 % of the cut is a coin flip
+
+Measured 2026-08-31 · `road-to-governed-harness-evolution` step **6.4** ·
+pre-registered in `agents/evidence/analysis/delivery-set-preregistration-2026-08-31.md`
+(commit `fe8749458`, which adds no measurement module and runs nothing).
+
+Reproduce: `./scripts-run src/scripts/measure_delivery_sets`.
+Machine record: `agents/evidence/analysis/delivery-set-measurement-2026-08-31.json`.
+
+Arm: the shipped `description` index. 82 train corpora, 764 distinct prompts,
+387 positives / 388 negatives, 299-skill catalogue, k = 5. The 18 sealed
+holdout corpora were not read.
+
+## The metric set the step asked for
+
+| Metric | Value | Bar |
+|---|---|---|
+| precision@5 | **82.51 %** over 303 adjudicated deliveries | — |
+| recall@5 | **64.60 %** | — |
+| recall loss vs full catalogue | **35.40 pp** | ceiling 20.0 pp — **BREACHED** |
+| false activation@5 | **13.66 %** | — |
+| context cost | **235.6 tokens/prompt** | target 500 — **MET** |
+| benefit, unconditional | **64.60 %** | — |
+| benefit, conditional on activation | **82.51 %** | — |
+| unadjudicated deliveries | 3 326 of 3 629 | reported, never scored |
+
+Recall curve: @1 44.70 % · @3 57.11 % · @5 64.60 % · @10 73.64 % · @20 80.62 %.
+
+**The ceiling is breached at every k the curve covers.** 80.0 % recall is not
+reached at k = 20, so no narrowing under 20 clears a 20.0 pp loss ceiling on this
+corpus. The token target is met with room — 235.6 against 500 — which locates
+the problem: the delivered set is cheap and is not the thing that is failing.
+
+**A breach is a finding, not a failed run.** The pre-registration says so
+explicitly, and no narrowed delivery is promoted from this.
+
+## Precision and benefit-given-activation are one quantity under two names
+
+The pre-registration defined `precision_at_k` and
+`benefit_conditional_on_activation` separately, and implementing them showed
+they are the same computation: the fraction of adjudicated deliveries that were
+wanted. This is a defect in the pre-registration, found by implementing it.
+Both are reported, at the same value, rather than one being silently dropped.
+
+The pair that does differ is the one the prereg`s own gloss names:
+`benefit_unconditional` (64.60 %, counts undelivered positives as zero benefit)
+against `benefit_conditional_on_activation` (82.51 %, blind to them). The 17.9 pp
+gap is exactly the delivery failure, and reporting only the conditional figure
+would have hidden it.
+
+## Set compatibility — 7 in the corpus, 0 delivered together
+
+**7 jointly-wrong pairs exist in the train corpus**, over 10 shared prompts:
+
+| Pair | Prompt |
+|---|---|
+| `experiment-loop` + `verify-repair-loop` | is this diff clean — naming, structure, conventions? |
+| `experiment-loop` + `verify-repair-loop` | review my changes before I open the PR |
+| `analysis-skill-router` + `forensics-report` | run a security audit on the auth module |
+| `agent-security-review` + `ai-code-blindspots` | threat-model this new payments endpoint before I build it |
+| `agent-security-review` + `security-audit` | (same prompt) |
+| `ai-code-blindspots` + `security-audit` | (same prompt) |
+| `evaluate-llm-feature` + `prompt-engineering-patterns` | what chunk size and embedding model should I use for my RAG pipeline? |
+
+**None of the seven is delivered together at any k ≤ 20.** That reads like good
+news and mostly is not — see the next section.
+
+**The pre-registration narrowed a corpus property into a delivery property, and
+that is corrected by reporting both rather than by rewriting the definition.**
+The step`s verify asks whether *the corpus* contains a jointly-wrong pair; the
+prereg`s definition added a third condition, "both members delivered in the
+top-k", which makes the count 0 and answers a different question. Both figures
+are now reported: `jointly_wrong_pairs_in_corpus` (7) and
+`jointly_wrong_pairs_delivered_at_k` (0), with the smallest k at which each pair
+would be jointly delivered.
+
+**The count is a lower bound and never an estimate.** A pair is observable only
+where two corpora adjudicate the *same* prompt, because the corpus labels one
+skill per prompt. A wrong pair whose members share no prompt cannot be seen from
+this corpus at all.
+
+## The finding that bounds every number above
+
+```
+78.80 % OF PROMPTS HAVE THEIR TOP-5 CUT DECIDED BY THE ALPHABETICAL TIE-BREAK.
+score(rank 5) === score(rank 6). THE BOUNDARY IS NAME ORDER, NOT RELEVANCE.
+```
+
+The scorer produces heavy ties. For *"threat-model this new payments endpoint
+before I build it"* the top six all score 23 — `ai-code-blindspots`,
+`customer-research`, `forecasting`, `source-discovery`, `spreadsheet-authoring`,
+`threat-modeling` — and the next twenty all score 12. Which five are delivered
+is then decided by `a` < `b`.
+
+So the 0-delivered-pairs result is **not** evidence that the ranker discriminates
+between incompatible skills. It is mostly evidence that at the boundary it does
+not rank at all, and the alphabet happened not to co-select any of the seven.
+Reading it as a compatibility success would be the strongest available
+misreading of this run, which is why it is stated here first.
+
+This is the same "recalls but does not rank" pathology
+`src/scripts/measure_lexical_ranking.ts:10-16` names for the memory store,
+observed here on the skill catalogue for the first time.
+
+## What this does NOT establish
+
+- It is not a promotion claim. Per
+  `internal/bench/council-topology-promotion-stats-PREREG.md`, a change to what
+  the suite does by default carries a trial count and a band; this is a
+  deterministic census over one corpus, published as an observation.
+- It says nothing about the sealed holdout, which stays unspent.
+- The absolute figures are properties of the lexical proxy, not of a real
+  session — the same Gap A bound the 5.1 result carries, and for the same
+  reason: step 5.2 parks the live harness.

--- a/agents/evidence/analysis/routing-body-signal-result-2026-08-31.md
+++ b/agents/evidence/analysis/routing-body-signal-result-2026-08-31.md
@@ -1,0 +1,108 @@
+<!-- evidence-type: analysis -->
+
+# Routing body signal — the measurement, and why the answer is not `null`
+
+Measured 2026-08-31 · `road-to-governed-harness-evolution` step **5.1** ·
+pre-registered in `agents/evidence/analysis/routing-signal-preregistration-2026-08-31.md`
+(commit `fe8749458`, which adds no measurement module and runs nothing).
+
+Reproduce: `./scripts-run src/scripts/measure_routing_signal`.
+Machine record: `agents/evidence/analysis/routing-body-signal-verdict.json`.
+
+## The verdict
+
+```
+VERDICT: harmful
+THE PRIMARY BAR WAS CLEARED. THE GUARD WAS BREACHED BY MORE.
+INDEXING THE BODY BUYS 5.7 pp OF RECALL AND PAYS 7.2 pp OF FALSE ACTIVATION.
+```
+
+| Arm | recall@5 | false activation@5 |
+|---|---|---|
+| `description` (shipped) | 64.60 % | 13.66 % |
+| `description+body` | 70.28 % | 20.88 % |
+| **delta** | **+5.68 pp** (bar +5.0) | **+7.22 pp** (guard +2.0) |
+
+Discordant positive pairs: 62 gained, 40 lost. McNemar exact two-sided
+**p = 0.0371**. Power floor (≥ 10 discordant) cleared with 102.
+
+Corpus: 82 train corpora, 775 cases, 387 positives / 388 negatives, ranked
+against a 299-skill catalogue. The 18 sealed holdout corpora were not read.
+
+## The pre-registered order is what produced this answer
+
+The primary bar was **met**: +5.68 pp of recall at p < 0.05. A pre-registration
+that had named only a recall bar would have returned `signal` on these numbers
+and licensed step 6.5 to index the body.
+
+The pre-registration named a guard **and** an evaluation order — power, then
+guard, then primary — and the guard is what fires. `tests/scripts/routing_signal_measurement.test.ts`
+pins exactly that combination, and a sabotage that moves the primary check ahead
+of the guard turns the verdict into `signal` and reds two tests.
+
+This is the case the two-sided bar existed for, and it is worth stating plainly:
+had the bar been one-sided, this run would have shipped a change that makes
+routing worse while reporting an improvement.
+
+## The prediction was half right, and the wrong half is the interesting one
+
+The pre-registration committed to a mechanism: `scoreSkill` computes
+`overlap = |taskTerms ∩ skillTerms| / |taskTerms|`, dividing by the **task's**
+term count. Adding body tokens can only grow `skillTerms`, so every skill's
+score is monotone non-decreasing under the body arm, and the prediction was that
+the guard would break.
+
+It did. What the prediction did not anticipate is that **40 positives were
+lost**. Monotone scores do not imply monotone ranks: a positive already inside
+the top-5 is pushed out when its competitors gain more from their bodies than it
+gains from its own. So the body arm is not a pure recall trade — it reorders,
+and 39 % of its discordant movement is in the wrong direction. That is a
+stronger reason not to index the body than the guard breach alone, and it was
+found by the run rather than reasoned to.
+
+## Gap A is `null`, and it bounds this result
+
+`proxy_to_real_fidelity` is carried as its own required field in the verdict
+record, with `status: unmeasured-by-construction`.
+
+The reason is structural, not budgetary. `src/scripts/description_route_check.ts:18-30`
+states that asking a model which units it would load is not the host's selection
+procedure, and that the gap is *"unquantified rather than small"*. Quantifying
+it needs real sessions; step 5.2 keeps the live-floors park intact for this
+whole roadmap and a scan enforces it. So the honest field value is `null` with
+the reason attached.
+
+**What that costs this result, said in one line:** the ranking measured here is
+a proxy for production routing whose fidelity to production routing is unknown.
+The internal comparison between the two arms is sound — both arms run through
+the same proxy, so the proxy's error is common to them — but the absolute
+figures (64.6 %, 70.3 %) are properties of the proxy and are not claims about a
+real session.
+
+## Two corrections made during the run, recorded rather than smoothed over
+
+**The loader dropped two corpora silently.** The first implementation understood
+only the modern `queries[]` shape and reported **80** train corpora where the
+frozen partition says 82. The two lost files — `brand-asset-generation` and
+`estimate-ticket` — are the legacy `should_trigger` / `should_not_trigger` pair
+that step 2.3 grandfathered. This was a defect in the reader, not a scoping
+decision, and it was fixed by reading both shapes rather than by narrowing the
+pre-registered corpus. The verdict is unchanged in both directions: at 80
+corpora the run read +5.57 / +7.41 pp and `harmful`; at 82 it reads +5.68 /
++7.22 pp and `harmful`. `legacy_shaped_corpora` is now a reported field so the
+count is explainable from the record.
+
+**A block comment ended early.** `/** … src/skills/*/SKILL.md … */` closes at
+the `*/` inside the glob. `tsc --noEmit` accepted the file and the runtime
+transform did not. Noted because the same trap will catch the next author who
+writes a skills glob into a doc comment.
+
+## What this does NOT establish
+
+- It does not say the body is useless to a **reader**. It says body tokens,
+  folded into this lexical scorer, degrade this ranking on this corpus.
+- It does not generalise to a different retrieval mechanism. A scorer that
+  normalised by the skill's own term count, or a BM25 core with length
+  normalisation, is a different measurement and this result does not predict it.
+- It does not touch the holdout. Every number here is train-partition only, and
+  a later run against the sealed set is a separate, still-unspent measurement.

--- a/agents/evidence/analysis/routing-body-signal-verdict.json
+++ b/agents/evidence/analysis/routing-body-signal-verdict.json
@@ -1,0 +1,63 @@
+{
+  "schema": 1,
+  "step": "5.1",
+  "roadmap": "road-to-governed-harness-evolution",
+  "preregistration": "agents/evidence/analysis/routing-signal-preregistration-2026-08-31.md",
+  "measured_at": "2026-08-31",
+  "proxy_to_real_fidelity": {
+    "value": null,
+    "status": "unmeasured-by-construction",
+    "reason": "Step 5.2 parks the live routing harness for this roadmap; a fidelity figure requires real sessions. Every routing conclusion in this file is bounded by this unmeasured quantity."
+  },
+  "body_signal": {
+    "verdict": "harmful",
+    "reason": "false activation +7.22 pp breaches the +2.0 pp guard",
+    "k": 5,
+    "delta_recall_pp": 5.685,
+    "delta_false_activation_pp": 7.216,
+    "p_value": 0.03707,
+    "discordant_positive_pairs": {
+      "gained": 62,
+      "lost": 40
+    },
+    "bars": {
+      "recall_gain_pp": 5,
+      "false_activation_guard_pp": 2,
+      "power_floor_discordant": 10,
+      "alpha": 0.05
+    },
+    "arms": {
+      "description": {
+        "positives": 387,
+        "positiveHits": 250,
+        "negatives": 388,
+        "negativeHits": 53
+      },
+      "description+body": {
+        "positives": 387,
+        "positiveHits": 272,
+        "negatives": 388,
+        "negativeHits": 81
+      }
+    },
+    "recall_pp": {
+      "description": 64.599,
+      "description+body": 70.284
+    },
+    "false_activation_pp": {
+      "description": 13.66,
+      "description+body": 20.876
+    }
+  },
+  "corpus": {
+    "partition": "train",
+    "holdout_sealed": true,
+    "train_corpora": 82,
+    "legacy_shaped_corpora": [
+      "brand-asset-generation",
+      "estimate-ticket"
+    ],
+    "cases": 775,
+    "catalogue_size": 299
+  }
+}

--- a/agents/evidence/analysis/routing-signal-preregistration-2026-08-31.md
+++ b/agents/evidence/analysis/routing-signal-preregistration-2026-08-31.md
@@ -1,0 +1,164 @@
+<!-- evidence-type: analysis -->
+
+# Routing-signal pre-registration — two gaps, named separately
+
+Registered 2026-08-31 · owner: maintainer ·
+`road-to-governed-harness-evolution` step **5.1**
+("Measure the description-vs-body signal, honest null permitted").
+
+**This record is written before the measurement code exists, and that is the
+point.** Its step's `verify:` clause is an ordering clause — *"the
+pre-registration lands before the first measurement commit and names both gaps
+separately"* — so a threshold chosen after seeing a number is not a threshold.
+The ordering is checkable in the git history rather than asserted here: this
+file is committed in a commit that adds no measurement module and runs nothing.
+
+## The two gaps are different questions, and the step exists because they were conflated
+
+```
+GAP A IS ABOUT THE INSTRUMENT. GAP B IS ABOUT THE INDEX.
+A IS NOT EVIDENCE ABOUT B, AND B IS NOT EVIDENCE ABOUT A.
+NEITHER IS CLOSED BY MEASURING THE OTHER.
+```
+
+### Gap A — proxy-to-real-session fidelity
+
+`src/scripts/description_route_check.ts:18-30` states it verbatim: asking a
+model *"which units would you load given this catalogue"* is **not the host's
+selection procedure**, so a green run there is evidence that the description
+signal did not regress and is *"NEVER evidence that production routing works …
+until that measurement exists the gap is unquantified rather than small"*.
+
+This gap bounds the external validity of every routing conclusion in this
+roadmap, including Gap B's. It is therefore carried as **its own named field**
+in the verdict file rather than folded into a caveat sentence.
+
+**Its status in this roadmap is fixed in advance, and it is not "we ran out of
+time".** Step 5.2 keeps the live-floors park intact — *"no step in this roadmap
+invokes a live routing harness"* — and that constraint is enforced by a scan
+(`tests/scripts/governed_harness_no_live_harness.test.ts`). A fidelity
+measurement requires real sessions. So Gap A is **unmeasurable by construction
+inside this roadmap**, and the pre-registered reporting rule is:
+
+| Field | Pre-registered value |
+|---|---|
+| `proxy_to_real_fidelity.value` | `null` |
+| `proxy_to_real_fidelity.status` | `unmeasured-by-construction` |
+| `proxy_to_real_fidelity.reason` | the 5.2 park, cited |
+
+A run that emitted a number here would have violated 5.2 to get it. Recording
+`null` with the reason is the honest outcome and is pre-registered as the
+**expected** one — not as a fallback discovered afterwards.
+
+### Gap B — does the skill BODY carry routing signal the description does not?
+
+The production ranker is `src/shared/skillRanking.ts`. Its `RankableSkill`
+interface documents the exclusion in one line: *"Deliberately not the body — see
+`rankSkills`"*, and `skillTerms` indexes `name + description` (plus
+`triggerText` only on request). Nothing in this tree has ever measured what that
+exclusion costs.
+
+## The measurement, fixed before it runs
+
+**Instrument.** `scoreSkill` / `skillTerms` from `src/shared/skillRanking.ts`,
+unchanged. The body arm adds body tokens to the indexed term set and changes
+nothing else. Two arms, one scorer, one corpus — an arm that used a second
+scorer would be measuring the scorer.
+
+| Arm | Indexed terms |
+|---|---|
+| `description` | `name + description` — today's production condition |
+| `description+body` | `name + description + SKILL.md body` |
+
+**Catalogue.** Every `src/skills/*/SKILL.md`. Ranking is over the whole
+catalogue, because a routing decision is a comparison against everything else.
+
+**Corpus.** The `src/skills/*/evals/triggers.json` cases, **train partition
+only**. The partition is the frozen one in
+`agents/evidence/analysis/trigger-corpus-holdout-2026-08-30.md`:
+`holdout iff sha256(<skill-directory-name>)[0] < 51`. The 18 holdout corpora are
+sealed and this measurement does not open them; the measuring module refuses
+them rather than filtering them afterwards, and a test asserts the refusal.
+
+**The seal covers the corpus files, not the catalogue.** A holdout skill's
+`SKILL.md` is still ranked against — it is part of the catalogue every prompt
+competes in, and removing it would measure a catalogue that does not exist. What
+is never read is a holdout `evals/triggers.json`. Stating the boundary here is
+cheaper than leaving a reader to infer which artefact the seal names.
+
+**k = 5.** A stated default, not a derived optimum, fixed here so it cannot be
+tuned to a result. *Revisit-if:* a delivered set of five is shown to be outside
+the token target of the 6.4 pre-registration, in which case k moves **before**
+the next run, never during one.
+
+**Case polarity.** `trigger: true` is a positive (the owning skill must be
+delivered); `trigger: false` is a negative (it must not). The three-class
+vocabulary of step 2.3 (`exemplar` / `near-miss` / `counterexample`) is
+reported as a breakdown where present, but the decision rule runs on polarity,
+because 876 of the 931 cases carry no class field and a rule keyed on the class
+would run on 6 % of the corpus.
+
+## The bar — pre-registered, two-sided
+
+```
+RECALL IS THE PRIMARY. FALSE ACTIVATION IS A GUARD, NOT A TIEBREAK.
+AN IMPROVEMENT THAT BREACHES THE GUARD IS `harmful`, NOT `signal`.
+AN HONEST NULL IS A LEGITIMATE OUTCOME AND CLOSES THE STEP.
+```
+
+| Quantity | Definition | Bar |
+|---|---|---|
+| ΔRecall@5 | (positives whose owning skill is in the top-5 under `description+body`) − (same under `description`), as a percentage of positives | **≥ +5.0 pp** |
+| significance | McNemar exact two-sided binomial over the discordant positive cases | **p < 0.05** |
+| ΔFalseActivation@5 | (negatives whose owning skill is in the top-5 under `description+body`) − (same under `description`), as a percentage of negatives | **≤ +2.0 pp** |
+| power | discordant pairs on the primary | **≥ 10** |
+
+**Verdict function, evaluated in this order:**
+
+1. discordant pairs < 10 → `underpowered`
+2. guard breached (ΔFalseActivation@5 > +2.0 pp) → `harmful`
+3. ΔRecall@5 ≥ +5.0 pp and p < 0.05 → `signal`
+4. otherwise → `null`
+
+`underpowered` and `harmful` are **not** `signal`. Only `signal` licenses
+step 6.5 to index the body.
+
+**Why McNemar and not a rerun band.** The estimator is deterministic — the same
+tree gives the same ranking every time — so a rerun band would be identically
+zero and would measure nothing. The variance that exists is **sampling variance
+over cases**, and the paired discordant-pair test is the form that addresses it.
+This is the same reasoning `internal/bench/council-topology-promotion-stats-PREREG.md`
+applies when it permits an explicit variance band in place of a confidence
+interval "where the metric supports one"; it is recorded here rather than
+inherited silently, because the two runs measure different kinds of object.
+
+## The prediction, committed in advance
+
+A pre-registration that predicts nothing cannot be embarrassed by the result.
+The prediction:
+
+**The guard will be breached, and the verdict will not be `signal`.**
+
+The mechanism is arithmetic rather than intuition. `scoreSkill` computes
+`overlap = |taskTerms ∩ skillTerms| / |taskTerms|` — the denominator is the
+**task's** term count, not the skill's. Adding body tokens can only grow
+`skillTerms`, so every skill's score is **monotone non-decreasing** under the
+body arm. Recall therefore cannot fall and false activation cannot fall either;
+only their ratio is open. Since a SKILL.md body is one to two orders of
+magnitude longer than its description, the body arm should raise scores across
+the whole catalogue and compress the ranking rather than sharpen it.
+
+If that prediction is right, the honest outcome is `null` or `harmful`, and
+either closes step 5.1 without licensing 6.5. If it is wrong, the bar above is
+what says so.
+
+## What this pre-registration does NOT buy
+
+- It does not fix **6.4's** loss ceiling or token target. Those are a separate
+  pre-registration, committed in the same commit as this one and binding on a
+  different run.
+- It does not establish that the ranking proxy predicts production routing.
+  That is Gap A, and Gap A is `null` by construction here.
+- It does not say the body is useless **to a reader**. It measures one question:
+  whether body tokens, folded into this lexical scorer, improve this ranking on
+  this corpus. A different retrieval mechanism is a different measurement.

--- a/agents/evidence/analysis/trigger-corpus-holdout-2026-08-30.md
+++ b/agents/evidence/analysis/trigger-corpus-holdout-2026-08-30.md
@@ -43,7 +43,7 @@ prevent.
 ## The set hash
 
 ```
-SET-SHA256  7e091dfc0b1e44aa81268dd69a4d0ab07d1ee1316d6b3120d7ccec62f9aa5da8
+SET-SHA256  0667fbd96d7d1da88368d4d587545ff03475208ab9d07ca5212975e8cdaaa4d6
 ```
 
 Computed over the lines `<skill> <sha256-of-file> <partition>\n` for all
@@ -65,6 +65,56 @@ for f in $(ls -1 src/skills/*/evals/triggers.json | sort); do
   printf '%s %s %s\n' "$s" "$(shasum -a 256 "$f" | cut -d' ' -f1)" "$p"
 done | LC_ALL=C sort | shasum -a 256
 ```
+
+## Correction 2026-08-31 — the pin was stale on arrival, and is re-pinned here
+
+```
+THE PIN WAS WRONG. THE CORPUS WAS NOT.
+RE-PINNED TO THE FROZEN BYTES, WHICH HAVE NOT MOVED SINCE THE FREEZE COMMIT.
+THE ORDERING CLAIM SURVIVES THE RE-PIN AND IS RE-VERIFIED BELOW.
+```
+
+**What was wrong.** The `SET-SHA256` published in this file's first revision,
+`7e091dfc…`, did not reproduce from this file's own documented recipe. Running
+that recipe on the tree yields `0667fbd9…`, and two near-variants — dropping the
+partition column, and tab separators — yield two further values, neither of them
+the pin. So the mismatch was not a formatting ambiguity in the recipe.
+
+**The corpus was checked before the pin was blamed, and it is intact.** The file
+set is identical to the freeze commit `34318f7f5` — 100 files, `git ls-tree`
+diff empty — and every file's bytes are unchanged since it.
+
+**The actual cause.** `34318f7f5`, the commit that RECORDED the freeze, also
+edited three of the files it was freezing. `markitdown`, `security-audit` and
+`threat-modeling` were pinned at their **pre-edit** hashes; the other 97 rows
+reproduce exactly, and the set hash inherited the three wrong rows. A hash
+computed from bytes that the same commit then replaced is stale the moment it is
+written, which is why this was never a drift and could never have been caught by
+re-running the recipe later and trusting the old number.
+
+**What was re-pinned**, to the frozen bytes as they stand at `34318f7f5` and
+today — `git diff 34318f7f..HEAD` over the three paths is empty:
+
+| Row | Was (pre-edit, stale) | Now (frozen bytes) |
+|---|---|---|
+| `SET-SHA256` | `7e091dfc…` | `0667fbd9…` |
+| `threat-modeling` | `0cc498c5…` | `6bdb1d3b…` |
+| `markitdown` | `ccaac56a…` | `663ee4c4…` |
+| `security-audit` | `8005676c…` | `27ccbdcd…` |
+
+**The ordering claim is re-verified, not assumed to survive.** AC-6 asserts the
+holdout partition's content hash predates the first commit of any proposer
+capability. `git merge-base --is-ancestor 34318f7f ac2501313` returns true:
+`34318f7f5` (2026-08-30 22:11:43) is a topological ancestor of `ac2501313`
+(2026-08-31 00:44:37), which added `src/scripts/_lib/candidate_proposer.ts` and
+`evolution_lab`'s `propose` verb. The near-miss was checked rather than waved
+past: `src/scripts/_lib/harness_evolution_guards.ts` (2026-08-30 17:55:29) names
+"proposer" but is the guard that REFUSES disclosure to one, not a proposer
+capability.
+
+Because the bytes have not moved since a commit that precedes the first proposer
+commit, the re-pin changes which number is written down and changes nothing about
+what the number certifies.
 
 ## Holdout — 18 files, sealed
 
@@ -91,7 +141,7 @@ open and which this file does not settle.
 | `php-coder` | `25950ef2e90e4055ba30de21b32204727dd953275a681f99ac60c5a59592be83` |
 | `playbook-authoring` | `e615f614da3c14439fca70f3477272a8323e579ac4961ce2ce83c3c0f099949b` |
 | `schema-review` | `7c98b3409de8ebb6ef3ee999a46e9c07f69574809c42283b25d2ab384f6cd53f` |
-| `threat-modeling` | `0cc498c5eeafe32b297f73f3bc791883b8efabc01e320e4fd83009ca45002036` |
+| `threat-modeling` | `6bdb1d3b44939ac8f6ba78bb6145ca3bea91adb50991cd44bd700987adf903f2` |
 | `worktree-lifecycle` | `1cdde59eaaadc1cb7dfa1cd86d9852326c352a7dcd884dbcbaa414f36d176326` |
 
 ## Train — 82 files
@@ -154,7 +204,7 @@ open and which this file does not settle.
 | `license-compliance-credits` | `d2838c7b4b722351d54ae91fd226a3314752a038769093f59b505a6e29d63bdf` |
 | `llm-provider-knowledge` | `9cfb3639dd7dee51520aebf2f180ce41ae752229b76716774468f6a9598461a1` |
 | `logging-monitoring` | `5e8406b3c814db3d1e100a1c817a9fce388afd40f4f3caa8230cd8f69e44f0f4` |
-| `markitdown` | `ccaac56a2bf19ba6b404d9fc56a603502fb13bf160be3e5a2b779fc906720940` |
+| `markitdown` | `663ee4c4f9d5c707ff96208d1723d9817639fca7c00b346e43be2cb557610f6a` |
 | `monorepo-workspace` | `766a958aae4898bd938e493be8597b6d8b9ee38914ed95ab87ed867422e38233` |
 | `nda-triage` | `01e4becd20b129780d82d2889099f07a8fe4ee241b31f909d1084af427f4323d` |
 | `operational-readiness` | `da1b223e882ce0a02637befb436d97df4264f96003ce1c55425c75ec62535322` |
@@ -167,7 +217,7 @@ open and which this file does not settle.
 | `reasoning-orchestrator` | `a968ef1f04693b46eb3838b43eb83b092429149069599c3aef2c2e4628701b85` |
 | `refine-ticket` | `bab09021f8664cd0676e9613bd511a3f87d115583ea5f4639fb4800df9715328` |
 | `screenshot-hygiene` | `2493ae6cee8869c659e34610c7ec6a7d7a6f5c76098136c98fa35c90484adb2c` |
-| `security-audit` | `8005676c28b6199c397a524caa72d25384bfac15a9f89293203563b8e41e6ee7` |
+| `security-audit` | `27ccbdcd02b8cf7fbd6b85da1043c680233a6ed840697eac6ef9dace37cb0993` |
 | `security-maturity-assessment` | `071894293d4c9a1997843d9bfc78f69b2fc64c0e5306544756cb6853bfd31b30` |
 | `server-hardening` | `8301bedcbcd9129f8c55d3640e66164baec4753e92a55a8b56df54449e3f3f46` |
 | `skill-writing` | `d2beba3976f5918450cc4fa5c96f7fdae488ef5ffebe1f3b05fe3519acbb8a26` |

--- a/agents/evidence/drain-run-summary.md
+++ b/agents/evidence/drain-run-summary.md
@@ -1,5 +1,146 @@
 <!-- evidence-type: analysis -->
 
+# Autonomous drain run — 2026-08-31 (run 10)
+
+> **The directory is NOT empty, and one roadmap of four archived.** The run found
+> **four** active roadmaps, advanced **all four**, closed **one completely**, and
+> left three active with every remaining item carrying a written reason. Net
+> movement across the estate: **65 → 74 closed steps**.
+>
+> **The seed inventory this run was handed was entirely stale** — it listed 36
+> roadmaps at commit `c536dbd`; the live tree had 4. Recomputed before anything
+> was executed, per the mandate's own instruction not to trust it blindly.
+
+## PRs — 4 opened, one per roadmap, none merged
+
+The run merged nothing. The mandate asked for one PR per roadmap and said
+nothing about merging, and a merge to a production trunk is a Hard-Floor action
+no autonomous mandate lifts.
+
+| PR | Roadmap | Progress | Outcome |
+|---|---|---|---|
+| #1774 | `road-to-obligation-delivery-verification` | 0/3 → 3/3 | **ARCHIVED** |
+| #1775 | `road-to-harness-promotion-bridge` | 0/9 → 7/9 | active; owner decision |
+| #1776 | `road-to-inbox-harvest-…-council-topology-evidence` | 28/77 → 35/77 | active; two Class-3 blockers |
+| #1777 | `road-to-governed-harness-evolution` | 46/59 → 55/59 | active; two guarded baselines |
+
+## Council decisions — 3 rounds, 2 convergent, 1 degraded
+
+**Quota spent: 9 anthropic, 9 openai** against 50 per provider per UTC day. All
+seats subscription-transport; **nothing billed**.
+
+1. **`gh-4-1-cascade-scope`** — may the deterministic prefix of the evaluation
+   cascade close step 4.1? Options A (close on the prefix) / B (build the prefix,
+   keep 4.1 open) / C (build all twelve stages). **Verdict: B, 2/2.**
+   It arrived as an apparent 1/1 split and became a convergence **by
+   measurement**: anthropic returned *"Conditional Option A"* gated on whether
+   Phase 1's families are failure-mode buckets or observation methods, and said
+   plainly *"Neither reviewer noticed we're guessing what Phase 1 families
+   mean."* Checked against the tree — step 1.1 reads *"classifiable … from the
+   recorded receipt alone"* — the condition fails, and anthropic's own rule then
+   selects B. The seat that lost the vote supplied the thing that made the
+   decision checkable.
+
+2. **`odv-delivery-closure`** — how does `road-to-obligation-delivery-verification`
+   close honestly? Options A (documented propagation model) / B
+   (BLOCKED-BY-ARCHITECTURE) / C, plus dispositions D1–D3. **Verdict: B + D3,
+   2/2 convergent.**
+   Option A was the run's own proposal and was **refuted**: *installation proves
+   availability, and AC-1 requires exposure.* A `type: auto` rule enters context
+   only on a trigger match, so a corpus defined as "sessions after the install
+   timestamp" necessarily contains sessions where the rule was installed and
+   never projected. Both seats refused to redefine *exposed* as *available*,
+   which would have lowered an owner-reserved floor.
+
+3. **`gh-44-and-ac10`** — 4.4's ranking/tie-break/replacement rule and the
+   `0.6` constant; and AC-10's re-key. **DEGRADED, single seat** —
+   anthropic returned `exit_1` with no output, the same seat-and-shape failure
+   already recorded for a long multi-decision question. Verdicts: **2c revised**
+   (recency, with a total ordering) and **D** (split AC-10 rather than re-key it).
+   The seat refuted the run's proposed re-key: *"that proves only that those
+   files were untouched. A daemon could be introduced entirely in source or
+   deployment config."*
+
+### One council question was NOT asked, and the refusal is the finding
+
+**`merge-authority`** was to be settled by option (b) — refusing preauthorized
+merge authority — on the argument that refusing *strengthens* a floor and is
+therefore council-decidable. **The question never reached a seat: the harness
+safety classifier refused it twice.**
+
+That refusal is more informative than a verdict would have been. ADR-239 § Decision 3
+reserves this decision because *"an agent that both wants the capability and
+writes the amendment authorising it is the shape the reservation exists for"* —
+and an agent drafting that amendment is exactly what the classifier saw. Two
+mechanisms sharing no code reached the same verdict about the same act.
+
+The argument is **undelivered, not refuted**. The run stopped rather than
+rephrasing past a safety refusal, which would have been the reservation defeated
+by persistence. Recorded in the roadmap so no future round rediscovers it.
+
+## Descopes and transfers
+
+| Item | Where it went | Why |
+|---|---|---|
+| AC-1 of `obligation-delivery-verification` | new stub `road-to-obligation-exposure-instrumentation.md`, `review_by: 2026-09-30` | exposure is unprovable under `type: auto` with no per-session record; carried **unweakened**, ten-session floor and exposure reading intact |
+| AC-9 of `harness-promotion-bridge` | left `[ ]` in place | needs a real promotion by a human; splitting it into a stub would not unblock the roadmap, which is gated on the same owner decision |
+| AC-10 of `governed-harness-evolution` | split into AC-10a `[-]` superseded + AC-10b `[x]` | byte-identity impossible because a *different* roadmap retired the claim by decision; purpose re-keyed onto the P2 boundary that still exists |
+
+## Findings — things that were wrong in the tree, not in the work
+
+1. **The holdout pin did not reproduce.** `SET-SHA256 7e091dfc…` yielded
+   `0667fbd9…`. The corpus was checked before the pin was blamed and is intact;
+   the cause is that the commit which *recorded* the freeze also edited three of
+   the files it was freezing, so three rows and the set hash were **stale on
+   arrival**. Re-pinned; 100/100 rows now reproduce, and a new test recomputes
+   the recipe — a stale pin is invisible to anyone who re-runs the recipe and
+   compares it to nothing.
+2. **The batching obligation is in zero installed trees**, and an earlier
+   analysis had grepped the *wrong heading* (`Size-gated reads`, which IS
+   installed) and drawn its conclusion from that mis-grep. The conclusion
+   survived; the reasoning did not.
+3. **Step 4.4's `0.6` had no referent.** The objection warning against reusing it
+   assumed it meant textual similarity. No such constant exists.
+4. **Path ownership is enforced inside the schema parse**, so its failures were
+   attributed to the wrong cascade stage — and the failing stage is what the
+   Phase 1 classification reads.
+5. **The retention defect's cause is established**, superseding the recorded
+   hypothesis: the auto-prune inside `save()` has **no production caller at all**.
+   764/798 response files are past a declared 7-day TTL because no reaper runs.
+6. **5.1 measured `harmful`, not the permitted null** — the primary bar was
+   cleared (+5.68 pp, p = 0.0371) and the guard was breached (+7.22 pp). A
+   one-sided pre-registration would have shipped a routing regression while
+   reporting an improvement.
+7. **6.4's ceiling was breached and reported as breached** — 35.40 pp against
+   20.0, clearing at no k ≤ 20.
+
+## Sensitivity probes that found gaps rather than confirming tests
+
+Three probes came back **green when they should have gone red**, and each one
+changed the work rather than being noted and moved past:
+
+- Deleting the `WHY` axis from the pathology cell key left **23/23 green** — the
+  existing case differed on both axes. Two axis-isolating tests added.
+- Neutralising the cascade's stage-2 abort left **15/15 green**, proving that
+  branch unreachable. It is now labelled an unproven guard rather than counted as
+  defense in depth.
+- A shortlist sabotage passed **23/23** because every earlier case shortlisted
+  every match. Two cases added under the still-sabotaged tree, observed red first.
+
+## What remains, and what would move it
+
+- **`governed-harness-evolution`** — 4.1 and 5.4 and 5.6 are guarded baselines
+  (RED-proved, not complete); AC-8 needs a candidate run against a metered
+  backend that step 5.2 forbids. 4.1 moves when a receipt producer exists.
+- **`harness-promotion-bridge`** — one owner decision on ADR-239 § Decision 3.
+  Nothing else.
+- **`council-topology-evidence`** — two Class-3 blockers. Phase 2 prices itself
+  at 1,584–1,804 provider calls across **20 consecutive UTC days** monopolising
+  both providers, and the roadmap already records that at N=2 it licenses no
+  promotion claim at all. That re-scope is a decision, not an execution.
+
+---
+
 # Autonomous drain run — 2026-08-31 (run 9)
 
 > **The directory is NOT empty, and emptying it was not reachable.** The run was

--- a/agents/roadmaps/road-to-governed-harness-evolution.md
+++ b/agents/roadmaps/road-to-governed-harness-evolution.md
@@ -1578,13 +1578,95 @@ once.
       is a STATED default at the conservative end of `lint_originality`'s range,
       not a measured optimum; `revisit-if` a screening run rejects a proposal a
       curator then re-adds by hand, or admits one a human calls a duplicate.
-- [ ] **5.6 Cheap proposer models first, and track evolution ROI.**
+- [ ] <!-- roadmap-status: guarded-baseline --> **5.6 Cheap proposer models first, and track evolution ROI.**
       `from-skipped-parent`, and this one is self-undercutting in the master:
       its own cross-critique faults both parents as cost-blind and answers with
       a hard budget cap, while dropping the only cost-*reduction* mechanism both
       parents proposed. Improvement per evolution dollar is a reported figure.
       verify: the ROI figure appears in every run report, and a cheaper model is
       tried before an expensive one on each defect class.
+      ```yaml
+      guarded_baseline:
+        category: future-mechanism
+        scope: src/scripts/_lib/evolution_roi.ts (assertCheapestFirst, LADDER, nextTier)
+        command: npx vitest run tests/scripts/_lib/evolution_roi.test.ts
+        red_proof: sabotage run 2026-08-31 — cheapest-first comparison neutralised, 3 of 28 tests RED, 28/28 GREEN after restore
+        sabotage_model: replaced the guard condition `if (cheapest !== null && a.tier !== cheapest)` at src/scripts/_lib/evolution_roi.ts:217 with `if (false)`, so an escalation past an untried cheaper rung stops being refused
+        recheck_when: src/scripts/_lib/ladder_attempt_recorder.ts recordLadderAttempt
+        discharged_ac: the ROI half is met with a live subject — every completed run of the `run` verb emits a report and buildRunReport REFUSES one without the figure
+        pending_ac: "a cheaper model is tried before an expensive one" under a real attempt sequence — nothing in this tree makes a metered proposer call, so the ordering is policed over a population of zero
+      ```
+      **PARTLY DONE 2026-08-31, and the split is per verify-clause conjunct
+      rather than per convenience.** `src/scripts/_lib/evolution_roi.ts`.
+      **The ROI conjunct is CLOSED, with a production caller.** `buildRunReport`
+      (`src/scripts/_lib/evolution_roi.ts:363`) REFUSES a report whose ROI
+      figure is absent or carries an unknown kind — the same shape
+      `_lib/evaluation_vector.ts:103`'s `buildVector` uses to refuse a vector
+      that omits its artifact-count row, and refused at RUNTIME because the
+      caller who drops the row is a JSON parse or an `as` cast the compiler
+      cannot see (proved with a `delete` past the type,
+      `tests/scripts/_lib/evolution_roi.test.ts:140`). The caller is real, not a
+      unit test: `verbRun` builds the report on the ONE path a run completes on
+      (`src/scripts/evolution_lab.ts:779`) and writes it to stdout
+      (`:800`), and evaluation evidence is parsed BEFORE the first clone
+      (`:745`) so a malformed vector aborts before the run spends anything.
+      Reproduce with
+      `./scripts-run src/scripts/evolution_lab run --record REC.json --vector VEC.json --estimated-spend-cents 250`.
+      **The figure is a union, not a number, because a ratio is not always
+      defined.** `ratio` at positive spend with something evaluated,
+      `no-spend` at zero spend, `unmeasured` when no candidate carried an
+      evaluation (`:302`). Neither `Infinity` nor `NaN` can reach a report, and
+      both are pinned. `unmeasured` is the honest state of this programme today
+      and reads as a finding: `run` clones and nothing in Phase 5 evaluates,
+      because 5.2 keeps the live-floors park intact.
+      **Measured end-to-end on the real CLI, not only in the builder's unit
+      test.** `tests/scripts/evolution_lab.test.ts:409` spawns the process over
+      five real clones and asserts exactly ONE `run-report: roi:` line on its
+      stdout reading `unmeasured`; a second invocation supplying a vector with
+      one `pass` row at 250 cents prints `0.400 improved rows per dollar`. The
+      vector goes through `parseMetricVectorJson` (`:428`), which calls
+      `buildVector` and therefore INHERITS the artifact-count refusal rather
+      than re-implementing it — verified against the live CLI, which rejects a
+      vector missing that row before any clone is made.
+      **Sensitivity proved on both halves, separately.** Deleting the report
+      emission from `verbRun` turns the e2e assertion RED (`expected [] to have
+      a length of 1`), 25/26 → restored 26/26; neutralising the ROI refusal in
+      `buildRunReport` turns the negative-polarity case RED, 27/28 → restored
+      28/28.
+      **The cheapest-first conjunct has NO LIVE SUBJECT, and that is why this
+      step is `guarded-baseline` and not `[x]`.** Policing "a cheaper model is
+      tried before an expensive one" needs an attempt sequence, and no step in
+      this roadmap invokes a live routing harness — 5.2, held by
+      `tests/scripts/governed_harness_no_live_harness.test.ts` (9/9 on this
+      branch, and its half B now scans `evolution_roi.ts` too, since that module
+      names this roadmap). So what shipped is an ordering POLICY plus a guard
+      proved to fire: `LADDER` (`:101`) is cheapest-first per defect class,
+      `assertLadderWellFormed` (`:132`) refuses a ladder that skips a rung —
+      which would try an expensive tier before a cheaper one by construction —
+      and `assertCheapestFirst` (`:191`) refuses an out-of-order attempt
+      sequence. Both are exercised in both polarities.
+      **Three defect classes carry an EMPTY ladder, which is the strongest cost
+      reduction available rather than an omission.** `policy_blocked`,
+      `dependency_unavailable` and `human_rejected` license NO metered attempt
+      at all: a candidate a policy refused, one that could not find its
+      dependency, or one a human turned down is not made acceptable by a larger
+      model. `nextTier` returns `null` there and the report prints
+      `next: spend nothing`; a metered attempt against such a class is refused
+      outright. The classes are REUSED from `_lib/pathology_archive.ts:65`'s
+      closed `PATHOLOGY_WHY` vocabulary — a second defect taxonomy beside it
+      would be the drift 4.4 exists to prevent — and a test pins the ladder's
+      key set against it so a vocabulary addition cannot leave a class
+      unpriced.
+      **Tiers are vendor-neutral (`lite < medium < high`, `:86`) on purpose.**
+      Naming a model would tie a cost policy to a price list that changes
+      without this file, and would put a vendor name into a module this
+      roadmap's own live-harness scan reads.
+      **What this does NOT establish.** That the ladder's per-class assignments
+      are the right ones. They are a stated policy with a written reason each,
+      not a measurement — nothing has been run cheap-first and then expensive to
+      compare. `revisit-if`: a run records a defect class where the cheap rung
+      never resolves anything, or one where an empty ladder blocked a fix a
+      model would have made.
 
 ## Phase 6 — Delivery: measure the existing substrate first
 

--- a/agents/roadmaps/road-to-governed-harness-evolution.md
+++ b/agents/roadmaps/road-to-governed-harness-evolution.md
@@ -1991,9 +1991,46 @@ once.
       Closing on the scanner alone would be closing on the met half of a
       conjunction. What closes it is a caller: 4.1's cascade, or `promote`
       consulting the verdict before it refuses.
-- [ ] AC-6 — The holdout partition's content hash predates the first commit of
+- [x] AC-6 — The holdout partition's content hash predates the first commit of
       any proposer capability, and a run leaking a holdout value into proposer
       context exits non-zero.
+      **CLOSED 2026-08-31 — the first conjunct's re-pin was PERFORMED, and a
+      guard now stands where the audit found none.** The audit below predicted
+      exactly this closure and is preserved rather than deleted, because it is
+      the record of what was falsified and why.
+      **The re-pin.** `agents/evidence/analysis/trigger-corpus-holdout-2026-08-30.md`
+      now publishes `SET-SHA256 0667fbd9…` in place of the stale `7e091dfc…`,
+      and the three per-file rows the freeze commit had pinned at pre-edit
+      bytes — `threat-modeling` `0cc498c5…` → `6bdb1d3b…`, `markitdown`
+      `ccaac56a…` → `663ee4c4…`, `security-audit` `8005676c…` → `27ccbdcd…`.
+      **Verified rather than asserted: 100 of 100 per-file rows and the set hash
+      now reproduce** from the artefact's own documented recipe on this tree, and
+      `git diff 34318f7f..HEAD` over the three paths is empty, so the re-pin
+      names the frozen bytes and not some later state.
+      **The ordering half was re-verified, not assumed to survive the re-pin.**
+      `git merge-base --is-ancestor 34318f7f ac2501313` returns true —
+      `34318f7f5` (2026-08-30 22:11:43) precedes `ac2501313`
+      (2026-08-31 00:44:37), which added `_lib/candidate_proposer.ts` and
+      `evolution_lab`'s `propose` verb. The near-miss was re-checked:
+      `_lib/harness_evolution_guards.ts` (2026-08-30 17:55:29) names "proposer"
+      but is the guard that REFUSES disclosure to one.
+      **What makes this durable rather than a one-off fix**, and it is the part
+      the audit could not have supplied: a stale pin is invisible to anyone who
+      re-runs the recipe and compares it to nothing.
+      `tests/scripts/trigger_corpus_holdout_pin.test.ts` recomputes the recipe
+      from the tree and asserts every published row AND the set hash reproduce,
+      with an anti-vacuity assertion so a scan over an empty corpus cannot pass.
+      **Proved SENSITIVE in both directions before it was trusted.** Appending
+      one byte to `src/skills/markitdown/evals/triggers.json` turned it red on
+      *"the published SET-SHA256 reproduces"* and *"every per-file row
+      reproduces"* (2 failed / 3 passed); restoring the byte returned 5/5.
+      Independently, falsifying the artefact's own `SET-SHA256` line turned it
+      red on one assertion (1 failed / 4 passed) and restoring returned 5/5. So
+      it fires on a corpus edit and on a pin edit, which are the two ways this
+      claim can go stale.
+      **Second conjunct unchanged and still met** —
+      `tests/scripts/harness_evolution_guard_call_sites.test.ts` 15/15, a holdout
+      value reaching proposer context exits 4 before any external call.
       **Audited 2026-08-31: the second conjunct is met, the first is
       FALSIFIED — by reproduction, not by doubt.**
       Second conjunct — met.

--- a/agents/roadmaps/road-to-governed-harness-evolution.md
+++ b/agents/roadmaps/road-to-governed-harness-evolution.md
@@ -1755,7 +1755,7 @@ once.
       detector DOES find all three declarations inside `router_match.ts` itself —
       a scanner tested only on hand-written strings can be silently wrong about
       the syntax it has to read.
-- [ ] **6.3 Only then consider a lexical shortlist, and only as a shortlist.**
+- [x] **6.3 Only then consider a lexical shortlist, and only as a shortlist.**
       Over the existing BM25 core. No embeddings —
       `docs/contracts/no-runtime-boundary.md:40` classifies a vector/embedding
       index as a **contract violation**, not a preference: "a vector/embedding
@@ -1763,6 +1763,104 @@ once.
       Class C". The BM25 core passes the same test. The skipped parent proposed
       the shortlist and explicitly refused it as final truth.
       verify: the shortlist feeds a later stage and never decides alone.
+      **DONE 2026-08-31.** `src/scripts/_lib/lexical_shortlist.ts`, over
+      `_lib/lexical_index.ts` — the hand-rolled BM25 core that already ships.
+      **THE CITATION IN THIS STEP HAD MOVED, and the constraint had not.**
+      `docs/contracts/no-runtime-boundary.md` was superseded on 2026-08-27 by
+      ADR-249 and is now a pointer stub whose line 40 reads
+      *"Its literal scope was Mission-Mode"* — not the classification quoted
+      above. The substance survived the move verbatim and is cited from its live
+      home instead: `docs/contracts/resident-process-governance.md:82`,
+      *"A code-graph cache passes; a vector index fails"*, under the P3
+      state-store test, with the P4 row at `:76` separately prohibiting any
+      index build requiring network or model calls. The step's quoted text is
+      left standing above rather than rewritten, because it is what the step
+      was written against; this note is the correction.
+      **The ordering dependency in "only then" is satisfied and was checked
+      rather than assumed.** 6.1 is `[x]` with
+      `agents/evidence/analysis/governed-harness-three-arm-delivery.md` present,
+      and 6.2 is `[x]` with `single_matcher_preserved.test.ts` 8/8 — so the
+      three arms were measured before this retrieval component was written,
+      which is exactly what 6.1's own verify clause reserved.
+      **AC-7's ordering claim SURVIVES this step, and its wording is now
+      historical.** That criterion reads *"measured against one another before
+      any new retrieval component exists"* — a temporal claim, and 6.1's
+      measurement was committed before this component, so it holds. Its audit
+      note's phrase *"6.3 has not started"* described the tree on 2026-08-31
+      before this commit and is left standing as the record of that moment; it
+      is not a live condition and nothing here reopens AC-7.
+      **First conjunct — it feeds a later stage, MEASURED, not asserted.** The
+      later stage is the per-prompt byte cap in `selectForInjection`, which now
+      takes an optional fourth argument
+      (`src/scripts/_lib/rule_injection.ts:224`) used as a TIE-BREAK. Wired
+      through `ArmExperimentInput.shortlist`
+      (`src/scripts/_lib/delivery_arm_experiment.ts:108`) to a real CLI flag,
+      `model_rule_injection --three-arm --shortlist`
+      (`src/scripts/model_rule_injection.ts:834`, flag at `:895`) — this is not
+      an unwired library. Run over `tests/eval/routing-matrix` on this commit:
+      OFF gives `delivery` 0.990 (302/305), 1 cap-drop, mean 2,026 injected
+      tokens; ON gives 0.984 (300/305), 3 cap-drops, mean 2,016. The shortlist
+      demonstrably changes what the cap does, which is the falsifiable form of
+      "feeds a later stage" — a shortlist nothing downstream reacts to would
+      have produced two identical tables.
+      **It currently makes delivery slightly WORSE, and that is reported rather
+      than tuned away.** −2 positives at the same corpus and cap. 6.3's verify
+      clause is about the shortlist's ROLE, not its win, and the pre-registered
+      loss ceiling that would adjudicate the trade-off is step 6.4, which is
+      `[ ]`. So the flag ships default-OFF: the 6.1 baseline reproduces
+      byte-for-byte without it (1.000 / 0.000 / 0.990 at 120,743 / 18,223 /
+      18,223, mean 2,026 p90 4,144), and a test pins that the absent argument is
+      the pre-6.3 behaviour.
+      **Second conjunct — never decides alone, closed in BOTH directions by
+      construction.** A shortlist decides alone by ADDITION (delivering what the
+      matcher never fired on) or by SUBTRACTION (removing a matcher hit, which
+      is a decision dressed as a filter). `orderByShortlist` (`:155`) takes the
+      matcher's output as its input domain and returns a PERMUTATION of it;
+      `assertPermutation` (`:171`) refuses any result whose id multiset differs
+      in either direction, counting multiplicity. At the cap, the same holds
+      independently: a shortlisted id absent from `matches` is never consulted,
+      and an unshortlisted match sorts at `Infinity` — behind the shortlisted
+      ones and still competing for the cap, never removed. The near-miss false
+      context stays 0/194 with the shortlist ON, which is the empirical form of
+      "added nothing".
+      **Subordination is a comparator key ORDER, and both implementations of it
+      are pinned.** `score desc → shortlist rank → router order`. The matcher's
+      verdict is read first and the shortlist only breaks its ties. The order
+      exists twice — in `orderByShortlist` and in the cap walk — so both are
+      tested, because a second implementation of one comparator is a thing that
+      drifts.
+      **Sensitivity proved by two sabotages, and the second one found a real
+      hole in the first test set.** (A) Turning `orderByShortlist` into
+      `filter(shortlisted).sort(rank)` — the shape a shortlist naturally
+      degrades into — turned 5 of 23 cases RED with the message *"the shortlist
+      changed the matcher`s set instead of ordering it — dropped r-b … decides
+      by subtraction"*; restored 23/23.
+      (B) Making the cap walk filter to the shortlist AND rank it above the
+      matcher score passed all 23 — because every case then shortlisted EVERY
+      match, so a membership filter changed nothing. Two cases were added under
+      the still-sabotaged tree and observed RED
+      (`tests/scripts/_lib/lexical_shortlist.test.ts:182` and `:193`,
+      *"expected ['command-suggestion-policy'] to deeply equal ['architecture',
+      …(5)]"*), then the sabotage was restored and the file is 25/25. The gap is
+      recorded rather than quietly patched: a sabotage that passes is the test
+      set's finding about itself.
+      **No embeddings, established by a scan proved to fire first.** Six banned
+      construct classes — embedding call, embedding identifier, vector store,
+      cosine similarity, network, child process — are matched against
+      `lexical_shortlist.ts` AND `lexical_index.ts`, after being shown to FIRE
+      on six synthetic sources and to stay silent on plain BM25 arithmetic. The
+      scanned byte count is asserted, because a scan over nothing exits green.
+      The module's import list is pinned to exactly
+      `['./lexical_index.js', './rule_injection.js']`. The banned literals live
+      in the test rather than in the module for a mechanical reason: a scanner
+      whose banned strings sit in the file it scans matches its own declaration
+      and can never pass.
+      **No second matcher.** This module answers "which text is lexically
+      closest", never "which rules fire on this prompt" — that stays
+      `_lib/router_match.ts`. `router_match_parity` (5/5),
+      `single_matcher_preserved` (8/8), `delivery_arm_experiment` (11/11),
+      `model_rule_injection` (13/13) and `rule_inject_hook` (16/16) are green on
+      this branch.
 - [ ] **6.4 Pre-register the loss ceiling, and measure set compatibility.**
       Recall-loss ceiling and token target fixed first; report precision,
       recall, false activation, context cost, benefit **conditional on**

--- a/agents/roadmaps/road-to-governed-harness-evolution.md
+++ b/agents/roadmaps/road-to-governed-harness-evolution.md
@@ -1791,9 +1791,48 @@ once.
       computation. Both are reported at the same value rather than one being
       dropped; the pair that genuinely differs is unconditional 64.60 % against
       conditional 82.51 %, and the 17.9 pp gap IS the delivery failure.
-- [ ] **6.5 Index the body only if 5.1 measured a signal.** Otherwise
+- [x] **6.5 Index the body only if 5.1 measured a signal.** Otherwise
       description-only.
       verify: the indexer's input set derives from the 5.1 verdict file.
+      **DONE 2026-08-31 — description-only, and the mechanism DERIVES it rather
+      than knowing it.** `src/scripts/_lib/routing_index_input.ts`.
+      `resolveIndexInput` opens
+      `agents/evidence/analysis/routing-body-signal-verdict.json`, reads
+      `body_signal.verdict`, and returns `['name','description','body']` on the
+      literal token `signal` (`:87`) and `['name','description']` on anything
+      else. It carries no opinion about the body — the outcome today is
+      description-only because 5.1 measured `harmful`, not because a literal
+      says so.
+      **The consumer is real, not a demo.** `measure_delivery_sets`
+      (`src/scripts/measure_delivery_sets.ts:133`) used to hardcode the
+      `description` arm; it now resolves it, and publishes
+      `index_input.{fields, verdict, reason}` in its record, so the derivation
+      is observable in `agents/evidence/analysis/delivery-set-measurement-2026-08-31.json`
+      rather than merely asserted here.
+      **THE SABOTAGE THE STEP ASKS FOR — the verdict file was flipped and the
+      input set followed, downstream numbers included.** Verdict → `signal`:
+      input `name + description + body`, precision@5 82.51 → 77.05 %, recall@5
+      64.60 → 70.28 %, adjudicated deliveries 303 → 353. Verdict deleted: back to
+      `name + description`, reason *"no readable 5.1 verdict … fail-closed"*.
+      Verdict `signal` with `proxy_to_real_fidelity` stripped: still
+      `name + description`, reason *"carries no proxy_to_real_fidelity bound —
+      refused"*. The tree was restored and re-measured to the committed figures
+      after each.
+      **FAIL-CLOSED ONLY NARROWS.** Missing file, unparseable JSON, unknown
+      token, and a provenance-stripped record all resolve to description-only
+      (`:73`). A stale or edited record can never widen what is indexed, and the
+      measured price of widening on a `harmful` verdict is +7.22 pp of false
+      activation. The bound gate is deliberate: 5.1 ships
+      `proxy_to_real_fidelity` inside the verdict so a consumer cannot take the
+      conclusion without it, and a record that lost it is refused rather than
+      half-trusted.
+      **SENSITIVITY, two sabotages, each red then green**
+      (`tests/scripts/routing_index_input.test.ts`, 8 tests): (a) hardcoding the
+      resolver to description-only — which is TODAY`S CORRECT ANSWER and still
+      reds the `signal`-widens case, 1 red, restored 8 green; (b) removing the
+      fidelity-bound gate — 1 red on the stripped-record case, restored 8 green.
+      No test writes the tracked verdict file; every fixture lives in a temp
+      directory.
 
 ## Phase 7 — Promotion bridge and the lifecycle after it
 

--- a/agents/roadmaps/road-to-governed-harness-evolution.md
+++ b/agents/roadmaps/road-to-governed-harness-evolution.md
@@ -2272,14 +2272,38 @@ once.
 - [ ] AC-8 — Programme success and failure criteria from 0.7 were committed
       before the first candidate run, and the run report carries an
       evolution-ROI figure.
-      **Audited 2026-08-31: first conjunct met, second not met.**
+      **RE-AUDITED 2026-08-31 after 5.6 landed: still OPEN, and the reason
+      moved rather than went away.**
+      *First conjunct, unchanged:*
       `agents/evidence/analysis/governed-harness-success-criteria.md` was
       committed at `172b87c6` (2026-08-30 10:32:57) and no candidate run has
       happened at all, so the criteria precede it — a real but currently
-      vacuous satisfaction, and worth naming as such. The second conjunct has no
-      subject: there is no run report anywhere in the tree, and the
-      evolution-ROI figure is step 5.6, which is `[ ]`. What closes it is 5.6
-      plus a first run whose report carries the figure.
+      vacuous satisfaction, and still worth naming as such.
+      *Second conjunct, half-closed.* 5.6 built the missing subject: a run
+      report now exists, `buildRunReport`
+      (`src/scripts/_lib/evolution_roi.ts:363`) REFUSES one without the ROI
+      figure, and `evolution_lab`'s `run` verb emits it on the one path a run
+      completes on (`src/scripts/evolution_lab.ts:779`). Any report this
+      programme produces from here on carries the figure structurally rather
+      than by an author remembering to add it. That is the SHAPE half.
+      **What is still missing is the run, and it is not reachable in this
+      roadmap.** A `run` invocation today clones candidate trees and evaluates
+      nothing — its honest ROI kind is `unmeasured`, which is the report telling
+      the truth. A *candidate run* in this programme's sense evaluates
+      candidates against an eval corpus over repeated trials, which needs a
+      metered backend, which step 5.2 forbids: no step in this roadmap invokes
+      a live routing harness, and
+      `tests/scripts/governed_harness_no_live_harness.test.ts` holds it.
+      **A fixture is not the first candidate run, and none of the artefacts
+      5.6 shipped is offered as one.** The end-to-end case at
+      `tests/scripts/evolution_lab.test.ts:409` drives the real CLI over five
+      real clones and asserts the report reaches stdout; it proves the report
+      is emitted, and it evaluates no candidate. Reading it as the run would be
+      exactly the substitution this criterion exists to catch.
+      **What closes it:** a first candidate run under a metered backend, which
+      belongs to whichever roadmap lifts the live-harness park — not to this
+      one. Until then AC-8 is `[ ]` with its shape half done and its subject
+      half absent.
 - [-] AC-9 — At least one promoted artefact has been through post-promotion
       re-evaluation and at least one RETIRE path has been exercised, so the
       lifecycle is shown to close in both directions.

--- a/agents/roadmaps/road-to-governed-harness-evolution.md
+++ b/agents/roadmaps/road-to-governed-harness-evolution.md
@@ -1448,7 +1448,7 @@ once.
       Pre-registration `agents/evidence/analysis/routing-signal-preregistration-2026-08-31.md`,
       commit **`fe8749458`**. Measurement
       `src/scripts/measure_routing_signal.ts` + `src/scripts/_lib/routing_corpus.ts`,
-      commit **`MEASUREMENT_SHA`**. `git merge-base --is-ancestor fe8749458 MEASUREMENT_SHA`
+      commit **`a86bd899c`**. `git merge-base --is-ancestor fe8749458 a86bd899c`
       is the ordering clause, checked in the history rather than asserted: the
       prereg commit adds no measurement module and runs nothing.
       **Both gaps are named separately, and only one was answerable here.** Gap A

--- a/agents/roadmaps/road-to-governed-harness-evolution.md
+++ b/agents/roadmaps/road-to-governed-harness-evolution.md
@@ -1018,7 +1018,121 @@ once.
 > outcome per case, expected-vs-observed is recorded against stable case ids at
 > that point — not before, and not as an empty file that looks like a carrier.
 
-- [ ] **4.1 Cascade cheap to expensive, abort on the first hard failure.** The
+- [ ] <!-- roadmap-status: guarded-baseline -->
+      **4.1 Cascade cheap to expensive, abort on the first hard failure.** The
+      **GUARDED BASELINE 2026-08-31 — the deterministic prefix is built, wired
+      and RED-proven; the box stays `[ ]` because the twelve-stage form is not.**
+
+      ```yaml
+      guarded_baseline:
+        category: future-mechanism
+        scope: src/scripts/_lib/evaluation_cascade.ts
+        command: npx vitest run tests/scripts/evaluation_cascade.test.ts
+        red_proof: sabotage run 2026-08-31 — 2 failed / 13 passed, then 1 failed / 14 passed
+        sabotage_model: let the prefix assign `activation`; then unwire the cascade from the runner
+        recheck_when: src/scripts/_lib/evaluation_receipt.ts
+        discharged_ac: the deterministic prefix aborts on the first hard failure at zero model calls, and AC-3 and AC-5 close on its production caller
+        pending_ac: the receipt-bearing stages and one settled twelve-stage enumeration
+      ```
+
+      **AI council 2026-08-31, and it resolved to a CONVERGENT Option B — but
+      only after a tie-break that the tree answered, so the route is recorded
+      rather than the conclusion alone.** anthropic/claude-sonnet-4-5 returned
+      *"Conditional Option A"*, explicitly gated: *"Choose Option A IF AND ONLY
+      IF verification confirms Phase 1 families are failure-mode buckets, not
+      observation methods … If either verification fails: Option B."*
+      openai/codex-default returned Option B outright. Both seats present, 2/2.
+      **The condition was checked against the tree and it FAILS**, which makes
+      this a convergence and not a split: Phase 1's step 1.1 verify clause reads
+      *"a deliberately failing trigger eval is classifiable as content vs
+      activation vs adherence **from the recorded receipt alone**"* — a receipt
+      is an observation, so the families are observation-grounded and Option A's
+      own precondition is false. Both seats therefore land on B.
+      **The seat that lost the vote supplied the thing that mattered.** It was
+      anthropic that noticed nobody had verified what the families actually are:
+      *"Neither reviewer noticed we're guessing what Phase 1 families mean."*
+      That objection is what made the decision checkable instead of a preference.
+
+      **What Option B licensed, and what it refused.** Both seats agreed the
+      deterministic prefix should be built now and both refused to let it close
+      4.1. openai: *"That supports implementing the prefix — not declaring the
+      full cascade complete."*
+
+      **Built: `src/scripts/_lib/evaluation_cascade.ts`**, six stages, aborting
+      on the first hard failure —
+      `schema-validity → path-ownership → holdout-disclosure → budget →
+      near-duplicate → metric-verdict`.
+      **Every stage is free**, which is why these six are the ones that can ship
+      without receipts, and it makes *"a candidate failing the cheapest stage
+      consumes no model call"* structurally true rather than asserted:
+      `model_calls` is a literal `0` on every path, not a counter, because there
+      is no code path in the module that could increment one.
+      **No stage is SOFT**, per the earlier round's convergent finding — every
+      stage either passes or aborts, with no third warn outcome a caller could
+      ignore.
+      **The prefix may assign only `content` and `unknown`.**
+      `PREFIX_ASSIGNABLE_FAMILIES` excludes `activation` and `adherence` by
+      construction and a test pins it, because assigning either from a
+      deterministic proxy is exactly the evidence-manufacturing openai named: *"a
+      holdout leak is not evidence of an `activation` failure … that produces
+      labels, but not trustworthy classifications."* No fifth family is invented.
+
+      **Wired into the real runner** — `evolution_lab.ts` `verbRun`, which
+      previously cloned and returned. It now re-reads each record from disk and
+      runs the cascade over it, so stage 1 is a real gate at the call site
+      rather than a formality over an already-parsed object, and it reports each
+      candidate's outcome, family and `model_calls` on stdout. A run with no
+      metric rows aborts at the verdict stage rather than passing silently,
+      which is the honest outcome for a run that measured nothing.
+
+      **A defect this work found in the tree, recorded rather than smoothed
+      over.** An unowned mutation path does NOT reach a distinct path-ownership
+      stage: `parseMutations` already calls `assertMutationPathsOwned`
+      (`_lib/candidate_record.ts:434`), so it throws inside stage 1. Catching
+      that as a schema failure would file a path-ownership violation under the
+      wrong stage — and the failing stage is precisely what Phase 1's
+      classification reads, so the mis-attribution would corrupt the
+      classification rather than merely mislabel a message. The cascade now
+      attributes it to stage 2 explicitly.
+      **The consequence is that stage 2's own re-check is UNREACHABLE and
+      therefore untested, and it is labelled as such in the code instead of
+      being counted as defense in depth.** Measured: neutralising its abort left
+      **15/15 green**. It is kept because it is free and fails closed if the
+      parser ever stops enforcing ownership, but an unproven guard is written
+      down as unproven.
+
+      **Sensitivity was OBSERVED in three directions and the first probe found a
+      real gap rather than confirming the tests.** (1) Neutralising the stage-2
+      abort: **15/15 stayed green** — the finding above, and the reason stage 2
+      now carries a label instead of a claim. (2) Letting the prefix assign
+      `activation`: 2 failed / 13 passed, naming both the family-permission test
+      and the holdout-classification test. (3) Unwiring the cascade from the
+      runner: 1 failed / 14 passed on *"a run EVALUATES each candidate"*. Every
+      probe restored to 15/15 and both files restored byte-identically.
+
+      **A downstream break this work caused, and the design it forced.** Wiring
+      the cascade initially made `run` exit non-zero whenever no metrics were
+      supplied, which reddened the existing
+      *"run materialises five candidates, compare passes, clean removes exactly
+      them"* in `tests/scripts/evolution_lab.test.ts` (expected 0, got 3). The
+      test was RIGHT and the change was wrong: materialising without measuring
+      has not failed, and turning it into a failure would have changed a verb's
+      contract to make a new stage look reachable. Fixed by giving the cascade a
+      THIRD outcome — `incomplete` — which is neither a pass (there is no
+      verdict, so nothing may read one) nor an abort (nothing failed). The run
+      prints `metric-verdict NOT REACHED` and exits 0. Naming the state is what
+      keeps "no metrics" from being silently benign; the alternative was to let
+      an unmeasured candidate read as evaluated.
+
+      **What is NOT built, stated so the closure cannot be read as more than it
+      is.** The receipt-bearing stages — activation/delivery, adherence, and the
+      statistical stages — are absent, because they need an independent,
+      append-only receipt producer with version-bound attributable observations,
+      and no such producer exists. One settled twelve-stage enumeration is also
+      still missing: the prior round recorded that one seat asked twice and
+      produced two materially different enumerations, which is why the arity was
+      decided and the stage semantics were not. `recheck_when` above names the
+      receipt module whose arrival reopens this step.
       stage set is E9; if the 12-stage form is chosen, activation/delivery and
       adherence are their own stages, which is what Phase 1's exit criterion
       requires.
@@ -2019,9 +2133,26 @@ once.
       `road-to-turnaround-followups` has entered the active set — it measures 0,
       so it needs no row. Same scope caveat as AC-1: the estate moves, and a new
       overlapping plan re-opens this.
-- [ ] AC-3 — A candidate variant of one harness dimension can be materialised,
+- [x] AC-3 — A candidate variant of one harness dimension can be materialised,
       evaluated and destroyed without any diff in the original tree, and a
       deliberate path-ownership sabotage exits non-zero.
+      **CLOSED 2026-08-31 — the third verb is met, by the wiring the audit below
+      predicted would close it.** That audit is preserved rather than deleted,
+      because it is the record of what was missing.
+      *Evaluated* is now a real production path: `evolution_lab`'s `run` verb
+      routes every candidate through `_lib/evaluation_cascade.ts`'s six-stage
+      deterministic prefix, so the modules the audit called "an UNWIRED library"
+      have a caller. *Materialised* and *destroyed* were already met by 3.1 and
+      are re-asserted end-to-end here rather than inherited: a test spawns the
+      real CLI, runs `run` with metrics, confirms a clone directory appeared,
+      runs `clean --yes`, and asserts `git status --porcelain` is
+      byte-identical before and after and that the clone is gone.
+      *Sabotage exits non-zero* is unchanged from 3.1.
+      **Asserted through the real CLI, never in-process** — the same discipline
+      `harness_evolution_guard_call_sites.test.ts` adopted for the identical
+      reason: a unit test observing a function's return is not evidence that a
+      runner routes through it. Proved sensitive: unwiring the cascade from
+      `verbRun` reds *"a run EVALUATES each candidate and says so on stdout"*.
       **Two of its three verbs are met, and it stays OPEN on the third rather
       than being read generously.** *Materialised* and *destroyed* with no diff
       in the original tree: 3.1, five candidates, asserted by `git status
@@ -2063,9 +2194,24 @@ once.
       `accepted` was expected is the reference-implementation defect 3.4 cites.
       *"Existence is not acceptance"* asserts `isAccepted` false for all eight
       non-promoted states.
-- [ ] AC-5 — Promotion is decided by `paired_verdict` per metric with
+- [x] AC-5 — Promotion is decided by `paired_verdict` per metric with
       `underpowered` refused as a pass, and no code path computes a weighted
       total score.
+      **CLOSED 2026-08-31 — the first conjunct now has the caller it lacked, so
+      the conjunction holds.** The audit below is preserved: it named exactly
+      what was missing and predicted exactly what would close it.
+      `promotionVerdict` (`_lib/evaluation_vector.ts:230`) is called by the
+      cascade's stage 6, which `evolution_lab`'s `run` verb executes for every
+      candidate. So a promotion in this tree IS decided by the paired verdict,
+      where before *"no promotion is decided at all"*.
+      **`underpowered` is still refused as a pass on the production path, not
+      only in the module's own tests** — a CLI run whose only paired row carries
+      `underpowered` reaches the verdict and reports a refusal.
+      **The second conjunct is unchanged, and so is its honest scope caveat**:
+      `findScalarCollapse` is a named-construct static scan over a bounded
+      population, not a semantic proof that no arithmetic anywhere reduces a set
+      of metrics to one number. Closing this criterion does not upgrade that
+      evidence class.
       **Audited 2026-08-31: the second conjunct is met, the first is not, and
       the criterion stays open on the conjunction.**
       Second conjunct — met, with its evidence class named rather than

--- a/agents/roadmaps/road-to-governed-harness-evolution.md
+++ b/agents/roadmaps/road-to-governed-harness-evolution.md
@@ -1732,7 +1732,7 @@ once.
       Class C". The BM25 core passes the same test. The skipped parent proposed
       the shortlist and explicitly refused it as final truth.
       verify: the shortlist feeds a later stage and never decides alone.
-- [ ] **6.4 Pre-register the loss ceiling, and measure set compatibility.**
+- [x] **6.4 Pre-register the loss ceiling, and measure set compatibility.**
       Recall-loss ceiling and token target fixed first; report precision,
       recall, false activation, context cost, benefit **conditional on**
       activation — and, `from-skipped-parent`, **set compatibility**: cases
@@ -1741,6 +1741,56 @@ once.
       artefact is closest. The corpus fixtures for it are authored in 2.3.
       verify: the ceiling is committed before the run, and the corpus contains
       at least one jointly-wrong pair.
+      **DONE 2026-08-31. Ceiling BREACHED and reported as breached; 7 jointly-wrong
+      pairs found in the corpus and 0 of them delivered together.**
+      Pre-registration `agents/evidence/analysis/delivery-set-preregistration-2026-08-31.md`,
+      commit **`fe8749458`** — recall-loss ceiling 20.0 pp, token target 500,
+      k = 5, and the jointly-wrong definition, all fixed in a commit that adds no
+      measurement module. Measurement `src/scripts/measure_delivery_sets.ts`,
+      commit **`DELIVERY_SHA`**; `git merge-base --is-ancestor fe8749458 DELIVERY_SHA`
+      is the first half of the verify, checked in the history rather than asserted.
+      **The metric set, over 82 train corpora / 764 distinct prompts / 299-skill
+      catalogue, holdout untouched** (`agents/evidence/analysis/delivery-set-measurement-2026-08-31.json`):
+      precision@5 82.51 % over 303 adjudicated deliveries · recall@5 64.60 % ·
+      recall loss **35.40 pp against a 20.0 pp ceiling — BREACHED** · false
+      activation@5 13.66 % · context cost 235.6 tokens/prompt against a 500 target
+      — MET · benefit unconditional 64.60 % · benefit conditional on activation
+      82.51 %. Curve: @1 44.70 · @3 57.11 · @5 64.60 · @10 73.64 · @20 80.62 %, so
+      the ceiling clears at no k ≤ 20 and the cost target is not what is failing.
+      A breach is a finding; **no narrowed delivery is promoted from this run**.
+      **The verify`s second half — 7 jointly-wrong pairs in the corpus**, over 10
+      shared prompts: `{experiment-loop, verify-repair-loop}` twice,
+      `{analysis-skill-router, forensics-report}`, the three pairs among
+      `{agent-security-review, ai-code-blindspots, security-audit}` on one prompt,
+      and `{evaluate-llm-feature, prompt-engineering-patterns}`. **0 are delivered
+      together at any k ≤ 20** (`src/scripts/measure_delivery_sets.ts:205-222`).
+      **THE PRE-REGISTRATION WAS WRONG AND IS CORRECTED BY REPORTING BOTH, NOT BY
+      REWRITING IT.** Its definition added "both members delivered in the top-k",
+      turning the corpus property this verify names into a delivery property whose
+      count is 0. Both ship: `jointly_wrong_pairs_in_corpus` = 7 and
+      `jointly_wrong_pairs_delivered_at_k` = 0, each pair carrying the smallest k
+      at which it would be jointly delivered. The count is a LOWER bound — a pair
+      is observable only where two corpora adjudicate the same prompt.
+      **The finding that bounds every number above: 78.80 % of prompts have their
+      top-5 cut decided by the ALPHABETICAL TIE-BREAK** —
+      `score(rank 5) === score(rank 6)`
+      (`src/scripts/measure_delivery_sets.ts:165-171`). So
+      0-delivered-pairs is not evidence of discrimination; at the boundary the
+      scorer does not rank at all and the alphabet happened not to co-select any
+      of the seven. Same "recalls but does not rank" pathology
+      `src/scripts/measure_lexical_ranking.ts:10-16` names for the memory store,
+      observed on the skill catalogue for the first time.
+      **SENSITIVITY, two sabotages, each red then green**
+      (`tests/scripts/delivery_set_compatibility.test.ts`): (a) dropping the
+      `!c.expect` polarity filter so any shared skill forms a pair — 3 red
+      including the DENIAL case, restored 11 green; (b) loosening the ceiling
+      constant 20.0 → 40.0 to turn the reported breach into a pass — 3 red,
+      restored 11 green.
+      **A second pre-registration defect, recorded:** `precision_at_k` and
+      `benefit_conditional_on_activation` were defined separately and are one
+      computation. Both are reported at the same value rather than one being
+      dropped; the pair that genuinely differs is unconditional 64.60 % against
+      conditional 82.51 %, and the 17.9 pp gap IS the delivery failure.
 - [ ] **6.5 Index the body only if 5.1 measured a signal.** Otherwise
       description-only.
       verify: the indexer's input set derives from the 5.1 verdict file.

--- a/agents/roadmaps/road-to-governed-harness-evolution.md
+++ b/agents/roadmaps/road-to-governed-harness-evolution.md
@@ -1429,7 +1429,7 @@ once.
 
 ## Phase 5 — Body signal and the proposer roles
 
-- [ ] **5.1 Measure the description-vs-body signal, honest null permitted.**
+- [x] **5.1 Measure the description-vs-body signal, honest null permitted.**
       `corrected-from-reproduction`: the master justified this by pointing at a
       proxy gap the tree documents as unquantified. That gap is real but it is a
       **different** gap. `src/scripts/description_route_check.ts:18-30`
@@ -1443,6 +1443,57 @@ once.
       it bounds the validity of every routing conclusion in this roadmap.
       verify: the pre-registration lands before the first measurement commit and
       names both gaps separately.
+      **DONE 2026-08-31 — the answer is `harmful`, which is neither the hoped-for
+      signal nor the permitted null, and it is the reason the bar was two-sided.**
+      Pre-registration `agents/evidence/analysis/routing-signal-preregistration-2026-08-31.md`,
+      commit **`fe8749458`**. Measurement
+      `src/scripts/measure_routing_signal.ts` + `src/scripts/_lib/routing_corpus.ts`,
+      commit **`MEASUREMENT_SHA`**. `git merge-base --is-ancestor fe8749458 MEASUREMENT_SHA`
+      is the ordering clause, checked in the history rather than asserted: the
+      prereg commit adds no measurement module and runs nothing.
+      **Both gaps are named separately, and only one was answerable here.** Gap A
+      (proxy-to-real-session fidelity) is the one
+      `src/scripts/description_route_check.ts:18-30` documents; quantifying it
+      needs real sessions, and step 5.2 parks the live harness for this whole
+      roadmap. So it is carried as its OWN required field —
+      `proxy_to_real_fidelity: {value: null, status:
+      "unmeasured-by-construction", reason: <the 5.2 park>}` — in the verdict
+      record, so a consumer cannot take the conclusion without its bound. Gap B
+      (does the body carry signal the description does not) is the one measured.
+      **The numbers, over 82 train corpora / 775 cases / 299-skill catalogue,
+      holdout untouched** (`agents/evidence/analysis/routing-body-signal-verdict.json`,
+      written by `--write`): recall@5 64.60 % → 70.28 % (**+5.68 pp**, bar +5.0),
+      false activation@5 13.66 % → 20.88 % (**+7.22 pp**, guard +2.0), McNemar
+      exact p = 0.0371 over 102 discordant positives.
+      **The primary bar was CLEARED and the verdict is still not `signal`.** A
+      one-sided pre-registration would have shipped this. The guard fires because
+      the pre-registered order is power → guard → primary
+      (`src/scripts/measure_routing_signal.ts:175-189`), and
+      `tests/scripts/routing_signal_measurement.test.ts:142-151` pins that exact
+      combination. **SENSITIVITY, three sabotages, each red then green:**
+      (a) removing the holdout skip in `loadTrainCases` — 4 red, restored 17
+      green; (b) moving the primary check ahead of the guard in the verdict
+      function — 2 red (verdict becomes `signal`), restored 17 green;
+      (c) editing the committed verdict file to `signal` with a fabricated
+      fidelity value — 2 red, restored 17 green.
+      **An unpredicted finding, from the run rather than from the argument.** The
+      prereg predicted the guard would break, on the arithmetic that
+      `overlap` divides by the TASK`s term count so body tokens can only raise a
+      score. It did — but 40 positives were also **lost**, because monotone
+      scores do not imply monotone ranks: a positive inside the top-5 is pushed
+      out when its competitors gain more. The body arm reorders rather than
+      merely widens.
+      **Two corrections recorded, not smoothed over**
+      (`agents/evidence/analysis/routing-body-signal-result-2026-08-31.md`): the
+      first loader understood only the modern `queries[]` shape and dropped the
+      two grandfathered legacy-shaped corpora SILENTLY, reporting 80 where the
+      partition says 82 — fixed by reading both shapes, verdict unchanged in
+      both directions (80 corpora: +5.57 / +7.41, `harmful`); and a doc comment
+      ended early at the `*/` inside a `src/skills/<slug>/SKILL.md` glob, which
+      `tsc --noEmit` accepted and the runtime transform did not.
+      **What it does NOT establish:** that the body is useless to a reader, that
+      the result transfers to a length-normalised scorer, or anything about the
+      sealed holdout, which stays unspent.
 - [x] **5.2 Keep the live-floors park intact.** No live harness.
       `agents/roadmaps/later/road-to-routing-assurance-live-floors.md` exists on
       this tree — verified — and its council park (2/2) is not reopened here.

--- a/agents/roadmaps/road-to-governed-harness-evolution.md
+++ b/agents/roadmaps/road-to-governed-harness-evolution.md
@@ -1747,7 +1747,7 @@ once.
       commit **`fe8749458`** — recall-loss ceiling 20.0 pp, token target 500,
       k = 5, and the jointly-wrong definition, all fixed in a commit that adds no
       measurement module. Measurement `src/scripts/measure_delivery_sets.ts`,
-      commit **`DELIVERY_SHA`**; `git merge-base --is-ancestor fe8749458 DELIVERY_SHA`
+      commit **`b7aafbb3b`**; `git merge-base --is-ancestor fe8749458 b7aafbb3b`
       is the first half of the verify, checked in the history rather than asserted.
       **The metric set, over 82 train corpora / 764 distinct prompts / 299-skill
       catalogue, holdout untouched** (`agents/evidence/analysis/delivery-set-measurement-2026-08-31.json`):

--- a/agents/roadmaps/road-to-governed-harness-evolution.md
+++ b/agents/roadmaps/road-to-governed-harness-evolution.md
@@ -1651,7 +1651,59 @@ once.
       **The judge stays optional**, as the step says: `buildSplitPipeline`
       (`:330`) returns `judge: null` when none is configured, and the three role
       prompts are produced regardless.
-- [ ] **5.4 An LLM proposer must beat the deterministic one to survive.** On at
+- [ ] <!-- roadmap-status: guarded-baseline -->
+      **5.4 An LLM proposer must beat the deterministic one to survive.** On at
+      **GUARDED BASELINE 2026-08-31 — the comparison cannot be run because there
+      is no second arm, and the fallback clause is now ENFORCED instead of
+      merely written.**
+
+      ```yaml
+      guarded_baseline:
+        category: absence-assertion
+        scope: src/scripts/_lib/candidate_proposer.ts
+        command: npx vitest run tests/scripts/proposer_survival_bar.test.ts
+        red_proof: sabotage run 2026-08-31 — 1 failed / 3 passed, restored 4/4
+        sabotage_model: added a fetch to an API host inside the proposer module
+        recheck_when: src/scripts/_lib/llm_candidate_proposer.ts
+        discharged_ac: the deterministic path is pinned as the only proposer, so it cannot be displaced silently
+        pending_ac: the paired-verdict comparison itself, which needs a second arm
+      ```
+
+      **Why it cannot be run, stated as a fact about the tree rather than as
+      effort.** `_lib/candidate_proposer.ts` is the only proposer and is
+      deterministic by construction — its own header says *"Fixed recipes for
+      known defect classes, so the loop is validated without model quality as a
+      confound"* and *"NOT claimed: that these three recipes improve
+      anything"*. Phase 5 ships no live model harness, which step 5.2 pins with
+      its own scan. A `paired_verdict` run needs two arms and one of them does
+      not exist. Running it against nothing and publishing the result would be
+      the *"argument, not a run"* this step's verify clause forbids.
+
+      **What the guard does buy.** The step's fallback — *"Otherwise the
+      deterministic path stays"* — was a sentence anyone could contradict by
+      adding a proposer. `tests/scripts/proposer_survival_bar.test.ts` now
+      asserts no model is in the proposer loop: no transport import, no
+      subprocess spawn, no API host, no key env var, across the proposer and its
+      dependency. So the day an LLM proposer lands it cannot become the default
+      without turning this red first, which is what makes "otherwise"
+      enforceable. `recheck_when` names the module whose arrival reopens the step.
+
+      **A false positive found by running it, and removed rather than
+      suppressed.** The construct list initially carried the bare vendor names
+      `anthropic` and `openai`, and the clean tree reported **2 hits** — both in
+      `_lib/candidate_record.ts`, and neither a client: they sit inside an
+      error-message STRING naming which council seats decided something
+      (*"2026-08-29, anthropic + openai, 2/2"*). Stripping comments does not
+      remove a string literal and should not; the detector was simply wrong. A
+      vendor's name in prose is evidence about the writing, not about the code,
+      so the names were dropped and only constructs that cannot appear
+      innocently were kept. Suppressing the two files instead would have blinded
+      the scan to the exact modules it exists to watch.
+      **Sensitivity OBSERVED after the narrowing, not before:** adding a `fetch`
+      to an API host inside the proposer reds *"no model is in the proposer
+      loop"* (1 failed / 3 passed); byte-identical restore returns 4/4. Both
+      anti-vacuity assertions — a non-empty scanned set and a stripper that does
+      not empty its input — ship with it, so a scan over nothing cannot pass.
       least one pre-registered eval family, with an explicit hypothesis and a
       named falsifier per mutation. Otherwise the deterministic path stays.
       verify: the comparison is a `paired_verdict` run, not an argument.

--- a/agents/roadmaps/road-to-governed-harness-evolution.md
+++ b/agents/roadmaps/road-to-governed-harness-evolution.md
@@ -2755,10 +2755,30 @@ once.
       decision. `[-]` records that the criterion was superseded, never met and
       never dropped; its safety purpose is carried forward unweakened as AC-10b
       below.
-- [ ] AC-10b — **This roadmap introduces no unsupervised background process
+- [x] AC-10b — **This roadmap introduces no unsupervised background process
       (class P2), and does not touch the claim or retirement surfaces.**
       Carries AC-10a's purpose — *"this roadmap did not quietly acquire a runtime
       daemon"* — re-keyed onto a boundary that still exists.
+
+      **CLOSED 2026-08-31, read at completion rather than mid-flight.** The
+      earlier note on AC-10a deliberately refused to close this on a partial
+      branch, because a tripwire read before the work is finished has not been
+      read. This is the reading taken once the roadmap reached its terminal
+      state.
+      **Surfaces untouched.** `git diff --name-only origin/main..HEAD --
+      README.md docs/CLAIMS.md` is empty, so neither the claim surface nor its
+      retirement record moved on this branch.
+      **No process of any class introduced.** The branch adds 13 files and
+      2,691 lines under `src/`, and a scan of the added lines for
+      `setInterval`, `setTimeout(`, `while (true)`, `daemon`, `.unref(`,
+      `spawn(`, `fork(`, `listen(` and `createServer` returns **nothing**. So
+      the question of whether a new process would be a supervised P1 or an
+      unsupervised P2 does not arise: there is no process.
+      **What this criterion does and does not certify.** It is a scan over the
+      lines this branch ADDED, which is the population the criterion is about —
+      *this* roadmap's contribution. It certifies nothing about processes the
+      tree already carried; `src/scripts/collector_daemon.ts` predates this work
+      and is governed by ADR-249, not by this row.
       **AI council 2026-08-31, verdict D (split), and it is a SINGLE-SEAT
       DEGRADED round — recorded as such, never as convergence.** Present:
       openai/codex-default. Absent: anthropic/claude-sonnet-4-5, `exit_1` with

--- a/agents/roadmaps/road-to-governed-harness-evolution.md
+++ b/agents/roadmaps/road-to-governed-harness-evolution.md
@@ -1126,7 +1126,102 @@ once.
       yields `[]`. The separation is structural: `paretoFrontier` (`:205`) is
       never consulted by `promotionVerdict`, so a frontier preference has no
       path by which to become a promotion.
-- [ ] **4.4 Keep a pathology archive, not only a frontier.**
+- [x] **4.4 Keep a pathology archive, not only a frontier.**
+      **DONE 2026-08-31.** `src/scripts/_lib/pathology_archive.ts`, 25 tests in
+      `tests/scripts/pathology_archive.test.ts`, plus 2 in
+      `harness_evolution_guards.test.ts` for the registration.
+
+      **Objection 2 is settled — AI council 2026-08-31, and it was a SINGLE-SEAT
+      DEGRADED round, recorded as such rather than as convergence.** Present:
+      openai/codex-default. Absent: anthropic/claude-sonnet-4-5, `exit_1`, no
+      output — the same seat-and-shape failure 4.1 already records for a long
+      multi-decision question. Under the N=3 budget the run took the best
+      available seat and did not retry.
+      Verdict **2c revised**: of the three candidate rules, 2a needs a human
+      gold standard and 2b needs a coverage metric, and neither exists, so
+      recency is the only currently supportable deterministic rule. The seat's
+      own caveat is carried into the code rather than dropped: *"recency says
+      nothing about quality and may replace a genuinely better intervention with
+      a regression"*, so history is append-only and every decision is stamped
+      with `ranking_rule_version` — representatives are RECOMPUTED when a
+      quality metric arrives, never lost.
+      **The rule is TOTAL, which is what the objection actually demanded.**
+      `replacesRetained` (`:186`) orders on
+      `attempt_sequence DESC, candidate_id ASC, attempt_id ASC`. Ordering is by
+      ingester-assigned sequence and **never** by timestamp — producer clocks
+      collide and arrive out of order, which makes a timestamp rule non-total,
+      and a tie-break that is declared but unreachable is the defect the seat
+      named in the alternative. All three tie-break levels are exercised
+      separately, and one test asserts a newer `observed_at` on a lower sequence
+      does NOT win.
+      **`WHERE` reuses the ladder** — `PATHOLOGY_WHERE` IS `LADDER_RUNGS`
+      (`_lib/activation_ladder.ts:36-43`), asserted by identity so a parallel
+      execution-stage taxonomy cannot drift into existence. `WHY` is a closed
+      8-value REASON axis whose order is its precedence order, with
+      `reason_unknown` last so it is a fallback and never a precedence winner. A
+      test asserts no `WHY` value is a ladder rung or a `<rung>_failed`, which is
+      the collapse-into-WHERE failure the seat rejected in the first draft.
+      **Objection 3 is discharged by the cell shape.** Each cell carries
+      frequency-bearing metadata from append-only attempt history —
+      `attempt_count`, `classifiable_count`, `unclassifiable_count`,
+      first/last observed sequence and time, the retained representative with
+      its `retained_ranking_key` and `retained_ranking_rule`, and the
+      schema/classification/ranking/cohort version quad. Ingest is **idempotent**
+      by `attempt_id`, because without that a retry loop silently inflates the
+      very frequency evidence the guard reads. Cells are keyed on the version
+      quad as well as on `WHERE x WHY`, so attempts recorded under a different
+      vocabulary are never summed with these.
+      **The guard consumes a versioned query, never storage internals**, as the
+      seat required: `dominanceWindow()` (`:239`) returns the version quad
+      alongside its rows and `dominanceVerdict` takes that query, so a caller
+      cannot hand it a raw array. It returns attempts rather than cells for the
+      reason the seat gave — a last-N window is not reconstructible from
+      aggregates.
+
+      **Objection 4, and the premise turned out to be FALSE — checked rather
+      than accepted.** The objection assumed the `0.6` in this step's verify
+      line already meant textual similarity, and warned that reusing it would be
+      *"a semantic change wearing a constant's clothes"*. **There is no such
+      constant.** `diversityCollapsed`
+      (`_lib/harness_evolution_guards.ts:215`) is a DISTINCT-COUNT check with
+      `minDistinct = 2` and no ratio anywhere, and the only near-duplicate
+      constant in the tree is `NEAR_DUPLICATE_THRESHOLD = 70`
+      (`_lib/curator_ops.ts:106`) — an integer percentage on a different scale.
+      So the collision the objection feared does not exist, and the number was
+      free to be given its own meaning. It is nonetheless given a **separate**
+      name rather than reused: `PATHOLOGY_DOMINANCE_THRESHOLD = 0.6`, with the
+      denominator, window and floor the objection asked for —
+      `PATHOLOGY_WINDOW_SIZE = 50` (latest N classifiable attempts) and
+      `PATHOLOGY_MIN_CLASSIFIABLE_ATTEMPTS = 20`. All three are STATED policy
+      defaults, not measured optima, and say so at the constant with a
+      `Revisit-if`.
+      **`warming-up` is a real state and explicitly NOT a pass.** Below the
+      floor the guard refuses to return `ok`, so an empty archive cannot read as
+      healthy — the same discipline `underpowered` gets in 4.3.
+
+      **Wired, not an unwired library — which is the lesson AC-3 and AC-5 are
+      still open on.** `STOP_CONDITIONS` gains `pathology-dominance`
+      (`detector: 'dominanceVerdict'`), and a test resolves that detector name
+      to a real exported function rather than trusting the string.
+      **The arity of step 0.6's stop set therefore moves 4 -> 5, and it is
+      recorded here instead of being bumped silently.** It is an ADDITION and
+      never a replacement — a second test pins both `diversity-collapse` and
+      `pathology-dominance` so neither can be dropped into the other — so it
+      STRENGTHENS 0.6's set rather than relaxing anything 0.6 decided. The two
+      catch different things: the older row asks whether this run's candidates
+      are distinct, and cannot see a search that keeps producing textually
+      different candidates which all fail the same way.
+
+      **Sensitivity was OBSERVED in four directions, and the first probe found a
+      REAL GAP in these tests rather than confirming them.** Deleting `a.why`
+      from the cell key left **23/23 green** — the "both retained" case differs
+      on both axes, so it could not tell a two-axis key from a one-axis one.
+      Two axis-isolating tests were added in response; re-probed, dropping `why`
+      reds *"the WHY axis is load-bearing"* and dropping `where` reds *"the
+      WHERE axis is load-bearing"*, one failure each. Neutralising the
+      `warming-up` floor reds *"below the minimum sample it reports warming-up,
+      which is NOT a pass"*. Every probe restored to 25/25, and the module's
+      byte-identical restore was confirmed with `git diff`.
       `from-skipped-parent`, and it was that parent's headline contribution: a
       pure frontier loses the information about *why* a candidate exists, so
       archive the best intervention per `WHERE × WHY` failure cell over closed
@@ -2110,8 +2205,54 @@ once.
       carried there verbatim, with its 2026-08-31 audit note intact. `[-]`
       means TRANSFERRED, never met and never dropped: the criterion is open in
       the receiver, where 7.6 is what closes it, after `merge-authority`.
-- [ ] AC-10 — The `no-runtime-daemon` claim in `README.md` and its
-      `docs/CLAIMS.md` entry are byte-identical to their pre-roadmap state.
+- [-] AC-10a — **SUPERSEDED by ADR-249 2026-08-31.** Original criterion,
+      verbatim: *"The `no-runtime-daemon` claim in `README.md` and its
+      `docs/CLAIMS.md` entry are byte-identical to their pre-roadmap state."*
+      Byte-identity is **impossible**, and not because of anything this roadmap
+      did: a different roadmap deliberately retired the claim by governance
+      decision. `[-]` records that the criterion was superseded, never met and
+      never dropped; its safety purpose is carried forward unweakened as AC-10b
+      below.
+- [ ] AC-10b — **This roadmap introduces no unsupervised background process
+      (class P2), and does not touch the claim or retirement surfaces.**
+      Carries AC-10a's purpose — *"this roadmap did not quietly acquire a runtime
+      daemon"* — re-keyed onto a boundary that still exists.
+      **AI council 2026-08-31, verdict D (split), and it is a SINGLE-SEAT
+      DEGRADED round — recorded as such, never as convergence.** Present:
+      openai/codex-default. Absent: anthropic/claude-sonnet-4-5, `exit_1` with
+      no output. That is the same seat-and-shape failure step 4.1 already
+      records for a long multi-decision question, so it is a known mode rather
+      than a new one; under the N=3 budget the run took the best available seat
+      and did not retry.
+      **Why the split rather than a re-key.** Option A — re-key to *"no diff
+      attributable to THIS roadmap"* and close on a two-file documentation diff —
+      was put to the seat and REFUTED: *"Option A's suggested `git diff --stat`
+      over two documentation files proves only that those files were untouched.
+      A daemon could be introduced entirely in source or deployment config."*
+      The tripwire would have been closed by a check that cannot see the thing
+      it guards.
+      **Why the criterion had to move at all.** `docs/contracts/no-runtime-boundary.md:25`
+      records that the absolute prohibition AC-10a guarded no longer exists:
+      background processes are **governed**, not banned — a supervised process is
+      class **P1** and permitted under four conditions, an unsupervised one is
+      class **P2** and stays prohibited. `src/scripts/collector_daemon.ts` is in
+      the tree today. So a criterion phrased as *"the no-daemon claim is
+      byte-identical"* now guards a claim the suite has withdrawn on purpose, and
+      re-keying it to the same wording would re-assert a floor ADR-249 lowered by
+      decision. AC-10b is deliberately phrased against **P2**, the half that
+      survived.
+      **Reading at this commit, and it is explicitly NOT a closure.** The branch
+      diff against `origin/main` is three files — one evidence artefact, this
+      roadmap, and one test — with zero changes under `src/` and no process of
+      any class introduced; the same diff restricted to `README.md` and
+      `docs/CLAIMS.md` is empty. AC-10b stays `[ ]` because a tripwire read
+      before the roadmap is finished has not been read: later commits on this
+      branch can still falsify it, and the reading that closes it is the one
+      taken at completion.
+      **Attribution, re-checked rather than carried.** The removing commit is
+      `68463a1e` (2026-08-28), *"roadmap: complete runtime-governance-flip
+      (ADR-249 ...)"*. Step 0.3 already recorded that retirement and repaired its
+      own count-keyed guard against it; AC-10 was the survivor of that same edit.
       **Audited 2026-08-31: FALSIFIED as written — and not by this roadmap.**
       The pre-roadmap state is `9e8344a3`, the parent of `15447f47` which added
       this file on 2026-08-26. At `9e8344a3` the README's line 19 carried the

--- a/src/scripts/_lib/delivery_arm_experiment.ts
+++ b/src/scripts/_lib/delivery_arm_experiment.ts
@@ -104,6 +104,17 @@ export interface ArmExperimentInput {
     readonly standing: Readonly<Record<ArmName, number>>;
     /** Exact-BPE tokenizer, injected so this module imports none. */
     readonly tokensOf: (text: string) => number;
+    /**
+     * STEP 6.3 — optional per-prompt lexical shortlist, injected so this module
+     * builds no index of its own.
+     *
+     * Absent (the default) the delivery arm is byte-for-byte the arm 6.1
+     * measured, which is why its recorded figures stay reproducible. Present,
+     * it reaches `selectForInjection` as a TIE-BREAK under the matcher's score —
+     * it can change which matched bodies survive a binding cap and can change
+     * nothing else, so `delivered` can only move through `capDropped`.
+     */
+    readonly shortlist?: ((prompt: string) => readonly string[]) | null;
 }
 
 /**
@@ -143,7 +154,7 @@ function hasBody(repoRoot: string, id: string): boolean {
  * a different case set than another.
  */
 export function runArmExperiment(input: ArmExperimentInput): ArmRow[] {
-    const { repoRoot, router, cases, capBytes, standing, tokensOf } = input;
+    const { repoRoot, router, cases, capBytes, standing, tokensOf, shortlist } = input;
     const thinStanding = thinStandingIds(router);
 
     const delivered: Record<ArmName, number> = { 'eager-all': 0, thin: 0, delivery: 0 };
@@ -158,7 +169,12 @@ export function runArmExperiment(input: ArmExperimentInput): ArmRow[] {
         const inThin = thinStanding.has(c.rule) && inEager;
 
         const matches = matchTierRules(router, c.prompt, c.openFiles);
-        const sel = selectForInjection(repoRoot, matches, capBytes);
+        const sel = selectForInjection(
+            repoRoot,
+            matches,
+            capBytes,
+            shortlist ? shortlist(c.prompt) : null,
+        );
         const injectedIds = new Set(sel.selected.map((m) => m.id));
         const inDelivery = inThin || injectedIds.has(c.rule);
 

--- a/src/scripts/_lib/evaluation_cascade.ts
+++ b/src/scripts/_lib/evaluation_cascade.ts
@@ -156,9 +156,9 @@ export interface CascadeInput {
     readonly plan: RunPlan;
     readonly budget: RunBudget;
     /** Sibling candidate texts, for the near-duplicate screen. */
-    readonly peers?: readonly string[];
+    readonly peers?: readonly string[] | undefined;
     /** Metric rows, when the caller has them. Absent means the run measured nothing. */
-    readonly rows?: readonly MetricRow[];
+    readonly rows?: readonly MetricRow[] | undefined;
     /**
      * An already-built vector, when the caller has one.
      *
@@ -167,7 +167,7 @@ export interface CascadeInput {
      * here from loose rows would give the verdict a second, less-checked path
      * to the same number.
      */
-    readonly vector?: MetricVector;
+    readonly vector?: MetricVector | undefined;
 }
 
 function abort(

--- a/src/scripts/_lib/evaluation_cascade.ts
+++ b/src/scripts/_lib/evaluation_cascade.ts
@@ -1,0 +1,291 @@
+/**
+ * The deterministic evaluation cascade — cheap to expensive, abort on the first
+ * hard failure.
+ *
+ * `road-to-governed-harness-evolution` step 4.1, built to the AI council's
+ * **Option B** of 2026-08-31 and NOT to Option A. The distinction is the whole
+ * design of this file, so it is recorded here rather than only in the roadmap.
+ *
+ * ## Why this is a PREFIX and not the twelve-stage cascade
+ *
+ * Step 4.1 names a twelve-stage form whose stages include activation/delivery
+ * and adherence. Those stages classify a candidate by observing how the harness
+ * BEHAVED, and Phase 1's step 1.1 fixes what that classification rests on: *"a
+ * deliberately failing trigger eval is classifiable as content vs activation vs
+ * adherence **from the recorded receipt alone**"*. There is no receipt producer.
+ * Until there is, a stage that assigned `activation` from a deterministic proxy
+ * would be manufacturing evidence — a holdout leak is not an observation that
+ * activation failed, and an `underpowered` result asserts insufficient evidence
+ * rather than a cause.
+ *
+ * So this module implements exactly the stages whose evidence the process
+ * produces ITSELF and can stand behind:
+ *
+ * | # | Stage | Cost | Family on failure |
+ * |---|---|---|---|
+ * | 1 | schema validity        | zero model calls | `content` |
+ * | 2 | path ownership *(unreachable today — see the stage)* | zero model calls | `content` |
+ * | 3 | holdout disclosure     | zero model calls | `unknown` |
+ * | 4 | budget                 | zero model calls | `unknown` |
+ * | 5 | near-duplicate screen  | zero model calls | `content` |
+ * | 6 | metric vector + verdict| zero model calls | `unknown` |
+ *
+ * **Every stage here is free.** That is not an accident of the current stage
+ * set — it is why these six are the ones that can ship without receipts, and it
+ * makes the step's "a candidate failing the cheapest stage consumes no model
+ * call" trivially true rather than merely asserted.
+ *
+ * **No stage is SOFT.** A condition whose failure does not block is a
+ * diagnostic, not a cascade gate — so every stage here either passes or aborts
+ * the cascade, and there is no third "warn" outcome a caller could ignore.
+ *
+ * ## The families, and the one this prefix may NOT assign
+ *
+ * `content | activation | adherence | unknown` are Phase 1's, and no fifth is
+ * invented. This prefix assigns `content` and `unknown` only. It NEVER assigns
+ * `activation` or `adherence`, because those are the receipt-bearing families
+ * and nothing here has a receipt. `unknown` is the honest family for a stage
+ * that establishes a candidate is unusable without establishing why in
+ * behavioural terms — it is a real classification, not a fallback.
+ */
+
+import {
+    assertMutationPathsOwned,
+    parseCandidateRecord,
+    PathOwnershipError,
+    CandidateSchemaError,
+    type CandidateRecord,
+} from './candidate_record.js';
+import {
+    assertWithinBudget,
+    BudgetExceededError,
+    diversityCollapsed,
+    type RunBudget,
+    type RunPlan,
+} from './harness_evolution_guards.js';
+import {
+    buildVector,
+    promotionVerdict,
+    type MetricRow,
+    type MetricVector,
+    type PromotionVerdict,
+} from './evaluation_vector.js';
+
+/** Phase 1's families. No fifth is invented here. */
+export const FAILURE_FAMILIES = ['content', 'activation', 'adherence', 'unknown'] as const;
+export type FailureFamily = (typeof FAILURE_FAMILIES)[number];
+
+/**
+ * The families this prefix is permitted to assign.
+ *
+ * `activation` and `adherence` are deliberately absent: assigning either from a
+ * deterministic proxy is the evidence-manufacturing the council refused.
+ */
+export const PREFIX_ASSIGNABLE_FAMILIES: readonly FailureFamily[] = ['content', 'unknown'];
+
+export const CASCADE_STAGES = [
+    'schema-validity',
+    'path-ownership',
+    'holdout-disclosure',
+    'budget',
+    'near-duplicate',
+    'metric-verdict',
+] as const;
+export type CascadeStage = (typeof CASCADE_STAGES)[number];
+
+/** The cheapest stage. Its failure must cost nothing. */
+export const CHEAPEST_STAGE: CascadeStage = 'schema-validity';
+
+const STAGE_FAMILY: Readonly<Record<CascadeStage, FailureFamily>> = {
+    'schema-validity': 'content',
+    'path-ownership': 'content',
+    'holdout-disclosure': 'unknown',
+    budget: 'unknown',
+    'near-duplicate': 'content',
+    'metric-verdict': 'unknown',
+};
+
+export function familyForStage(stage: CascadeStage): FailureFamily {
+    return STAGE_FAMILY[stage];
+}
+
+export interface CascadePass {
+    readonly outcome: 'pass';
+    readonly candidate_id: string;
+    readonly stages_run: readonly CascadeStage[];
+    readonly model_calls: 0;
+    readonly verdict: PromotionVerdict;
+}
+
+export interface CascadeAbort {
+    readonly outcome: 'abort';
+    readonly candidate_id: string | null;
+    /** The FIRST failing stage. The cascade does not continue past it. */
+    readonly failed_stage: CascadeStage;
+    readonly family: FailureFamily;
+    readonly detail: string;
+    readonly stages_run: readonly CascadeStage[];
+    readonly model_calls: 0;
+}
+
+/**
+ * Stages 1-5 passed and the verdict stage was NOT REACHED because the run
+ * supplied no measurements.
+ *
+ * This is deliberately a third outcome and not an abort. A run that materialises
+ * candidates without measuring them has not failed — materialising is what
+ * `evolution_lab run` is for, and turning that into a non-zero exit would change
+ * a verb's contract to make a new stage look reachable. Nor is it a pass: there
+ * is no verdict, so nothing may read one. Naming the state is what keeps "no
+ * metrics" from being silently benign.
+ */
+export interface CascadeIncomplete {
+    readonly outcome: 'incomplete';
+    readonly candidate_id: string;
+    readonly stages_run: readonly CascadeStage[];
+    readonly model_calls: 0;
+    readonly not_reached: CascadeStage;
+    readonly why: string;
+}
+
+export type CascadeResult = CascadePass | CascadeAbort | CascadeIncomplete;
+
+export interface CascadeInput {
+    /** The raw, unparsed record. Stage 1 is what turns it into a `CandidateRecord`. */
+    readonly raw: unknown;
+    readonly plan: RunPlan;
+    readonly budget: RunBudget;
+    /** Sibling candidate texts, for the near-duplicate screen. */
+    readonly peers?: readonly string[];
+    /** Metric rows, when the caller has them. Absent means the run measured nothing. */
+    readonly rows?: readonly MetricRow[];
+}
+
+function abort(
+    stage: CascadeStage,
+    detail: string,
+    run: CascadeStage[],
+    candidate_id: string | null,
+): CascadeAbort {
+    return {
+        outcome: 'abort',
+        candidate_id,
+        failed_stage: stage,
+        family: familyForStage(stage),
+        detail,
+        stages_run: [...run],
+        model_calls: 0,
+    };
+}
+
+/**
+ * Run the deterministic prefix over one candidate.
+ *
+ * Aborts on the FIRST hard failure — later stages are not attempted, so a
+ * candidate that fails stage 1 never reaches stage 6. `model_calls` is a literal
+ * `0` on every path rather than a counter, because a counter can be wrong and a
+ * literal cannot: there is no code path in this module that could increment one.
+ */
+export function runCascade(input: CascadeInput): CascadeResult {
+    const run: CascadeStage[] = [];
+
+    // Stage 1 — schema validity. The cheapest, and the one whose failure must
+    // cost nothing: it runs before any other stage touches the record.
+    run.push('schema-validity');
+    let record: CandidateRecord;
+    try {
+        record = parseCandidateRecord(input.raw);
+    } catch (e) {
+        // ATTRIBUTION, not just error handling. `parseMutations` already calls
+        // `assertMutationPathsOwned` (`_lib/candidate_record.ts:434`), so an
+        // unowned path throws from INSIDE the parse. Catching everything here
+        // as a schema failure would file a path-ownership violation under the
+        // wrong stage and the wrong evidence — the failing stage is what Phase
+        // 1's classification reads, so getting it wrong is not cosmetic.
+        if (e instanceof PathOwnershipError) {
+            run.push('path-ownership');
+            return abort('path-ownership', e.message, run, null);
+        }
+        const why = e instanceof CandidateSchemaError ? e.message : String(e);
+        return abort('schema-validity', why, run, null);
+    }
+
+    // Stage 2 — path ownership, re-checked.
+    //
+    // HONEST LABEL: this branch is UNREACHABLE through this function's public
+    // API today, and therefore untested. `runCascade` only ever accepts `raw`
+    // and parses it, and `parseMutations` already calls
+    // `assertMutationPathsOwned` (`_lib/candidate_record.ts:434`), so every
+    // unowned path throws inside stage 1 and is attributed above. Measured
+    // 2026-08-31 by neutralising the abort below: 15/15 stayed green.
+    //
+    // It is kept rather than deleted because it is free and it fails closed if
+    // the parser ever stops enforcing ownership — but "defense in depth" is a
+    // claim, and this one has no test behind it, so it is written down as an
+    // unproven guard instead of counted as a proven one. Deleting it is a
+    // legitimate future call; silently trusting it is not.
+    run.push('path-ownership');
+    try {
+        assertMutationPathsOwned(record.mutations);
+    } catch (e) {
+        const why = e instanceof PathOwnershipError ? e.message : String(e);
+        return abort('path-ownership', why, run, record.id);
+    }
+
+    // Stage 3 — holdout disclosure. The guard that REFUSES disclosure to a
+    // proposer already exists and exits non-zero at its own call sites; what
+    // this stage adds is that a record carrying a holdout reference never
+    // reaches the verdict stage.
+    run.push('holdout-disclosure');
+    const leaked = record.mutations.find((m) => m.path.includes('holdout'));
+    if (leaked !== undefined) {
+        return abort('holdout-disclosure', `mutation path names a holdout: ${leaked.path}`, run, record.id);
+    }
+
+    // Stage 4 — budget. Before any expensive stage, and before any spend.
+    run.push('budget');
+    try {
+        assertWithinBudget(input.plan, input.budget);
+    } catch (e) {
+        const why = e instanceof BudgetExceededError ? e.message : String(e);
+        return abort('budget', why, run, record.id);
+    }
+
+    // Stage 5 — near-duplicate screen. Deterministic, zero model calls, and it
+    // runs BEFORE the verdict so a paraphrase never consumes a measurement.
+    run.push('near-duplicate');
+    const peers = input.peers ?? [];
+    if (peers.length > 0 && diversityCollapsed([record.id, ...peers])) {
+        return abort('near-duplicate', 'candidate set collapsed to duplicates', run, record.id);
+    }
+
+    // Stage 6 — metric vector and the promotion verdict. This is the ONLY
+    // promoter consulted, and it is `_lib/evaluation_vector.ts`'s, never a
+    // second verdict computed here.
+    if (input.rows === undefined || input.rows.length === 0) {
+        return {
+            outcome: 'incomplete',
+            candidate_id: record.id,
+            stages_run: [...run],
+            model_calls: 0,
+            not_reached: 'metric-verdict',
+            why: 'no metric rows: the run measured nothing, so no verdict exists',
+        };
+    }
+    run.push('metric-verdict');
+    let vector: MetricVector;
+    try {
+        vector = buildVector(record.id, input.rows);
+    } catch (e) {
+        return abort('metric-verdict', String((e as Error).message), run, record.id);
+    }
+    const verdict = promotionVerdict(vector);
+
+    return {
+        outcome: 'pass',
+        candidate_id: record.id,
+        stages_run: [...run],
+        model_calls: 0,
+        verdict,
+    };
+}

--- a/src/scripts/_lib/evolution_roi.ts
+++ b/src/scripts/_lib/evolution_roi.ts
@@ -1,0 +1,538 @@
+/**
+ * The run report, and the two things step 5.6 asks it to carry.
+ *
+ * `road-to-governed-harness-evolution` Phase 5, step 5.6.
+ *
+ * > *5.6 Cheap proposer models first, and track evolution ROI. […] its own
+ * > cross-critique faults both parents as cost-blind and answers with a hard
+ * > budget cap, while dropping the only cost-*reduction* mechanism both parents
+ * > proposed. Improvement per evolution dollar is a reported figure.*
+ * > verify: **the ROI figure appears in every run report, and a cheaper model
+ * > is tried before an expensive one on each defect class.**
+ *
+ * ## Why the ROI row is a refusal and not a field somebody remembers
+ *
+ * A budget cap answers "how much may this cost". It says nothing about whether
+ * the spend bought anything, so a programme can spend its whole ceiling on
+ * candidates that improved nothing and read as compliant the entire way. The
+ * figure that would have caught that is improvement per dollar, and a figure
+ * that a report MAY omit is a figure that goes missing on exactly the run whose
+ * ratio is embarrassing.
+ *
+ * So {@link buildRunReport} REFUSES a report without the ROI figure, in the
+ * same spirit as `_lib/evaluation_vector.ts`'s {@link buildVector} refusing a
+ * vector that omits its artifact-count row: the sprawl measurement belongs
+ * inside the gate, and the cost measurement belongs inside the report.
+ * {@link RunReport} carries no optional `roi` field, and because types vanish
+ * at runtime the refusal is checked against an object cast past the compiler.
+ *
+ * ## Three ROI kinds, because a ratio is not always defined
+ *
+ * `improved_rows / dollars` is `Infinity` at zero spend and `NaN` at zero of
+ * both. Printing either would be a number where the honest answer is "there is
+ * no ratio here". So the figure is a union: `ratio` when spend is positive and
+ * at least one candidate was evaluated, `no-spend` when the run cost nothing
+ * (the counts are still real and still printed), and `unmeasured` when no
+ * candidate carried an evaluation at all.
+ *
+ * `unmeasured` is the honest state of this programme today and is meant to be
+ * read as a finding rather than as a placeholder: `run` clones candidates, and
+ * nothing in Phase 5 evaluates them, because step 5.2 keeps the live-floors
+ * park intact and there is no live harness to evaluate against. A report that
+ * says `unmeasured` is telling the truth about a run that measured nothing.
+ *
+ * ## The ladder is an ORDERING POLICY, and it has no live subject
+ *
+ * "A cheaper model is tried before an expensive one" needs an attempt sequence
+ * to police, and there is none: no step in this roadmap invokes a live routing
+ * harness (5.2), and `tests/scripts/governed_harness_no_live_harness.test.ts`
+ * holds that. So {@link assertCheapestFirst} is a guard proved to FIRE on a
+ * synthetic out-of-order sequence, standing over a mechanism that does not yet
+ * exist. That is stated here rather than implied, because a guard described as
+ * if it were policing real traffic is the coverage inflation this tree's own
+ * records name repeatedly.
+ *
+ * What IS live is the plan: {@link buildRunReport} puts the per-class ladder
+ * into every report, so the cheapest untried tier for each defect class is on
+ * the operator's screen before the first metered call is licensed.
+ *
+ * ## Tiers are vendor-neutral, and three classes carry an EMPTY ladder
+ *
+ * `lite | medium | high` is a capability band, not a vendor. Naming a model
+ * would tie a cost policy to a price list that changes without this file.
+ *
+ * `policy_blocked`, `dependency_unavailable` and `human_rejected` get an empty
+ * ladder, and that is the strongest cost reduction available rather than an
+ * omission: a candidate that a policy refused, that could not find its
+ * dependency, or that a human turned down is not made acceptable by a larger
+ * model, so no tier is licensed for it at all. {@link nextTier} returns `null`
+ * there, which a caller must read as "spend nothing", never as "start at the
+ * top".
+ */
+import type { PairedVerdict, PairedVerdictKind } from './paired_verdict.js';
+import { PATHOLOGY_WHY, type PathologyWhy } from './pathology_archive.js';
+import {
+    ARTIFACT_COUNT_METRIC,
+    type MetricRow,
+    type MetricVector,
+    buildVector,
+} from './evaluation_vector.js';
+
+/** The defect-class axis. REUSED from the pathology archive, never re-invented. */
+export type DefectClass = PathologyWhy;
+export const DEFECT_CLASSES = PATHOLOGY_WHY;
+
+/** Capability bands, CHEAPEST FIRST. The order is the policy. */
+export const MODEL_TIERS = ['lite', 'medium', 'high'] as const;
+export type ModelTier = (typeof MODEL_TIERS)[number];
+
+/** Position in {@link MODEL_TIERS}. Lower is cheaper. */
+export function tierRank(tier: ModelTier): number {
+    return MODEL_TIERS.indexOf(tier);
+}
+
+/**
+ * The ladder per defect class, cheapest first.
+ *
+ * Every list is a prefix of {@link MODEL_TIERS} or empty — a ladder that skipped
+ * a rung would be an expensive tier tried before a cheaper one by construction,
+ * which is the thing the step forbids. {@link assertLadderWellFormed} checks it.
+ */
+export const LADDER: Readonly<Record<DefectClass, readonly ModelTier[]>> = {
+    // A missing precondition is usually a prompt/context defect: cheap first,
+    // and there is a real ceiling because a large model still cannot invent a
+    // precondition that is absent.
+    precondition_unsatisfied: ['lite', 'medium'],
+    // A policy refusal is not a capability problem.
+    policy_blocked: [],
+    // Neither is a missing dependency.
+    dependency_unavailable: [],
+    // Execution failures are where capability plausibly helps, so the full ladder.
+    execution_failed: ['lite', 'medium', 'high'],
+    // A violated output contract is the classic cheap-model-first case: most are
+    // format, and format is the cheapest thing a small model gets right.
+    output_contract_violated: ['lite', 'medium'],
+    // Missing evidence needs more trials, not a bigger proposer.
+    evidence_missing: ['lite'],
+    // A human said no. No tier changes that.
+    human_rejected: [],
+    // Unclassified: one cheap attempt is licensed, and no more, because
+    // escalating on a reason nobody established is spending on a guess.
+    reason_unknown: ['lite'],
+};
+
+export class LadderOrderError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'LadderOrderError';
+    }
+}
+
+/** Every ladder is a prefix of {@link MODEL_TIERS}, or the empty ladder. */
+export function assertLadderWellFormed(
+    ladder: Readonly<Record<DefectClass, readonly ModelTier[]>> = LADDER,
+): void {
+    for (const cls of DEFECT_CLASSES) {
+        const rungs = ladder[cls];
+        for (let i = 0; i < rungs.length; i += 1) {
+            const expected = MODEL_TIERS[i];
+            if (rungs[i] !== expected) {
+                throw new LadderOrderError(
+                    `${cls}: rung ${String(i)} is '${String(rungs[i])}' where the cheapest-first ` +
+                        `order requires '${String(expected)}' — a ladder that skips a rung tries ` +
+                        'an expensive tier before a cheaper one by construction',
+                );
+            }
+        }
+    }
+}
+
+/** The ladder for one class. Empty means no metered attempt is licensed. */
+export function ladderFor(cls: DefectClass): readonly ModelTier[] {
+    return LADDER[cls];
+}
+
+/**
+ * The cheapest tier not yet tried for this class, or `null`.
+ *
+ * `null` means STOP, in both of its two causes: the ladder is empty for this
+ * class, or every licensed rung has been spent. A caller that reads `null` as
+ * "escalate" has inverted the policy.
+ */
+export function nextTier(cls: DefectClass, tried: readonly ModelTier[]): ModelTier | null {
+    const spent = new Set(tried);
+    for (const rung of ladderFor(cls)) {
+        if (!spent.has(rung)) return rung;
+    }
+    return null;
+}
+
+/** One metered attempt, as it would be recorded by a harness that made one. */
+export interface LadderAttempt {
+    readonly defect_class: DefectClass;
+    readonly tier: ModelTier;
+    /** Monotonic within one class. The ONLY ordering key. */
+    readonly sequence: number;
+}
+
+/**
+ * Refuse an attempt sequence in which a costlier tier ran before a cheaper one
+ * for the same defect class, or in which a tier outside the class's ladder ran
+ * at all.
+ *
+ * Per class, in sequence order: each attempt's tier must be the cheapest rung
+ * not already spent. A repeat of an already-spent rung is allowed — retrying
+ * `lite` is not an escalation — but a jump is not.
+ *
+ * NO LIVE SUBJECT. Nothing in this programme produces {@link LadderAttempt}s
+ * today; see the header. This is a guard waiting for a harness, and its unit
+ * test proves it fires rather than proving anything ran.
+ */
+export function assertCheapestFirst(attempts: readonly LadderAttempt[]): void {
+    const byClass = new Map<DefectClass, LadderAttempt[]>();
+    for (const a of attempts) {
+        const list = byClass.get(a.defect_class) ?? [];
+        list.push(a);
+        byClass.set(a.defect_class, list);
+    }
+    for (const [cls, list] of byClass) {
+        const rungs = ladderFor(cls);
+        if (rungs.length === 0) {
+            const first = [...list].sort((x, y) => x.sequence - y.sequence)[0] as LadderAttempt;
+            throw new LadderOrderError(
+                `${cls}: tier '${first.tier}' was tried on a class whose ladder is empty — ` +
+                    'no metered attempt is licensed here, so the cheapest thing to try is nothing',
+            );
+        }
+        const spent: ModelTier[] = [];
+        for (const a of [...list].sort((x, y) => x.sequence - y.sequence)) {
+            if (!rungs.includes(a.tier)) {
+                throw new LadderOrderError(
+                    `${cls}: tier '${a.tier}' is not on this class's ladder ` +
+                        `(${rungs.join(' < ') || 'empty'})`,
+                );
+            }
+            if (spent.includes(a.tier)) continue;
+            const cheapest = nextTier(cls, spent);
+            if (cheapest !== null && a.tier !== cheapest) {
+                throw new LadderOrderError(
+                    `${cls}: tier '${a.tier}' was tried at sequence ${String(a.sequence)} while ` +
+                        `'${cheapest}' was still untried — cheaper models go first`,
+                );
+            }
+            spent.push(a.tier);
+        }
+    }
+}
+
+/** One class's ladder as it goes into a report. */
+export interface LadderPlanRow {
+    readonly defect_class: DefectClass;
+    readonly ladder: readonly ModelTier[];
+    /** The cheapest untried rung given `tried`, or `null` for "spend nothing". */
+    readonly next: ModelTier | null;
+}
+
+/** The whole ladder plan, one row per defect class, in vocabulary order. */
+export function ladderPlan(
+    tried: Readonly<Partial<Record<DefectClass, readonly ModelTier[]>>> = {},
+): LadderPlanRow[] {
+    return DEFECT_CLASSES.map((cls) => ({
+        defect_class: cls,
+        ladder: ladderFor(cls),
+        next: nextTier(cls, tried[cls] ?? []),
+    }));
+}
+
+// --- the ROI figure ---------------------------------------------------------
+
+/** Row counts read off the evaluated vectors. Never inferred. */
+export interface RoiCounts {
+    readonly evaluated_candidates: number;
+    readonly improved_rows: number;
+    readonly regressed_rows: number;
+    readonly underpowered_rows: number;
+}
+
+/**
+ * Improvement per evolution dollar.
+ *
+ * `regressed_rows` and `underpowered_rows` ride alongside the ratio rather than
+ * being netted into it. Netting would let a candidate that improved two rows
+ * and regressed two report as neutral, which is the collapse
+ * `_lib/evaluation_vector.ts` refuses for the same reason.
+ */
+export type RoiFigure =
+    | ({ readonly kind: 'ratio'; readonly spend_cents: number; readonly improvement_per_dollar: number } & RoiCounts)
+    | ({ readonly kind: 'no-spend'; readonly spend_cents: 0 } & RoiCounts)
+    | ({ readonly kind: 'unmeasured'; readonly spend_cents: number } & RoiCounts);
+
+/** Count the paired rows by verdict kind across the evaluated vectors. */
+export function roiCounts(vectors: readonly MetricVector[]): RoiCounts {
+    let improved = 0;
+    let regressed = 0;
+    let underpowered = 0;
+    for (const v of vectors) {
+        for (const r of v.rows) {
+            if (r.kind !== 'paired') continue;
+            if (r.verdict.kind === 'pass') improved += 1;
+            else if (r.verdict.kind === 'regression') regressed += 1;
+            else if (r.verdict.kind === 'underpowered') underpowered += 1;
+        }
+    }
+    return {
+        evaluated_candidates: vectors.length,
+        improved_rows: improved,
+        regressed_rows: regressed,
+        underpowered_rows: underpowered,
+    };
+}
+
+export class RoiShapeError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'RoiShapeError';
+    }
+}
+
+/**
+ * The figure. `spendCents` is the run's declared spend in WHOLE CENTS, matching
+ * `RunBudget.maxSpendCents` — no float ever decides a kind.
+ */
+export function roiFigure(vectors: readonly MetricVector[], spendCents: number): RoiFigure {
+    if (!Number.isInteger(spendCents) || spendCents < 0) {
+        throw new RoiShapeError(
+            `spend must be a non-negative whole number of cents (got ${String(spendCents)})`,
+        );
+    }
+    const counts = roiCounts(vectors);
+    if (counts.evaluated_candidates === 0) {
+        return { kind: 'unmeasured', spend_cents: spendCents, ...counts };
+    }
+    if (spendCents === 0) {
+        return { kind: 'no-spend', spend_cents: 0, ...counts };
+    }
+    return {
+        kind: 'ratio',
+        spend_cents: spendCents,
+        improvement_per_dollar: counts.improved_rows / (spendCents / 100),
+        ...counts,
+    };
+}
+
+// --- the run report ---------------------------------------------------------
+
+/**
+ * A run report. There is no optional field here, and `roi` is the reason:
+ * an optional ROI figure is one a report omits on the run that needed it.
+ */
+export interface RunReport {
+    readonly run_id: string;
+    readonly candidates: number;
+    readonly trials_per_candidate: number;
+    readonly roi: RoiFigure;
+    readonly ladder: readonly LadderPlanRow[];
+}
+
+export interface RunReportInput {
+    readonly run_id: string;
+    readonly candidates: number;
+    readonly trials_per_candidate: number;
+    readonly roi: RoiFigure;
+    readonly ladder?: readonly LadderPlanRow[];
+}
+
+export class RunReportShapeError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'RunReportShapeError';
+    }
+}
+
+/** Kinds a `roi` value may carry. Checked at runtime, where types are gone. */
+const ROI_KINDS = new Set(['ratio', 'no-spend', 'unmeasured']);
+
+/**
+ * Build a report, REFUSING one without an ROI figure.
+ *
+ * The check is deliberately a runtime one over a value the compiler already
+ * types: a caller reaching this function through `as RunReportInput`, a JSON
+ * parse, or a `delete` is exactly the caller who would drop the row, and the
+ * type system cannot see any of them.
+ */
+export function buildRunReport(input: RunReportInput): RunReport {
+    if (input.run_id.trim() === '') {
+        throw new RunReportShapeError('a report with no run id names no run');
+    }
+    const roi = (input as { roi?: unknown }).roi;
+    if (roi === undefined || roi === null || typeof roi !== 'object') {
+        throw new RunReportShapeError(
+            'missing the ROI figure — improvement per evolution dollar is what a budget cap ' +
+                'does not report, so a run report without it is the cost-blind report step 5.6 ' +
+                'exists to prevent',
+        );
+    }
+    const kind = (roi as { kind?: unknown }).kind;
+    if (typeof kind !== 'string' || !ROI_KINDS.has(kind)) {
+        throw new RunReportShapeError(
+            `ROI figure carries an unknown kind ${JSON.stringify(kind)} — expected one of ` +
+                `${[...ROI_KINDS].join(', ')}`,
+        );
+    }
+    assertLadderWellFormed();
+    return {
+        run_id: input.run_id,
+        candidates: input.candidates,
+        trials_per_candidate: input.trials_per_candidate,
+        roi: input.roi,
+        ladder: input.ladder ?? ladderPlan(),
+    };
+}
+
+/** The ROI line, verbatim. One line, always present, never conditional. */
+export function renderRoi(roi: RoiFigure): string {
+    const head =
+        `roi: improved=${String(roi.improved_rows)} regressed=${String(roi.regressed_rows)} ` +
+        `underpowered=${String(roi.underpowered_rows)} over ` +
+        `${String(roi.evaluated_candidates)} evaluated candidate(s), spend=${String(roi.spend_cents)}c`;
+    if (roi.kind === 'ratio') {
+        return `${head} -> ${roi.improvement_per_dollar.toFixed(3)} improved rows per dollar`;
+    }
+    if (roi.kind === 'no-spend') {
+        return `${head} -> no ratio: the run spent nothing, so improvement per dollar is undefined`;
+    }
+    return `${head} -> no ratio: no candidate in this run carried an evaluation`;
+}
+
+/** The whole report as lines a caller writes to stdout unchanged. */
+export function renderRunReport(r: RunReport): string[] {
+    const lines = [
+        `run-report: ${r.run_id}`,
+        `run-report: candidates=${String(r.candidates)} trials-per-candidate=${String(r.trials_per_candidate)}`,
+        `run-report: ${renderRoi(r.roi)}`,
+    ];
+    for (const row of r.ladder) {
+        const rungs = row.ladder.length === 0 ? '(none licensed)' : row.ladder.join(' < ');
+        const next = row.next === null ? 'spend nothing' : row.next;
+        lines.push(`run-report: ladder ${row.defect_class}: ${rungs} | next: ${next}`);
+    }
+    return lines;
+}
+
+// --- reading an evaluation off disk -----------------------------------------
+
+/**
+ * Parse a `MetricVector` from JSON, reusing {@link buildVector} so the
+ * artifact-count refusal is inherited rather than re-implemented.
+ */
+export function parseMetricVectorJson(text: string, source: string): MetricVector {
+    let raw: unknown;
+    try {
+        raw = JSON.parse(text);
+    } catch (e) {
+        throw new RoiShapeError(`${source}: not JSON — ${(e as Error).message}`);
+    }
+    // An array IS an object in JS, so the array check is not pedantry: without
+    // it a `[]` payload falls through to the field checks and reports a missing
+    // `candidate_id`, which names the wrong defect.
+    if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+        throw new RoiShapeError(`${source}: expected a JSON object`);
+    }
+    const obj = raw as { candidate_id?: unknown; rows?: unknown };
+    if (typeof obj.candidate_id !== 'string' || obj.candidate_id.trim() === '') {
+        throw new RoiShapeError(`${source}: 'candidate_id' must be a non-empty string`);
+    }
+    if (!Array.isArray(obj.rows)) {
+        throw new RoiShapeError(`${source}: 'rows' must be an array`);
+    }
+    const rows: MetricRow[] = [];
+    for (const [i, r] of (obj.rows as unknown[]).entries()) {
+        rows.push(parseRow(r, `${source}: rows[${String(i)}]`));
+    }
+    return buildVector(obj.candidate_id, rows);
+}
+
+const DIRECTIONS = new Set(['higher-better', 'lower-better']);
+const VERDICT_KINDS = new Set(['pass', 'no-change', 'regression', 'underpowered']);
+
+function parseRow(raw: unknown, where: string): MetricRow {
+    if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+        throw new RoiShapeError(`${where}: expected an object`);
+    }
+    const r = raw as Record<string, unknown>;
+    const metric = r.metric;
+    const direction = r.direction;
+    if (typeof metric !== 'string' || metric.trim() === '') {
+        throw new RoiShapeError(`${where}: 'metric' must be a non-empty string`);
+    }
+    if (typeof direction !== 'string' || !DIRECTIONS.has(direction)) {
+        throw new RoiShapeError(`${where}: 'direction' must be higher-better or lower-better`);
+    }
+    if (r.kind === 'counted') {
+        if (!Number.isInteger(r.delta)) {
+            throw new RoiShapeError(`${where}: a counted row needs an integer 'delta'`);
+        }
+        return {
+            kind: 'counted',
+            metric,
+            direction: direction as 'higher-better' | 'lower-better',
+            delta: r.delta as number,
+        };
+    }
+    if (r.kind === 'paired') {
+        const v = r.verdict;
+        if (typeof v !== 'object' || v === null) {
+            throw new RoiShapeError(`${where}: a paired row needs a 'verdict' object`);
+        }
+        const raw_v = v as Record<string, unknown>;
+        const kind = raw_v.kind;
+        if (typeof kind !== 'string' || !VERDICT_KINDS.has(kind)) {
+            throw new RoiShapeError(
+                `${where}: verdict kind ${JSON.stringify(kind)} is not one of ` +
+                    `${[...VERDICT_KINDS].join(', ')}`,
+            );
+        }
+        // Every counted field is validated rather than spread through: a
+        // verdict read off disk is untrusted input, and a string where an
+        // integer belongs is how a report ends up printing `NaN` per dollar.
+        const verdict: PairedVerdict = {
+            kind: kind as PairedVerdictKind,
+            discordant: intField(raw_v, 'discordant', where),
+            wins: intField(raw_v, 'wins', where),
+            losses: intField(raw_v, 'losses', where),
+            p: numField(raw_v, 'p', where),
+            magnitude_mean:
+                raw_v.magnitude_mean === null || raw_v.magnitude_mean === undefined
+                    ? null
+                    : numField(raw_v, 'magnitude_mean', where),
+            at_floor: raw_v.at_floor === true,
+            reason: typeof raw_v.reason === 'string' ? raw_v.reason : '',
+        };
+        return {
+            kind: 'paired',
+            metric,
+            direction: direction as 'higher-better' | 'lower-better',
+            verdict,
+        };
+    }
+    throw new RoiShapeError(
+        `${where}: 'kind' must be 'paired' or 'counted' (got ${JSON.stringify(r.kind)}) — ` +
+            `a metric row without a kind cannot be counted toward ${ARTIFACT_COUNT_METRIC} or ROI`,
+    );
+}
+
+function intField(o: Record<string, unknown>, key: string, where: string): number {
+    const v = o[key];
+    if (!Number.isInteger(v)) {
+        throw new RoiShapeError(`${where}: verdict '${key}' must be an integer`);
+    }
+    return v as number;
+}
+
+function numField(o: Record<string, unknown>, key: string, where: string): number {
+    const v = o[key];
+    if (typeof v !== 'number' || !Number.isFinite(v)) {
+        throw new RoiShapeError(`${where}: verdict '${key}' must be a finite number`);
+    }
+    return v;
+}

--- a/src/scripts/_lib/harness_evolution_guards.ts
+++ b/src/scripts/_lib/harness_evolution_guards.ts
@@ -189,6 +189,16 @@ export const STOP_CONDITIONS: readonly StopCondition[] = [
         detector: 'diversityCollapsed',
     },
     {
+        id: 'pathology-dominance',
+        // The sibling above asks whether THIS run's candidates are distinct.
+        // This asks whether the SEARCH has stopped exploring: one WHERE x WHY
+        // failure cell dominating the recent window means the proposer keeps
+        // rediscovering one pathology, which a distinct-count check cannot see
+        // because the candidates are all textually different.
+        why: 'one WHERE x WHY pathology cell dominates the recent classifiable window, so the search is rediscovering one failure mode rather than exploring',
+        detector: 'dominanceVerdict',
+    },
+    {
         id: 'cross-component-interference',
         why: 'two components changed in one run and credit cannot be assigned to either',
         // Honest null: deciding whether two changes interfere needs a causal

--- a/src/scripts/_lib/lexical_shortlist.ts
+++ b/src/scripts/_lib/lexical_shortlist.ts
@@ -1,0 +1,215 @@
+/**
+ * A lexical shortlist over the existing BM25 core — a SHORTLIST, never a decider.
+ *
+ * `road-to-governed-harness-evolution` Phase 6, step 6.3.
+ *
+ * > *6.3 Only then consider a lexical shortlist, and only as a shortlist. Over
+ * > the existing BM25 core. No embeddings […]. The skipped parent proposed the
+ * > shortlist and explicitly refused it as final truth.*
+ * > verify: **the shortlist feeds a later stage and never decides alone.**
+ *
+ * ## No embeddings, and the citation this step carried had moved
+ *
+ * The step's own text cites `docs/contracts/no-runtime-boundary.md:40` for the
+ * classification. That file is now a **superseded pointer** (ADR-249,
+ * 2026-08-27) and line 40 no longer says it. The substance survived the move
+ * intact and is quoted from its live home instead:
+ * `docs/contracts/resident-process-governance.md:82` — *"A code-graph cache
+ * passes; a vector index fails"*, under the P3 state-store test, with P4
+ * separately prohibiting any index build requiring network or model calls.
+ * So this module builds over `_lib/lexical_index.ts` — hand-rolled BM25, pure
+ * Node stdlib, the core ADR-061 already sanctions. A static scan in
+ * `tests/scripts/_lib/lexical_shortlist.test.ts` asserts this module and that
+ * core reach no embedding construct, no vector store and no model call. The
+ * construct list lives in the test rather than here for a mechanical reason:
+ * a scanner whose banned literals sit in the file it scans matches its own
+ * declaration and can never pass — the same reason
+ * `tests/scripts/governed_harness_no_live_harness.test.ts` keeps its banned set
+ * on the test side.
+ *
+ * ## "Never decides alone", made mechanical rather than promised
+ *
+ * A shortlist decides alone in exactly two ways, and both are closed here by
+ * construction rather than by a caller's discipline:
+ *
+ *   1. **By addition** — delivering something the authoritative matcher did not
+ *      fire on. Impossible: {@link orderByShortlist} takes the matcher's output
+ *      as its input domain and returns a PERMUTATION of it. Ids the shortlist
+ *      ranks that the matcher did not return are dropped on the floor, and
+ *      {@link selectForInjection}'s tie-break argument is consulted only to
+ *      order ids that are already in `matches`.
+ *   2. **By subtraction** — silently removing a matcher hit, which is a
+ *      decision dressed as a filter. Impossible: the same permutation
+ *      invariant. {@link ShortlistDecidedAloneError} is thrown when the output
+ *      id multiset differs from the input's in either direction, so a future
+ *      edit that turns the reordering into a filter fails loudly instead of
+ *      quietly losing recall.
+ *
+ * The shortlist's actual job is the third thing, and it is a real one: when the
+ * per-prompt byte cap BINDS, something has to choose which matched bodies
+ * survive it. Today that is the matcher's trigger-hit count and then router
+ * declaration order — and the hit count is a coarse integer on which most rules
+ * tie, so the surviving set is decided by declaration order, which is not a
+ * relevance signal at all. The shortlist supplies one, subordinate to the
+ * matcher score and never above it.
+ *
+ * ## Subordination is an ORDER of comparison keys, and the order is the contract
+ *
+ * `score desc → shortlist rank → router order`. The matcher's verdict is read
+ * first and the shortlist only breaks its ties. Promoting the shortlist above
+ * `score` would let a lexically-similar rule outrank one the matcher fired on
+ * twice, which is the shortlist deciding — a test pins the key order and is
+ * proved to go red when it is inverted.
+ *
+ * ## What this module does NOT claim
+ *
+ * That the shortlist improves anything. Whether a lexical tie-break beats
+ * declaration order under a binding cap is a MEASUREMENT, and step 6.4 is where
+ * the loss ceiling for it gets pre-registered. `model_rule_injection
+ * --three-arm --shortlist` runs the arm with it, default OFF, so 6.1's recorded
+ * figures are reproducible unchanged.
+ */
+import { LexicalIndex, type IndexDoc } from './lexical_index.js';
+import { allTierRules, loadRuleBody, type Router, type TierRuleMatch } from './rule_injection.js';
+
+/**
+ * How many ids a shortlist may carry.
+ *
+ * A STATED default, not a measured optimum, and deliberately generous: this
+ * shortlist narrows nothing (it reorders), so `k` bounds only how far down the
+ * BM25 ranking a tie-break signal is available before router order takes over.
+ * Revisit-if 6.4 measures a cap-drop the shortlist could have prevented at a
+ * rank beyond it.
+ */
+export const SHORTLIST_SIZE = 40;
+
+export class ShortlistDecidedAloneError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'ShortlistDecidedAloneError';
+    }
+}
+
+/**
+ * Index every tier rule that has a projected body.
+ *
+ * Kernel rules are excluded for the same reason `_lib/rule_injection.ts`
+ * excludes them from injection: they are standing context by definition, so
+ * they are never candidates for a cap that only ever binds on injected bodies.
+ * `allTierRules` already returns the non-kernel set.
+ */
+export function buildRuleIndex(repoRoot: string, router: Router): LexicalIndex {
+    const docs: IndexDoc[] = [];
+    for (const r of allTierRules(router)) {
+        const body = loadRuleBody(repoRoot, r.id);
+        if (body === null) continue;
+        // The id is joined into the text on purpose: a rule's own name is the
+        // single most reliable lexical signal it carries, and hyphenated ids
+        // tokenise into exactly the words a prompt about that rule would use.
+        docs.push({ id: r.id, text: `${r.id.split('-').join(' ')}\n${body}` });
+    }
+    return new LexicalIndex(docs);
+}
+
+/**
+ * The ranked shortlist for one prompt. BM25 only; no model call, no embedding.
+ *
+ * Returns ids in descending relevance, capped at `k`. An empty result is a real
+ * answer — it means no indexed body shares a scoring term with the prompt, and
+ * the caller then falls back to router order exactly as it does today.
+ */
+export function shortlistIds(
+    index: LexicalIndex,
+    prompt: string,
+    k: number = SHORTLIST_SIZE,
+): string[] {
+    if (k <= 0) return [];
+    return index.rank([prompt]).slice(0, k).map((r) => r.id);
+}
+
+/**
+ * Rank lookup: id → position in the shortlist, or `Infinity` for absent.
+ *
+ * `Infinity` rather than a large integer so an unshortlisted id can never sort
+ * above a shortlisted one by arithmetic accident.
+ */
+export function shortlistRanks(ranked: readonly string[]): Map<string, number> {
+    const m = new Map<string, number>();
+    for (const [i, id] of ranked.entries()) {
+        if (!m.has(id)) m.set(id, i);
+    }
+    return m;
+}
+
+/**
+ * Reorder the matcher's output by the shortlist — a PERMUTATION, always.
+ *
+ * This is the function that makes "never decides alone" checkable. It takes the
+ * matcher's verdict as its input domain, applies the same key order
+ * {@link selectForInjection} applies (`score desc → shortlist rank → router
+ * order`), and REFUSES to return anything whose id multiset differs from what
+ * it was given.
+ *
+ * @throws {ShortlistDecidedAloneError} when the result would add or drop an id.
+ */
+export function orderByShortlist(
+    matches: readonly TierRuleMatch[],
+    ranked: readonly string[],
+): TierRuleMatch[] {
+    const rank = shortlistRanks(ranked);
+    const out = [...matches].sort(
+        (a, b) =>
+            b.score - a.score ||
+            (rank.get(a.id) ?? Infinity) - (rank.get(b.id) ?? Infinity) ||
+            a.order - b.order,
+    );
+    assertPermutation(matches, out);
+    return out;
+}
+
+/** Same-multiset assertion, in both directions. Exported so a test can drive it. */
+export function assertPermutation(
+    before: readonly TierRuleMatch[],
+    after: readonly TierRuleMatch[],
+): void {
+    const count = (xs: readonly TierRuleMatch[]): Map<string, number> => {
+        const m = new Map<string, number>();
+        for (const x of xs) m.set(x.id, (m.get(x.id) ?? 0) + 1);
+        return m;
+    };
+    const a = count(before);
+    const b = count(after);
+    const added: string[] = [];
+    const dropped: string[] = [];
+    for (const [id, n] of b) {
+        if ((a.get(id) ?? 0) < n) added.push(id);
+    }
+    for (const [id, n] of a) {
+        if ((b.get(id) ?? 0) < n) dropped.push(id);
+    }
+    if (added.length > 0 || dropped.length > 0) {
+        throw new ShortlistDecidedAloneError(
+            'the shortlist changed the matcher`s set instead of ordering it' +
+                (added.length > 0 ? ` — added ${added.sort().join(', ')}` : '') +
+                (dropped.length > 0 ? ` — dropped ${dropped.sort().join(', ')}` : '') +
+                '. A shortlist that adds delivers what the matcher never fired on; one that ' +
+                'drops decides by subtraction. Both are the shortlist deciding alone.',
+        );
+    }
+}
+
+/**
+ * A per-prompt shortlist function, bound to one repo root and router.
+ *
+ * The index is built ONCE and reused for every prompt — building it per prompt
+ * would make the cheap stage the expensive one, which is the opposite of what a
+ * shortlist is for.
+ */
+export function makePromptShortlist(
+    repoRoot: string,
+    router: Router,
+    k: number = SHORTLIST_SIZE,
+): (prompt: string) => readonly string[] {
+    const index = buildRuleIndex(repoRoot, router);
+    return (prompt: string) => shortlistIds(index, prompt, k);
+}

--- a/src/scripts/_lib/pathology_archive.ts
+++ b/src/scripts/_lib/pathology_archive.ts
@@ -1,0 +1,393 @@
+/**
+ * The pathology archive — best-known intervention per `WHERE x WHY` failure
+ * cell, over closed vocabularies, backed by append-only attempt history.
+ *
+ * `road-to-governed-harness-evolution` step 4.4. A pure Pareto frontier orders
+ * candidates by their metric vectors and throws away the reason each candidate
+ * exists, so two candidates that fail for completely different reasons compete
+ * as if they were interchangeable. This module keeps the reason.
+ *
+ * ## What this is NOT
+ *
+ * It is not a second verdict beside `_lib/paired_verdict.ts`. Nothing here
+ * decides whether a candidate is better; the archive records WHY attempts
+ * failed and which intervention is currently RETAINED per cell. Promotion stays
+ * with `_lib/evaluation_vector.ts`'s `promotionVerdict`, which this module never
+ * calls and never reimplements.
+ *
+ * ## "Best" is a retained representative, not a quality claim
+ *
+ * The AI council of 2026-08-31 was explicit that "archive the best intervention
+ * per cell" names no operation until ranking, tie-break and replacement are all
+ * total. Two of the three candidate rules it enumerated need evidence systems
+ * that do not exist — lowest edit distance to a human gold standard (there is no
+ * gold standard) and highest measured failure-class coverage (there is no
+ * coverage metric). The third, recency, is trivially deterministic and is what
+ * ships. So the retained entry is a REPRESENTATIVE selected by recency, and this
+ * module says so in its type names rather than calling it "best" and implying a
+ * measurement nobody took.
+ *
+ * Because recency says nothing about quality, the attempt history is append-only
+ * and every ranking decision is stamped with `ranking_rule_version`. When a real
+ * quality metric arrives, representatives are RECOMPUTED from history rather
+ * than lost.
+ *
+ * ## Ordering is by sequence, never by timestamp
+ *
+ * `attempt_sequence` is assigned by the ingester, monotonically. Timestamps come
+ * from producer clocks: they collide, they arrive out of order, and they make a
+ * replacement rule that is not total. `observed_at` is retained for reporting
+ * and is never consulted for ordering.
+ */
+
+import { LADDER_RUNGS, type LadderRung } from './activation_ladder.js';
+
+/** `WHERE` — reused from the activation ladder, never re-invented. */
+export const PATHOLOGY_WHERE = LADDER_RUNGS;
+export type PathologyWhere = LadderRung;
+
+/**
+ * `WHY` — the closed failure-REASON vocabulary.
+ *
+ * Closed means: a versioned enum, exactly one value per attempt, and an addition
+ * requires a `classification_rule_version` bump plus migration. Free-form
+ * explanation belongs in `reason_detail` and never in this axis.
+ *
+ * The order IS the precedence order. When several reasons could apply, the
+ * earliest applicable value wins, so classification is deterministic rather than
+ * dependent on evaluation order. `reason_unknown` applies only when none of the
+ * first seven can be established — it is a real state, not a default.
+ *
+ * These are REASONS, deliberately not places. An earlier draft of this
+ * vocabulary used names like `projection_failed` and `delivery_failed`, which
+ * restate `WHERE` and collapse the very distinction the two axes exist to draw.
+ */
+export const PATHOLOGY_WHY = [
+    'precondition_unsatisfied',
+    'policy_blocked',
+    'dependency_unavailable',
+    'execution_failed',
+    'output_contract_violated',
+    'evidence_missing',
+    'human_rejected',
+    'reason_unknown',
+] as const;
+export type PathologyWhy = (typeof PATHOLOGY_WHY)[number];
+
+/** Bumped when the cell/query shape changes. */
+export const ARCHIVE_SCHEMA_VERSION = 1;
+/** Bumped when `PATHOLOGY_WHY` or its precedence changes. */
+export const CLASSIFICATION_RULE_VERSION = 1;
+/** Bumped when the ranking/tie-break/replacement rule changes. */
+export const RANKING_RULE_VERSION = 1;
+
+/**
+ * Dominance threshold for the search-collapse guard.
+ *
+ * STATED POLICY DEFAULT, not a measured optimum — and deliberately a NEW
+ * constant rather than a reuse.
+ *
+ * The step's own verify line carries a bare `0.6`, and the prior council warned
+ * that reusing it would be "a semantic change wearing a constant's clothes" IF
+ * it already meant textual similarity. Checked against the tree on 2026-08-31:
+ * it does not, because no such constant exists. `diversityCollapsed`
+ * (`_lib/harness_evolution_guards.ts:215`) is a DISTINCT-COUNT check with
+ * `minDistinct = 2` and no ratio at all, and the only near-duplicate constant is
+ * `NEAR_DUPLICATE_THRESHOLD = 70` in `_lib/curator_ops.ts:106` — an integer
+ * percentage on a different scale. So the collision the objection feared is not
+ * present, and the number below is free to be given its own meaning.
+ *
+ * Revisit-if: a run records a collapse the guard did not catch, or a warm-up
+ * period in which the floor below suppressed a real signal.
+ */
+export const PATHOLOGY_DOMINANCE_THRESHOLD = 0.6;
+/** Observation window: the latest N classifiable failed attempts. */
+export const PATHOLOGY_WINDOW_SIZE = 50;
+/** No verdict below this many classifiable attempts in the window. */
+export const PATHOLOGY_MIN_CLASSIFIABLE_ATTEMPTS = 20;
+
+export type ClassificationStatus = 'classified' | 'unclassifiable';
+export type ValidationStatus = 'valid' | 'invalid';
+
+/** One append-only attempt observation. Never mutated, never deleted. */
+export interface PathologyAttempt {
+    readonly attempt_id: string;
+    /** Monotonic, ingester-assigned. The ONLY ordering key. */
+    readonly attempt_sequence: number;
+    readonly candidate_id: string;
+    readonly intervention_ref: string;
+    readonly where: PathologyWhere;
+    readonly why: PathologyWhy;
+    readonly reason_detail: string;
+    readonly classification_status: ClassificationStatus;
+    readonly validation_status: ValidationStatus;
+    /** Reporting only. Never consulted for ordering. */
+    readonly observed_at: string;
+    readonly archive_schema_version: number;
+    readonly classification_rule_version: number;
+    readonly ranking_rule_version: number;
+    readonly cohort_id: string;
+    readonly cohort_version: number;
+}
+
+/** A versioned cell query result. The guard consumes THIS, never storage internals. */
+export interface PathologyCell {
+    readonly where: PathologyWhere;
+    readonly why: PathologyWhy;
+    readonly archive_schema_version: number;
+    readonly classification_rule_version: number;
+    readonly ranking_rule_version: number;
+    readonly cohort_id: string;
+    readonly cohort_version: number;
+    readonly attempt_count: number;
+    readonly classifiable_count: number;
+    readonly unclassifiable_count: number;
+    readonly first_observed_attempt_sequence: number;
+    readonly first_observed_at: string;
+    readonly last_observed_attempt_sequence: number;
+    readonly last_observed_at: string;
+    readonly retained_candidate_id: string | null;
+    readonly retained_intervention_ref: string | null;
+    readonly retained_attempt_id: string | null;
+    readonly retained_attempt_sequence: number | null;
+    readonly retained_observed_at: string | null;
+    readonly retained_ranking_rule: string;
+    readonly retained_ranking_key: string | null;
+    readonly retained_validation_status: ValidationStatus | null;
+}
+
+/** A versioned window query result. The guard's only legal input. */
+export interface PathologyWindowQuery {
+    readonly archive_schema_version: number;
+    readonly classification_rule_version: number;
+    readonly ranking_rule_version: number;
+    readonly window_size: number;
+    readonly unclassifiable_excluded: number;
+    readonly rows: readonly PathologyAttempt[];
+}
+
+export interface DominanceOptions {
+    readonly threshold?: number;
+    readonly windowSize?: number;
+    readonly minClassifiable?: number;
+}
+
+export const RETAINED_RANKING_RULE = 'recency-v1: attempt_sequence DESC, candidate_id ASC, attempt_id ASC';
+
+export function cellKey(where: PathologyWhere, why: PathologyWhy): string {
+    return `${where} ${why}`;
+}
+
+export class PathologyArchiveError extends Error {}
+
+/**
+ * Is `incoming` a better representative than `retained`?
+ *
+ * Total by construction: the tuple `(attempt_sequence DESC, candidate_id ASC,
+ * attempt_id ASC)` orders any two distinct attempts, and `attempt_id` is unique,
+ * so the comparison never falls through to "equal" for two different attempts.
+ * A rule whose tie-break is declared but unreachable is not total, which is the
+ * defect the council named in the timestamp-ordered alternative.
+ */
+export function replacesRetained(incoming: PathologyAttempt, retained: PathologyAttempt): boolean {
+    if (incoming.attempt_sequence !== retained.attempt_sequence) {
+        return incoming.attempt_sequence > retained.attempt_sequence;
+    }
+    if (incoming.candidate_id !== retained.candidate_id) {
+        return incoming.candidate_id < retained.candidate_id;
+    }
+    return incoming.attempt_id < retained.attempt_id;
+}
+
+/** Only a validated, classified attempt may become a representative. */
+function eligibleAsRepresentative(a: PathologyAttempt): boolean {
+    return a.classification_status === 'classified' && a.validation_status === 'valid';
+}
+
+/**
+ * Append-only, idempotent attempt store.
+ *
+ * Re-ingesting an existing `attempt_id` is a no-op: it cannot alter counts and
+ * cannot change a representative. Without that, a retry loop silently inflates
+ * the very frequency evidence the dominance guard reads.
+ */
+export class PathologyArchive {
+    private readonly byId = new Map<string, PathologyAttempt>();
+    private readonly order: PathologyAttempt[] = [];
+
+    /** @returns true when the attempt was new, false when it was a duplicate. */
+    ingest(a: PathologyAttempt): boolean {
+        if (!PATHOLOGY_WHERE.includes(a.where)) {
+            throw new PathologyArchiveError(`unknown WHERE '${a.where}'`);
+        }
+        if (!PATHOLOGY_WHY.includes(a.why)) {
+            throw new PathologyArchiveError(`unknown WHY '${a.why}'`);
+        }
+        if (this.byId.has(a.attempt_id)) return false;
+        this.byId.set(a.attempt_id, a);
+        this.order.push(a);
+        return true;
+    }
+
+    /** Every attempt, in ingest order. Callers must not mutate. */
+    attempts(): readonly PathologyAttempt[] {
+        return this.order;
+    }
+
+    /**
+     * The versioned window query the collapse guard consumes.
+     *
+     * The guard may not read `attempts()` directly: the council required it to
+     * consume "a versioned archive query rather than storage internals", so the
+     * version/cohort quad travels WITH the rows and a guard cannot silently mix
+     * two classification vocabularies. It returns attempts rather than cells
+     * because a last-N window is not reconstructible from aggregates — which is
+     * the same reason `cells()` alone is not the guard's input.
+     */
+    dominanceWindow(windowSize: number = PATHOLOGY_WINDOW_SIZE): PathologyWindowQuery {
+        const classifiable = this.order
+            .filter((a) => a.classification_status === 'classified')
+            .sort((a, b) => a.attempt_sequence - b.attempt_sequence);
+        const rows = classifiable.slice(-windowSize);
+        const head = rows[0] ?? this.order[0];
+        return {
+            archive_schema_version: head?.archive_schema_version ?? ARCHIVE_SCHEMA_VERSION,
+            classification_rule_version: head?.classification_rule_version ?? CLASSIFICATION_RULE_VERSION,
+            ranking_rule_version: head?.ranking_rule_version ?? RANKING_RULE_VERSION,
+            window_size: windowSize,
+            unclassifiable_excluded: this.order.length - classifiable.length,
+            rows,
+        };
+    }
+
+    /** The collapse verdict, read through the versioned query above. */
+    collapseVerdict(opts: DominanceOptions = {}): DominanceVerdict {
+        return dominanceVerdict(this.dominanceWindow(opts.windowSize ?? PATHOLOGY_WINDOW_SIZE), opts);
+    }
+
+    /**
+     * The versioned cell query. Cells are keyed on `WHERE x WHY` AND on the
+     * version/cohort quad — attempts recorded under a different classification
+     * rule describe a different vocabulary and must not be summed with these.
+     */
+    cells(): readonly PathologyCell[] {
+        const groups = new Map<string, PathologyAttempt[]>();
+        for (const a of this.order) {
+            const k = [
+                a.where,
+                a.why,
+                a.archive_schema_version,
+                a.classification_rule_version,
+                a.ranking_rule_version,
+                a.cohort_id,
+                a.cohort_version,
+            ].join(' ');
+            const bucket = groups.get(k);
+            if (bucket) bucket.push(a);
+            else groups.set(k, [a]);
+        }
+
+        const out: PathologyCell[] = [];
+        for (const bucket of groups.values()) {
+            const first = bucket.reduce((m, a) => (a.attempt_sequence < m.attempt_sequence ? a : m));
+            const last = bucket.reduce((m, a) => (a.attempt_sequence > m.attempt_sequence ? a : m));
+            let rep: PathologyAttempt | null = null;
+            for (const a of bucket) {
+                if (!eligibleAsRepresentative(a)) continue;
+                if (rep === null || replacesRetained(a, rep)) rep = a;
+            }
+            const head = bucket[0]!;
+            out.push({
+                where: head.where,
+                why: head.why,
+                archive_schema_version: head.archive_schema_version,
+                classification_rule_version: head.classification_rule_version,
+                ranking_rule_version: head.ranking_rule_version,
+                cohort_id: head.cohort_id,
+                cohort_version: head.cohort_version,
+                attempt_count: bucket.length,
+                classifiable_count: bucket.filter((a) => a.classification_status === 'classified').length,
+                unclassifiable_count: bucket.filter((a) => a.classification_status === 'unclassifiable').length,
+                first_observed_attempt_sequence: first.attempt_sequence,
+                first_observed_at: first.observed_at,
+                last_observed_attempt_sequence: last.attempt_sequence,
+                last_observed_at: last.observed_at,
+                retained_candidate_id: rep?.candidate_id ?? null,
+                retained_intervention_ref: rep?.intervention_ref ?? null,
+                retained_attempt_id: rep?.attempt_id ?? null,
+                retained_attempt_sequence: rep?.attempt_sequence ?? null,
+                retained_observed_at: rep?.observed_at ?? null,
+                retained_ranking_rule: RETAINED_RANKING_RULE,
+                retained_ranking_key: rep
+                    ? `${rep.attempt_sequence}|${rep.candidate_id}|${rep.attempt_id}`
+                    : null,
+                retained_validation_status: rep?.validation_status ?? null,
+            });
+        }
+        return out.sort((a, b) => (cellKey(a.where, a.why) < cellKey(b.where, b.why) ? -1 : 1));
+    }
+}
+
+export type DominanceVerdict =
+    | { readonly status: 'warming-up'; readonly classifiable_in_window: number; readonly floor: number }
+    | {
+          readonly status: 'ok' | 'collapsed';
+          readonly dominant_share: number;
+          readonly dominant_cell: string;
+          readonly classifiable_in_window: number;
+          readonly window_size: number;
+          readonly threshold: number;
+      };
+
+/**
+ * The search-collapse guard, reading the archive through `cells()`-shaped data.
+ *
+ * Why a share and not the occupancy the frontier already gives: retaining one
+ * winner per cell erases whether attempts were distributed 50/50 or 99.9/0.1 —
+ * identical occupancy, radically different evidence of collapse. The denominator
+ * is therefore CLASSIFIABLE ATTEMPTS in the window, not distinct cells.
+ *
+ * `warming-up` is a real state and NOT a pass. A guard that returned "ok" on
+ * three observations would be reporting a confidence it does not have; the floor
+ * exists so an empty archive cannot look healthy.
+ */
+export function dominanceVerdict(
+    query: PathologyWindowQuery,
+    opts: DominanceOptions = {},
+): DominanceVerdict {
+    const threshold = opts.threshold ?? PATHOLOGY_DOMINANCE_THRESHOLD;
+    const windowSize = query.window_size;
+    const floor = opts.minClassifiable ?? PATHOLOGY_MIN_CLASSIFIABLE_ATTEMPTS;
+
+    // The query has already excluded unclassifiable rows and applied the
+    // window; re-filtering here would let a caller pass raw storage and get a
+    // verdict, which is the coupling this signature exists to prevent.
+    const window = query.rows;
+
+    if (window.length < floor) {
+        return { status: 'warming-up', classifiable_in_window: window.length, floor };
+    }
+
+    const counts = new Map<string, number>();
+    for (const a of window) {
+        const k = cellKey(a.where, a.why);
+        counts.set(k, (counts.get(k) ?? 0) + 1);
+    }
+    let dominantCell = '';
+    let dominantCount = 0;
+    for (const [k, n] of [...counts.entries()].sort((x, y) => (x[0] < y[0] ? -1 : 1))) {
+        if (n > dominantCount) {
+            dominantCount = n;
+            dominantCell = k;
+        }
+    }
+    const share = dominantCount / window.length;
+    return {
+        status: share >= threshold ? 'collapsed' : 'ok',
+        dominant_share: share,
+        dominant_cell: dominantCell.replace(' ', ' x '),
+        classifiable_in_window: window.length,
+        window_size: windowSize,
+        threshold,
+    };
+}

--- a/src/scripts/_lib/routing_corpus.ts
+++ b/src/scripts/_lib/routing_corpus.ts
@@ -1,0 +1,272 @@
+/**
+ * The corpus and catalogue substrate for the two routing measurements of
+ * `road-to-governed-harness-evolution` — step 5.1 (description vs body) and
+ * step 6.4 (delivery sets).
+ *
+ * ONE LOADER, TWO MEASUREMENTS. Both runs need the same three things: the
+ * frozen train/holdout partition, the trigger cases, and the skill catalogue
+ * the prompts are ranked against. Two loaders over one corpus is how two
+ * measurements start disagreeing about what they measured, so there is one.
+ *
+ * THE SEAL IS ENFORCED BY REFUSAL, NOT BY FILTERING. The holdout partition
+ * frozen in `agents/evidence/analysis/trigger-corpus-holdout-2026-08-30.md`
+ * says: no analyzer authored in Phase 5 may read the sealed corpora. So
+ * `loadTrainCases` never opens a holdout `evals/triggers.json` at all — the
+ * partition is computed from the DIRECTORY NAME, before any file is read.
+ * Filtering after the read would satisfy the letter and not the seal.
+ *
+ * The seal covers the corpus files and not the catalogue: a holdout skill's
+ * `SKILL.md` is still ranked against, because removing it would measure a
+ * catalogue that does not exist. The boundary is stated in the 5.1
+ * pre-registration rather than left to be inferred here.
+ *
+ * NO SCORER OF ITS OWN. Every score comes from `src/shared/skillRanking.ts`,
+ * the module the production ranker and the MCP handler already share. A second
+ * scorer in a measurement module would measure the measurement.
+ *
+ * Pure of network and of clock; reads files and nothing else.
+ */
+import * as fs from 'node:fs';
+import { createHash } from 'node:crypto';
+import * as path from 'node:path';
+
+import { scoreSkill, tokenize, type RankableSkill } from '../../shared/skillRanking.js';
+
+/**
+ * The partition constant the freeze artefact fixes. Changing it re-partitions
+ * the corpus and voids every result measured under the old one, which is why
+ * it is a named export a test can pin rather than a literal.
+ */
+export const HOLDOUT_CEILING = 51;
+
+export type Partition = 'holdout' | 'train';
+
+/** `holdout iff sha256(<skill-directory-name>)[0] < 51`, from the freeze artefact. */
+export function partitionOf(skill: string): Partition {
+    const bucket = parseInt(createHash('sha256').update(skill).digest('hex').slice(0, 2), 16);
+    return bucket < HOLDOUT_CEILING ? 'holdout' : 'train';
+}
+
+/** One adjudicated case: a prompt, and whether the owning skill must be delivered. */
+export interface CorpusCase {
+    readonly skill: string;
+    readonly prompt: string;
+    /** `true` = positive (must be delivered) · `false` = negative (must not). */
+    readonly expect: boolean;
+    /** Step 2.3's vocabulary where the file declares it; 876 of 931 cases do not. */
+    readonly caseClass: 'exemplar' | 'near-miss' | 'counterexample' | null;
+    readonly language: string | null;
+}
+
+interface RawQuery {
+    q?: unknown;
+    trigger?: unknown;
+    class?: unknown;
+    language?: unknown;
+}
+
+/**
+ * The two corpus shapes this tree carries.
+ *
+ * `queries[]` is the modern one. Two train files — `brand-asset-generation` and
+ * `estimate-ticket` — are the legacy `should_trigger` / `should_not_trigger`
+ * pair that step 2.3 grandfathered, and `lint_skill_trigger_corpus` returns
+ * before its class rules for exactly those two. A reader that understood only
+ * the modern shape would drop them SILENTLY, which is worse than refusing them:
+ * the run would report 80 train corpora where the partition says 82 and nothing
+ * would say which two were missing. So both shapes are read, and
+ * `legacyShaped` records which file used which.
+ */
+interface RawCorpus {
+    queries?: RawQuery[];
+    should_trigger?: unknown;
+    should_not_trigger?: unknown;
+}
+
+export function skillsDir(repoRoot: string): string {
+    return path.join(repoRoot, 'src', 'skills');
+}
+
+/** Every skill directory that carries a trigger corpus, with its partition. */
+export function corpusSkills(repoRoot: string): { skill: string; partition: Partition }[] {
+    const dir = skillsDir(repoRoot);
+    if (!fs.existsSync(dir)) return [];
+    return fs
+        .readdirSync(dir)
+        .sort()
+        .filter((skill) => fs.existsSync(path.join(dir, skill, 'evals', 'triggers.json')))
+        .map((skill) => ({ skill, partition: partitionOf(skill) }));
+}
+
+/**
+ * The train cases. A holdout corpus is never opened — the partition is decided
+ * from the directory name and the sealed path is skipped before any read.
+ */
+export function loadTrainCases(repoRoot: string): CorpusCase[] {
+    const dir = skillsDir(repoRoot);
+    const out: CorpusCase[] = [];
+    for (const { skill, partition } of corpusSkills(repoRoot)) {
+        if (partition === 'holdout') continue;
+        const raw = JSON.parse(
+            fs.readFileSync(path.join(dir, skill, 'evals', 'triggers.json'), 'utf8'),
+        ) as RawCorpus;
+        if (Array.isArray(raw.queries)) {
+            for (const q of raw.queries) {
+                if (typeof q.q !== 'string' || typeof q.trigger !== 'boolean') continue;
+                const declared = typeof q.class === 'string' ? q.class : null;
+                out.push({
+                    skill,
+                    prompt: q.q,
+                    expect: q.trigger,
+                    caseClass:
+                        declared === 'exemplar' ||
+                        declared === 'near-miss' ||
+                        declared === 'counterexample'
+                            ? declared
+                            : null,
+                    language: typeof q.language === 'string' ? q.language : null,
+                });
+            }
+            continue;
+        }
+        for (const [key, expect] of [
+            ['should_trigger', true],
+            ['should_not_trigger', false],
+        ] as const) {
+            const list = raw[key];
+            if (!Array.isArray(list)) continue;
+            for (const prompt of list) {
+                if (typeof prompt !== 'string') continue;
+                out.push({ skill, prompt, expect, caseClass: null, language: null });
+            }
+        }
+    }
+    return out;
+}
+
+/** Which train corpora use the legacy shape. Reported so the count is explainable. */
+export function legacyShaped(repoRoot: string): string[] {
+    const dir = skillsDir(repoRoot);
+    const out: string[] = [];
+    for (const { skill, partition } of corpusSkills(repoRoot)) {
+        if (partition === 'holdout') continue;
+        const raw = JSON.parse(
+            fs.readFileSync(path.join(dir, skill, 'evals', 'triggers.json'), 'utf8'),
+        ) as RawCorpus;
+        if (!Array.isArray(raw.queries)) out.push(skill);
+    }
+    return out;
+}
+
+/** A catalogue entry: what the ranker sees, plus the body the 5.1 arm adds. */
+export interface CatalogueEntry extends RankableSkill {
+    readonly name: string;
+    readonly description: string;
+    readonly personas: readonly string[];
+    /** SKILL.md with its frontmatter removed. Empty when the file has none. */
+    readonly body: string;
+}
+
+/** Minimal frontmatter split. Returns `[block, body]`; `['', text]` when absent. */
+export function splitFrontmatter(text: string): [string, string] {
+    if (!text.startsWith('---')) return ['', text];
+    const end = text.indexOf('\n---', 3);
+    if (end === -1) return ['', text];
+    return [text.slice(3, end), text.slice(end + 4)];
+}
+
+/** `name`, `description` and `personas` out of a frontmatter block. */
+export function readMeta(block: string): { name: string; description: string; personas: string[] } {
+    let name = '';
+    let description = '';
+    const personas: string[] = [];
+    let inPersonas = false;
+    for (const raw of block.split('\n')) {
+        const line = raw.replace(/\s+$/, '');
+        if (inPersonas && /^ {2}- /.test(line)) {
+            personas.push(line.slice(4).trim().replace(/^["']|["']$/g, ''));
+            continue;
+        }
+        inPersonas = false;
+        const m = /^([a-zA-Z_][\w-]*)[ \t]*:[ \t]*(.*)$/.exec(line);
+        if (!m) continue;
+        const key = m[1] as string;
+        const value = (m[2] as string).trim().replace(/^["']|["']$/g, '');
+        if (key === 'personas' && value === '') inPersonas = true;
+        else if (key === 'name') name = value;
+        else if (key === 'description') description = value;
+    }
+    return { name, description, personas };
+}
+
+/** Every skill directory`s `SKILL.md`, name-sorted. The ranking universe. */
+export function loadCatalogue(repoRoot: string): CatalogueEntry[] {
+    const dir = skillsDir(repoRoot);
+    if (!fs.existsSync(dir)) return [];
+    const out: CatalogueEntry[] = [];
+    for (const skill of fs.readdirSync(dir).sort()) {
+        const file = path.join(dir, skill, 'SKILL.md');
+        if (!fs.existsSync(file)) continue;
+        const [block, body] = splitFrontmatter(fs.readFileSync(file, 'utf8'));
+        const meta = readMeta(block);
+        out.push({
+            name: meta.name || skill,
+            description: meta.description,
+            personas: meta.personas,
+            body,
+        });
+    }
+    return out;
+}
+
+/** The two 5.1 arms. `description` is today's production condition. */
+export const ARMS = ['description', 'description+body'] as const;
+export type Arm = (typeof ARMS)[number];
+
+/**
+ * The indexed term set per arm.
+ *
+ * The `description` arm reproduces `skillTerms(skill, {})` exactly — same
+ * inputs, same tokenizer — so the control arm IS the shipped behaviour rather
+ * than a re-implementation of it.
+ */
+export function armTerms(entry: CatalogueEntry, arm: Arm): Set<string> {
+    const parts = [entry.name, entry.description];
+    if (arm === 'description+body') parts.push(entry.body);
+    return tokenize(parts.join(' '));
+}
+
+export interface RankedName {
+    readonly name: string;
+    readonly score: number;
+}
+
+/**
+ * Top-k by score, ties broken on name — the total order `rankSkills` already
+ * defines. Zero scores are dropped, because a skill the scorer gives 0 is not
+ * delivered by the shipped ranker either.
+ */
+export function topK(
+    prompt: string,
+    catalogue: readonly CatalogueEntry[],
+    terms: ReadonlyMap<string, Set<string>>,
+    k: number,
+): RankedName[] {
+    const taskTerms = tokenize(prompt);
+    const rows: RankedName[] = [];
+    for (const entry of catalogue) {
+        const t = terms.get(entry.name);
+        if (t === undefined) continue;
+        const score = scoreSkill(taskTerms, entry, t);
+        if (score > 0) rows.push({ name: entry.name, score });
+    }
+    rows.sort((a, b) => b.score - a.score || (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+    return rows.slice(0, k);
+}
+
+/** Term sets for one arm, keyed by the name `topK` ranks on. */
+export function termIndex(catalogue: readonly CatalogueEntry[], arm: Arm): Map<string, Set<string>> {
+    const index = new Map<string, Set<string>>();
+    for (const entry of catalogue) index.set(entry.name, armTerms(entry, arm));
+    return index;
+}

--- a/src/scripts/_lib/routing_index_input.ts
+++ b/src/scripts/_lib/routing_index_input.ts
@@ -1,0 +1,104 @@
+/**
+ * routing_index_input — what the skill index is built OVER, derived from the
+ * 5.1 verdict file (`road-to-governed-harness-evolution` step 6.5).
+ *
+ * Step 6.5 reads: *"Index the body only if 5.1 measured a signal. Otherwise
+ * description-only. verify: the indexer`s input set derives from the 5.1
+ * verdict file."*
+ *
+ * SO THE ANSWER IS NOT WRITTEN HERE. This module contains no opinion about the
+ * body. It opens
+ * `agents/evidence/analysis/routing-body-signal-verdict.json`, reads
+ * `body_signal.verdict`, and returns the input set that verdict licenses. Flip
+ * the file and the input set flips; delete the file and it falls back. A module
+ * that hardcoded `description` would satisfy the step`s OUTCOME today and fail
+ * its verify, because the outcome would not derive from anything.
+ *
+ * FAIL-CLOSED, IN THE DIRECTION THAT COSTS LESS. Missing file, unparseable
+ * JSON, unknown verdict token, or a missing `proxy_to_real_fidelity` field all
+ * resolve to **description-only** with the reason recorded. Only the literal
+ * token `signal` widens the index. The asymmetry is deliberate: a stale or
+ * broken record must never be able to widen what the suite indexes, and the
+ * measured cost of widening on a `harmful` verdict is +7.22 pp of false
+ * activation.
+ *
+ * WHY THE FIDELITY FIELD GATES THE READ. The 5.1 verdict ships its own bound —
+ * `proxy_to_real_fidelity`, null and unmeasured-by-construction — precisely so
+ * a consumer cannot take the conclusion without it. A record that has lost that
+ * field is a record whose provenance has been edited, and this resolver refuses
+ * it rather than trusting the half that survived.
+ *
+ * Pure of network and of clock; reads one file.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/** Where step 5.1 writes its machine-readable verdict. */
+export const VERDICT_REL = 'agents/evidence/analysis/routing-body-signal-verdict.json';
+
+/** The two input sets step 6.5 can resolve to. Ordered, so they are comparable. */
+export const DESCRIPTION_ONLY = ['name', 'description'] as const;
+export const DESCRIPTION_AND_BODY = ['name', 'description', 'body'] as const;
+
+export interface IndexInput {
+    readonly fields: readonly string[];
+    /** The token read from the verdict file, or `null` when none could be read. */
+    readonly verdict: string | null;
+    readonly reason: string;
+    /** `true` only when the verdict file licensed the wider set. */
+    readonly indexesBody: boolean;
+}
+
+const descriptionOnly = (verdict: string | null, reason: string): IndexInput => ({
+    fields: DESCRIPTION_ONLY,
+    verdict,
+    reason,
+    indexesBody: false,
+});
+
+/**
+ * The input set the 5.1 verdict at `repoRoot` licenses.
+ *
+ * `verdictPath` exists so a test can point the resolver at a fixture record
+ * instead of writing to the tracked one.
+ */
+export function resolveIndexInput(repoRoot: string, verdictPath?: string): IndexInput {
+    const file = verdictPath ?? path.join(repoRoot, VERDICT_REL);
+    let parsed: Record<string, unknown>;
+    try {
+        parsed = JSON.parse(fs.readFileSync(file, 'utf8')) as Record<string, unknown>;
+    } catch {
+        return descriptionOnly(null, `no readable 5.1 verdict at ${VERDICT_REL} — fail-closed`);
+    }
+    if (parsed['proxy_to_real_fidelity'] === undefined) {
+        return descriptionOnly(
+            null,
+            'the 5.1 verdict carries no proxy_to_real_fidelity bound — refused, fail-closed',
+        );
+    }
+    const body = parsed['body_signal'];
+    const token =
+        typeof body === 'object' && body !== null
+            ? (body as Record<string, unknown>)['verdict']
+            : undefined;
+    if (typeof token !== 'string') {
+        return descriptionOnly(null, 'the 5.1 verdict carries no body_signal.verdict — fail-closed');
+    }
+    if (token === 'signal') {
+        return {
+            fields: DESCRIPTION_AND_BODY,
+            verdict: token,
+            reason: 'the 5.1 verdict is `signal` — the body is indexed',
+            indexesBody: true,
+        };
+    }
+    return descriptionOnly(token, `the 5.1 verdict is \`${token}\`, not \`signal\` — description-only`);
+}
+
+/** The `Arm` name the routing corpus uses for the resolved input set. */
+export function resolveIndexArm(
+    repoRoot: string,
+    verdictPath?: string,
+): 'description' | 'description+body' {
+    return resolveIndexInput(repoRoot, verdictPath).indexesBody ? 'description+body' : 'description';
+}

--- a/src/scripts/_lib/rule_injection.ts
+++ b/src/scripts/_lib/rule_injection.ts
@@ -214,13 +214,34 @@ export function selectForInjection(
     repoRoot: string,
     matches: TierRuleMatch[],
     capBytes: number,
+    shortlist?: readonly string[] | null,
 ): SelectionResult {
     const bodyBytes = new Map<string, number>();
     for (const m of matches) {
         const body = loadRuleBody(repoRoot, m.id);
         bodyBytes.set(m.id, body === null ? 0 : bytesOf(body));
     }
-    const ranked = [...matches].sort((a, b) => b.score - a.score || a.order - b.order);
+    // STEP 6.3 — the optional lexical shortlist, as a TIE-BREAK and nothing more.
+    //
+    // Absent (the default), the cap order is exactly what it was: score, then
+    // router order. Present, it sits BETWEEN them, never above `score` — the
+    // matcher's verdict is read first and the shortlist only orders what the
+    // matcher already tied. Membership is untouched in both directions: a
+    // shortlisted id the matcher did not return is not in `matches` and so is
+    // never consulted, and no matched id is dropped for being unshortlisted
+    // (it sorts at Infinity, behind the shortlisted ones, and still competes
+    // for the cap). That is `_lib/lexical_shortlist.ts`'s "never decides
+    // alone" expressed at the one place the cap actually binds.
+    const rank = new Map<string, number>();
+    for (const [i, id] of (shortlist ?? []).entries()) {
+        if (!rank.has(id)) rank.set(id, i);
+    }
+    const ranked = [...matches].sort(
+        (a, b) =>
+            b.score - a.score ||
+            (rank.get(a.id) ?? Infinity) - (rank.get(b.id) ?? Infinity) ||
+            a.order - b.order,
+    );
     const selected: TierRuleMatch[] = [];
     const dropped: TierRuleMatch[] = [];
     let total = 0;

--- a/src/scripts/evolution_lab.ts
+++ b/src/scripts/evolution_lab.ts
@@ -68,7 +68,6 @@ import {
     type CascadeResult,
 } from './_lib/evaluation_cascade.js';
 import type { MetricVector } from './_lib/evaluation_vector.js';
-import type { MetricRow } from './_lib/evaluation_vector.js';
 import {
     type CandidateRecord,
     CandidateSchemaError,

--- a/src/scripts/evolution_lab.ts
+++ b/src/scripts/evolution_lab.ts
@@ -67,6 +67,7 @@ import {
     CHEAPEST_STAGE,
     type CascadeResult,
 } from './_lib/evaluation_cascade.js';
+import type { MetricVector } from './_lib/evaluation_vector.js';
 import type { MetricRow } from './_lib/evaluation_vector.js';
 import {
     type CandidateRecord,
@@ -97,7 +98,6 @@ import {
     serialiseCandidateRecord,
 } from './_lib/candidate_proposer.js';
 import {
-    type MetricVector,
     type RunReport,
     buildRunReport,
     parseMetricVectorJson,
@@ -836,7 +836,7 @@ function verbRun(argv: readonly string[]): number {
             process.stdout.write(
                 `evolution_lab:cascade · ${r.candidate_id} · passed ${r.stages_run.length} stage(s) · ` +
                     `model_calls=${r.model_calls} · verdict=${r.verdict.promote ? 'promote' : 'refuse'} · ` +
-                    `${r.verdict.why}\n`,
+                    `${r.verdict.reason}\n`,
             );
         }
     }

--- a/src/scripts/evolution_lab.ts
+++ b/src/scripts/evolution_lab.ts
@@ -85,6 +85,14 @@ import {
     serialiseCandidateRecord,
 } from './_lib/candidate_proposer.js';
 import {
+    type MetricVector,
+    type RunReport,
+    buildRunReport,
+    parseMetricVectorJson,
+    renderRunReport,
+    roiFigure,
+} from './_lib/evolution_roi.js';
+import {
     BudgetExceededError,
     type DisclosureRecord,
     type FieldVisibility,
@@ -379,7 +387,7 @@ const USAGE = `usage: evolution_lab <verb> [options]
 
   inspect  [--record FILE]... [--records DIR] [--clones]
   propose  --observations FILE --out DIR [--force]
-  run      --record FILE... [--refresh]
+  run      --record FILE... [--refresh] [--vector FILE]...
            [--trials-per-candidate N] [--estimated-spend-cents N]
   compare  [--verbose]
   explain  [--record FILE [--to STATE]] [--criteria]
@@ -698,7 +706,7 @@ function verbRun(argv: readonly string[]): number {
     const flags = parseFlags(
         argv,
         ['refresh'],
-        ['record', 'records', 'trials-per-candidate', 'estimated-spend-cents'],
+        ['record', 'records', 'trials-per-candidate', 'estimated-spend-cents', 'vector'],
     );
     const files: string[] = [...(flags.values.get('record') ?? [])];
     const dir = one(flags, 'records');
@@ -734,6 +742,19 @@ function verbRun(argv: readonly string[]): number {
         }
         throw e;
     }
+    // Evaluation evidence is parsed BEFORE the first clone, for the same reason
+    // the budget guard runs before it: a malformed vector discovered after the
+    // work is a failed run that already spent, and `parseMetricVectorJson`
+    // inherits `buildVector`'s refusal of a vector missing its artifact-count
+    // row, so this is also where that refusal lands.
+    const vectors: MetricVector[] = [];
+    for (const vf of flags.values.get('vector') ?? []) {
+        try {
+            vectors.push(parseMetricVectorJson(fs.readFileSync(vf, 'utf-8'), vf));
+        } catch (e) {
+            return fail(`vector ${vf} rejected — ${(e as Error).message}`);
+        }
+    }
     const seen = new Set<string>();
     for (const f of files.sort(byteCompare)) {
         let record: CandidateRecord;
@@ -754,6 +775,30 @@ function verbRun(argv: readonly string[]): number {
             }
             return fail(`candidate ${record.id} failed — ${(e as Error).message}`);
         }
+    }
+    // STEP 5.6 — the run report, on the ONE path a run completes on.
+    //
+    // Placed after the clone loop and before the only success return, so there
+    // is no completed run without a report. Every other exit from this verb is
+    // an abort (budget) or a failure (unreadable record), and neither is a run
+    // whose ROI could be reported: nothing was cloned and nothing was spent.
+    let report: RunReport;
+    try {
+        report = buildRunReport({
+            // Deterministic and identifying: the candidate ids, in the byte
+            // order the run walked them. Two runs over the same record set
+            // produce the same id, and a run over a different set cannot
+            // borrow another run's report line.
+            run_id: `run:${[...seen].sort(byteCompare).join('+')}`,
+            candidates: files.length,
+            trials_per_candidate: intFlag(flags, 'trials-per-candidate', 1),
+            roi: roiFigure(vectors, intFlag(flags, 'estimated-spend-cents', 0)),
+        });
+    } catch (e) {
+        return fail(`run report rejected — ${(e as Error).message}`);
+    }
+    for (const line of renderRunReport(report)) {
+        process.stdout.write(`${line}\n`);
     }
     return EXIT_OK;
 }

--- a/src/scripts/evolution_lab.ts
+++ b/src/scripts/evolution_lab.ts
@@ -63,6 +63,12 @@ import {
 } from './bench_ab_clone.js';
 import { main as integrity_main } from './bench_ab_integrity.js';
 import {
+    runCascade,
+    CHEAPEST_STAGE,
+    type CascadeResult,
+} from './_lib/evaluation_cascade.js';
+import type { MetricRow } from './_lib/evaluation_vector.js';
+import {
     type CandidateRecord,
     CandidateSchemaError,
     LIFECYCLE_SPINE,
@@ -698,7 +704,7 @@ function verbRun(argv: readonly string[]): number {
     const flags = parseFlags(
         argv,
         ['refresh'],
-        ['record', 'records', 'trials-per-candidate', 'estimated-spend-cents'],
+        ['record', 'records', 'trials-per-candidate', 'estimated-spend-cents', 'metrics'],
     );
     const files: string[] = [...(flags.values.get('record') ?? [])];
     const dir = one(flags, 'records');
@@ -734,7 +740,23 @@ function verbRun(argv: readonly string[]): number {
         }
         throw e;
     }
+    // Metric rows are OPTIONAL and their absence is not silently benign: with
+    // no rows the cascade reaches its verdict stage and aborts there, which is
+    // the honest outcome for a run that measured nothing. A caller that has
+    // measurements passes them; a caller that does not learns it has none.
+    let rows: readonly MetricRow[] | undefined;
+    const metricsFile = one(flags, 'metrics');
+    if (metricsFile !== undefined) {
+        try {
+            rows = JSON.parse(fs.readFileSync(metricsFile, 'utf-8')) as readonly MetricRow[];
+        } catch (e) {
+            return fail(`metrics file not readable at ${metricsFile} — ${(e as Error).message}`);
+        }
+    }
+
     const seen = new Set<string>();
+    const ids: string[] = [];
+    const results: CascadeResult[] = [];
     for (const f of files.sort(byteCompare)) {
         let record: CandidateRecord;
         try {
@@ -754,6 +776,66 @@ function verbRun(argv: readonly string[]): number {
             }
             return fail(`candidate ${record.id} failed — ${(e as Error).message}`);
         }
+
+        // EVALUATE. Step 4.1's deterministic prefix, wired here because a
+        // library nothing calls has no coverage — the defect AC-3 and AC-5
+        // were both open on. The record is re-read from disk rather than
+        // reusing `record`, so stage 1 is a real schema gate at this call
+        // site and not a formality over an already-parsed object.
+        let raw: unknown;
+        try {
+            raw = JSON.parse(fs.readFileSync(f, 'utf-8'));
+        } catch (e) {
+            return fail(`${f} unreadable at evaluation — ${(e as Error).message}`);
+        }
+        const result = runCascade({
+            raw,
+            plan: {
+                candidates: files.length,
+                trialsPerCandidate: intFlag(flags, 'trials-per-candidate', 1),
+                estimatedSpendCents: intFlag(flags, 'estimated-spend-cents', 0),
+            },
+            budget: loadRunBudget(),
+            peers: ids,
+            rows,
+        });
+        ids.push(record.id);
+        results.push(result);
+    }
+
+    for (const r of results) {
+        if (r.outcome === 'abort') {
+            process.stdout.write(
+                `evolution_lab:cascade · ${r.candidate_id ?? '<unparsed>'} · aborted at ` +
+                    `${r.failed_stage} · family=${r.family} · model_calls=${r.model_calls} · ${r.detail}\n`,
+            );
+        } else if (r.outcome === 'incomplete') {
+            process.stdout.write(
+                `evolution_lab:cascade · ${r.candidate_id} · passed ${r.stages_run.length} stage(s) · ` +
+                    `model_calls=${r.model_calls} · ${r.not_reached} NOT REACHED · ${r.why}\n`,
+            );
+        } else {
+            process.stdout.write(
+                `evolution_lab:cascade · ${r.candidate_id} · passed ${r.stages_run.length} stage(s) · ` +
+                    `model_calls=${r.model_calls} · verdict=${r.verdict.promote ? 'promote' : 'refuse'} · ` +
+                    `${r.verdict.why}\n`,
+            );
+        }
+    }
+
+    // A cascade abort is a run outcome, not a crash: the run did its job by
+    // refusing. The cheapest stage is named so a reader can see that a stage-1
+    // abort cost nothing.
+    const aborted = results.filter((r) => r.outcome === 'abort');
+    if (aborted.length > 0) {
+        const atCheapest = aborted.filter(
+            (r) => r.outcome === 'abort' && r.failed_stage === CHEAPEST_STAGE,
+        ).length;
+        process.stdout.write(
+            `evolution_lab:cascade · ${aborted.length} of ${results.length} aborted ` +
+                `(${atCheapest} at the cheapest stage, ${CHEAPEST_STAGE}, costing no model call)\n`,
+        );
+        return EXIT_REFUSED;
     }
     return EXIT_OK;
 }

--- a/src/scripts/measure_delivery_sets.ts
+++ b/src/scripts/measure_delivery_sets.ts
@@ -20,10 +20,12 @@
  * an estimate of it: a wrong pair whose members share no prompt cannot be seen
  * from this corpus at all.
  *
- * THE RANKING ARM IS THE SHIPPED ONE. `description` only — this run measures
- * what delivery costs over the substrate that exists, not over a candidate
- * index. Which fields a future index carries is step 6.5`s question and is
- * answered from the 5.1 verdict file, not here.
+ * THE RANKING ARM IS NOT CHOSEN HERE. It is resolved from the 5.1 verdict file
+ * by `_lib/routing_index_input.ts` (step 6.5): `signal` widens the index to the
+ * body, anything else — including a missing or provenance-stripped record —
+ * resolves to description-only. Today`s verdict is `harmful`, so this run
+ * measures the description index; flipping the verdict file flips what this run
+ * indexes, which is the property step 6.5`s verify asks for.
  *
  * ZERO MODEL CALLS AND ZERO SPEND: the imports are a file reader and a pure
  * scorer.
@@ -46,6 +48,7 @@ import {
     termIndex,
     topK,
 } from './_lib/routing_corpus.js';
+import { resolveIndexInput } from './_lib/routing_index_input.js';
 
 export const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 export const PREREG_REL = 'agents/evidence/analysis/delivery-set-preregistration-2026-08-31.md';
@@ -106,6 +109,7 @@ export interface DeliveryMeasurement {
      * any of the figures above are about discrimination at all.
      */
     readonly tieDecidedCutPp: number;
+    readonly indexInput: ReturnType<typeof resolveIndexInput>;
     readonly sharedPrompts: number;
     readonly jointlyWrongPairs: readonly JointlyWrongPair[];
     readonly jointlyWrongCandidates: readonly JointlyWrongCandidate[];
@@ -126,7 +130,8 @@ export function measureDelivery(repo = REPO, k = K): DeliveryMeasurement {
     if (catalogue.length === 0 || cases.length === 0) {
         throw new Error('measure_delivery_sets: empty catalogue or corpus — a run over nothing');
     }
-    const index = termIndex(catalogue, 'description');
+    const indexInput = resolveIndexInput(repo);
+    const index = termIndex(catalogue, indexInput.indexesBody ? 'description+body' : 'description');
     const adjudicated = adjudicationIndex(cases);
     const cost = new Map<string, number>();
     for (const e of catalogue) cost.set(e.name, `${e.name} ${e.description}`.length);
@@ -259,6 +264,7 @@ export function measureDelivery(repo = REPO, k = K): DeliveryMeasurement {
         tokenTargetMet: tokens <= TOKEN_TARGET,
         benefitUnconditionalPp: recall,
         benefitConditionalPp: precision,
+        indexInput,
         tieDecidedCutPp: pp(tieDecidedCuts, byPrompt.size),
         sharedPrompts,
         jointlyWrongPairs: jointly,
@@ -273,6 +279,12 @@ export function record(m: DeliveryMeasurement): Record<string, unknown> {
         roadmap: 'road-to-governed-harness-evolution',
         preregistration: PREREG_REL,
         k: m.k,
+        index_input: {
+            fields: m.indexInput.fields,
+            derived_from: '5.1 verdict file, via _lib/routing_index_input.ts',
+            verdict: m.indexInput.verdict,
+            reason: m.indexInput.reason,
+        },
         bars: { recall_loss_ceiling_pp: RECALL_LOSS_CEILING_PP, token_target: TOKEN_TARGET },
         metrics: {
             precision_at_k: Number(m.precisionPp.toFixed(3)),
@@ -306,6 +318,7 @@ export function render(m: DeliveryMeasurement): string {
     const curve = CURVE_KS.map((ck) => `@${ck} ${(m.recallCurvePp[ck] ?? 0).toFixed(1)}%`).join('  ');
     return [
         `measure_delivery_sets — step 6.4, k=${m.k}`,
+        `  index input ${m.indexInput.fields.join(' + ')} (${m.indexInput.reason})`,
         `  catalogue ${m.catalogueSize} · prompts ${m.prompts} · positives ${m.positives} · negatives ${m.negatives}`,
         `  precision@${m.k}             ${m.precisionPp.toFixed(2)} % over ${m.adjudicatedDeliveries} adjudicated deliveries`,
         `  recall@${m.k}                ${m.recallPp.toFixed(2)} %`,

--- a/src/scripts/measure_delivery_sets.ts
+++ b/src/scripts/measure_delivery_sets.ts
@@ -1,0 +1,348 @@
+#!/usr/bin/env tsx
+/**
+ * measure_delivery_sets — what a narrowed delivery costs, and which SETS are
+ * wrong together (`road-to-governed-harness-evolution` step 6.4).
+ *
+ * THE CEILING WAS FIXED BEFORE THIS FILE EXISTED. Recall-loss ceiling 20.0 pp,
+ * token target 500, k = 5, and the definition of a jointly-wrong pair all live
+ * in `agents/evidence/analysis/delivery-set-preregistration-2026-08-31.md`,
+ * committed in `fe8749458` — a commit that adds no measurement module and runs
+ * nothing. The constants below are transcribed from it.
+ *
+ * WHY A PAIR METRIC AT ALL. Precision, recall and false activation each score
+ * ONE delivery in isolation, so none of them can see the failure where two
+ * individually plausible skills are wrong TOGETHER. The right question is which
+ * set to deliver, and a per-artefact metric cannot ask it.
+ *
+ * ITS BOUND, STATED RATHER THAN IMPLIED. A pair is only observable when the
+ * SAME prompt is adjudicated by BOTH corpora, because the corpus labels one
+ * skill per prompt. So the count is a LOWER bound on joint wrongness and never
+ * an estimate of it: a wrong pair whose members share no prompt cannot be seen
+ * from this corpus at all.
+ *
+ * THE RANKING ARM IS THE SHIPPED ONE. `description` only — this run measures
+ * what delivery costs over the substrate that exists, not over a candidate
+ * index. Which fields a future index carries is step 6.5`s question and is
+ * answered from the 5.1 verdict file, not here.
+ *
+ * ZERO MODEL CALLS AND ZERO SPEND: the imports are a file reader and a pure
+ * scorer.
+ *
+ * Usage:
+ *   ./scripts-run src/scripts/measure_delivery_sets           human table
+ *   ./scripts-run src/scripts/measure_delivery_sets --json    machine record
+ *
+ * Exit 0 = the measurement ran; 2 = it could not run.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import {
+    type CatalogueEntry,
+    type CorpusCase,
+    loadCatalogue,
+    loadTrainCases,
+    termIndex,
+    topK,
+} from './_lib/routing_corpus.js';
+
+export const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+export const PREREG_REL = 'agents/evidence/analysis/delivery-set-preregistration-2026-08-31.md';
+export const RECORD_REL = 'agents/evidence/analysis/delivery-set-measurement-2026-08-31.json';
+
+export const K = 5;
+export const RECALL_LOSS_CEILING_PP = 20.0;
+export const TOKEN_TARGET = 500;
+/** The recall curve reported beside k, so a breach says at which k it would clear. */
+export const CURVE_KS = [1, 3, 5, 10, 20] as const;
+
+export interface JointlyWrongPair {
+    readonly prompt: string;
+    readonly pair: readonly [string, string];
+}
+
+/**
+ * A pair the CORPUS adjudicates wrong together, whether or not delivery
+ * currently hands them over together.
+ *
+ * The step`s verify asks whether *the corpus* contains a jointly-wrong pair.
+ * The pre-registration`s own definition added a third condition — both members
+ * delivered in the top-k — which turns a corpus property into a delivery
+ * property. That is a defect in the pre-registration, found by implementing it,
+ * and it is fixed by reporting BOTH rather than by rewriting the definition
+ * after seeing the count. `jointlyDeliveredAtK` is the smallest k at which the
+ * pair is actually handed over together, or `null` inside the reported curve.
+ */
+export interface JointlyWrongCandidate {
+    readonly prompt: string;
+    readonly pair: readonly [string, string];
+    readonly jointlyDeliveredAtK: number | null;
+}
+
+export interface DeliveryMeasurement {
+    readonly k: number;
+    readonly catalogueSize: number;
+    readonly cases: number;
+    readonly prompts: number;
+    readonly positives: number;
+    readonly negatives: number;
+    readonly recallPp: number;
+    readonly recallLossPp: number;
+    readonly ceilingMet: boolean;
+    readonly recallCurvePp: Record<number, number>;
+    readonly falseActivationPp: number;
+    readonly precisionPp: number;
+    readonly adjudicatedDeliveries: number;
+    readonly unadjudicatedDeliveries: number;
+    readonly contextCostTokens: number;
+    readonly tokenTargetMet: boolean;
+    readonly benefitUnconditionalPp: number;
+    readonly benefitConditionalPp: number;
+    /**
+     * Prompts where the top-k CUT was decided by the alphabetical tie-break
+     * rather than by score — `score(k) === score(k+1)`. Reported, not barred:
+     * it is the "recalls but does not rank" pathology, and it bounds how much
+     * any of the figures above are about discrimination at all.
+     */
+    readonly tieDecidedCutPp: number;
+    readonly sharedPrompts: number;
+    readonly jointlyWrongPairs: readonly JointlyWrongPair[];
+    readonly jointlyWrongCandidates: readonly JointlyWrongCandidate[];
+}
+
+/** The corpus verdict for a `(skill, prompt)` key, absent when unadjudicated. */
+export function adjudicationIndex(cases: readonly CorpusCase[]): Map<string, boolean> {
+    const index = new Map<string, boolean>();
+    for (const c of cases) index.set(`${c.skill} ${c.prompt.trim().toLowerCase()}`, c.expect);
+    return index;
+}
+
+const pp = (hits: number, total: number): number => (total === 0 ? 0 : (hits / total) * 100);
+
+export function measureDelivery(repo = REPO, k = K): DeliveryMeasurement {
+    const catalogue: CatalogueEntry[] = loadCatalogue(repo);
+    const cases: CorpusCase[] = loadTrainCases(repo);
+    if (catalogue.length === 0 || cases.length === 0) {
+        throw new Error('measure_delivery_sets: empty catalogue or corpus — a run over nothing');
+    }
+    const index = termIndex(catalogue, 'description');
+    const adjudicated = adjudicationIndex(cases);
+    const cost = new Map<string, number>();
+    for (const e of catalogue) cost.set(e.name, `${e.name} ${e.description}`.length);
+
+    // One delivery per distinct prompt: a prompt carried by two corpora is one
+    // delivery event, adjudicated twice.
+    const byPrompt = new Map<string, CorpusCase[]>();
+    for (const c of cases) {
+        const key = c.prompt.trim().toLowerCase();
+        const bucket = byPrompt.get(key);
+        if (bucket === undefined) byPrompt.set(key, [c]);
+        else bucket.push(c);
+    }
+
+    const curveHits: Record<number, number> = {};
+    for (const ck of CURVE_KS) curveHits[ck] = 0;
+    const maxK = Math.max(k, ...CURVE_KS);
+
+    let positives = 0;
+    let negatives = 0;
+    let recallHits = 0;
+    let falseHits = 0;
+    let adjudicatedDeliveries = 0;
+    let correctDeliveries = 0;
+    let unadjudicatedDeliveries = 0;
+    let totalChars = 0;
+    let tieDecidedCuts = 0;
+    let sharedPrompts = 0;
+    const jointly: JointlyWrongPair[] = [];
+    const candidates: JointlyWrongCandidate[] = [];
+
+    for (const [key, group] of [...byPrompt.entries()].sort((a, b) => (a[0] < b[0] ? -1 : 1))) {
+        const prompt = (group[0] as CorpusCase).prompt;
+        const rankedFull = topK(prompt, catalogue, index, maxK);
+        const ranked = rankedFull.map((r) => r.name);
+        const delivered = ranked.slice(0, k);
+        if (
+            rankedFull.length > k &&
+            (rankedFull[k - 1] as { score: number }).score ===
+                (rankedFull[k] as { score: number }).score
+        ) {
+            tieDecidedCuts += 1;
+        }
+        const deliveredSet = new Set(delivered);
+
+        for (const c of group) {
+            if (c.expect) {
+                positives += 1;
+                if (deliveredSet.has(c.skill)) recallHits += 1;
+                for (const ck of CURVE_KS) {
+                    if (ranked.slice(0, ck).includes(c.skill)) curveHits[ck] = (curveHits[ck] ?? 0) + 1;
+                }
+            } else {
+                negatives += 1;
+                if (deliveredSet.has(c.skill)) falseHits += 1;
+            }
+        }
+
+        for (const name of delivered) {
+            totalChars += cost.get(name) ?? 0;
+            const verdict = adjudicated.get(`${name} ${key}`);
+            if (verdict === undefined) unadjudicatedDeliveries += 1;
+            else {
+                adjudicatedDeliveries += 1;
+                if (verdict) correctDeliveries += 1;
+            }
+        }
+
+        // Set compatibility. Observable only where two corpora adjudicate the
+        // same prompt; both members must be delivered AND both recorded false.
+        if (group.length < 2) continue;
+        sharedPrompts += 1;
+
+        // The corpus-level property the step`s verify names: two corpora
+        // adjudicating the same prompt `false`. Independent of delivery.
+        const wrongInCorpus = group
+            .filter((c) => !c.expect)
+            .map((c) => c.skill)
+            .sort();
+        for (let i = 0; i < wrongInCorpus.length; i++) {
+            for (let j = i + 1; j < wrongInCorpus.length; j++) {
+                const a = wrongInCorpus[i] as string;
+                const b = wrongInCorpus[j] as string;
+                let at: number | null = null;
+                for (const ck of CURVE_KS) {
+                    const head = ranked.slice(0, ck);
+                    if (head.includes(a) && head.includes(b)) {
+                        at = ck;
+                        break;
+                    }
+                }
+                candidates.push({ prompt, pair: [a, b], jointlyDeliveredAtK: at });
+            }
+        }
+
+        const wrongHere = group
+            .filter((c) => !c.expect && deliveredSet.has(c.skill))
+            .map((c) => c.skill)
+            .sort();
+        for (let i = 0; i < wrongHere.length; i++) {
+            for (let j = i + 1; j < wrongHere.length; j++) {
+                jointly.push({ prompt, pair: [wrongHere[i] as string, wrongHere[j] as string] });
+            }
+        }
+    }
+
+    const recall = pp(recallHits, positives);
+    const loss = 100 - recall;
+    const curve: Record<number, number> = {};
+    for (const ck of CURVE_KS) curve[ck] = pp(curveHits[ck] ?? 0, positives);
+    const tokens = byPrompt.size === 0 ? 0 : totalChars / 4 / byPrompt.size;
+    const precision = pp(correctDeliveries, adjudicatedDeliveries);
+
+    return {
+        k,
+        catalogueSize: catalogue.length,
+        cases: cases.length,
+        prompts: byPrompt.size,
+        positives,
+        negatives,
+        recallPp: recall,
+        recallLossPp: loss,
+        ceilingMet: loss <= RECALL_LOSS_CEILING_PP,
+        recallCurvePp: curve,
+        falseActivationPp: pp(falseHits, negatives),
+        precisionPp: precision,
+        adjudicatedDeliveries,
+        unadjudicatedDeliveries,
+        contextCostTokens: tokens,
+        tokenTargetMet: tokens <= TOKEN_TARGET,
+        benefitUnconditionalPp: recall,
+        benefitConditionalPp: precision,
+        tieDecidedCutPp: pp(tieDecidedCuts, byPrompt.size),
+        sharedPrompts,
+        jointlyWrongPairs: jointly,
+        jointlyWrongCandidates: candidates,
+    };
+}
+
+export function record(m: DeliveryMeasurement): Record<string, unknown> {
+    return {
+        schema: 1,
+        step: '6.4',
+        roadmap: 'road-to-governed-harness-evolution',
+        preregistration: PREREG_REL,
+        k: m.k,
+        bars: { recall_loss_ceiling_pp: RECALL_LOSS_CEILING_PP, token_target: TOKEN_TARGET },
+        metrics: {
+            precision_at_k: Number(m.precisionPp.toFixed(3)),
+            recall_at_k: Number(m.recallPp.toFixed(3)),
+            recall_loss_pp: Number(m.recallLossPp.toFixed(3)),
+            ceiling_met: m.ceilingMet,
+            recall_curve_pp: Object.fromEntries(
+                Object.entries(m.recallCurvePp).map(([kk, v]) => [kk, Number(v.toFixed(3))]),
+            ),
+            false_activation_at_k: Number(m.falseActivationPp.toFixed(3)),
+            context_cost_tokens: Number(m.contextCostTokens.toFixed(1)),
+            token_target_met: m.tokenTargetMet,
+            benefit_unconditional: Number(m.benefitUnconditionalPp.toFixed(3)),
+            benefit_conditional_on_activation: Number(m.benefitConditionalPp.toFixed(3)),
+            adjudicated_deliveries: m.adjudicatedDeliveries,
+            unadjudicated_deliveries: m.unadjudicatedDeliveries,
+            tie_decided_cut_pp: Number(m.tieDecidedCutPp.toFixed(3)),
+        },
+        set_compatibility: {
+            shared_prompts: m.sharedPrompts,
+            jointly_wrong_pairs_delivered_at_k: m.jointlyWrongPairs.length,
+            pairs_delivered_at_k: m.jointlyWrongPairs,
+            jointly_wrong_pairs_in_corpus: m.jointlyWrongCandidates.length,
+            candidates: m.jointlyWrongCandidates,
+        },
+        corpus: { partition: 'train', holdout_sealed: true, cases: m.cases, prompts: m.prompts },
+    };
+}
+
+export function render(m: DeliveryMeasurement): string {
+    const curve = CURVE_KS.map((ck) => `@${ck} ${(m.recallCurvePp[ck] ?? 0).toFixed(1)}%`).join('  ');
+    return [
+        `measure_delivery_sets — step 6.4, k=${m.k}`,
+        `  catalogue ${m.catalogueSize} · prompts ${m.prompts} · positives ${m.positives} · negatives ${m.negatives}`,
+        `  precision@${m.k}             ${m.precisionPp.toFixed(2)} % over ${m.adjudicatedDeliveries} adjudicated deliveries`,
+        `  recall@${m.k}                ${m.recallPp.toFixed(2)} %`,
+        `  recall loss              ${m.recallLossPp.toFixed(2)} pp (ceiling ${RECALL_LOSS_CEILING_PP.toFixed(1)} pp: ${m.ceilingMet ? 'MET' : 'BREACHED'})`,
+        `  recall curve             ${curve}`,
+        `  false activation@${m.k}      ${m.falseActivationPp.toFixed(2)} %`,
+        `  context cost             ${m.contextCostTokens.toFixed(1)} tokens/prompt (target ${TOKEN_TARGET}: ${m.tokenTargetMet ? 'MET' : 'BREACHED'})`,
+        `  benefit unconditional    ${m.benefitUnconditionalPp.toFixed(2)} %`,
+        `  benefit given activation ${m.benefitConditionalPp.toFixed(2)} %`,
+        `  unadjudicated deliveries ${m.unadjudicatedDeliveries}`,
+        `  tie-decided top-${m.k} cut   ${m.tieDecidedCutPp.toFixed(2)} % of prompts`,
+        `  set compatibility        corpus ${m.jointlyWrongCandidates.length} jointly-wrong pair(s)` +
+            ` over ${m.sharedPrompts} shared prompt(s); delivered together at k=${m.k}: ${m.jointlyWrongPairs.length}`,
+        ...m.jointlyWrongCandidates.map(
+            (p) =>
+                `    - {${p.pair[0]}, ${p.pair[1]}} jointly delivered at k=` +
+                `${p.jointlyDeliveredAtK ?? 'never (k<=20)'} :: ${p.prompt}`,
+        ),
+    ].join('\n');
+}
+
+export function main(argv: readonly string[]): number {
+    const m = measureDelivery();
+    if (argv.includes('--write')) {
+        fs.writeFileSync(path.join(REPO, RECORD_REL), `${JSON.stringify(record(m), null, 2)}\n`);
+    }
+    process.stdout.write(
+        argv.includes('--json') ? `${JSON.stringify(record(m), null, 2)}\n` : `${render(m)}\n`,
+    );
+    return 0;
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    try {
+        process.exit(main(process.argv.slice(2)));
+    } catch (err) {
+        process.stderr.write(`measure_delivery_sets: ${(err as Error).message}\n`);
+        process.exit(2);
+    }
+}

--- a/src/scripts/measure_routing_signal.ts
+++ b/src/scripts/measure_routing_signal.ts
@@ -1,0 +1,307 @@
+#!/usr/bin/env tsx
+/**
+ * measure_routing_signal — does the skill BODY carry routing signal the
+ * description does not? (`road-to-governed-harness-evolution` step 5.1.)
+ *
+ * THE BAR WAS FIXED BEFORE THIS FILE EXISTED. Every threshold, the k, the
+ * corpus partition, the verdict function and a committed prediction live in
+ * `agents/evidence/analysis/routing-signal-preregistration-2026-08-31.md`,
+ * which is committed in an earlier commit that adds no measurement module. The
+ * constants below are transcribed from it; they are not chosen here.
+ *
+ * TWO GAPS, AND ONLY ONE OF THEM IS MEASURABLE HERE.
+ *
+ *   Gap A — proxy-to-real-session fidelity. Stated by the description-surface
+ *           route checker's own header: asking a model which units it would
+ *           load is not the host's selection procedure. Measuring it needs real
+ *           sessions, and step 5.2 parks the live harness for this whole
+ *           roadmap. So this run emits `null` with `status:
+ *           unmeasured-by-construction` and the reason. That field is not a
+ *           caveat — it bounds the external validity of the Gap B verdict, and
+ *           a consumer reading the verdict file gets both or neither.
+ *
+ *   Gap B — the description-vs-body question this run answers.
+ *
+ * WHY McNEMAR AND NOT A RERUN BAND. The estimator is deterministic: same tree,
+ * same ranking, every time. A rerun band would be identically zero and would
+ * measure nothing. The variance that exists is sampling variance over cases, so
+ * the paired discordant-pair test is the form that addresses it.
+ *
+ * ZERO MODEL CALLS AND ZERO SPEND, and that follows from the imports rather
+ * than from good behaviour: this module imports a file reader and a pure
+ * scorer, and nothing that can open a socket.
+ *
+ * Usage:
+ *   ./scripts-run src/scripts/measure_routing_signal            human table
+ *   ./scripts-run src/scripts/measure_routing_signal --json     machine record
+ *   ./scripts-run src/scripts/measure_routing_signal --write    persist verdict
+ *
+ * Exit 0 = the measurement ran · 2 = it could not run.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import {
+    ARMS,
+    type Arm,
+    type CatalogueEntry,
+    type CorpusCase,
+    legacyShaped,
+    loadCatalogue,
+    loadTrainCases,
+    termIndex,
+    topK,
+} from './_lib/routing_corpus.js';
+
+export const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+/** Where the verdict lands. Step 6.5 derives its input set from this file. */
+export const VERDICT_REL = 'agents/evidence/analysis/routing-body-signal-verdict.json';
+export const PREREG_REL = 'agents/evidence/analysis/routing-signal-preregistration-2026-08-31.md';
+
+// --- the pre-registered constants, transcribed ------------------------------
+
+export const K = 5;
+export const RECALL_GAIN_BAR_PP = 5.0;
+export const FALSE_ACTIVATION_GUARD_PP = 2.0;
+export const POWER_FLOOR_DISCORDANT = 10;
+export const ALPHA = 0.05;
+
+export type Verdict = 'signal' | 'null' | 'harmful' | 'underpowered';
+
+export interface ArmCounts {
+    readonly positives: number;
+    readonly positiveHits: number;
+    readonly negatives: number;
+    readonly negativeHits: number;
+}
+
+export interface Discordance {
+    /** control miss → body hit. */
+    readonly gained: number;
+    /** control hit → body miss. */
+    readonly lost: number;
+}
+
+export interface Measurement {
+    readonly k: number;
+    readonly catalogueSize: number;
+    readonly trainCorpora: number;
+    readonly legacyShaped: readonly string[];
+    readonly cases: number;
+    readonly arms: Record<Arm, ArmCounts>;
+    readonly recallPp: Record<Arm, number>;
+    readonly falseActivationPp: Record<Arm, number>;
+    readonly deltaRecallPp: number;
+    readonly deltaFalseActivationPp: number;
+    readonly positiveDiscordance: Discordance;
+    readonly pValue: number;
+    readonly verdict: Verdict;
+    readonly verdictReason: string;
+}
+
+/** Exact two-sided McNemar: a binomial sign test over the discordant pairs. */
+export function mcnemarExactP(gained: number, lost: number): number {
+    const n = gained + lost;
+    if (n === 0) return 1;
+    const logFact: number[] = [0];
+    for (let i = 1; i <= n; i++) logFact.push((logFact[i - 1] as number) + Math.log(i));
+    const logChoose = (a: number, b: number): number =>
+        (logFact[a] as number) - (logFact[b] as number) - (logFact[a - b] as number);
+    const extreme = Math.min(gained, lost);
+    let tail = 0;
+    for (let i = 0; i <= extreme; i++) tail += Math.exp(logChoose(n, i) - n * Math.LN2);
+    return Math.min(1, 2 * tail);
+}
+
+const pp = (hits: number, total: number): number => (total === 0 ? 0 : (hits / total) * 100);
+
+export function measure(repo = REPO, k = K): Measurement {
+    const catalogue: CatalogueEntry[] = loadCatalogue(repo);
+    const cases: CorpusCase[] = loadTrainCases(repo);
+    if (catalogue.length === 0 || cases.length === 0) {
+        throw new Error('measure_routing_signal: empty catalogue or corpus — a run over nothing');
+    }
+    const indexes = new Map<Arm, ReturnType<typeof termIndex>>();
+    for (const arm of ARMS) indexes.set(arm, termIndex(catalogue, arm));
+
+    const counts: Record<string, { p: number; ph: number; n: number; nh: number }> = {};
+    for (const arm of ARMS) counts[arm] = { p: 0, ph: 0, n: 0, nh: 0 };
+    let gained = 0;
+    let lost = 0;
+
+    // One ranking pass per (case, arm). The prompt is re-tokenized per arm by
+    // `topK`; that is the price of keeping the control arm byte-identical to
+    // the shipped call rather than hand-rolling a shared fast path.
+    for (const c of cases) {
+        const hit: Record<string, boolean> = {};
+        for (const arm of ARMS) {
+            const ranked = topK(c.prompt, catalogue, indexes.get(arm) as Map<string, Set<string>>, k);
+            hit[arm] = ranked.some((r) => r.name === c.skill);
+            const bucket = counts[arm] as { p: number; ph: number; n: number; nh: number };
+            if (c.expect) {
+                bucket.p += 1;
+                if (hit[arm]) bucket.ph += 1;
+            } else {
+                bucket.n += 1;
+                if (hit[arm]) bucket.nh += 1;
+            }
+        }
+        if (c.expect) {
+            const control = hit['description'] === true;
+            const body = hit['description+body'] === true;
+            if (!control && body) gained += 1;
+            if (control && !body) lost += 1;
+        }
+    }
+
+    const arms = {} as Record<Arm, ArmCounts>;
+    const recallPp = {} as Record<Arm, number>;
+    const falsePp = {} as Record<Arm, number>;
+    for (const arm of ARMS) {
+        const b = counts[arm] as { p: number; ph: number; n: number; nh: number };
+        arms[arm] = { positives: b.p, positiveHits: b.ph, negatives: b.n, negativeHits: b.nh };
+        recallPp[arm] = pp(b.ph, b.p);
+        falsePp[arm] = pp(b.nh, b.n);
+    }
+    const deltaRecall = (recallPp['description+body'] as number) - (recallPp['description'] as number);
+    const deltaFalse =
+        (falsePp['description+body'] as number) - (falsePp['description'] as number);
+    const p = mcnemarExactP(gained, lost);
+
+    // The pre-registered verdict function, in its pre-registered order.
+    let verdict: Verdict;
+    let reason: string;
+    if (gained + lost < POWER_FLOOR_DISCORDANT) {
+        verdict = 'underpowered';
+        reason = `${gained + lost} discordant positive pairs < power floor ${POWER_FLOOR_DISCORDANT}`;
+    } else if (deltaFalse > FALSE_ACTIVATION_GUARD_PP) {
+        verdict = 'harmful';
+        reason = `false activation +${deltaFalse.toFixed(2)} pp breaches the +${FALSE_ACTIVATION_GUARD_PP.toFixed(1)} pp guard`;
+    } else if (deltaRecall >= RECALL_GAIN_BAR_PP && p < ALPHA) {
+        verdict = 'signal';
+        reason = `recall +${deltaRecall.toFixed(2)} pp at p=${p.toExponential(2)}`;
+    } else {
+        verdict = 'null';
+        reason = `recall +${deltaRecall.toFixed(2)} pp at p=${p.toExponential(2)} does not clear +${RECALL_GAIN_BAR_PP.toFixed(1)} pp and p<${ALPHA}`;
+    }
+
+    return {
+        k,
+        catalogueSize: catalogue.length,
+        trainCorpora: new Set(cases.map((c) => c.skill)).size,
+        legacyShaped: legacyShaped(repo),
+        cases: cases.length,
+        arms,
+        recallPp,
+        falseActivationPp: falsePp,
+        deltaRecallPp: deltaRecall,
+        deltaFalseActivationPp: deltaFalse,
+        positiveDiscordance: { gained, lost },
+        pValue: p,
+        verdict,
+        verdictReason: reason,
+    };
+}
+
+/**
+ * The verdict record step 6.5 reads.
+ *
+ * `proxy_to_real_fidelity` is a REQUIRED field carrying `null`. A consumer that
+ * reads `body_signal` without reading it has taken the conclusion without its
+ * bound, so the two ship in one object.
+ */
+export function verdictRecord(m: Measurement, measuredAt: string): Record<string, unknown> {
+    return {
+        schema: 1,
+        step: '5.1',
+        roadmap: 'road-to-governed-harness-evolution',
+        preregistration: PREREG_REL,
+        measured_at: measuredAt,
+        proxy_to_real_fidelity: {
+            value: null,
+            status: 'unmeasured-by-construction',
+            reason:
+                'Step 5.2 parks the live routing harness for this roadmap; a fidelity ' +
+                'figure requires real sessions. Every routing conclusion in this file is ' +
+                'bounded by this unmeasured quantity.',
+        },
+        body_signal: {
+            verdict: m.verdict,
+            reason: m.verdictReason,
+            k: m.k,
+            delta_recall_pp: Number(m.deltaRecallPp.toFixed(3)),
+            delta_false_activation_pp: Number(m.deltaFalseActivationPp.toFixed(3)),
+            p_value: Number(m.pValue.toPrecision(4)),
+            discordant_positive_pairs: m.positiveDiscordance,
+            bars: {
+                recall_gain_pp: RECALL_GAIN_BAR_PP,
+                false_activation_guard_pp: FALSE_ACTIVATION_GUARD_PP,
+                power_floor_discordant: POWER_FLOOR_DISCORDANT,
+                alpha: ALPHA,
+            },
+            arms: m.arms,
+            recall_pp: {
+                description: Number((m.recallPp['description'] as number).toFixed(3)),
+                'description+body': Number((m.recallPp['description+body'] as number).toFixed(3)),
+            },
+            false_activation_pp: {
+                description: Number((m.falseActivationPp['description'] as number).toFixed(3)),
+                'description+body': Number(
+                    (m.falseActivationPp['description+body'] as number).toFixed(3),
+                ),
+            },
+        },
+        corpus: {
+            partition: 'train',
+            holdout_sealed: true,
+            train_corpora: m.trainCorpora,
+            legacy_shaped_corpora: m.legacyShaped,
+            cases: m.cases,
+            catalogue_size: m.catalogueSize,
+        },
+    };
+}
+
+export function render(m: Measurement): string {
+    const rows = ARMS.map(
+        (arm) =>
+            `  ${arm.padEnd(18)} recall@${m.k} ${(m.recallPp[arm] as number).toFixed(2).padStart(6)} %` +
+            `   false-activation@${m.k} ${(m.falseActivationPp[arm] as number).toFixed(2).padStart(6)} %`,
+    );
+    return [
+        `measure_routing_signal — step 5.1, k=${m.k}`,
+        `  catalogue ${m.catalogueSize} skills · train corpora ${m.trainCorpora}` +
+            ` (${m.legacyShaped.length} legacy-shaped: ${m.legacyShaped.join(', ') || 'none'})` +
+            ` · cases ${m.cases}`,
+        ...rows,
+        `  delta recall ${m.deltaRecallPp >= 0 ? '+' : ''}${m.deltaRecallPp.toFixed(2)} pp` +
+            ` (bar +${RECALL_GAIN_BAR_PP.toFixed(1)} pp)`,
+        `  delta false activation ${m.deltaFalseActivationPp >= 0 ? '+' : ''}${m.deltaFalseActivationPp.toFixed(2)} pp` +
+            ` (guard +${FALSE_ACTIVATION_GUARD_PP.toFixed(1)} pp)`,
+        `  discordant positives gained ${m.positiveDiscordance.gained} lost ${m.positiveDiscordance.lost}` +
+            ` · McNemar exact p=${m.pValue.toExponential(3)}`,
+        `  proxy-to-real fidelity: null (unmeasured-by-construction — 5.2 park)`,
+        `  VERDICT: ${m.verdict} — ${m.verdictReason}`,
+    ].join('\n');
+}
+
+export function main(argv: readonly string[]): number {
+    const m = measure();
+    const record = verdictRecord(m, new Date().toISOString().slice(0, 10));
+    if (argv.includes('--write')) {
+        fs.writeFileSync(path.join(REPO, VERDICT_REL), `${JSON.stringify(record, null, 2)}\n`);
+    }
+    process.stdout.write(argv.includes('--json') ? `${JSON.stringify(record, null, 2)}\n` : `${render(m)}\n`);
+    return 0;
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    try {
+        process.exit(main(process.argv.slice(2)));
+    } catch (err) {
+        process.stderr.write(`measure_routing_signal: ${(err as Error).message}\n`);
+        process.exit(2);
+    }
+}

--- a/src/scripts/model_rule_injection.ts
+++ b/src/scripts/model_rule_injection.ts
@@ -52,6 +52,7 @@ import { parse as parseYaml } from 'yaml';
 
 import { LexicalIndex } from './_lib/lexical_index.js';
 import { gpt_tokens } from './_lib/token_count.js';
+import { makePromptShortlist } from './_lib/lexical_shortlist.js';
 import {
     allTierRules,
     kernelIds,
@@ -820,6 +821,7 @@ export function runSelftest(corpusDir: string): SelftestCase[] {
 export function runThreeArm(
     corpusDir: string,
     capBytes: number = CAP_BYTES,
+    useShortlist = false,
 ): { rows: ArmRow[]; lines: string[] } {
     const router = loadRouter(REPO_ROOT);
     const cases = loadCorpus(corpusDir);
@@ -829,6 +831,10 @@ export function runThreeArm(
         thin: sc.thinTokens,
         delivery: sc.thinTokens,
     };
+    // STEP 6.3 — the shortlist is OPT-IN and OFF by default, so the figures 6.1
+    // recorded reproduce byte-for-byte without it. It reaches the delivery arm
+    // as a tie-break under the matcher's score and can move nothing but which
+    // matched bodies survive a binding cap.
     const rows = runArmExperiment({
         repoRoot: REPO_ROOT,
         router,
@@ -836,8 +842,15 @@ export function runThreeArm(
         capBytes,
         standing,
         tokensOf,
+        shortlist: useShortlist ? makePromptShortlist(REPO_ROOT, router) : null,
     });
-    return { rows, lines: renderArmExperiment(rows, capBytes) };
+    const lines = renderArmExperiment(rows, capBytes);
+    lines.push(
+        useShortlist
+            ? 'shortlist: ON — lexical BM25 tie-break under the matcher score (step 6.3)'
+            : 'shortlist: OFF — cap order is score then router order (step 6.1 baseline)',
+    );
+    return { rows, lines };
 }
 
 // ── CLI ──────────────────────────────────────────────────────────────────
@@ -845,7 +858,7 @@ export function runThreeArm(
 const USAGE = `usage: model_rule_injection [--corpus DIR] [--baseline-comparison]
                             [--honour-open-files]
                             [--selftest] [--endpoints] [--json]
-                            [--three-arm] [--cap-bytes N]
+                            [--three-arm] [--cap-bytes N] [--shortlist]
 
 Offline recall + cost model for trigger-delivered rule bodies. No metered call
 on any path.
@@ -860,6 +873,7 @@ export function main(argv: string[] | null = null): number {
     let endpoints = false;
     let json = false;
     let threeArm = false;
+    let shortlist = false;
     let capBytes = CAP_BYTES;
     for (let i = 0; i < args.length; i += 1) {
         const a = args[i] as string;
@@ -878,6 +892,8 @@ export function main(argv: string[] | null = null): number {
             json = true;
         } else if (a === '--three-arm') {
             threeArm = true;
+        } else if (a === '--shortlist') {
+            shortlist = true;
         } else if (a === '--cap-bytes') {
             i += 1;
             capBytes = Number.parseInt(args[i] as string, 10);
@@ -895,7 +911,7 @@ export function main(argv: string[] | null = null): number {
     }
 
     if (threeArm) {
-        const res = runThreeArm(corpus, capBytes);
+        const res = runThreeArm(corpus, capBytes, shortlist);
         if (json) {
             process.stdout.write(`${JSON.stringify(res.rows, null, 2)}\n`);
         } else {

--- a/tests/scripts/_lib/evolution_roi.test.ts
+++ b/tests/scripts/_lib/evolution_roi.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Step 5.6 — the ROI figure in every run report, and cheapest-model-first.
+ *
+ * > verify: **the ROI figure appears in every run report, and a cheaper model
+ * > is tried before an expensive one on each defect class.**
+ *
+ * ## What each half is actually proved against
+ *
+ * The ROI half has a live subject: `evolution_lab run` builds its report through
+ * {@link buildRunReport} on the one path a run completes on, so the refusal
+ * below is over a function a production caller reaches. The end-to-end
+ * assertion that the line reaches stdout lives in `evolution_lab.test.ts`,
+ * beside the clone fixture it needs.
+ *
+ * The ladder half has NO live subject and this file does not pretend otherwise:
+ * nothing in this programme produces a {@link LadderAttempt}, because step 5.2
+ * keeps the live-floors park intact and there is no harness to make a metered
+ * call. {@link assertCheapestFirst} is therefore proved to FIRE on synthetic
+ * out-of-order sequences and to stay silent on in-order ones — a guard with a
+ * proved polarity standing over a mechanism that does not exist yet.
+ */
+import { describe, expect, it } from 'vitest';
+
+import type { MetricRow, MetricVector } from '../../../src/scripts/_lib/evaluation_vector.js';
+import { buildVector } from '../../../src/scripts/_lib/evaluation_vector.js';
+import type { PairedVerdictKind } from '../../../src/scripts/_lib/paired_verdict.js';
+import {
+    DEFECT_CLASSES,
+    LADDER,
+    type LadderAttempt,
+    LadderOrderError,
+    MODEL_TIERS,
+    type ModelTier,
+    RoiShapeError,
+    RunReportShapeError,
+    assertCheapestFirst,
+    assertLadderWellFormed,
+    buildRunReport,
+    ladderFor,
+    ladderPlan,
+    nextTier,
+    parseMetricVectorJson,
+    renderRoi,
+    renderRunReport,
+    roiCounts,
+    roiFigure,
+} from '../../../src/scripts/_lib/evolution_roi.js';
+
+const ARTIFACT_ROW: MetricRow = {
+    kind: 'counted',
+    metric: 'artifact-count-delta',
+    direction: 'lower-better',
+    delta: 0,
+};
+
+function paired(metric: string, kind: PairedVerdictKind): MetricRow {
+    return {
+        kind: 'paired',
+        metric,
+        direction: 'higher-better',
+        verdict: {
+            kind,
+            discordant: 10,
+            wins: kind === 'pass' ? 9 : 5,
+            losses: kind === 'pass' ? 1 : 5,
+            p: kind === 'pass' ? 0.01 : 0.5,
+            magnitude_mean: 0,
+            at_floor: false,
+            reason: `synthetic ${kind}`,
+        },
+    };
+}
+
+function vector(id: string, kinds: readonly PairedVerdictKind[]): MetricVector {
+    return buildVector(id, [ARTIFACT_ROW, ...kinds.map((k, i) => paired(`m${String(i)}`, k))]);
+}
+
+// --- § the ROI figure -------------------------------------------------------
+
+describe('5.6 — the ROI figure', () => {
+    it('counts paired rows by verdict kind, and nets nothing', () => {
+        const counts = roiCounts([
+            vector('a', ['pass', 'regression', 'underpowered']),
+            vector('b', ['pass', 'no-change']),
+        ]);
+        // Two passes and one regression stay two and one. A netted figure would
+        // report one improvement and hide the regression entirely.
+        expect(counts).toEqual({
+            evaluated_candidates: 2,
+            improved_rows: 2,
+            regressed_rows: 1,
+            underpowered_rows: 1,
+        });
+    });
+
+    it('is a ratio when spend is positive and something was evaluated', () => {
+        const f = roiFigure([vector('a', ['pass', 'pass'])], 250);
+        expect(f.kind).toBe('ratio');
+        // 2 improved rows over $2.50.
+        expect(f.kind === 'ratio' && f.improvement_per_dollar).toBeCloseTo(0.8, 10);
+    });
+
+    it('never prints Infinity: zero spend is its own kind', () => {
+        const f = roiFigure([vector('a', ['pass'])], 0);
+        expect(f.kind).toBe('no-spend');
+        expect(renderRoi(f)).toContain('improvement per dollar is undefined');
+        expect(renderRoi(f)).not.toContain('Infinity');
+    });
+
+    it('never prints NaN: no evaluated candidate is its own kind', () => {
+        const f = roiFigure([], 500);
+        expect(f.kind).toBe('unmeasured');
+        expect(f.spend_cents).toBe(500);
+        expect(renderRoi(f)).toContain('no candidate in this run carried an evaluation');
+        expect(renderRoi(f)).not.toContain('NaN');
+    });
+
+    it('refuses a fractional or negative spend, so no float decides a kind', () => {
+        expect(() => roiFigure([], 1.5)).toThrow(RoiShapeError);
+        expect(() => roiFigure([], -1)).toThrow(RoiShapeError);
+    });
+});
+
+// --- § the report REFUSES a missing ROI figure ------------------------------
+
+describe('5.6 — a run report without the ROI figure is refused', () => {
+    const ok = {
+        run_id: 'run:a',
+        candidates: 1,
+        trials_per_candidate: 1,
+        roi: roiFigure([vector('a', ['pass'])], 100),
+    };
+
+    it('builds when the figure is present', () => {
+        const r = buildRunReport(ok);
+        expect(r.roi.kind).toBe('ratio');
+        expect(r.ladder.length).toBe(DEFECT_CLASSES.length);
+    });
+
+    it('REFUSES when the figure is absent (negative polarity, past the compiler)', () => {
+        // The cast is the point: a caller who drops the row is a caller the
+        // type system cannot see — a JSON parse, a `delete`, an `as`.
+        const stripped = { ...ok } as Record<string, unknown>;
+        delete stripped.roi;
+        expect(() => buildRunReport(stripped as unknown as typeof ok)).toThrow(RunReportShapeError);
+        expect(() => buildRunReport(stripped as unknown as typeof ok)).toThrow(
+            /missing the ROI figure/,
+        );
+    });
+
+    it('REFUSES an ROI value that is not one of the three kinds', () => {
+        const bogus = { ...ok, roi: { kind: 'looks-fine' } } as unknown as typeof ok;
+        expect(() => buildRunReport(bogus)).toThrow(/unknown kind/);
+    });
+
+    it('REFUSES a report that names no run', () => {
+        expect(() => buildRunReport({ ...ok, run_id: '  ' })).toThrow(RunReportShapeError);
+    });
+
+    it('every rendered report carries exactly one roi line', () => {
+        const lines = renderRunReport(buildRunReport(ok));
+        expect(lines.filter((l) => l.startsWith('run-report: roi:'))).toHaveLength(1);
+    });
+});
+
+// --- § the ladder -----------------------------------------------------------
+
+describe('5.6 — the ladder is cheapest-first by construction', () => {
+    it('every class ladder is a prefix of the tier order, or empty', () => {
+        expect(() => assertLadderWellFormed()).not.toThrow();
+        for (const cls of DEFECT_CLASSES) {
+            expect(MODEL_TIERS.slice(0, ladderFor(cls).length)).toEqual([...ladderFor(cls)]);
+        }
+    });
+
+    it('the well-formedness check FIRES on a rung-skipping ladder (negative polarity)', () => {
+        const skipping = { ...LADDER, execution_failed: ['medium', 'high'] as ModelTier[] };
+        expect(() => assertLadderWellFormed(skipping)).toThrow(LadderOrderError);
+        expect(() => assertLadderWellFormed(skipping)).toThrow(/cheapest-first/);
+    });
+
+    it('covers every defect class in the pathology vocabulary, with none invented', () => {
+        expect(Object.keys(LADDER).sort()).toEqual([...DEFECT_CLASSES].sort());
+    });
+
+    it('nextTier walks up one rung at a time and then stops', () => {
+        expect(nextTier('execution_failed', [])).toBe('lite');
+        expect(nextTier('execution_failed', ['lite'])).toBe('medium');
+        expect(nextTier('execution_failed', ['lite', 'medium'])).toBe('high');
+        expect(nextTier('execution_failed', ['lite', 'medium', 'high'])).toBeNull();
+    });
+
+    it('an empty ladder means SPEND NOTHING, never "start at the top"', () => {
+        for (const cls of ['policy_blocked', 'dependency_unavailable', 'human_rejected'] as const) {
+            expect(ladderFor(cls)).toEqual([]);
+            expect(nextTier(cls, [])).toBeNull();
+        }
+        const plan = ladderPlan();
+        const row = plan.find((r) => r.defect_class === 'human_rejected');
+        expect(row?.next).toBeNull();
+        expect(renderRunReport(
+            buildRunReport({
+                run_id: 'run:x',
+                candidates: 0,
+                trials_per_candidate: 0,
+                roi: roiFigure([], 0),
+            }),
+        ).some((l) => l.includes('human_rejected: (none licensed) | next: spend nothing'))).toBe(true);
+    });
+});
+
+describe('5.6 — assertCheapestFirst, a guard with no live subject', () => {
+    const seq = (rows: ReadonlyArray<[string, ModelTier]>): LadderAttempt[] =>
+        rows.map(([cls, tier], i) => ({
+            defect_class: cls as LadderAttempt['defect_class'],
+            tier,
+            sequence: i,
+        }));
+
+    it('accepts an in-order escalation (positive polarity)', () => {
+        expect(() =>
+            assertCheapestFirst(
+                seq([
+                    ['execution_failed', 'lite'],
+                    ['execution_failed', 'medium'],
+                    ['execution_failed', 'high'],
+                ]),
+            ),
+        ).not.toThrow();
+    });
+
+    it('accepts a repeat of an already-spent rung — a retry is not an escalation', () => {
+        expect(() =>
+            assertCheapestFirst(
+                seq([
+                    ['execution_failed', 'lite'],
+                    ['execution_failed', 'lite'],
+                    ['execution_failed', 'medium'],
+                ]),
+            ),
+        ).not.toThrow();
+    });
+
+    it('FIRES when an expensive tier runs before a cheaper untried one', () => {
+        expect(() =>
+            assertCheapestFirst(seq([['execution_failed', 'high'], ['execution_failed', 'lite']])),
+        ).toThrow(/cheaper models go first/);
+    });
+
+    it('FIRES when a class jumps the middle rung', () => {
+        expect(() =>
+            assertCheapestFirst(seq([['execution_failed', 'lite'], ['execution_failed', 'high']])),
+        ).toThrow(LadderOrderError);
+    });
+
+    it('FIRES on any metered attempt against an empty-ladder class', () => {
+        expect(() => assertCheapestFirst(seq([['human_rejected', 'lite']]))).toThrow(
+            /ladder is empty/,
+        );
+    });
+
+    it('FIRES on a tier outside the class ladder', () => {
+        expect(() => assertCheapestFirst(seq([['evidence_missing', 'high']]))).toThrow(
+            /not on this class's ladder/,
+        );
+    });
+
+    it('is per class: two classes each starting cheap is in order', () => {
+        expect(() =>
+            assertCheapestFirst(
+                seq([
+                    ['execution_failed', 'lite'],
+                    ['output_contract_violated', 'lite'],
+                    ['execution_failed', 'medium'],
+                ]),
+            ),
+        ).not.toThrow();
+    });
+
+    it('orders by sequence, not by array position', () => {
+        const out: LadderAttempt[] = [
+            { defect_class: 'execution_failed', tier: 'medium', sequence: 1 },
+            { defect_class: 'execution_failed', tier: 'lite', sequence: 0 },
+        ];
+        expect(() => assertCheapestFirst(out)).not.toThrow();
+        const reversed: LadderAttempt[] = [
+            { defect_class: 'execution_failed', tier: 'lite', sequence: 1 },
+            { defect_class: 'execution_failed', tier: 'medium', sequence: 0 },
+        ];
+        expect(() => assertCheapestFirst(reversed)).toThrow(LadderOrderError);
+    });
+});
+
+// --- § the vector parser inherits the artifact-count refusal ----------------
+
+describe('5.6 — parseMetricVectorJson', () => {
+    const good = JSON.stringify({
+        candidate_id: 'c1',
+        rows: [
+            ARTIFACT_ROW,
+            {
+                kind: 'paired',
+                metric: 'recall',
+                direction: 'higher-better',
+                verdict: {
+                    kind: 'pass',
+                    discordant: 12,
+                    wins: 11,
+                    losses: 1,
+                    p: 0.003,
+                    magnitude_mean: 0.1,
+                    at_floor: false,
+                    reason: 'won',
+                },
+            },
+        ],
+    });
+
+    it('parses a well-formed vector', () => {
+        const v = parseMetricVectorJson(good, 'good.json');
+        expect(v.candidate_id).toBe('c1');
+        expect(roiCounts([v]).improved_rows).toBe(1);
+    });
+
+    it('inherits buildVector`s refusal of a vector missing the artifact-count row', () => {
+        const stripped = JSON.stringify({
+            candidate_id: 'c1',
+            rows: JSON.parse(good).rows.slice(1),
+        });
+        expect(() => parseMetricVectorJson(stripped, 'bad.json')).toThrow(
+            /missing the 'artifact-count-delta' row/,
+        );
+    });
+
+    it('refuses a verdict field that is a string where an integer belongs', () => {
+        const bad = JSON.parse(good);
+        bad.rows[1].verdict.wins = '11';
+        expect(() => parseMetricVectorJson(JSON.stringify(bad), 'bad.json')).toThrow(RoiShapeError);
+    });
+
+    it('refuses an unknown verdict kind and an unknown row kind', () => {
+        const badVerdict = JSON.parse(good);
+        badVerdict.rows[1].verdict.kind = 'improved';
+        expect(() => parseMetricVectorJson(JSON.stringify(badVerdict), 'x')).toThrow(RoiShapeError);
+        const badRow = JSON.parse(good);
+        badRow.rows[1].kind = 'weighted';
+        expect(() => parseMetricVectorJson(JSON.stringify(badRow), 'x')).toThrow(RoiShapeError);
+    });
+
+    it('refuses non-JSON and a non-object payload', () => {
+        expect(() => parseMetricVectorJson('{', 'x')).toThrow(/not JSON/);
+        expect(() => parseMetricVectorJson('[]', 'x')).toThrow(/expected a JSON object/);
+    });
+});

--- a/tests/scripts/_lib/lexical_shortlist.test.ts
+++ b/tests/scripts/_lib/lexical_shortlist.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Step 6.3 — a lexical shortlist, and only a shortlist.
+ *
+ * > verify: **the shortlist feeds a later stage and never decides alone.**
+ *
+ * The verify clause has a positive half and a negative half, and the negative
+ * half is the load-bearing one. A shortlist that decides nothing is trivially
+ * compliant and useless; a shortlist that decides is the failure. So this file
+ * proves BOTH: that the shortlist demonstrably changes what the later stage
+ * (the byte cap in `selectForInjection`) does, and that it cannot change the
+ * SET the matcher decided, in either direction.
+ *
+ * ## The banned-construct list lives here, not in the module
+ *
+ * A scanner whose banned literals sit inside the file it scans matches its own
+ * declaration and can never pass. `governed_harness_no_live_harness.test.ts`
+ * keeps its banned set on the test side for the same reason.
+ */
+import { readFileSync } from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+    SHORTLIST_SIZE,
+    ShortlistDecidedAloneError,
+    assertPermutation,
+    buildRuleIndex,
+    makePromptShortlist,
+    orderByShortlist,
+    shortlistIds,
+    shortlistRanks,
+} from '../../../src/scripts/_lib/lexical_shortlist.js';
+import {
+    allTierRules,
+    loadRouter,
+    loadRuleBody,
+    matchTierRules,
+    selectForInjection,
+    type TierRuleMatch,
+} from '../../../src/scripts/_lib/rule_injection.js';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const router = loadRouter(REPO);
+
+function m(id: string, score: number, order: number): TierRuleMatch {
+    return { id, tier: 'tier_2', score, order };
+}
+
+/** Real tier-rule ids that carry a projected body — the cap's real subjects. */
+const bodied = allTierRules(router)
+    .filter((r) => loadRuleBody(REPO, r.id) !== null)
+    .map((r) => r.id);
+
+// --- § the index is BM25 over what already ships ----------------------------
+
+describe('6.3 — the shortlist is built over the existing BM25 core', () => {
+    it('indexes the bodied tier rules and ranks deterministically', () => {
+        const index = buildRuleIndex(REPO, router);
+        expect(index.size).toBeGreaterThan(20);
+        expect(index.size).toBeLessThanOrEqual(bodied.length);
+        const a = shortlistIds(index, 'never commit or push without permission');
+        const b = shortlistIds(index, 'never commit or push without permission');
+        expect(a).toEqual(b);
+        expect(a.length).toBeGreaterThan(0);
+        expect(a.length).toBeLessThanOrEqual(SHORTLIST_SIZE);
+    });
+
+    it('a shortlist is a ranking, so its first entry moves with the prompt', () => {
+        const index = buildRuleIndex(REPO, router);
+        const commit = shortlistIds(index, 'commit policy, when may I commit');
+        const design = shortlistIds(index, 'design fidelity of the provided prototype mockup');
+        expect(commit[0]).toBeDefined();
+        expect(design[0]).toBeDefined();
+        // A ranker that returned the same head for every prompt would be a
+        // constant wearing a ranking's clothes.
+        expect(commit[0]).not.toBe(design[0]);
+    });
+
+    it('an empty shortlist is a real answer, not a crash', () => {
+        const index = buildRuleIndex(REPO, router);
+        expect(shortlistIds(index, 'zzzzqqqxvv', 40)).toEqual([]);
+        expect(shortlistIds(index, 'commit', 0)).toEqual([]);
+    });
+
+    it('shortlistRanks keeps the FIRST position of a duplicated id', () => {
+        expect([...shortlistRanks(['a', 'b', 'a']).entries()]).toEqual([
+            ['a', 0],
+            ['b', 1],
+        ]);
+    });
+});
+
+// --- § never decides alone: the permutation invariant -----------------------
+
+describe('6.3 — the shortlist never decides alone (the negative half)', () => {
+    const matches = [m('r-a', 1, 0), m('r-b', 1, 1), m('r-c', 1, 2)];
+
+    it('orderByShortlist returns a permutation of the matcher`s output', () => {
+        const out = orderByShortlist(matches, ['r-c', 'r-a']);
+        expect(out.map((x) => x.id)).toEqual(['r-c', 'r-a', 'r-b']);
+        expect([...out].map((x) => x.id).sort()).toEqual(['r-a', 'r-b', 'r-c']);
+    });
+
+    it('ids the shortlist ranks that the matcher did not return are dropped on the floor', () => {
+        // `r-zzz` never fired. It appears first in the shortlist and is still
+        // nowhere in the output — this is "cannot add" at its source.
+        const out = orderByShortlist(matches, ['r-zzz', 'r-b']);
+        expect(out.map((x) => x.id)).not.toContain('r-zzz');
+        expect(out.map((x) => x.id)).toEqual(['r-b', 'r-a', 'r-c']);
+    });
+
+    it('the matcher`s score dominates the shortlist rank, never the other way round', () => {
+        // `r-a` fired twice; `r-c` is the shortlist's favourite. The matcher wins.
+        const scored = [m('r-a', 2, 0), m('r-c', 1, 2)];
+        expect(orderByShortlist(scored, ['r-c', 'r-a']).map((x) => x.id)).toEqual(['r-a', 'r-c']);
+    });
+
+    it('the shortlist breaks ties the matcher left, ahead of router order', () => {
+        expect(orderByShortlist(matches, ['r-c']).map((x) => x.id)).toEqual(['r-c', 'r-a', 'r-b']);
+    });
+
+    it('an unshortlisted match still competes — it sorts last, it is not removed', () => {
+        const out = orderByShortlist(matches, ['r-b']);
+        expect(out.map((x) => x.id)).toEqual(['r-b', 'r-a', 'r-c']);
+        expect(out).toHaveLength(matches.length);
+    });
+
+    // --- the sabotage the verify clause actually asks for --------------------
+
+    it('FIRES when the shortlist DECIDES BY SUBTRACTION (negative polarity)', () => {
+        // The sabotage in one line: filter the matcher's output down to the
+        // shortlist. This is the shape a "shortlist" naturally degrades into.
+        const decided = matches.filter((x) => ['r-c'].includes(x.id));
+        expect(() => assertPermutation(matches, decided)).toThrow(ShortlistDecidedAloneError);
+        expect(() => assertPermutation(matches, decided)).toThrow(/dropped r-a, r-b/);
+        expect(() => assertPermutation(matches, decided)).toThrow(/decides by subtraction/);
+    });
+
+    it('FIRES when the shortlist DECIDES BY ADDITION (negative polarity)', () => {
+        const decided = [...matches, m('r-zzz', 1, 99)];
+        expect(() => assertPermutation(matches, decided)).toThrow(/added r-zzz/);
+        expect(() => assertPermutation(matches, decided)).toThrow(
+            /delivers what the matcher never fired on/,
+        );
+    });
+
+    it('is silent on a genuine reorder (positive polarity)', () => {
+        expect(() => assertPermutation(matches, [...matches].reverse())).not.toThrow();
+    });
+
+    it('counts multiplicity, so a swap of one id for a duplicate of another is caught', () => {
+        const decided = [m('r-a', 1, 0), m('r-a', 1, 0), m('r-b', 1, 1)];
+        expect(() => assertPermutation(matches, decided)).toThrow(ShortlistDecidedAloneError);
+    });
+});
+
+// --- § it feeds a LATER STAGE, and the later stage still owns membership -----
+
+describe('6.3 — the shortlist feeds selectForInjection`s cap', () => {
+    const ids = bodied.slice(0, 6);
+
+    it('with a slack cap, membership is identical with and without a shortlist', () => {
+        const matches = ids.map((id, i) => m(id, 1, i));
+        const slack = 10_000_000;
+        const off = selectForInjection(REPO, [...matches], slack);
+        const on = selectForInjection(REPO, [...matches], slack, [...ids].reverse());
+        expect(off.selected.map((x) => x.id).sort()).toEqual(on.selected.map((x) => x.id).sort());
+        expect(on.dropped).toEqual([]);
+    });
+
+    it('selected + dropped is exactly the matcher`s set, in both modes', () => {
+        const matches = ids.map((id, i) => m(id, 1, i));
+        for (const sl of [null, [...ids].reverse()]) {
+            const sel = selectForInjection(REPO, [...matches], 1, sl);
+            const seen = [...sel.selected, ...sel.dropped].map((x) => x.id).sort();
+            expect(seen).toEqual([...ids].sort());
+        }
+    });
+
+    it('a PARTIAL shortlist drops no matched body when the cap is slack', () => {
+        // The gap a sabotage found: every earlier case shortlisted EVERY match,
+        // so a `filter(x => shortlisted)` inside the cap walk changed nothing
+        // and no test moved. Here the shortlist names one of six.
+        const matches = ids.map((id, i) => m(id, 1, i));
+        const partial = [ids[3] as string];
+        const sel = selectForInjection(REPO, [...matches], 10_000_000, partial);
+        expect(sel.selected.map((x) => x.id).sort()).toEqual([...ids].sort());
+        expect(sel.dropped).toEqual([]);
+    });
+
+    it('the matcher`s score outranks the shortlist INSIDE the cap walk too', () => {
+        // `orderByShortlist` pins the key order in the shortlist module; this
+        // pins the identical order at the place the cap actually binds, which
+        // is a second implementation of the same comparator and can drift.
+        const hi = ids[0] as string;
+        const lo = ids[1] as string;
+        const matches = [m(hi, 2, 0), m(lo, 1, 1)];
+        const cap = 1; // admits exactly one body
+        const sel = selectForInjection(REPO, [...matches], cap, [lo]);
+        expect(sel.selected.map((x) => x.id)).toEqual([hi]);
+        expect(sel.dropped.map((x) => x.id)).toEqual([lo]);
+    });
+
+    it('a shortlisted id the matcher did not return is never delivered', () => {
+        const matches = ids.slice(0, 2).map((id, i) => m(id, 1, i));
+        const sel = selectForInjection(REPO, [...matches], 10_000_000, ['r-not-a-match', ...ids]);
+        expect(sel.selected.map((x) => x.id)).not.toContain('r-not-a-match');
+        expect(sel.selected).toHaveLength(2);
+    });
+
+    it('CHANGES which body survives a binding cap — the shortlist is not decorative', () => {
+        // A cap that admits exactly one body. Without a shortlist the winner is
+        // router order; with one naming the last id first, the winner moves.
+        const matches = ids.map((id, i) => m(id, 1, i));
+        const cap = 1;
+        const off = selectForInjection(REPO, [...matches], cap);
+        const on = selectForInjection(REPO, [...matches], cap, [ids[ids.length - 1] as string]);
+        expect(off.selected.map((x) => x.id)).toEqual([ids[0]]);
+        expect(on.selected.map((x) => x.id)).toEqual([ids[ids.length - 1]]);
+    });
+
+    it('the default is byte-for-byte the pre-6.3 behaviour', () => {
+        const matches = ids.map((id, i) => m(id, 1, i));
+        const a = selectForInjection(REPO, [...matches], 20_480);
+        const b = selectForInjection(REPO, [...matches], 20_480, null);
+        expect(a.selected.map((x) => x.id)).toEqual(b.selected.map((x) => x.id));
+        expect(a.bytes).toBe(b.bytes);
+    });
+});
+
+// --- § over the real router and a real prompt -------------------------------
+
+describe('6.3 — over the real router', () => {
+    it('a bound shortlist reorders real matches without changing the set', () => {
+        const shortlist = makePromptShortlist(REPO, router);
+        const prompt = 'I need to commit and push this change to a production branch';
+        const matches = matchTierRules(router, prompt);
+        expect(matches.length).toBeGreaterThan(0);
+        const ranked = shortlist(prompt);
+        expect(ranked.length).toBeGreaterThan(0);
+        const out = orderByShortlist(matches, ranked);
+        expect(out.map((x) => x.id).sort()).toEqual(matches.map((x) => x.id).sort());
+    });
+});
+
+// --- § no embeddings, no vector store, no model call ------------------------
+
+/** Constructs `resident-process-governance.md:82` and its P4 row prohibit. */
+const BANNED: ReadonlyArray<readonly [string, RegExp]> = [
+    ['embedding-call', /\bembed(?:ding)?s?\s*\(/i],
+    ['embedding-identifier', /\b(?:createEmbedding|getEmbedding|sentenceTransformer)\b/],
+    ['vector-store', /\b(?:pgvector|faiss|hnswlib|qdrant|chromadb|pinecone|weaviate|milvus)\b/i],
+    ['cosine-similarity', /\bcosine(?:Similarity|Distance|_similarity|_distance)\b/i],
+    ['network', /\bfetch\s*\(|node:https?\b|node:net\b|XMLHttpRequest/],
+    ['child-process', /\bchild_process\b/],
+];
+
+function findBanned(source: string): string[] {
+    return BANNED.filter(([, re]) => re.test(source)).map(([name]) => name);
+}
+
+const SUBJECTS = [
+    'src/scripts/_lib/lexical_shortlist.ts',
+    'src/scripts/_lib/lexical_index.ts',
+];
+
+describe('6.3 — no embeddings (contract, not preference)', () => {
+    it('the scan FIRES on synthetic sources carrying each construct', () => {
+        // Proved before it is trusted to be silent. A scanner never seen fire
+        // has unknown sensitivity, and "no hits" would then mean nothing.
+        expect(findBanned('const v = await embed(text);')).toContain('embedding-call');
+        expect(findBanned('import { createEmbedding } from "x";')).toContain(
+            'embedding-identifier',
+        );
+        expect(findBanned('const db = new Qdrant();')).toContain('vector-store');
+        expect(findBanned('return cosineSimilarity(a, b);')).toContain('cosine-similarity');
+        expect(findBanned('await fetch("https://example.invalid");')).toContain('network');
+        expect(findBanned("import cp from 'node:child_process';")).toContain('child-process');
+    });
+
+    it('is silent on plain BM25 arithmetic (positive polarity)', () => {
+        expect(findBanned('const s = (idf * (tf * (K1 + 1))) / denom;')).toEqual([]);
+    });
+
+    it('and the real sources carry none of them', () => {
+        const offenders: Record<string, string[]> = {};
+        let bytesScanned = 0;
+        for (const rel of SUBJECTS) {
+            const src = readFileSync(path.join(REPO, rel), 'utf-8');
+            bytesScanned += src.length;
+            const hits = findBanned(src);
+            if (hits.length > 0) offenders[rel] = hits;
+        }
+        // A scan over nothing exits green, so the denominator is asserted too.
+        expect(bytesScanned).toBeGreaterThan(8000);
+        expect(offenders).toEqual({});
+    });
+
+    it('the shortlist module imports only the BM25 core and the injection module', () => {
+        const src = readFileSync(path.join(REPO, SUBJECTS[0] as string), 'utf-8');
+        const imports = [...src.matchAll(/^import[^;]*from '([^']+)';/gm)].map((x) => x[1]);
+        expect(imports.sort()).toEqual(['./lexical_index.js', './rule_injection.js']);
+    });
+});

--- a/tests/scripts/delivery_set_compatibility.test.ts
+++ b/tests/scripts/delivery_set_compatibility.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Step 6.4 of road-to-governed-harness-evolution — the delivery-set measurement.
+ *
+ * The step`s verify has two halves and only the second is testable from code:
+ * the ceiling`s ordering is a property of the git history, and the corpus
+ * property — "the corpus contains at least one jointly-wrong pair" — is what
+ * this file guards.
+ *
+ * THE POLARITY IS THE WHOLE TEST. A pair metric that counted any two skills
+ * sharing a prompt would report a large number and mean nothing. So both
+ * directions are pinned: every reported candidate has BOTH members adjudicated
+ * `false` on that prompt, and the shared prompts where one member is `true` are
+ * asserted ABSENT. A pattern gate needs its denial tested, not only its claim.
+ *
+ * THE BARS ARE PINNED so they cannot be re-tuned to a result after the fact:
+ * the run breaches the recall-loss ceiling, and a silent edit of the constant
+ * would turn a reported breach into a reported pass.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { loadTrainCases } from '../../src/scripts/_lib/routing_corpus.js';
+import {
+    K,
+    RECALL_LOSS_CEILING_PP,
+    TOKEN_TARGET,
+    measureDelivery,
+    record,
+} from '../../src/scripts/measure_delivery_sets.js';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const RECORD = path.join(REPO, 'agents/evidence/analysis/delivery-set-measurement-2026-08-31.json');
+
+const m = measureDelivery(REPO);
+
+describe('6.4 — the pre-registered bars are the ones the run used', () => {
+    it('ceiling 20.0 pp, token target 500, k = 5', () => {
+        expect(RECALL_LOSS_CEILING_PP).toBe(20.0);
+        expect(TOKEN_TARGET).toBe(500);
+        expect(K).toBe(5);
+    });
+
+    it('the ceiling breach is reported as a breach, not rounded away', () => {
+        expect(m.recallLossPp).toBeGreaterThan(RECALL_LOSS_CEILING_PP);
+        expect(m.ceilingMet).toBe(false);
+    });
+
+    it('the token target is met, and the two verdicts are independent', () => {
+        expect(m.contextCostTokens).toBeLessThan(TOKEN_TARGET);
+        expect(m.tokenTargetMet).toBe(true);
+    });
+});
+
+describe('6.4 — the run is non-vacuous', () => {
+    it('it ranked a real catalogue over a real corpus', () => {
+        expect(m.catalogueSize).toBeGreaterThan(200);
+        expect(m.prompts).toBeGreaterThan(500);
+        expect(m.positives).toBeGreaterThan(300);
+        expect(m.negatives).toBeGreaterThan(300);
+    });
+
+    it('the recall curve is monotone in k — a decreasing one would be a bug', () => {
+        const ks = [1, 3, 5, 10, 20];
+        for (let i = 1; i < ks.length; i++) {
+            expect(m.recallCurvePp[ks[i] as number]).toBeGreaterThanOrEqual(
+                m.recallCurvePp[ks[i - 1] as number] as number,
+            );
+        }
+    });
+
+    it('precision and benefit-given-activation are ONE quantity under two names', () => {
+        // The pre-registration defined them separately and they coincide. Said
+        // here rather than quietly dropping one of the two required fields.
+        expect(m.benefitConditionalPp).toBe(m.precisionPp);
+        expect(m.benefitUnconditionalPp).toBe(m.recallPp);
+        expect(m.benefitConditionalPp).not.toBe(m.benefitUnconditionalPp);
+    });
+});
+
+describe('6.4 — set compatibility, both polarities', () => {
+    const cases = loadTrainCases(REPO);
+    const verdict = new Map<string, boolean>();
+    for (const c of cases) verdict.set(`${c.skill} ${c.prompt.trim().toLowerCase()}`, c.expect);
+
+    it('the corpus contains at least one jointly-wrong pair (the verify clause)', () => {
+        expect(m.jointlyWrongCandidates.length).toBeGreaterThanOrEqual(1);
+        expect(m.sharedPrompts).toBeGreaterThan(0);
+    });
+
+    it('CLAIM — every reported pair has both members adjudicated false', () => {
+        const bad = m.jointlyWrongCandidates.filter((c) => {
+            const key = c.prompt.trim().toLowerCase();
+            return (
+                verdict.get(`${c.pair[0]} ${key}`) !== false ||
+                verdict.get(`${c.pair[1]} ${key}`) !== false
+            );
+        });
+        expect(bad).toEqual([]);
+    });
+
+    it('DENIAL — a shared prompt with a `true` member yields no pair', () => {
+        // `keep fixing until the tests pass` is adjudicated false by
+        // experiment-loop and TRUE by verify-repair-loop. A metric that keyed on
+        // "two corpora share this prompt" would report it; this one must not.
+        const mixed = 'keep fixing until the tests pass';
+        expect(verdict.get(`experiment-loop ${mixed}`)).toBe(false);
+        expect(verdict.get(`verify-repair-loop ${mixed}`)).toBe(true);
+        expect(
+            m.jointlyWrongCandidates.filter((c) => c.prompt.trim().toLowerCase() === mixed),
+        ).toEqual([]);
+    });
+
+    it('the delivered-together count is reported separately from the corpus count', () => {
+        // They are different questions and the pre-registration conflated them.
+        expect(m.jointlyWrongPairs.length).toBeLessThanOrEqual(m.jointlyWrongCandidates.length);
+    });
+});
+
+describe('6.4 — the published record reproduces from the tree', () => {
+    it('every metric and every pair reproduces', () => {
+        const published = JSON.parse(fs.readFileSync(RECORD, 'utf8')) as Record<string, never>;
+        const fresh = record(m) as Record<string, never>;
+        expect(published['metrics']).toEqual(fresh['metrics']);
+        expect(published['set_compatibility']).toEqual(fresh['set_compatibility']);
+        expect(published['bars']).toEqual(fresh['bars']);
+    });
+});

--- a/tests/scripts/evaluation_cascade.test.ts
+++ b/tests/scripts/evaluation_cascade.test.ts
@@ -20,9 +20,9 @@ import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node
 import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
-import { CLONES, REPO_ROOT, TSX_BIN } from './_bench_ab.js';
+import { CLONES, REPO_ROOT, TSX_BIN, acquireClonesLock, releaseClonesLock } from './_bench_ab.js';
 import { CANDIDATE_OWNED_PATHS } from '../../src/scripts/_lib/candidate_record.js';
 import {
     CASCADE_STAGES,
@@ -37,7 +37,16 @@ import type { MetricRow } from '../../src/scripts/_lib/evaluation_vector.js';
 
 const LAB_TS = join(REPO_ROOT, 'src', 'scripts', 'evolution_lab.ts');
 const scratch = mkdtempSync(join(tmpdir(), 'ac-cascade-'));
+
+// The clones directory is SHARED across test files, and `_bench_ab.removeClones`
+// wipes the whole root. Without this lock the CLI cases below are racy by
+// construction: a sibling file can delete the tree mid-clone, and the run then
+// fails for a reason that has nothing to do with the property under test.
+// Observed twice in the full parallel suite while passing in isolation, which is
+// the signature of shared state rather than of a defect in the code.
+beforeAll(() => acquireClonesLock());
 afterAll(() => {
+    releaseClonesLock();
     rmSync(scratch, { recursive: true, force: true });
 });
 

--- a/tests/scripts/evaluation_cascade.test.ts
+++ b/tests/scripts/evaluation_cascade.test.ts
@@ -23,6 +23,7 @@ import { join } from 'node:path';
 import { afterAll, describe, expect, it } from 'vitest';
 
 import { CLONES, REPO_ROOT, TSX_BIN } from './_bench_ab.js';
+import { CANDIDATE_OWNED_PATHS } from '../../src/scripts/_lib/candidate_record.js';
 import {
     CASCADE_STAGES,
     CHEAPEST_STAGE,
@@ -264,23 +265,44 @@ describe('the real runner routes through the cascade (AC-3 and AC-5)', () => {
 
     it('materialise, evaluate and destroy leaves the original tree unchanged', () => {
         // AC-3's three verbs in one run, asserted against the real repo.
+        //
+        // TWO SCOPING DECISIONS, both learned by getting them wrong first.
+        //
+        // 1. Destruction removes THIS candidate's clone directly rather than
+        //    calling `clean --yes`, which removes EVERY candidate clone. The
+        //    first version did call it, and in the full parallel suite it
+        //    deleted the clones `bench_ab_integrity.test.ts` was mid-run
+        //    against — reddening that file and this one while both passed in
+        //    isolation. `harness_evolution_guard_call_sites.test.ts` already
+        //    records the same hazard in its own clone probe. The `clean` verb
+        //    itself is covered by `evolution_lab.test.ts`; duplicating it here
+        //    bought nothing and broke a sibling.
+        //
+        // 2. The no-diff assertion is scoped to the paths a candidate can
+        //    actually write — `CANDIDATE_OWNED_PATHS` — not to whole-repo
+        //    `git status --porcelain`. A global comparison measures every
+        //    other test running concurrently, which is watching shared state
+        //    rather than the property AC-3 states.
         const f = recordFile('e2e-cycle', record({ id: 'e2e-cycle-a' }));
         const m = join(scratch, 'metrics2.json');
         writeFileSync(m, JSON.stringify(passingRows(), null, 2), 'utf-8');
 
-        const before = spawnSync('git', ['status', '--porcelain'], {
-            cwd: REPO_ROOT,
-            encoding: 'utf8',
-        }).stdout;
-        lab(['run', '--record', f, '--metrics', m]);
-        expect(clonesFrom('e2e-cycle-a').length).toBeGreaterThan(0);
-        lab(['clean', '--yes']);
-        const after = spawnSync('git', ['status', '--porcelain'], {
-            cwd: REPO_ROOT,
-            encoding: 'utf8',
-        }).stdout;
+        const owned = (): string =>
+            spawnSync('git', ['status', '--porcelain', '--', ...CANDIDATE_OWNED_PATHS], {
+                cwd: REPO_ROOT,
+                encoding: 'utf8',
+            }).stdout;
 
-        expect(after).toBe(before);
+        const before = owned();
+        lab(['run', '--record', f, '--metrics', m]);
+        const mine = clonesFrom('e2e-cycle-a');
+        expect(mine.length).toBeGreaterThan(0);
+        // Materialised, and the original tree is untouched WHILE the clone exists.
+        expect(owned()).toBe(before);
+
+        for (const dir of mine) rmSync(join(CLONES, dir), { recursive: true, force: true });
+
+        expect(owned()).toBe(before);
         expect(clonesFrom('e2e-cycle-a')).toEqual([]);
     });
 });

--- a/tests/scripts/evaluation_cascade.test.ts
+++ b/tests/scripts/evaluation_cascade.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Tests for the deterministic evaluation cascade
+ * (`src/scripts/_lib/evaluation_cascade.ts`, road-to-governed-harness-evolution
+ * step 4.1) and for its wiring into the real runner.
+ *
+ * Step 4.1's verify clause is two claims — *"a candidate failing the cheapest
+ * stage consumes no model call, and the stage list can produce the Phase 1
+ * classification"* — so those two are the load-bearing assertions.
+ *
+ * The second half of this file is deliberately written the way
+ * `harness_evolution_guard_call_sites.test.ts` is written, and for the same
+ * reason its header gives: a unit test observing a function's return is not
+ * evidence that an executable runner routes through it. AC-3 asks that a
+ * candidate can be *materialised, evaluated and destroyed*, and AC-5 asks that
+ * a promotion is *decided by* the paired verdict — both are claims about a
+ * production path, so both are asserted by spawning the real CLI and reading
+ * its process exit and stdout.
+ */
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { CLONES, REPO_ROOT, TSX_BIN } from './_bench_ab.js';
+import {
+    CASCADE_STAGES,
+    CHEAPEST_STAGE,
+    FAILURE_FAMILIES,
+    PREFIX_ASSIGNABLE_FAMILIES,
+    familyForStage,
+    runCascade,
+    type CascadeStage,
+} from '../../src/scripts/_lib/evaluation_cascade.js';
+import type { MetricRow } from '../../src/scripts/_lib/evaluation_vector.js';
+
+const LAB_TS = join(REPO_ROOT, 'src', 'scripts', 'evolution_lab.ts');
+const scratch = mkdtempSync(join(tmpdir(), 'ac-cascade-'));
+afterAll(() => {
+    rmSync(scratch, { recursive: true, force: true });
+});
+
+const BUDGET = { maxCandidates: 100, maxTrialsPerCandidate: 10, maxSpendCents: 10_000 };
+const PLAN = { candidates: 1, trialsPerCandidate: 1, estimatedSpendCents: 0 };
+
+function record(over: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+        kind: 'candidate',
+        version: 1,
+        id: 'cand-ok',
+        dimension: 'content',
+        lifecycle: 'proposed',
+        mutations: [{ path: '.claude/rules/x.md', content: '# x\n' }],
+        ...over,
+    };
+}
+
+/** A vector that passes: one paired row plus the mandatory artifact-count row. */
+function passingRows(): MetricRow[] {
+    return [
+        { metric: 'task-success', kind: 'paired', direction: 'higher-better', verdict: 'pass' },
+        { metric: 'artifact-count-delta', kind: 'counted', delta: 0 },
+    ] as unknown as MetricRow[];
+}
+
+describe('the stage list and the Phase 1 classification', () => {
+    it('every stage maps to one of Phase 1s four families and invents no fifth', () => {
+        for (const stage of CASCADE_STAGES) {
+            expect(FAILURE_FAMILIES).toContain(familyForStage(stage));
+        }
+        expect(FAILURE_FAMILIES).toHaveLength(4);
+    });
+
+    it('the prefix NEVER assigns activation or adherence — the receipt-bearing families', () => {
+        // This is the whole reason 4.1 shipped as Option B. Assigning either
+        // from a deterministic proxy is the evidence-manufacturing the council
+        // refused, so it must be impossible rather than merely avoided.
+        for (const stage of CASCADE_STAGES) {
+            expect(PREFIX_ASSIGNABLE_FAMILIES).toContain(familyForStage(stage));
+        }
+        expect(PREFIX_ASSIGNABLE_FAMILIES).not.toContain('activation');
+        expect(PREFIX_ASSIGNABLE_FAMILIES).not.toContain('adherence');
+    });
+
+    it('schema validity is the cheapest stage and runs first', () => {
+        expect(CHEAPEST_STAGE).toBe('schema-validity');
+        expect(CASCADE_STAGES[0]).toBe(CHEAPEST_STAGE);
+    });
+});
+
+describe('abort on the FIRST hard failure, at zero model calls', () => {
+    it('a malformed record aborts at the cheapest stage having run only it', () => {
+        const r = runCascade({ raw: { nonsense: true }, plan: PLAN, budget: BUDGET });
+        expect(r.outcome).toBe('abort');
+        if (r.outcome !== 'abort') return;
+        expect(r.failed_stage).toBe('schema-validity');
+        expect(r.family).toBe('content');
+        expect(r.model_calls).toBe(0);
+        // "Abort on the FIRST hard failure" — later stages were not attempted.
+        expect(r.stages_run).toEqual(['schema-validity']);
+    });
+
+    it('an unowned mutation path aborts at stage 2, not later', () => {
+        const r = runCascade({
+            raw: record({ mutations: [{ path: 'src/scripts/x.ts', content: 'x' }] }),
+            plan: PLAN,
+            budget: BUDGET,
+        });
+        expect(r.outcome).toBe('abort');
+        if (r.outcome !== 'abort') return;
+        expect(r.failed_stage).toBe('path-ownership');
+        // Attributed to stage 2 even though the throw originates inside the
+        // stage-1 parse: `parseMutations` enforces ownership at
+        // `candidate_record.ts:434`, and filing it under `schema-validity`
+        // would give Phase 1's classification the wrong stage to read.
+        expect(r.stages_run).toEqual(['schema-validity', 'path-ownership']);
+    });
+
+    it('a holdout-naming mutation aborts at stage 3 and is classified unknown, not activation', () => {
+        const r = runCascade({
+            raw: record({ mutations: [{ path: '.claude/rules/holdout-notes.md', content: 'x' }] }),
+            plan: PLAN,
+            budget: BUDGET,
+        });
+        expect(r.outcome).toBe('abort');
+        if (r.outcome !== 'abort') return;
+        expect(r.failed_stage).toBe('holdout-disclosure');
+        // A holdout leak is NOT evidence that activation failed.
+        expect(r.family).toBe('unknown');
+    });
+
+    it('a plan past the ceiling aborts at stage 4, before the near-duplicate screen', () => {
+        const r = runCascade({
+            raw: record(),
+            plan: { candidates: 9999, trialsPerCandidate: 1, estimatedSpendCents: 0 },
+            budget: BUDGET,
+        });
+        expect(r.outcome).toBe('abort');
+        if (r.outcome !== 'abort') return;
+        expect(r.failed_stage).toBe('budget');
+        expect(r.stages_run).not.toContain('near-duplicate');
+    });
+
+    it('a run with no metric rows is INCOMPLETE — neither a pass nor an abort', () => {
+        // A third outcome on purpose. Materialising without measuring has not
+        // failed, so it is not an abort; and there is no verdict, so nothing
+        // may read one. Collapsing it into either direction is the silent
+        // outcome this state exists to prevent.
+        const r = runCascade({ raw: record(), plan: PLAN, budget: BUDGET });
+        expect(r.outcome).toBe('incomplete');
+        if (r.outcome !== 'incomplete') return;
+        expect(r.not_reached).toBe('metric-verdict');
+        expect(r.stages_run).not.toContain('metric-verdict');
+        expect(r.why).toContain('measured nothing');
+        expect(r.model_calls).toBe(0);
+    });
+
+    it('every abort reports zero model calls, on every stage', () => {
+        const seen = new Set<CascadeStage>();
+        const cases: { raw: unknown; plan: typeof PLAN }[] = [
+            { raw: { nope: 1 }, plan: PLAN },
+            { raw: record({ mutations: [{ path: 'src/x.ts', content: 'x' }] }), plan: PLAN },
+            { raw: record({ mutations: [{ path: '.claude/holdout.md', content: 'x' }] }), plan: PLAN },
+            { raw: record(), plan: { candidates: 9999, trialsPerCandidate: 1, estimatedSpendCents: 0 } },
+            { raw: record(), plan: PLAN },
+        ];
+        for (const c of cases) {
+            const r = runCascade({ raw: c.raw, plan: c.plan, budget: BUDGET });
+            expect(r.model_calls).toBe(0);
+            if (r.outcome === 'abort') seen.add(r.failed_stage);
+        }
+        // Anti-vacuity: the loop actually exercised distinct stages.
+        expect(seen.size).toBeGreaterThanOrEqual(4);
+    });
+});
+
+describe('the verdict stage consults the paired verdict and nothing else', () => {
+    it('a complete vector reaches a promotion verdict', () => {
+        const r = runCascade({ raw: record(), plan: PLAN, budget: BUDGET, rows: passingRows() });
+        expect(r.outcome).toBe('pass');
+        if (r.outcome !== 'pass') return;
+        expect(r.stages_run).toEqual([...CASCADE_STAGES]);
+        expect(r.model_calls).toBe(0);
+        expect(typeof r.verdict.promote).toBe('boolean');
+    });
+
+    it('an underpowered row is refused as a pass, through the real verdict', () => {
+        const rows = [
+            { metric: 'task-success', kind: 'paired', direction: 'higher-better', verdict: 'underpowered' },
+            { metric: 'artifact-count-delta', kind: 'counted', delta: 0 },
+        ] as unknown as MetricRow[];
+        const r = runCascade({ raw: record(), plan: PLAN, budget: BUDGET, rows });
+        expect(r.outcome).toBe('pass');
+        if (r.outcome !== 'pass') return;
+        expect(r.verdict.promote).toBe(false);
+    });
+});
+
+// --- the production path ----------------------------------------------------
+
+interface Ran {
+    status: number | null;
+    stdout: string;
+    stderr: string;
+}
+
+function lab(args: readonly string[], timeout = 180_000): Ran {
+    const res = spawnSync(TSX_BIN, [LAB_TS, ...args], {
+        cwd: REPO_ROOT,
+        encoding: 'utf8',
+        timeout,
+    });
+    return { status: res.status, stdout: res.stdout ?? '', stderr: res.stderr ?? '' };
+}
+
+function recordFile(name: string, body: unknown): string {
+    const p = join(scratch, `${name}.json`);
+    writeFileSync(p, `${JSON.stringify(body, null, 2)}\n`, 'utf-8');
+    return p;
+}
+
+function clonesFrom(prefix: string): string[] {
+    try {
+        return readdirSync(CLONES).filter((n) => n.startsWith(`candidate-${prefix}`));
+    } catch {
+        return [];
+    }
+}
+
+describe('the real runner routes through the cascade (AC-3 and AC-5)', () => {
+    it('a run EVALUATES each candidate and says so on stdout', () => {
+        // AC-3's unmet verb. Before this wiring the runner cloned and returned;
+        // nothing evaluated anything, and every evaluation module was
+        // unreferenced outside its own tests.
+        const f = recordFile('e2e-eval', record({ id: 'e2e-eval-a' }));
+        const ran = lab(['run', '--record', f]);
+        expect(ran.stdout, ran.stderr).toContain('evolution_lab:cascade');
+        expect(ran.stdout).toContain('e2e-eval-a');
+        // No metrics were supplied, so the honest outcome is an abort at the
+        // verdict stage — not a silent pass.
+        expect(ran.stdout).toContain('metric-verdict NOT REACHED');
+        // Materialising without measuring is not a failure: the verb's
+        // contract is unchanged and the run still exits 0.
+        expect(ran.status).toBe(0);
+    });
+
+    it('a cascade abort at the cheapest stage is reported as costing no model call', () => {
+        const f = recordFile('e2e-bad', { kind: 'candidate', version: 1, id: 'nope' });
+        const ran = lab(['run', '--record', f]);
+        expect(ran.status).not.toBe(0);
+        expect(ran.stdout + ran.stderr).toMatch(/schema-validity|rejected/);
+    });
+
+    it('a run WITH metrics reaches the paired verdict through the real CLI', () => {
+        // AC-5's unmet conjunct: `promotionVerdict` had no caller anywhere.
+        const f = recordFile('e2e-pass', record({ id: 'e2e-pass-a' }));
+        const m = join(scratch, 'metrics.json');
+        writeFileSync(m, JSON.stringify(passingRows(), null, 2), 'utf-8');
+        const ran = lab(['run', '--record', f, '--metrics', m]);
+        expect(ran.stdout, ran.stderr).toContain('verdict=');
+        expect(ran.stdout).toContain('model_calls=0');
+        expect(ran.status).toBe(0);
+    });
+
+    it('materialise, evaluate and destroy leaves the original tree unchanged', () => {
+        // AC-3's three verbs in one run, asserted against the real repo.
+        const f = recordFile('e2e-cycle', record({ id: 'e2e-cycle-a' }));
+        const m = join(scratch, 'metrics2.json');
+        writeFileSync(m, JSON.stringify(passingRows(), null, 2), 'utf-8');
+
+        const before = spawnSync('git', ['status', '--porcelain'], {
+            cwd: REPO_ROOT,
+            encoding: 'utf8',
+        }).stdout;
+        lab(['run', '--record', f, '--metrics', m]);
+        expect(clonesFrom('e2e-cycle-a').length).toBeGreaterThan(0);
+        lab(['clean', '--yes']);
+        const after = spawnSync('git', ['status', '--porcelain'], {
+            cwd: REPO_ROOT,
+            encoding: 'utf8',
+        }).stdout;
+
+        expect(after).toBe(before);
+        expect(clonesFrom('e2e-cycle-a')).toEqual([]);
+    });
+});

--- a/tests/scripts/evaluation_cascade.test.ts
+++ b/tests/scripts/evaluation_cascade.test.ts
@@ -16,7 +16,7 @@
  * production path, so both are asserted by spawning the real CLI and reading
  * its process exit and stdout.
  */
-import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';

--- a/tests/scripts/evolution_lab.test.ts
+++ b/tests/scripts/evolution_lab.test.ts
@@ -406,6 +406,60 @@ describe.skipIf(!HAVE_FIXTURE)('run, compare and clean over real clones', () => 
             expect(existsSync(join(CLONES, `candidate-e2e${String(i)}`))).toBe(true);
         }
 
+        // STEP 5.6 — the ROI figure reaches an operator's screen on a REAL run,
+        // not only through a unit test of the builder. This is the end-to-end
+        // half of "the ROI figure appears in every run report": the process is
+        // spawned, the report is on its stdout, and there is exactly one roi
+        // line in it. Without a `--vector`, the honest figure is `unmeasured` —
+        // this run cloned five candidates and evaluated none of them.
+        const roiLines = ran.stdout.split('\n').filter((l) => l.startsWith('run-report: roi:'));
+        expect(roiLines).toHaveLength(1);
+        expect(roiLines[0]).toContain('no candidate in this run carried an evaluation');
+        expect(ran.stdout).toContain('run-report: run:e2e0+e2e1+e2e2+e2e3+e2e4');
+        expect(ran.stdout).toContain('run-report: ladder human_rejected: (none licensed)');
+
+        // A run whose evaluation evidence IS supplied reports a real ratio.
+        // The vector goes through `parseMetricVectorJson`, which inherits
+        // `buildVector`'s refusal of a vector missing its artifact-count row.
+        const vecPath = join(scratch, 'vec-e2e0.json');
+        writeFileSync(
+            vecPath,
+            `${JSON.stringify({
+                candidate_id: 'e2e0',
+                rows: [
+                    {
+                        kind: 'counted',
+                        metric: 'artifact-count-delta',
+                        direction: 'lower-better',
+                        delta: 0,
+                    },
+                    {
+                        kind: 'paired',
+                        metric: 'activation-recall',
+                        direction: 'higher-better',
+                        verdict: {
+                            kind: 'pass',
+                            discordant: 12,
+                            wins: 11,
+                            losses: 1,
+                            p: 0.003,
+                            magnitude_mean: 0.12,
+                            at_floor: false,
+                            reason: 'treatment won 11 of 12 discordant',
+                        },
+                    },
+                ],
+            })}\n`,
+            'utf-8',
+        );
+        const withRoi = lab(
+            ['run', '--record', records[0] as string, '--vector', vecPath, '--estimated-spend-cents', '250'],
+            600_000,
+        );
+        expect(withRoi.status, withRoi.stderr).toBe(0);
+        expect(withRoi.stdout).toContain('improved=1 regressed=0 underpowered=0');
+        expect(withRoi.stdout).toContain('0.400 improved rows per dollar');
+
         const clean = lab(['compare'], 600_000);
         expect(clean.signal).toBeNull();
         expect(clean.status, clean.stderr).toBe(0);

--- a/tests/scripts/harness_evolution_guards.test.ts
+++ b/tests/scripts/harness_evolution_guards.test.ts
@@ -162,7 +162,20 @@ describe('0.6 — epistemic stop conditions', () => {
     it('every stop condition either names a detector or is explicitly model-carried', () => {
         // Step 0.6's verify clause. The assertion is that no condition is
         // AMBIGUOUS — a missing field would read as enforced.
-        expect(STOP_CONDITIONS.length).toBe(4);
+        //
+        // ARITY MOVED 4 -> 5 on 2026-08-31 by step 4.4, and the pin is updated
+        // rather than deleted so the next change is still visible. 4.4's verify
+        // clause requires "a diversity-collapse stop (0.6) [that] reads the
+        // archive", and the existing `diversity-collapse` row cannot be it: it
+        // is a DISTINCT-COUNT check (`minDistinct = 2`) with no ratio, so it
+        // cannot see a search that keeps producing textually different
+        // candidates which all fail the same way. `pathology-dominance` is
+        // therefore an ADDITION and never a replacement — the test below pins
+        // both ids so neither can be dropped into the other.
+        //
+        // This ADDS a stop the run must clear, so it strengthens 0.6's set; it
+        // does not relax anything 0.6 decided.
+        expect(STOP_CONDITIONS.length).toBe(5);
         for (const c of STOP_CONDITIONS) {
             expect(c.id).toMatch(/^[a-z-]+$/);
             expect(c.why.length).toBeGreaterThan(40);

--- a/tests/scripts/pathology_archive.test.ts
+++ b/tests/scripts/pathology_archive.test.ts
@@ -1,0 +1,369 @@
+/**
+ * Tests for the pathology archive (`src/scripts/_lib/pathology_archive.ts`,
+ * road-to-governed-harness-evolution step 4.4).
+ *
+ * The step states its verify clause as two observable facts — "two candidates
+ * with equal vectors but different pathology cells are both retained, and a
+ * diversity-collapse stop reads the archive" — so those two are the
+ * load-bearing tests here. Everything else exists because the council of
+ * 2026-08-31 ruled the archive cannot be built until ranking, tie-break and
+ * replacement are TOTAL, and a rule is only total if its tie-breaks are
+ * reachable. Each one is exercised in isolation below.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { LADDER_RUNGS } from '../../src/scripts/_lib/activation_ladder.js';
+import {
+    ARCHIVE_SCHEMA_VERSION,
+    CLASSIFICATION_RULE_VERSION,
+    PATHOLOGY_DOMINANCE_THRESHOLD,
+    PATHOLOGY_MIN_CLASSIFIABLE_ATTEMPTS,
+    PATHOLOGY_WHERE,
+    PATHOLOGY_WHY,
+    PATHOLOGY_WINDOW_SIZE,
+    PathologyArchive,
+    PathologyArchiveError,
+    RANKING_RULE_VERSION,
+    cellKey,
+    dominanceVerdict,
+    replacesRetained,
+    type PathologyAttempt,
+    type PathologyWhere,
+    type PathologyWhy,
+} from '../../src/scripts/_lib/pathology_archive.js';
+
+let seq = 0;
+function attempt(over: Partial<PathologyAttempt> = {}): PathologyAttempt {
+    seq += 1;
+    return {
+        attempt_id: `a${seq}`,
+        attempt_sequence: seq,
+        candidate_id: `c${seq}`,
+        intervention_ref: `i${seq}`,
+        where: 'delivered',
+        why: 'execution_failed',
+        reason_detail: '',
+        classification_status: 'classified',
+        validation_status: 'valid',
+        observed_at: '2026-08-31T00:00:00Z',
+        archive_schema_version: ARCHIVE_SCHEMA_VERSION,
+        classification_rule_version: CLASSIFICATION_RULE_VERSION,
+        ranking_rule_version: RANKING_RULE_VERSION,
+        cohort_id: 'cohort-a',
+        cohort_version: 1,
+        ...over,
+    };
+}
+
+describe('closed vocabularies', () => {
+    it('WHERE reuses the activation ladder rather than inventing a taxonomy', () => {
+        // The council warned a parallel execution-stage taxonomy must not be
+        // invented if the ladder already defines the semantics. It does.
+        expect([...PATHOLOGY_WHERE]).toEqual([...LADDER_RUNGS]);
+        expect(PATHOLOGY_WHERE).toHaveLength(6);
+    });
+
+    it('WHY is a closed reason axis and does not restate WHERE', () => {
+        expect(PATHOLOGY_WHY).toHaveLength(8);
+        // The failure mode this pins: names like `projection_failed` /
+        // `delivery_failed` collapse the two axes into one.
+        for (const rung of LADDER_RUNGS) {
+            expect(PATHOLOGY_WHY as readonly string[]).not.toContain(`${rung}_failed`);
+            expect(PATHOLOGY_WHY as readonly string[]).not.toContain(rung);
+        }
+    });
+
+    it('reason_unknown is last, so it is a fallback and never a precedence winner', () => {
+        expect(PATHOLOGY_WHY[PATHOLOGY_WHY.length - 1]).toBe('reason_unknown');
+    });
+
+    it('an out-of-vocabulary value is refused on both axes', () => {
+        const ar = new PathologyArchive();
+        expect(() => ar.ingest(attempt({ where: 'nowhere' as PathologyWhere }))).toThrow(
+            PathologyArchiveError,
+        );
+        expect(() => ar.ingest(attempt({ why: 'vibes' as PathologyWhy }))).toThrow(
+            PathologyArchiveError,
+        );
+    });
+});
+
+describe('the verify clause — different cells are both retained', () => {
+    it('two candidates with equal vectors but different cells are BOTH retained', () => {
+        const ar = new PathologyArchive();
+        // "Equal vectors" is the premise: nothing here distinguishes them
+        // except the pathology cell. A pure frontier would keep one.
+        ar.ingest(
+            attempt({
+                attempt_id: 'x1',
+                candidate_id: 'same-vector',
+                where: 'projected',
+                why: 'dependency_unavailable',
+            }),
+        );
+        ar.ingest(
+            attempt({
+                attempt_id: 'x2',
+                candidate_id: 'same-vector',
+                where: 'adhered',
+                why: 'output_contract_violated',
+            }),
+        );
+        const cells = ar.cells();
+        expect(cells).toHaveLength(2);
+        expect(cells.map((c) => cellKey(c.where, c.why)).sort()).toEqual([
+            'adhered output_contract_violated',
+            'projected dependency_unavailable',
+        ]);
+        for (const c of cells) expect(c.retained_attempt_id).not.toBeNull();
+    });
+
+    it('same WHERE, different WHY is TWO cells — the WHY axis is load-bearing', () => {
+        // Without this, keying the cell on WHERE alone passes every other test
+        // in this file: the "both retained" case above differs on both axes, so
+        // it cannot tell a two-axis key from a one-axis one. Observed 2026-08-31
+        // by deleting `a.why` from the cell key and watching 23/23 stay green.
+        const ar = new PathologyArchive();
+        ar.ingest(attempt({ attempt_id: 'w1', where: 'delivered', why: 'policy_blocked' }));
+        ar.ingest(attempt({ attempt_id: 'w2', where: 'delivered', why: 'evidence_missing' }));
+        expect(ar.cells()).toHaveLength(2);
+    });
+
+    it('same WHY, different WHERE is TWO cells — the WHERE axis is load-bearing', () => {
+        const ar = new PathologyArchive();
+        ar.ingest(attempt({ attempt_id: 'v1', where: 'selected', why: 'policy_blocked' }));
+        ar.ingest(attempt({ attempt_id: 'v2', where: 'visible', why: 'policy_blocked' }));
+        expect(ar.cells()).toHaveLength(2);
+    });
+
+    it('two attempts in the SAME cell collapse to one representative', () => {
+        const ar = new PathologyArchive();
+        ar.ingest(attempt({ attempt_id: 'y1', attempt_sequence: 10 }));
+        ar.ingest(attempt({ attempt_id: 'y2', attempt_sequence: 11 }));
+        const cells = ar.cells();
+        expect(cells).toHaveLength(1);
+        expect(cells[0]!.attempt_count).toBe(2);
+        expect(cells[0]!.retained_attempt_id).toBe('y2');
+    });
+});
+
+describe('the ranking rule is TOTAL — every tie-break is reachable', () => {
+    it('ranks by attempt_sequence', () => {
+        const lo = attempt({ attempt_sequence: 1 });
+        const hi = attempt({ attempt_sequence: 2 });
+        expect(replacesRetained(hi, lo)).toBe(true);
+        expect(replacesRetained(lo, hi)).toBe(false);
+    });
+
+    it('tie-breaks on candidate_id when sequences collide', () => {
+        const a = attempt({ attempt_sequence: 7, candidate_id: 'aaa' });
+        const b = attempt({ attempt_sequence: 7, candidate_id: 'bbb' });
+        expect(replacesRetained(a, b)).toBe(true);
+        expect(replacesRetained(b, a)).toBe(false);
+    });
+
+    it('tie-breaks on attempt_id when sequence AND candidate_id collide', () => {
+        const a = attempt({ attempt_sequence: 7, candidate_id: 'same', attempt_id: 'aaa' });
+        const b = attempt({ attempt_sequence: 7, candidate_id: 'same', attempt_id: 'bbb' });
+        expect(replacesRetained(a, b)).toBe(true);
+        expect(replacesRetained(b, a)).toBe(false);
+    });
+
+    it('ordering never consults observed_at — producer clocks do not decide', () => {
+        // A newer timestamp on a lower sequence must NOT win.
+        const older = attempt({ attempt_sequence: 9, observed_at: '2020-01-01T00:00:00Z' });
+        const newerClock = attempt({ attempt_sequence: 8, observed_at: '2099-01-01T00:00:00Z' });
+        expect(replacesRetained(newerClock, older)).toBe(false);
+    });
+
+    it('an invalid or unclassifiable attempt can never become the representative', () => {
+        const ar = new PathologyArchive();
+        ar.ingest(attempt({ attempt_id: 'good', attempt_sequence: 1 }));
+        ar.ingest(attempt({ attempt_id: 'bad', attempt_sequence: 99, validation_status: 'invalid' }));
+        ar.ingest(
+            attempt({
+                attempt_id: 'murky',
+                attempt_sequence: 98,
+                classification_status: 'unclassifiable',
+            }),
+        );
+        const cell = ar.cells()[0]!;
+        expect(cell.retained_attempt_id).toBe('good');
+        expect(cell.attempt_count).toBe(3);
+        expect(cell.unclassifiable_count).toBe(1);
+    });
+});
+
+describe('append-only and idempotent', () => {
+    it('re-ingesting an attempt_id is a no-op and cannot inflate counts', () => {
+        const ar = new PathologyArchive();
+        const a = attempt({ attempt_id: 'dupe' });
+        expect(ar.ingest(a)).toBe(true);
+        expect(ar.ingest(a)).toBe(false);
+        expect(ar.ingest({ ...a, candidate_id: 'sneaky' })).toBe(false);
+        expect(ar.cells()[0]!.attempt_count).toBe(1);
+        expect(ar.cells()[0]!.retained_candidate_id).not.toBe('sneaky');
+    });
+
+    it('a different classification_rule_version does not merge into the same cell', () => {
+        const ar = new PathologyArchive();
+        ar.ingest(attempt({ attempt_id: 'v1' }));
+        ar.ingest(attempt({ attempt_id: 'v2', classification_rule_version: 2 }));
+        // Same WHERE x WHY, different vocabulary version: summing them would
+        // add counts described by two different enums.
+        expect(ar.cells()).toHaveLength(2);
+    });
+
+    it('every cell carries the frequency-bearing metadata the guard needs', () => {
+        const ar = new PathologyArchive();
+        ar.ingest(attempt({ attempt_id: 'm1', attempt_sequence: 3 }));
+        ar.ingest(attempt({ attempt_id: 'm2', attempt_sequence: 5 }));
+        const c = ar.cells()[0]!;
+        // Occupancy alone cannot tell 50/50 from 99.9/0.1 — these fields can.
+        expect(c.attempt_count).toBe(2);
+        expect(c.classifiable_count).toBe(2);
+        expect(c.first_observed_attempt_sequence).toBe(3);
+        expect(c.last_observed_attempt_sequence).toBe(5);
+        expect(c.retained_ranking_rule).toMatch(/attempt_sequence DESC/);
+        expect(c.retained_ranking_key).toBe('5|' + c.retained_candidate_id + '|m2');
+        expect(c.archive_schema_version).toBe(ARCHIVE_SCHEMA_VERSION);
+    });
+});
+
+describe('the diversity-collapse stop reads the archive', () => {
+    function fill(n: number, where: PathologyWhere, why: PathologyWhy, from = 0): PathologyAttempt[] {
+        return Array.from({ length: n }, (_, i) =>
+            attempt({ attempt_id: `f${where}${why}${from + i}`, attempt_sequence: from + i, where, why }),
+        );
+    }
+
+    /**
+     * The guard is reached through the ARCHIVE, never through a raw array.
+     * That is the point of the rewiring: `dominanceVerdict` takes a versioned
+     * query, so a caller cannot hand it storage internals and get a verdict.
+     */
+    function verdictOf(rows: readonly PathologyAttempt[]) {
+        const ar = new PathologyArchive();
+        for (const r of rows) ar.ingest(r);
+        return ar.collapseVerdict();
+    }
+
+    it('below the minimum sample it reports warming-up, which is NOT a pass', () => {
+        const v = verdictOf(fill(3, 'delivered', 'execution_failed'));
+        expect(v.status).toBe('warming-up');
+        // The failure this pins: a guard that says "ok" on three observations.
+        expect(v.status).not.toBe('ok');
+    });
+
+    it('a collapsed search trips the stop', () => {
+        const attempts = [
+            ...fill(24, 'delivered', 'execution_failed', 0),
+            ...fill(6, 'adhered', 'policy_blocked', 100),
+        ];
+        const v = verdictOf(attempts);
+        expect(v.status).toBe('collapsed');
+        if (v.status === 'collapsed') {
+            expect(v.dominant_share).toBeGreaterThanOrEqual(PATHOLOGY_DOMINANCE_THRESHOLD);
+            expect(v.dominant_cell).toBe('delivered x execution_failed');
+        }
+    });
+
+    it('a diverse search does not trip the stop', () => {
+        const attempts = [
+            ...fill(10, 'delivered', 'execution_failed', 0),
+            ...fill(10, 'adhered', 'policy_blocked', 100),
+            ...fill(10, 'projected', 'dependency_unavailable', 200),
+        ];
+        const v = verdictOf(attempts);
+        expect(v.status).toBe('ok');
+        if (v.status === 'ok') expect(v.dominant_share).toBeLessThan(PATHOLOGY_DOMINANCE_THRESHOLD);
+    });
+
+    it('unclassifiable attempts are excluded from the denominator', () => {
+        // 24 in one cell + 30 unclassifiable. Counting the unclassifiable ones
+        // would put the share at 24/54 = 0.44 and hide a real collapse.
+        const attempts = [
+            ...fill(24, 'delivered', 'execution_failed', 0),
+            ...Array.from({ length: 30 }, (_, i) =>
+                attempt({
+                    attempt_id: `u${i}`,
+                    attempt_sequence: 500 + i,
+                    classification_status: 'unclassifiable',
+                }),
+            ),
+        ];
+        const v = verdictOf(attempts);
+        expect(v.status).toBe('collapsed');
+        if (v.status === 'collapsed') expect(v.classifiable_in_window).toBe(24);
+    });
+
+    it('the window is the LATEST N classifiable attempts, so old collapse ages out', () => {
+        const attempts = [
+            ...fill(50, 'delivered', 'execution_failed', 0),
+            ...fill(25, 'adhered', 'policy_blocked', 100),
+            ...fill(25, 'projected', 'evidence_missing', 200),
+        ];
+        const v = verdictOf(attempts);
+        expect(v.status).toBe('ok');
+        if (v.status === 'ok') expect(v.classifiable_in_window).toBe(PATHOLOGY_WINDOW_SIZE);
+    });
+
+    it('the constants are the ones the module publishes', () => {
+        expect(PATHOLOGY_DOMINANCE_THRESHOLD).toBe(0.6);
+        expect(PATHOLOGY_WINDOW_SIZE).toBe(50);
+        expect(PATHOLOGY_MIN_CLASSIFIABLE_ATTEMPTS).toBe(20);
+    });
+});
+
+describe('the guard consumes a versioned query, not storage internals', () => {
+    it('the window query carries the version quad with its rows', () => {
+        const ar = new PathologyArchive();
+        ar.ingest(attempt({ attempt_id: 'q1' }));
+        const q = ar.dominanceWindow();
+        expect(q.archive_schema_version).toBe(ARCHIVE_SCHEMA_VERSION);
+        expect(q.classification_rule_version).toBe(CLASSIFICATION_RULE_VERSION);
+        expect(q.window_size).toBe(PATHOLOGY_WINDOW_SIZE);
+        expect(q.rows).toHaveLength(1);
+    });
+
+    it('the query excludes unclassifiable rows and reports how many it dropped', () => {
+        const ar = new PathologyArchive();
+        ar.ingest(attempt({ attempt_id: 'ok1' }));
+        ar.ingest(attempt({ attempt_id: 'no1', classification_status: 'unclassifiable' }));
+        ar.ingest(attempt({ attempt_id: 'no2', classification_status: 'unclassifiable' }));
+        const q = ar.dominanceWindow();
+        expect(q.rows).toHaveLength(1);
+        expect(q.unclassifiable_excluded).toBe(2);
+    });
+
+    it('collapseVerdict is the archive-side entry point and agrees with the query', () => {
+        const ar = new PathologyArchive();
+        for (let i = 0; i < 24; i += 1) {
+            ar.ingest(attempt({ attempt_id: `z${i}`, attempt_sequence: i }));
+        }
+        expect(ar.collapseVerdict()).toEqual(dominanceVerdict(ar.dominanceWindow()));
+    });
+});
+
+describe('the stop condition is wired, not an unwired library', () => {
+    it('STOP_CONDITIONS names this guard, and the name resolves to a real export', async () => {
+        // AC-3 and AC-5 on this roadmap are both open because their modules
+        // have no production caller. A guard nobody registers has the same
+        // problem, so the registration is asserted rather than assumed.
+        const guards = await import('../../src/scripts/_lib/harness_evolution_guards.js');
+        const mod = await import('../../src/scripts/_lib/pathology_archive.js');
+        const row = guards.STOP_CONDITIONS.find((c) => c.id === 'pathology-dominance');
+        expect(row).toBeDefined();
+        expect(row!.detector).toBe('dominanceVerdict');
+        expect(typeof (mod as Record<string, unknown>)[row!.detector!]).toBe('function');
+    });
+
+    it('it is a SECOND condition, not a replacement for diversity-collapse', () => {
+        // Deleting the older one would silently drop the distinct-count check.
+        return import('../../src/scripts/_lib/harness_evolution_guards.js').then((g) => {
+            const ids = g.STOP_CONDITIONS.map((c) => c.id);
+            expect(ids).toContain('diversity-collapse');
+            expect(ids).toContain('pathology-dominance');
+        });
+    });
+});

--- a/tests/scripts/proposer_survival_bar.test.ts
+++ b/tests/scripts/proposer_survival_bar.test.ts
@@ -1,0 +1,120 @@
+/**
+ * The proposer survival bar — road-to-governed-harness-evolution step 5.4.
+ *
+ * The step: *"An LLM proposer must beat the deterministic one to survive. On at
+ * least one pre-registered eval family, with an explicit hypothesis and a named
+ * falsifier per mutation. Otherwise the deterministic path stays."*
+ * `verify: the comparison is a `paired_verdict` run, not an argument.`
+ *
+ * **The comparison cannot be run, and that is a fact about the tree rather than
+ * about effort: there is no second arm.** `_lib/candidate_proposer.ts` is the
+ * only proposer, it is deterministic by construction, and Phase 5 ships no live
+ * model harness — step 5.2 pins that with its own scan. A `paired_verdict` run
+ * needs two arms; one of them does not exist.
+ *
+ * So this file does NOT claim the comparison happened. It is an
+ * **absence-assertion**: it pins the state the step's own fallback clause names
+ * — *"Otherwise the deterministic path stays"* — so that the day an LLM
+ * proposer appears, it cannot quietly become the default without the
+ * comparison. The guard is the thing that makes "otherwise" enforceable instead
+ * of aspirational.
+ *
+ * What it asserts:
+ *   1. The proposer path is deterministic — no model client, no network, no
+ *      subprocess anywhere in it or its dependencies.
+ *   2. The assertion is not vacuous: the scanned set is non-empty and contains
+ *      the module it names.
+ *
+ * What it deliberately does NOT assert: that the deterministic recipes are any
+ * good. That is the paired verdict's question, and answering it here would be
+ * the "argument, not a run" the step forbids.
+ */
+import { readFileSync } from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(HERE, '..', '..');
+
+/** The proposer path: the module plus every `_lib` sibling it imports. */
+const PROPOSER_CHAIN = [
+    'src/scripts/_lib/candidate_proposer.ts',
+    'src/scripts/_lib/candidate_record.ts',
+];
+
+/**
+ * Constructs that would put a model in the proposer loop.
+ *
+ * Named literally rather than described, so the scan is falsifiable: adding any
+ * one of these to the chain must turn this file red.
+ */
+const MODEL_IN_THE_LOOP = [
+    'fetch(',
+    'node:http',
+    'node:https',
+    'node:net',
+    'child_process',
+    'spawnSync',
+    'api.anthropic.com',
+    'api.openai.com',
+    'ANTHROPIC_API_KEY',
+    'OPENAI_API_KEY',
+];
+
+// Bare vendor names — `anthropic`, `openai` — were in this list and were
+// REMOVED after they fired on the clean tree. Both appear in
+// `candidate_record.ts`, not as a client but inside an error-message STRING
+// naming which council seats decided something ("2026-08-29, anthropic +
+// openai, 2/2"). Stripping comments does not remove a string literal, and it
+// should not: the detector was simply wrong. A vendor's name in prose is not
+// evidence of a model call, and a scan that reds on it measures the writing
+// rather than the code. What is left cannot appear innocently: a transport
+// import, a subprocess spawn, an API host, or a key env var.
+// Measured 2026-08-31 — with the names in, the clean tree reported
+// 2 hits, both prose.
+
+/** Strip comments, so a docstring naming a construct is not a hit. */
+function code(src: string): string {
+    return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '');
+}
+
+describe('the deterministic path stays until a comparison is run', () => {
+    const bodies = PROPOSER_CHAIN.map((rel) => ({
+        rel,
+        body: code(readFileSync(path.join(REPO, rel), 'utf8')),
+    }));
+
+    it('the scan is not vacuous — it reads real, non-empty modules', () => {
+        // A scan over nothing exits green, which is the failure mode this
+        // assertion exists to make impossible.
+        expect(bodies.length).toBeGreaterThan(0);
+        for (const b of bodies) {
+            expect(b.body.length).toBeGreaterThan(500);
+        }
+        expect(bodies.map((b) => b.rel)).toContain('src/scripts/_lib/candidate_proposer.ts');
+    });
+
+    it('the comment stripper does not empty the file it scans', () => {
+        // Its own anti-vacuity: a stripper returning '' would make every
+        // assertion below pass over nothing.
+        for (const b of bodies) {
+            expect(b.body).toMatch(/export/);
+        }
+    });
+
+    it('no model is in the proposer loop', () => {
+        const hits: string[] = [];
+        for (const b of bodies) {
+            for (const needle of MODEL_IN_THE_LOOP) {
+                if (b.body.includes(needle)) hits.push(`${b.rel}: ${needle}`);
+            }
+        }
+        expect(hits).toEqual([]);
+    });
+
+    it('the construct list is non-empty, so the scan above can actually fail', () => {
+        expect(MODEL_IN_THE_LOOP.length).toBeGreaterThan(5);
+    });
+});

--- a/tests/scripts/routing_index_input.test.ts
+++ b/tests/scripts/routing_index_input.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Step 6.5 of road-to-governed-harness-evolution — the index input set derives
+ * from the 5.1 verdict file.
+ *
+ * > *Index the body only if 5.1 measured a signal. Otherwise description-only.*
+ * > verify: **the indexer`s input set derives from the 5.1 verdict file.**
+ *
+ * THE OUTCOME IS NOT WHAT IS UNDER TEST. Today`s verdict is `harmful`, so
+ * description-only is the right answer — and a resolver that returned
+ * description-only unconditionally would produce that same right answer while
+ * failing the verify completely. So every case below flips the FIXTURE and
+ * asserts the resolved set follows it. The sabotage is the test.
+ *
+ * NO TRACKED FILE IS WRITTEN. The fixtures live in a temp directory and the
+ * resolver is pointed at them, because a test that mutates
+ * `agents/evidence/analysis/routing-body-signal-verdict.json` would corrupt the
+ * artefact the run publishes.
+ *
+ * FAIL-CLOSED IS ASSERTED IN BOTH DIRECTIONS. A record that says `signal` but
+ * has lost its `proxy_to_real_fidelity` bound must NOT widen the index: the
+ * bound ships with the conclusion, and a provenance-stripped record is refused
+ * rather than half-trusted.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import {
+    DESCRIPTION_AND_BODY,
+    DESCRIPTION_ONLY,
+    resolveIndexArm,
+    resolveIndexInput,
+} from '../../src/scripts/_lib/routing_index_input.js';
+import { measureDelivery } from '../../src/scripts/measure_delivery_sets.js';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'routing-index-input-'));
+
+afterAll(() => {
+    fs.rmSync(TMP, { recursive: true, force: true });
+});
+
+/** A verdict fixture on disk, returning its path. */
+function fixture(name: string, body: unknown): string {
+    const file = path.join(TMP, `${name}.json`);
+    fs.writeFileSync(file, JSON.stringify(body, null, 2));
+    return file;
+}
+
+const bound = { value: null, status: 'unmeasured-by-construction', reason: 'the 5.2 park' };
+
+describe('6.5 — the input set follows the verdict token', () => {
+    it('`signal` widens the index to the body', () => {
+        const f = fixture('signal', {
+            proxy_to_real_fidelity: bound,
+            body_signal: { verdict: 'signal' },
+        });
+        const got = resolveIndexInput(REPO, f);
+        expect(got.fields).toEqual([...DESCRIPTION_AND_BODY]);
+        expect(got.indexesBody).toBe(true);
+        expect(resolveIndexArm(REPO, f)).toBe('description+body');
+    });
+
+    it('every non-signal token resolves to description-only', () => {
+        for (const token of ['harmful', 'null', 'underpowered', 'Signal', 'SIGNAL', '']) {
+            const f = fixture(`t-${token || 'empty'}`, {
+                proxy_to_real_fidelity: bound,
+                body_signal: { verdict: token },
+            });
+            const got = resolveIndexInput(REPO, f);
+            expect(got.fields).toEqual([...DESCRIPTION_ONLY]);
+            expect(got.indexesBody).toBe(false);
+            expect(got.verdict).toBe(token);
+        }
+    });
+});
+
+describe('6.5 — fail-closed, and only in the narrowing direction', () => {
+    it('a missing verdict file narrows, it does not widen', () => {
+        const got = resolveIndexInput(REPO, path.join(TMP, 'does-not-exist.json'));
+        expect(got.fields).toEqual([...DESCRIPTION_ONLY]);
+        expect(got.verdict).toBeNull();
+        expect(got.reason).toContain('fail-closed');
+    });
+
+    it('unparseable JSON narrows', () => {
+        const f = path.join(TMP, 'broken.json');
+        fs.writeFileSync(f, '{ not json');
+        expect(resolveIndexInput(REPO, f).fields).toEqual([...DESCRIPTION_ONLY]);
+    });
+
+    it('`signal` WITHOUT the fidelity bound is REFUSED, not honoured', () => {
+        // The sharpest case: the token says widen, the provenance is gone.
+        const f = fixture('stripped', { body_signal: { verdict: 'signal' } });
+        const got = resolveIndexInput(REPO, f);
+        expect(got.fields).toEqual([...DESCRIPTION_ONLY]);
+        expect(got.indexesBody).toBe(false);
+        expect(got.reason).toContain('proxy_to_real_fidelity');
+    });
+
+    it('a record with the bound but no verdict token narrows', () => {
+        const f = fixture('no-token', { proxy_to_real_fidelity: bound, body_signal: {} });
+        expect(resolveIndexInput(REPO, f).fields).toEqual([...DESCRIPTION_ONLY]);
+    });
+});
+
+describe('6.5 — the real tree resolves to description-only, and it DERIVES it', () => {
+    it('the committed 5.1 verdict is `harmful`, so the body is not indexed', () => {
+        const got = resolveIndexInput(REPO);
+        expect(got.verdict).toBe('harmful');
+        expect(got.fields).toEqual([...DESCRIPTION_ONLY]);
+        expect(got.indexesBody).toBe(false);
+    });
+
+    it('the consumer`s index set comes from the resolver, not from a literal', () => {
+        // `measureDelivery` records the resolved input on its own result, so the
+        // derivation is observable in the published record rather than asserted.
+        const m = measureDelivery(REPO);
+        expect(m.indexInput.fields).toEqual([...DESCRIPTION_ONLY]);
+        expect(m.indexInput.reason).toContain('harmful');
+    });
+});

--- a/tests/scripts/routing_signal_measurement.test.ts
+++ b/tests/scripts/routing_signal_measurement.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Step 5.1 of road-to-governed-harness-evolution — the body-signal measurement.
+ *
+ * Four things need a guard, and only one of them is the number.
+ *
+ * 1. THE SEAL. The 18 holdout corpora frozen in
+ *    `agents/evidence/analysis/trigger-corpus-holdout-2026-08-30.md` must not
+ *    be read by an analyzer authored in Phase 5. The loader skips them from the
+ *    directory NAME, before any read, and the first block asserts that no case
+ *    from a holdout skill reaches the measurement.
+ *
+ * 2. THE VERDICT FUNCTION. It was pre-registered with an ORDER — power floor,
+ *    then guard, then primary — and the order is load-bearing: the run that
+ *    actually happened clears the recall bar AND breaches the guard, so a
+ *    verdict function that checked the primary first would have returned
+ *    `signal` on the same numbers. That exact combination is pinned.
+ *
+ * 3. THE PUBLISHED VERDICT REPRODUCES. Step 6.5 derives its input set from the
+ *    committed verdict file. A verdict nobody recomputes is a verdict nobody
+ *    has checked — the failure mode the holdout pin already had once.
+ *
+ * 4. NON-VACUITY. A measurement over an empty catalogue or an empty corpus
+ *    exits green and means nothing, so the sizes are asserted first.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+    HOLDOUT_CEILING,
+    corpusSkills,
+    legacyShaped,
+    loadCatalogue,
+    loadTrainCases,
+    partitionOf,
+    termIndex,
+    topK,
+} from '../../src/scripts/_lib/routing_corpus.js';
+import {
+    FALSE_ACTIVATION_GUARD_PP,
+    K,
+    POWER_FLOOR_DISCORDANT,
+    RECALL_GAIN_BAR_PP,
+    mcnemarExactP,
+    measure,
+    verdictRecord,
+} from '../../src/scripts/measure_routing_signal.js';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const FREEZE = path.join(REPO, 'agents/evidence/analysis/trigger-corpus-holdout-2026-08-30.md');
+const VERDICT = path.join(REPO, 'agents/evidence/analysis/routing-body-signal-verdict.json');
+
+/** The skills the freeze artefact lists under its `## Holdout` heading. */
+function sealedSkills(): string[] {
+    const md = fs.readFileSync(FREEZE, 'utf8');
+    const start = md.indexOf('## Holdout');
+    const end = md.indexOf('## Train', start);
+    expect(start).toBeGreaterThan(0);
+    expect(end).toBeGreaterThan(start);
+    return [...md.slice(start, end).matchAll(/^\| `([a-z0-9-]+)` \|/gm)].map((m) => m[1] as string);
+}
+
+describe('5.1 — the seal is enforced by refusal, not by filtering', () => {
+    const sealed = sealedSkills();
+
+    it('the freeze artefact still lists a non-empty holdout (a check over nothing passes)', () => {
+        expect(sealed.length).toBe(18);
+    });
+
+    it('the loader`s partition agrees with every published holdout row', () => {
+        expect(sealed.filter((s) => partitionOf(s) !== 'holdout')).toEqual([]);
+        expect(HOLDOUT_CEILING).toBe(51);
+    });
+
+    it('no train case belongs to a sealed skill', () => {
+        const used = new Set(loadTrainCases(REPO).map((c) => c.skill));
+        expect(sealed.filter((s) => used.has(s))).toEqual([]);
+    });
+
+    it('and the partition is not vacuously all-train', () => {
+        const all = corpusSkills(REPO);
+        expect(all.length).toBe(100);
+        expect(all.filter((r) => r.partition === 'holdout').length).toBe(18);
+    });
+});
+
+describe('5.1 — the measurement is non-vacuous', () => {
+    it('the catalogue and the corpus are both large', () => {
+        expect(loadCatalogue(REPO).length).toBeGreaterThan(200);
+        const cases = loadTrainCases(REPO);
+        expect(cases.length).toBeGreaterThan(500);
+        expect(new Set(cases.map((c) => c.skill)).size).toBe(82);
+    });
+
+    it('both legacy-shaped train corpora are read, not silently dropped', () => {
+        // The first implementation understood only `queries[]` and reported 80
+        // train corpora where the partition says 82, with nothing naming the
+        // two it lost. Both are asserted present as CASES, not merely listed.
+        expect(legacyShaped(REPO)).toEqual(['brand-asset-generation', 'estimate-ticket']);
+        const used = new Set(loadTrainCases(REPO).map((c) => c.skill));
+        expect(used.has('brand-asset-generation')).toBe(true);
+        expect(used.has('estimate-ticket')).toBe(true);
+    });
+
+    it('the ranker returns a bounded, ordered set', () => {
+        const catalogue = loadCatalogue(REPO);
+        const index = termIndex(catalogue, 'description');
+        const ranked = topK('review the authorization on this endpoint', catalogue, index, K);
+        expect(ranked.length).toBeGreaterThan(0);
+        expect(ranked.length).toBeLessThanOrEqual(K);
+        for (let i = 1; i < ranked.length; i++) {
+            expect((ranked[i - 1] as { score: number }).score).toBeGreaterThanOrEqual(
+                (ranked[i] as { score: number }).score,
+            );
+        }
+    });
+});
+
+describe('5.1 — McNemar exact, against values computable by hand', () => {
+    it('no discordant pairs is p = 1', () => {
+        expect(mcnemarExactP(0, 0)).toBe(1);
+    });
+
+    it('a perfectly split 5/5 is p = 1', () => {
+        expect(mcnemarExactP(5, 5)).toBeCloseTo(1, 10);
+    });
+
+    it('10 gained and 0 lost is 2 / 2^10', () => {
+        expect(mcnemarExactP(10, 0)).toBeCloseTo(2 / 1024, 12);
+    });
+
+    it('it is symmetric — direction is the verdict function`s job, not the test`s', () => {
+        expect(mcnemarExactP(12, 3)).toBeCloseTo(mcnemarExactP(3, 12), 12);
+    });
+});
+
+describe('5.1 — the verdict function is the pre-registered one, in its order', () => {
+    const m = measure(REPO);
+
+    it('the run that happened clears the recall bar and still is not `signal`', () => {
+        // The load-bearing polarity. Primary met, guard breached: a verdict
+        // function that tested the primary first would return `signal` here.
+        expect(m.deltaRecallPp).toBeGreaterThanOrEqual(RECALL_GAIN_BAR_PP);
+        expect(m.pValue).toBeLessThan(0.05);
+        expect(m.deltaFalseActivationPp).toBeGreaterThan(FALSE_ACTIVATION_GUARD_PP);
+        expect(m.verdict).toBe('harmful');
+    });
+
+    it('power is checked before the guard', () => {
+        expect(m.positiveDiscordance.gained + m.positiveDiscordance.lost).toBeGreaterThanOrEqual(
+            POWER_FLOOR_DISCORDANT,
+        );
+    });
+
+    it('the body arm is monotone non-decreasing, as the pre-registration predicted', () => {
+        // `overlap` divides by the TASK`s term count, so adding body tokens can
+        // only raise a score. Recall and false activation must both be up.
+        expect(m.recallPp['description+body']).toBeGreaterThanOrEqual(m.recallPp['description']);
+        expect(m.falseActivationPp['description+body']).toBeGreaterThanOrEqual(
+            m.falseActivationPp['description'],
+        );
+        // Monotone SCORES do not imply monotone RANKS: a positive already in
+        // the top-5 can be pushed out when its competitors gain more. `lost`
+        // being non-zero is that effect, and it is why the guard is not
+        // redundant with the primary.
+        expect(m.positiveDiscordance.lost).toBeGreaterThan(0);
+    });
+});
+
+describe('5.1 — the published verdict reproduces from the tree', () => {
+    const published = JSON.parse(fs.readFileSync(VERDICT, 'utf8')) as Record<string, never>;
+    const fresh = verdictRecord(measure(REPO), '') as Record<string, never>;
+
+    it('the verdict, the deltas and the corpus counts all reproduce', () => {
+        expect(published['body_signal']).toEqual(fresh['body_signal']);
+        expect(published['corpus']).toEqual(fresh['corpus']);
+    });
+
+    it('gap A is carried as its own field, null, with the reason', () => {
+        const gap = published['proxy_to_real_fidelity'] as unknown as Record<string, unknown>;
+        expect(gap['value']).toBeNull();
+        expect(gap['status']).toBe('unmeasured-by-construction');
+        expect(String(gap['reason'])).toContain('5.2');
+    });
+
+    it('it names the pre-registration it was measured under', () => {
+        expect(published['preregistration']).toContain('routing-signal-preregistration');
+    });
+});

--- a/tests/scripts/trigger_corpus_holdout_pin.test.ts
+++ b/tests/scripts/trigger_corpus_holdout_pin.test.ts
@@ -1,0 +1,90 @@
+/**
+ * The holdout pin must reproduce from the tree
+ * (`agents/evidence/analysis/trigger-corpus-holdout-2026-08-30.md`,
+ * road-to-governed-harness-evolution AC-6).
+ *
+ * AC-6 asserts the holdout partition's content hash predates the first commit
+ * of any proposer capability. That claim is worth nothing if the published hash
+ * does not describe the corpus it names — and it did not: the commit that
+ * RECORDED the freeze also edited three of the files it was freezing, so three
+ * per-file rows and the set hash were pinned at pre-edit bytes and were stale
+ * the moment they were written. Re-running the artefact's own recipe and
+ * trusting the old number could never have caught that.
+ *
+ * So this file is the guard the artefact lacked: it recomputes the recipe from
+ * the tree and asserts every published row, and the set hash, reproduce. A
+ * frozen corpus whose pin nobody recomputes is a corpus nobody has checked.
+ */
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(HERE, '..', '..');
+const ARTEFACT = path.join(
+    REPO,
+    'agents/evidence/analysis/trigger-corpus-holdout-2026-08-30.md',
+);
+const SKILLS = path.join(REPO, 'src/skills');
+
+/** The partition constant the artefact freezes. Changing it re-partitions the corpus. */
+const HOLDOUT_CEILING = 51;
+
+function sha256(buf: Buffer | string): string {
+    return createHash('sha256').update(buf).digest('hex');
+}
+
+/** The artefact's documented recipe, in TypeScript rather than shell. */
+function corpusRows(): { skill: string; hash: string; partition: string }[] {
+    const rows: { skill: string; hash: string; partition: string }[] = [];
+    for (const skill of fs.readdirSync(SKILLS).sort()) {
+        const f = path.join(SKILLS, skill, 'evals', 'triggers.json');
+        if (!fs.existsSync(f)) continue;
+        const bucket = parseInt(sha256(skill).slice(0, 2), 16);
+        rows.push({
+            skill,
+            hash: sha256(fs.readFileSync(f)),
+            partition: bucket < HOLDOUT_CEILING ? 'holdout' : 'train',
+        });
+    }
+    // `LC_ALL=C sort` over the whole "<skill> <hash> <partition>" line.
+    return rows.sort((a, b) =>
+        `${a.skill} ${a.hash} ${a.partition}` < `${b.skill} ${b.hash} ${b.partition}` ? -1 : 1,
+    );
+}
+
+function setHash(rows: ReturnType<typeof corpusRows>): string {
+    return sha256(rows.map((r) => `${r.skill} ${r.hash} ${r.partition}\n`).join(''));
+}
+
+describe('trigger-corpus holdout pin', () => {
+    const artefact = fs.readFileSync(ARTEFACT, 'utf8');
+    const rows = corpusRows();
+
+    it('the corpus is non-empty — a scan over nothing would pass vacuously', () => {
+        expect(rows.length).toBeGreaterThan(50);
+    });
+
+    it('the artefact still declares a set hash', () => {
+        expect(artefact).toMatch(/^SET-SHA256\s+[0-9a-f]{64}$/m);
+    });
+
+    it('the published SET-SHA256 reproduces from the tree', () => {
+        const published = /^SET-SHA256\s+([0-9a-f]{64})$/m.exec(artefact)?.[1];
+        expect(published).toBe(setHash(rows));
+    });
+
+    it('every per-file row reproduces from the tree', () => {
+        const stale = rows.filter((r) => !artefact.includes(`| \`${r.skill}\` | \`${r.hash}\` |`));
+        expect(stale.map((r) => r.skill)).toEqual([]);
+    });
+
+    it('the partition split is the one the artefact names', () => {
+        const holdout = rows.filter((r) => r.partition === 'holdout');
+        expect(holdout.length).toBeGreaterThan(0);
+        expect(holdout.length).toBeLessThan(rows.length);
+    });
+});


### PR DESCRIPTION
Takes `road-to-governed-harness-evolution` from 46/59 to **55/59**: eight steps
and acceptance criteria closed, two landed as guarded baselines, one criterion
split. It does **not** archive — two guarded baselines and AC-8 remain, and each
says why.

## The keystone: step 4.1, and a council split that the tree resolved

**Question put:** may the deterministic prefix of the evaluation cascade close
4.1 today, with the receipt-bearing stages scoped out?

**Verdict: Option B, convergent 2/2** — anthropic/claude-sonnet-4-5 +
openai/codex-default, subscription transport, nothing billed.

It arrived as an apparent 1/1 split and became a convergence by measurement,
which is the part worth reading. anthropic returned *"Conditional Option A"* and
named its own tie-break: *"Choose Option A IF AND ONLY IF verification confirms
Phase 1 families are failure-mode buckets, not observation methods … If either
verification fails: Option B."* It also named the gap honestly — *"Neither
reviewer noticed we're guessing what Phase 1 families mean."* Checked against
the tree: step 1.1's verify clause reads *"classifiable as content vs activation
vs adherence **from the recorded receipt alone**"*. A receipt is an observation,
so the condition fails and both seats land on B. The seat that lost supplied the
thing that made the decision checkable.

**Built:** `src/scripts/_lib/evaluation_cascade.ts` — six stages, aborting on
the first hard failure. Every stage is free, which is *why* these six can ship
without a receipt producer, and it makes *"a candidate failing the cheapest
stage consumes no model call"* structural rather than asserted: `model_calls` is
a literal `0` on every path because no path could increment a counter. The
prefix may assign only `content` and `unknown` — `activation` and `adherence`
are excluded by construction, since assigning either from a deterministic proxy
is the evidence-manufacturing openai named: *"a holdout leak is not evidence of
an `activation` failure … that produces labels, but not trustworthy
classifications."*

**Wired into `evolution_lab run`**, which previously cloned and returned. That
wiring is what closes AC-3 and AC-5.

4.1 itself stays a **guarded baseline**, not `[x]`: the twelve-stage form and the
receipt producer do not exist, and the prior round recorded that one seat asked
twice and produced two materially different twelve-stage enumerations.

## Closed

- **AC-3** — `evaluated` was the unmet verb; the modules were, in the audit's own
  words, "an UNWIRED library". Now asserted end to end through the real CLI.
- **AC-5** — `promotionVerdict` had **no caller anywhere**. It has one.
- **AC-6** — the holdout pin **did not reproduce**. The corpus was checked before
  the pin was blamed and is intact; the cause is that the commit which *recorded*
  the freeze also edited three of the files it was freezing, so three rows and
  the set hash were stale on arrival. Re-pinned; all 100 rows and the set hash
  now reproduce, and the ordering claim was re-verified rather than assumed to
  survive. A new test recomputes the recipe and pins it, because a stale pin is
  invisible to anyone who re-runs the recipe and compares it to nothing.
- **4.4** — the pathology archive, per a single-seat council (recorded as
  DEGRADED, anthropic `exit_1`). Ranking is total; ordering is by
  ingester-assigned sequence and never by timestamp, because producer clocks
  collide and make the rule non-total. `WHERE` reuses the activation ladder by
  identity; `WHY` is a closed eight-value reason axis and a test asserts no value
  restates a rung.
- **5.1** — measured, verdict **`harmful`**, not the permitted null. recall@5
  +5.68 pp (bar +5.0, p = 0.0371) but false activation +7.22 pp against a +2.0
  guard. **The primary bar was cleared and the verdict is still not `signal`** —
  a one-sided pre-registration would have shipped a change that makes routing
  worse while reporting an improvement.
- **6.4** — recall loss **35.40 pp against a 20.0 pp ceiling: BREACHED**, and it
  clears at no k ≤ 20. Reported as breached; no narrowed delivery promoted. 7
  jointly-wrong pairs found against a bar of "at least one".
- **6.5** — description-only, *derived* from 5.1's verdict file rather than
  hardcoded, proved by flipping the verdict and watching the input set change.
- **6.3** — lexical shortlist over the existing BM25 core, no embeddings. It
  currently makes delivery **slightly worse** (0.990 → 0.984) — reported, not
  tuned away — and ships default-OFF.
- **AC-10b** — read at completion, not mid-flight.

## Guarded baselines — RED-proved, and not counted as done

- **4.1** `recheck_when` the receipt module.
- **5.4** — the comparison **cannot be run: there is no second arm.** The only
  proposer is deterministic and Phase 5 ships no live harness. What ships is the
  enforcement its fallback clause lacked: *"otherwise the deterministic path
  stays"* is now a test rather than a sentence.
- **5.6** — the ROI half closed with a production caller; the cheapest-first half
  has no live subject.

## Open, with reasons

- **AC-8** — the run report shape now exists and structurally carries the ROI
  figure. The missing half is a candidate run, which needs a metered backend that
  5.2 forbids. The e2e CLI case is explicitly **not** offered as that run.
- **AC-9** → transferred to `road-to-harness-promotion-bridge` (PR #1775).
- **AC-10a** → `[-]` superseded by ADR-249. Byte-identity is impossible because
  a *different* roadmap retired the claim by governance decision. Re-keying it
  to a two-file diff was put to the council and **refused**: *"that proves only
  that those files were untouched. A daemon could be introduced entirely in
  source or deployment config."* Split instead, with AC-10b carrying the purpose
  onto the boundary that still exists — P2, since ADR-249 governs background
  processes rather than banning them.

## Findings recorded rather than smoothed over

- **Path ownership is already enforced inside the schema parse**, so its failures
  were being attributed to the wrong stage — and the failing stage is exactly
  what the Phase 1 classification reads. Fixed. The consequence is that the
  cascade's own stage-2 re-check is **unreachable and untested**; a sabotage left
  the suite green, so it is labelled an unproven guard instead of counted as
  defense in depth.
- **The 4.4 sensitivity probe found a gap in its own tests**: deleting the `WHY`
  axis from the cell key left 23/23 green, because the existing case differed on
  both axes. Two axis-isolating tests were added; each axis now reds on its own.
- **A false positive removed rather than suppressed** in 5.4's scan: the bare
  vendor names fired twice on the clean tree, both inside an error-message string
  naming council seats. A vendor name in prose is evidence about the writing, not
  the code.
- **The step's `0.6` had no referent.** The objection warning against reusing it
  assumed it meant textual similarity; there is no such constant — the diversity
  guard is a distinct-count check and the near-duplicate constant is an integer
  70 on a different scale.
- **Step 0.6's stop-set arity moves 4 → 5.** An addition, never a replacement,
  with both ids pinned; the pin is updated with its rationale rather than deleted.
- **The first wiring broke an existing test** by making a metric-less run exit
  non-zero. The test was right. Fixed with a third outcome, `incomplete`, so the
  verb's contract is unchanged and an unmeasured candidate still cannot read as
  evaluated.
- **The cascade CLI cases were racy** against siblings that wipe the shared
  clones root — passing in isolation, red in the full suite. The repo already has
  a cross-file lock; the file simply was not taking it.

## Gates

`lint_roadmap_blockers`, `lint_roadmap_complexity`, `lint_roadmap_ci_steps`,
`check_roadmap_trackable`, `check_no_roadmap_refs`, `lint_empty_roadmaps`,
`lint_roadmap_later_disposition`, `lint_evidence_artifacts`, `lint_output_slop`,
`check_no_external_sources`, `lint_framework_leakage`, `check_references` — all
exit 0. `npm run typecheck` clean, ESLint clean on changed files.

**Full suite: 17,159 passed / 1 failed.** The one failure is
`check_rule_projection_integrity`, a **documented worktree false red** — it
asserts `> 50` projected rules and a worktree without `.agent-settings.yml`
projects only the project layer. Verified: it **passes on the main checkout at
the same commit range**.
