### PR TITLE
roadmap(promotion-bridge): repair two stale claims; blocker stays owner-reserved

### DIFF
--- a/agents/roadmaps/road-to-harness-promotion-bridge.md
+++ b/agents/roadmaps/road-to-harness-promotion-bridge.md
@@ -642,7 +642,7 @@ removed or reordered.
 |------|------|-----------|-------------|------------|----------------|
 | 1 | `[-] MERGED` in the parent is later read as cancelled or as satisfied | product | The parent now carries nine `[-]` markers for work that is open here. A reader who takes `[-]` at its usual meaning concludes Phase 7 was dropped or done, and this file's whole purpose — keeping seven specified steps and AC-9 alive — is defeated silently | Every one of the nine markers states in as many words that `[-]` means TRANSFERRED, not cancelled and not satisfied, and names this file. The `relates:` block and § Provenance make the link machine-readable from both ends | Provenance |
 | 2 | The carried non-promotion condition is discharged by a check over a population of zero | implementation | A gate written before any promotion path exists scans nothing and exits green, which is exactly why the parent left the condition UNMET rather than closing it | The condition's own text forbids it: *"A check over a population of zero does not discharge this condition"*, and its discharge point is named as the first commit that creates a promotion path | Carried blocking condition |
-| 3 | ~~The discharge point may already have passed and nobody adjudicated it~~ **RETIRED 2026-08-31 — adjudicated** | implementation | Parent steps 3.4 and 3.6 are `[x]`, and `src/scripts/evolution_lab.ts:858-888` carries a `promote` verb returning `EXIT_REFUSED` unconditionally — a non-empty population with a mechanical refusal. The risk was that nobody would decide whether that discharges the condition, because *an undecided condition reads as satisfied to the next reader* | **Decided.** AI council 2026-08-31, **(B) NOT DISCHARGED**, 2×B / 1×A across two rounds, with the gap named falsifiably: the condition covers *any write into `src/` derived from a candidate* and only the verb plus the `-> promoted` transition are gated. Two discharge routes are recorded, one buildable and one owner-reserved. The condition is now undischarged **on evidence** rather than undecided | Carried blocking condition |
+| 3 | ~~The discharge point may already have passed and nobody adjudicated it~~ **RETIRED 2026-08-31 — adjudicated** | implementation | Parent steps 3.4 and 3.6 are `[x]`, and `src/scripts/evolution_lab.ts:858-888` carries a `promote` verb returning `EXIT_REFUSED` unconditionally — a non-empty population with a mechanical refusal. The risk was that nobody would decide whether that discharges the condition, because *an undecided condition reads as satisfied to the next reader* | **Decided.** AI council 2026-08-31, **(B) NOT DISCHARGED**, 2×B / 1×A across two rounds, with the gap named falsifiably: the condition covers *any write into `src/` derived from a candidate* and only the verb plus the `-> promoted` transition are gated. Two discharge routes are recorded, one buildable and one owner-reserved. The condition is now undischarged **on evidence** rather than undecided. **SUPERSEDED 2026-08-31 (drain run 11):** route 1 was subsequently BUILT, and `:170-172` records the condition **DISCHARGED BY ROUTE 1** — the guarded capability plus the bypass check, green and proven sensitive. The `(B) NOT DISCHARGED` verdict in this cell is the intermediate finding that *motivated* route 1, not the final state; leaving it unqualified made this row contradict `:170`. Route 2 remains untaken and owner-reserved | Carried blocking condition |
 | 4 | This roadmap sits blocked indefinitely on an owner decision | product | ADR-239 § Decision 3 has been open since 2026-08-22 with no recorded movement. An ACTIVE roadmap that never resumes consumes governed-estate headroom without producing anything | Deliberate and council-chosen: both seats ruled that active membership is what preserves the criteria, and the Resume condition routes owner REFUSAL back to the owner rather than letting this file decide its own disposition | Resume condition |
 | 5 | A Phase 1-6 step in the parent creates a promotion path before this file resumes | implementation | The `merge-authority` blocker is scoped to gate Phase 7. A parent step that promotes anything would escape that scoping, and the mechanical non-promotion condition would bind to a change nobody expected it to | The Revisit-if clause binds both the blocker and the carried condition to any such earlier change, by name | Resume condition |
 
@@ -658,9 +658,18 @@ removed or reordered.
       re-evaluation and at least one RETIRE path has been exercised, so the
       lifecycle is shown to close in both directions.
       **Audited 2026-08-31: not met, and not closeable from this branch.**
-      Every Phase 7 step is `[ ]` and the phase is gated on the OPEN,
-      owner-reserved `blocker: merge-authority`. Nothing in this tree is
-      promoted, so no promoted artefact can reach post-promotion re-evaluation.
+      Every Phase 7 step was `[ ]` **at the moment of this first audit** and the
+      phase is gated on the OPEN, owner-reserved `blocker: merge-authority`.
+      Nothing in this tree is promoted, so no promoted artefact can reach
+      post-promotion re-evaluation.
+      **TENSE CORRECTED 2026-08-31 (drain run 11) — a factual repair, not a
+      criterion change.** The sentence asserted the present tense and is false
+      in it: the seven Phase 7 steps read `[x]` at `:342`, `:365`, `:387`,
+      `:409`, `:445`, `:463` and `:493`, closed as MECHANISM under the Phase 7
+      gate header's own reading at `:313-315`. The clause is kept in past tense
+      rather than deleted because the audit it belongs to was true when taken;
+      the RE-AUDITED block below carries the current state. **AC-9 is untouched
+      and stays `[ ]`** — nothing here closes, weakens, or re-keys it.
       The RETIRE half was checked separately and does not rescue it: 5.5 carries
       `RETIRE` in E6's seven-op set and tests its arity
       (`tests/scripts/curator_ops.test.ts:63-66`), but every screened proposal


### PR DESCRIPTION
## What this is

Drain run 11 on `road-to-harness-promotion-bridge.md`. **The roadmap does not close, and the PR title says so rather than claiming completion.** The mandate's `roadmap: complete <slug>` title form was not used because it would assert something this branch does not establish.

Two factual repairs landed. The checkbox census is unchanged: **7 `[x]` / 1 `[~]` / 1 `[ ]`**.

## Why it does not close — evidence, not judgement

The only open item is **AC-9** (`agents/roadmaps/road-to-harness-promotion-bridge.md:657`). Its own audit at `:690-694` names three conjuncts that close it, and states none is performable from this branch: a human promotes an artefact through the capability *after the owner settles ADR-239 § Decision 3*, that artefact reaches a review trigger, and the verdict is recorded.

Every remaining exit is owner-reserved, and both council-decidable moves are already spent:

- **Option (c)** — declare Phases 1–6 legal, gate only Phase 7 — **is already taken** (`:520-527`, restated `:743-744`, AI council 2026-08-29, 2/2 convergent). Its `Resolved when` field (`:624-628`) states the scope decision *"needs nothing further"* and assigns closure to the **owner**. So (c) cannot close the blocker, cannot flip 0.8, and cannot close AC-9.
- **Route 1** of the carried non-promotion condition — **already discharged** (`:170-172`), by the guarded capability plus the bypass check.
- **Option (b)** — refuse preauthorized merge authority — was **attempted and refused twice by the harness safety classifier before reaching any council seat** (`:588-612`), which records the instruction verbatim: *"no council round should be spent on it until a human either answers it or explicitly asks for the (b) argument to be put."* No council round was spent on it here.
- **Option (a)** and **route 2** are owner-reserved by name.

`docs/decisions/ADR-239-drain-command-surface-and-merge-authority.md` is `status: accepted`, and its § Decision 3 policy question is recorded `open` in three independent places — the decision table row at `:188` (`| Preauthorized merge authority is granted or refused | owner | open |`), the `review_trigger:` at `:10-14`, and `:157`.

**The gate is executable code keyed on this file's own text.** `src/scripts/_lib/promotion_capability.ts:54` pins `MERGE_AUTHORITY_ROADMAP` to this roadmap; `:111-125` (`readMergeAuthorityStatus`) matches `/^-[ \t]*\*\*Status:\*\*[ \t]*resolved/im` against its `### blocker: merge-authority` Status field. The literal token `open` at `:520` is what makes promotion capability unobtainable. Editing it would mint the capability and, per `src/scripts/lint_promotion_paths.ts:609-627`, silently switch R0 off. That is why no Status edit is in this diff.

## What landed

### 1. AC-9 first-audit tense repair (`:661`)

The note asserted, in the present tense, *"Every Phase 7 step is `[ ]`"*. All seven read `[x]` — `:342`, `:365`, `:387`, `:409`, `:445`, `:463`, `:493` — closed as MECHANISM under the Phase 7 gate header's own reading at `:313-315`. The clause is re-tensed rather than deleted, because the audit it belongs to was true when taken and the file's convention preserves superseded audits; the `RE-AUDITED` block below it already carries the current state. **AC-9 stays `[ ]`.**

### 2. Risk-3 mitigation supersession (`:645`)

The cell recorded the intermediate council verdict *"(B) NOT DISCHARGED"* and concluded the condition *"is now undischarged on evidence"*. That contradicts `:170-172`, which records the carried condition **DISCHARGED BY ROUTE 1** after the guarded capability and the bypass check were built and proven sensitive. The cell now marks its own verdict superseded, explains that `(B)` is the finding which *motivated* route 1, and states route 2 remains untaken and owner-reserved.

## Council decisions

**None taken on this roadmap, deliberately.** The two questions this file carries are the ones its own record forbids putting: option (b) is marked *"no council round should be spent on it"* (`:588-612`), and options (a) / route 2 are owner-reserved. Re-running the already-split carried-condition question would be verdict shopping under `src/rules/evaluator-independence.md`. The prior round is on record at 2×B / 1×A across two rounds, and both seats independently concluded that Phase 7 and AC-9 stay blocked.

## Gates

Run in the worktree at this commit:

| Gate | Result |
|---|---|
| `lint_roadmap_blockers` | rc=0 — 0 violations, no baseline needed |
| `lint_roadmap_complexity` | rc=0 — 3 roadmaps complexity-clean |
| `check_roadmap_trackable` | rc=0 — 2 violations against baseline 9 (unchanged; ratchet not lowered on a local reading) |
| `check_no_roadmap_refs` | rc=0 |
| `lint_empty_roadmaps` | rc=0 |
| `lint_roadmap_later_disposition` | rc=0 |
| pre-push static check | no changed `.ts` vs origin/main — skipped |

## Honest limits

- **Nothing was closed, cancelled, descoped, or re-keyed.** The Resume condition at `:60-64` forbids exactly that under owner refusal, and no owner decision has been recorded.
- **The roadmap stays ACTIVE and blocked, by recorded council verdict.** The 2026-08-31 council ruled 2/2 that Phase 7 must remain inside the mechanically governed active estate while its owner-reserved gate is open, and both seats rejected `agents/roadmaps/later/` by name. Descoping into a stub would be the disposition they refused.
- **Two further stale passages were left standing** because repairing them would require re-reading superseded audit rounds that the file deliberately preserves: Risk row 3 still occupies rank 3 while struck through, and it is not renumbered.