### PR TITLE
fix(tests): stop a test fixture from shifting the skill-catalogue count

### DIFF
--- a/src/scripts/_lib/routing_corpus.ts
+++ b/src/scripts/_lib/routing_corpus.ts
@@ -87,6 +87,39 @@ export function skillsDir(repoRoot: string): string {
     return path.join(repoRoot, 'src', 'skills');
 }
 
+/**
+ * Is this `src/skills/<name>` entry test scaffolding rather than a skill?
+ *
+ * A `__`-prefixed directory is scaffolding by convention, and a real skill can
+ * never be named one: `skill.schema.json` pins `name` to `^[a-z][a-z0-9-]*$`
+ * and requires it to match the parent directory, so a leading underscore fails
+ * `validate_frontmatter`. This predicate therefore cannot hide a shipped skill.
+ *
+ * WHY IT EXISTS, measured rather than assumed.
+ * `tests/scripts/lint_originality.test.ts:64` writes a re-skin fixture to
+ * `src/skills/__origtest_reskin_fixture/SKILL.md` in the REAL tree and removes
+ * it in `afterEach`, because the linter resolves its corpus from a
+ * module-level ROOT and takes no root argument. During that window any
+ * concurrently-running test file that counts the catalogue sees 300 where the
+ * commit holds 299 — which is what failed
+ * `tests/scripts/routing_signal_measurement.test.ts` on
+ * `Node Tests (ubuntu-latest, shard 2/4)` in runs 33418425604 and 33424783559,
+ * intermittently, while passing in isolation and passing on the next run over
+ * two markdown files nothing reads.
+ *
+ * Reproduced locally before this line was written: with the fixture present on
+ * disk the assertion fails `300` vs `299`, character for character the CI
+ * message; with this predicate active it passes.
+ *
+ * Excluding the prefix here rather than threading a root through the linter is
+ * the smaller change by an order of magnitude: ROOT is baked into ten
+ * module-level constants there, and refactoring a shipped gate to suit a test
+ * is a worse trade than a naming convention the tree already follows.
+ */
+export function isScaffoldingSkillDir(name: string): boolean {
+    return name.startsWith('__');
+}
+
 /** Every skill directory that carries a trigger corpus, with its partition. */
 export function corpusSkills(repoRoot: string): { skill: string; partition: Partition }[] {
     const dir = skillsDir(repoRoot);
@@ -94,6 +127,7 @@ export function corpusSkills(repoRoot: string): { skill: string; partition: Part
     return fs
         .readdirSync(dir)
         .sort()
+        .filter((skill) => !isScaffoldingSkillDir(skill))
         .filter((skill) => fs.existsSync(path.join(dir, skill, 'evals', 'triggers.json')))
         .map((skill) => ({ skill, partition: partitionOf(skill) }));
 }
@@ -205,6 +239,7 @@ export function loadCatalogue(repoRoot: string): CatalogueEntry[] {
     if (!fs.existsSync(dir)) return [];
     const out: CatalogueEntry[] = [];
     for (const skill of fs.readdirSync(dir).sort()) {
+        if (isScaffoldingSkillDir(skill)) continue;
         const file = path.join(dir, skill, 'SKILL.md');
         if (!fs.existsSync(file)) continue;
         const [block, body] = splitFrontmatter(fs.readFileSync(file, 'utf8'));

--- a/tests/_lib/skills-dir-guard.ts
+++ b/tests/_lib/skills-dir-guard.ts
@@ -1,0 +1,132 @@
+/**
+ * Per-test-file guard: `src/skills` must never gain an entry the git index
+ * does not track.
+ *
+ * WHY THIS EXISTS, measured rather than assumed. `Node Tests (ubuntu-latest,
+ * shard 2/4)` failed on runs 33418425604 and 33424783559 with one assertion,
+ * in `routing_signal_measurement.test.ts`:
+ *
+ *     "catalogue_size": 300,   <- fresh recompute, in CI
+ *     "catalogue_size": 299,   <- the published artefact
+ *
+ * `loadCatalogue` (`src/scripts/_lib/routing_corpus.ts`) counts directories
+ * under `src/skills` carrying a `SKILL.md`. Four independent counts of the
+ * committed tree — `git ls-files`, `git ls-tree` on a clean worktree, `ls` on
+ * disk, and `check_estate_count` — all say 299, so 300 was one more skill than
+ * exists and something wrote it during the run.
+ *
+ * That writer is now known and fixed: `lint_originality.test.ts` puts a re-skin
+ * fixture in the real tree, and `isScaffoldingSkillDir` makes the catalogue
+ * readers ignore it. This guard is the OTHER half — it catches the next writer,
+ * which will not have the courtesy of a `__` prefix.
+ *
+ * THE POINT OF PUTTING IT HERE rather than only fixing the one test. The
+ * failure flipped between runs whose content differed by two markdown files
+ * nothing reads, so it is order- and parallelism-dependent, and a single green
+ * run is not evidence of absence. Hunting such a writer by re-running a race is
+ * the expensive way; this makes the race name itself on first occurrence.
+ *
+ * WHAT IT DOES NOT CLAIM. Vitest runs test FILES in parallel workers, so the
+ * file this fails in is where the pollution was OBSERVED, not necessarily the
+ * file that wrote it. The `appeared during this file` line separates the two
+ * cases as far as an observation can: an entry already present at `beforeAll`
+ * came from somewhere else. That is a narrower claim than "this test did it",
+ * and it is the honest one.
+ *
+ * The comparison is against the git INDEX, not a snapshot, so an entry a
+ * previous run leaked and never cleaned up is reported too rather than being
+ * baked into the baseline.
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterAll, beforeAll } from 'vitest';
+
+import { isScaffoldingSkillDir } from '../../src/scripts/_lib/routing_corpus.js';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const SKILLS = path.join(REPO, 'src', 'skills');
+
+/** Skill directories on disk that carry a `SKILL.md` — what `loadCatalogue` counts. */
+function onDisk(): Set<string> {
+    if (!fs.existsSync(SKILLS)) return new Set();
+    const out = new Set<string>();
+    for (const name of fs.readdirSync(SKILLS)) {
+        // The same predicate the catalogue readers use, imported rather than
+        // re-spelled: a guard and the thing it guards must not hold two
+        // opinions about which entries count.
+        if (isScaffoldingSkillDir(name)) continue;
+        if (fs.existsSync(path.join(SKILLS, name, 'SKILL.md'))) out.add(name);
+    }
+    return out;
+}
+
+/**
+ * The same set according to the git index.
+ *
+ * Cached on `globalThis` because vitest re-evaluates a setup file per test file
+ * while reusing worker processes: without the cache this would spawn `git` 344
+ * times a shard, with it a handful.
+ */
+const CACHE_KEY = '__ac_tracked_skill_dirs__';
+
+function tracked(): Set<string> | null {
+    const g = globalThis as Record<string, unknown>;
+    if (g[CACHE_KEY] !== undefined) return g[CACHE_KEY] as Set<string> | null;
+    let value: Set<string> | null = null;
+    try {
+        const out = execFileSync('git', ['ls-files', '-z', 'src/skills/*/SKILL.md'], {
+            cwd: REPO,
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'ignore'],
+        });
+        const names = out
+            .split('\0')
+            .filter(Boolean)
+            .map((rel) => rel.split('/')[2] as string)
+            .filter((name) => !isScaffoldingSkillDir(name));
+        // An empty answer means "not a git checkout" or "git unavailable", not
+        // "no skills" — a guard that fires on its own inability to look is
+        // worse than one that stands down and says so.
+        value = names.length > 0 ? new Set(names) : null;
+    } catch {
+        value = null;
+    }
+    g[CACHE_KEY] = value;
+    return value;
+}
+
+let atStart: Set<string> = new Set();
+
+beforeAll(() => {
+    atStart = onDisk();
+});
+
+afterAll(() => {
+    const expected = tracked();
+    if (expected === null) return;
+    const now = onDisk();
+    const untracked = [...now].filter((n) => !expected.has(n)).sort();
+    if (untracked.length === 0) return;
+    const appearedHere = untracked.filter((n) => !atStart.has(n));
+    const lines = untracked.map(
+        (n) =>
+            `  src/skills/${n}/SKILL.md  (${atStart.has(n) ? 'already present at file start' : 'appeared during this file'})`,
+    );
+    throw new Error(
+        `src/skills gained ${untracked.length} entr${untracked.length === 1 ? 'y' : 'ies'} the git index does not track:\n` +
+            `${lines.join('\n')}\n\n` +
+            `A test wrote a skill directory into the real repository root. Anything that ` +
+            `counts the catalogue — loadCatalogue, check_estate_count, the routing-signal ` +
+            `verdict — now reads a tree that does not match the commit, and which test ` +
+            `sees the polluted count depends on scheduling.\n` +
+            (appearedHere.length > 0
+                ? `Write to a temp root instead, or name the directory with a leading '__' ` +
+                  `so isScaffoldingSkillDir excludes it. Observed while this file ran; with ` +
+                  `parallel workers that is where it was SEEN, not proof of who wrote it.\n`
+                : `Present before this file started, so the writer is elsewhere — or a ` +
+                  `previous run leaked it and never cleaned up.\n`),
+    );
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -47,7 +47,7 @@ export default defineConfig({
         // machine's `LANG` and fail on another's — the exact failure that made
         // PR #1458 red on `macos-latest, shard 2/4` while green everywhere else.
         // Rationale and the deliberate narrowness live in the file itself.
-        setupFiles: ['tests/_lib/hermetic-env.ts'],
+        setupFiles: ['tests/_lib/hermetic-env.ts', 'tests/_lib/skills-dir-guard.ts'],
         // Runs ONCE, in the main process, before any worker spawns. Builds the
         // gitignored `dist/` artefacts the four e2e suites spawn, but only when
         // they are absent. On a fresh checkout those four files accounted for 31


### PR DESCRIPTION
Closes the intermittent `Node Tests (ubuntu-latest, shard 2/4)` failure recorded in the stub `road-to-routing-verdict-ci-only-drift`.

## The failure

`routing_signal_measurement.test.ts`, one assertion:

```
"catalogue_size": 300,   <- fresh recompute, in CI
"catalogue_size": 299,   <- the published artefact
```

Four independent counts of the committed tree — `git ls-files`, `git ls-tree` on a clean worktree, `ls` on disk, `check_estate_count` — all say 299. So 300 was one more skill than exists.

## The writer

`tests/scripts/lint_originality.test.ts:64` puts a re-skin fixture at `src/skills/__origtest_reskin_fixture/SKILL.md` in the **real** tree and removes it in `afterEach`, because the linter resolves its corpus from a module-level `ROOT` and takes no root argument. Inside that window any concurrently-running test file that counts the catalogue sees 300.

That explains every observation the stub recorded: passes in isolation, passes locally, and flips between two CI runs whose content differs by two markdown files nothing reads.

The stub had cleared the obvious candidates because they all write under a temp root. This one cannot — hence it was missed.

## Two changes, covering different failures

**`isScaffoldingSkillDir()`** in `src/scripts/_lib/routing_corpus.ts` — the catalogue readers ignore `__`-prefixed directories. It cannot hide a shipped skill: `skill.schema.json` pins `name` to `^[a-z][a-z0-9-]*$` and requires it to match the parent directory, so a leading underscore fails `validate_frontmatter`.

Threading a root through the linter was the alternative: ten module-level constants in a shipped gate, refactored to suit a test.

**`tests/_lib/skills-dir-guard.ts`** — catches the *next* writer, which will not have the courtesy of a `__` prefix. After every test file it compares `src/skills` against the git index and names the entry.

It does not claim to name the writer. With parallel workers the file it fails in is where the pollution was **observed**, so it separates `appeared during this file` from `already present at file start` and says which it saw.

## Verification

Sensitivity proven in both directions before this landed — not argued:

| State | Result |
|---|---|
| fixture on disk, predicate neutralised | **fails `300` vs `299`** — character for character the CI message |
| fixture on disk, predicate active | passes |
| `zz-real-looking-probe` (no `__` prefix) on disk | **guard fires**, names the path and the classification |
| injected dir created mid-test | guard fires with `appeared during this file` |

Full suite: `1371 passed | 2 failed`, and **zero** `src/skills gained` errors — before the fix, six files failed on that guard in one run.

The two remaining failures are pre-existing local artefacts, verified as not mine by re-running with the guard disabled:
- `check_rule_projection_integrity` — the known local `agents/.agent-tools.yml` partial-tool-set artefact the stub already documents
- `tool_probe` case 5 — a timing assertion; fails identically without this change, and passes in CI on `main`

## Not done, deliberately

`catalogue_size` in `agents/evidence/analysis/routing-body-signal-verdict.json` is untouched. The stub forbids editing it, and correctly: the published figure matched every count of the committed tree. What was wrong was the count CI took.
