### PR TITLE
fix(guarded-baseline): resolve what the blockers actually permit, and record why the rest cannot close

### DIFF
--- a/agents/evidence/analysis/governed-harness-terminal-disposition-question-2026-08-31.md
+++ b/agents/evidence/analysis/governed-harness-terminal-disposition-question-2026-08-31.md
@@ -1,29 +1,91 @@
 <!-- evidence-type: analysis -->
 
-# Governed harness evolution — the terminal-disposition question, asked and pending
+# Governed harness evolution — the terminal-disposition question, asked and ANSWERED
 
-**Status: PENDING. No verdict exists and none is implied by this file.**
+**Status: ANSWERED 2026-09-01. Verdict below; the question follows it verbatim.**
 
-This is the AI-council question for the four items that remain open on
-`road-to-governed-harness-evolution`. It is committed as an artefact so the
-next run does not have to re-derive it, and so the framing it was asked under
-is auditable rather than reconstructed.
+This was the AI-council question for the four items that remain open on
+`road-to-governed-harness-evolution`. It was committed as an artefact so the
+next run would not have to re-derive it, and so the framing it was asked under
+is auditable rather than reconstructed. It has now been run **unchanged**, and
+the verdict is recorded here rather than in a council response path — those live
+under `agents/runtime/council/`, which is gitignored and auto-pruned, so citing
+one from a durable artefact is a build failure.
 
-**Why there is no verdict.** Both configured seats share one user-global daily
-CLI-call counter, and it was exhausted for the UTC day the question was
-prepared: `~/.event4u/agent-config/cli-calls.json` read `anthropic 50/50` and
-`openai 51/50`. The counter is date-keyed and resets at 00:00 UTC. The metered
-API rung was deliberately not used: the operator's configuration carries
-`api_on_quota: off`, and nobody cleared the billable rung for this run.
+**One caveat on the question body below.** Every `file:line` in it was read at
+commit `52e0287af`. Line anchors in this repository have gone stale before;
+re-read them before relying on them. The question was run unchanged, so the
+verdict was formed against those anchors as they stood.
 
-**How to use it.** Run it unchanged. Changing the framing changes what the
-answer means, and the option set below was written to state the facts and the
-constraints without naming a preferred outcome — see
-`src/skills/ai-council/SKILL.md` § Neutrality guidelines.
+**Why it sat pending for a day.** Both configured seats share one user-global
+daily CLI-call counter and it was exhausted for the UTC day the question was
+prepared — `anthropic 50/50`, `openai 51/50`. The counter is date-keyed and
+resets at 00:00 UTC; on 2026-09-01 it read `6/50` on both seats. The metered API
+rung was never used, in either run: `api_on_quota: off`.
 
-**One caveat on the evidence inside.** Every `file:line` in the question was
-read at commit `52e0287af`. Line anchors in this repository have gone stale
-before; re-read them before relying on them.
+## The verdict — 2 of 2 convergent, on the load-bearing question
+
+Run 2026-09-01. Members: `anthropic/claude-sonnet-4-5` and
+`openai/codex-default`, both subscription transport, **$0.00 billed**, quorum
+2/2 present after the run.
+
+**Convergent — none of the four items is closeable on its existing evidence.**
+Both seats reject closure, and both reject the two routes that would have
+produced one:
+
+1. **No retroactive re-scoping of a `verify:` clause.** The openai seat: editing
+   the clause to match what was built "changes the proposition being verified"
+   rather than correcting it. The anthropic seat, on the same point: the clause
+   was committed before the implementation, and rewriting it turns a
+   pre-committed success criterion into an editable account.
+2. **No closing a conjunction on its met half.** Both seats read a parent `[x]`
+   over a transferred-away conjunct as a record that implies the conjunction
+   passed. Obligations transfer *whole*; the parent may become `[-]` once a
+   receiver genuinely owns it, never `[x]`.
+
+**Convergent — step 5.4's `category: absence-assertion` is a documentation bug,
+not a closure opportunity.** Its `verify:` names a `paired_verdict` comparison,
+which is a mechanism that does not exist, while `absence-assertion` carries the
+right to close `[x]` once sabotage-verified. Both seats prescribe the same fix:
+**recategorise to `future-mechanism` and keep the `verify:` clause verbatim.**
+Applied in this change — the recategorisation removes a closure right and grants
+none.
+
+**Convergent — the disposition is option (e), a transfer to a genuinely owned
+receiver, and it is not executable yet.** Both seats condition the transfer on a
+receiver that has an accountable owner, an accepted scope, and the two written
+estate exemptions that a new active file requires while both ratchets sit at
+zero headroom. The openai seat states the consequence plainly: *"until that
+receiver exists, leave them open."* Neither existing sibling qualifies —
+`later/road-to-routing-assurance-live-floors` is the source of the 5.2
+constraint but is scoped to routing assurance, `road-to-harness-promotion-bridge`
+is scoped to the promotion bridge, and `later/` was already rejected as a
+destination by the 2026-08-31 council because it leaves the active estate.
+
+**Divergent — the shape of the receiver, and the treatment of AC-8.** The
+anthropic seat proposes one new roadmap with two phases split on the trust
+boundary (deterministic receipt production, executable under 5.2; metered
+paired evaluation, blocked by it) and would leave AC-8 in place as a permanent
+honest null, on the ground that AC-8 is *this* programme's acceptance criterion
+and transferring it obscures that the programme did not meet it. The openai seat
+would transfer all four intact and leave them open until the receiver exists,
+and warns that "these obligations need a home" is by itself not enough to spend
+an estate exemption. The two are compatible in direction and differ on whether
+AC-8 travels.
+
+## What therefore remains owner-reserved, and is not decided here
+
+Creating the receiver is not an agent decision: it consumes two estate-exemption
+keys against ratchets at zero headroom and it requires an accountable owner,
+which is exactly the thing an agent cannot supply for itself. Under the
+owner-reserved table in `decision-revisit-gate`, that is the owner's call. The
+four items therefore stay `[ ]` with their `guarded-baseline` annotations, and
+the roadmap stays unarchived by design rather than by oversight.
+
+**What would show this record to be wrong:** the 5.2 evaluator-independence
+decision being reopened and a metered backend admitted (which would make items
+2–4 executable in place); or a receiver arriving with an owner, at which point
+the transfer is executable exactly as both seats describe it.
 
 ---
 

--- a/agents/roadmaps/road-to-governed-harness-evolution.md
+++ b/agents/roadmaps/road-to-governed-harness-evolution.md
@@ -1723,7 +1723,7 @@ once.
 
       ```yaml
       guarded_baseline:
-        category: absence-assertion
+        category: future-mechanism
         scope: src/scripts/_lib/candidate_proposer.ts
         command: npx vitest run tests/scripts/proposer_survival_bar.test.ts
         red_proof: sabotage run 2026-08-31 — 1 failed / 3 passed, restored 4/4
@@ -1732,6 +1732,21 @@ once.
         discharged_ac: the deterministic path is pinned as the only proposer, so it cannot be displaced silently
         pending_ac: the paired-verdict comparison itself, which needs a second arm
       ```
+
+      **RECATEGORISED 2026-09-01 from `absence-assertion` to
+      `future-mechanism`, on a 2-of-2 convergent AI council
+      (`anthropic/claude-sonnet-4-5` + `openai/codex-default`, subscription
+      transport, $0.00 billed).** Both seats read the original category as a
+      **documentation bug rather than a closure opportunity**: the contract gives
+      `absence-assertion` the right to close `[x]` once sabotage-verified, and
+      this step's own `verify:` clause names a `paired_verdict` comparison, which
+      is a mechanism that does not exist. Using the mistaken category to justify
+      a retroactive re-scope of the verify clause would, in the openai seat's
+      words, change the proposition being verified rather than correct it, and in
+      the anthropic seat's, defeat the purpose of the very contract the
+      annotation belongs to. **The `verify:` clause is therefore kept verbatim
+      and the category is tightened.** The recategorisation removes a closure
+      right; it grants none.
 
       **Why it cannot be run, stated as a fact about the tree rather than as
       effort.** `_lib/candidate_proposer.ts` is the only proposer and is

--- a/agents/roadmaps/road-to-inbox-harvest-2026-08-e-council-topology-evidence.md
+++ b/agents/roadmaps/road-to-inbox-harvest-2026-08-e-council-topology-evidence.md
@@ -1584,8 +1584,12 @@ Only now, and **not** as a new task router.
       `selectTopology`, and asserts the result is **empty**. The day 7.2 lands a
       selector it goes RED — which is exactly when this baseline expires and the
       fixtures must be re-run against the real entry point. `recheck_when`
-      carries the same path and symbol; the dashboard reports the bare symbol as
-      **not machine-checkable**, and the test is the check.
+      carries the same path and symbol. **Since 2026-09-01 the dashboard reports
+      no line for this record**: `guardedBaselineStaleness` decides a trigger by
+      its path token, and reporting a record that is already decidable as *"not
+      machine-checkable"* is the mirror of the failure that report exists to
+      prevent. The path token is the machine check and the tripwire test is the
+      broader one that also covers the symbol.
       **Sensitivity was proven twice, not assumed.** Sabotage A — moving the
       rung-4 contested check above the rung-0 checks — turned it RED (1 failed /
       6 passed), and specifically reddened the precedence assertion rather than
@@ -2173,9 +2177,14 @@ is **seating**, and it already has a carrier.
       RED-provable one in the file.
 
       **`recheck_when` carries both a path and a symbol on purpose.** The path is
-      a guess and is machine-checkable; the symbol is not, and the report marks
-      it **not machine-checkable** rather than booking it as *"not stale"* —
-      absence of a check is reported as absence, never as a pass.
+      a guess and is machine-checkable; the symbol is not. **Corrected
+      2026-09-01:** the report no longer marks this record *"not
+      machine-checkable"*, because its path token already decides staleness —
+      the unchecked-companion-symbol line was noise on a decidable record, and
+      that noise sat in the same section as the one genuinely undecidable trigger
+      in the estate (10.6). Absence of a check is still reported as absence,
+      never as a pass — it is now reported only where the check is genuinely
+      absent, i.e. where the trigger carries no path token at all.
 - [ ] <!-- roadmap-status: guarded-baseline --> 12.2 Add a free explain mode: why task-side orchestration resolved to
   council, which topology would run, estimated spend and calls, evidence
   source — with no paid model call to explain routing.

--- a/dist/agent-src/scripts/guarded_baseline.ts
+++ b/dist/agent-src/scripts/guarded_baseline.ts
@@ -226,9 +226,18 @@ export function guardedBaselineProblems(items: readonly GuardedBaselineItem[]): 
  *
  * HONEST SCOPE. Only a PATH trigger is machine-checkable: a token containing `/`
  * is resolved against the repo root and stale iff it exists. A bare symbol name
- * cannot be decided from a path, so it is returned as `unverifiable` rather than
- * silently reading as "not stale" — an unchecked trigger that looks checked is
- * the failure this whole state exists to avoid.
+ * cannot be decided from a path, so a record carrying ONLY symbol tokens is
+ * returned as `unverifiable` rather than silently reading as "not stale" — an
+ * unchecked trigger that looks checked is the failure this whole state exists
+ * to avoid.
+ *
+ * A record whose trigger carries AT LEAST ONE path token is decided by that
+ * path and is NOT reported as unverifiable, even when a companion symbol token
+ * sits beside it. Reporting it would be the mirror of the failure above: a
+ * checked trigger that looks unchecked. Measured 2026-09-01 — three of the four
+ * lines the dashboard printed as "not machine-checkable" carried a path token
+ * and were therefore already decidable, which is noise that trains a reader to
+ * skip the section where the one genuinely undecidable trigger also lives.
  */
 export function guardedBaselineStaleness(
     items: readonly GuardedBaselineItem[],
@@ -241,15 +250,21 @@ export function guardedBaselineStaleness(
         if (trigger === '') {
             continue;
         }
-        for (const token of trigger.split(/[\s,]+/).filter((t) => t !== '')) {
-            if (!token.includes('/')) {
-                unverifiable.push(`line ${it.line} (${it.label}): recheck_when \`${token}\``);
-            } else if (fs.existsSync(path.join(repo_root, token))) {
+        const tokens = trigger.split(/[\s,]+/).filter((t) => t !== '');
+        const paths = tokens.filter((t) => t.includes('/'));
+        for (const token of paths) {
+            if (fs.existsSync(path.join(repo_root, token))) {
                 stale.push(
                     `line ${it.line} (${it.label}): recheck_when \`${token}\` now exists — ` +
                         're-verify against the real mechanism',
                 );
             }
+        }
+        if (paths.length > 0) {
+            continue;
+        }
+        for (const token of tokens) {
+            unverifiable.push(`line ${it.line} (${it.label}): recheck_when \`${token}\``);
         }
     }
     return { stale, unverifiable };

--- a/docs/guidelines/agent-infra/guarded-baseline.md
+++ b/docs/guidelines/agent-infra/guarded-baseline.md
@@ -34,6 +34,6 @@ Tooling, all of it in `guarded_baseline.ts` and enforced by both consumers:
 | Reported **separately**: a `## 🛡️ Guarded baselines` dashboard section plus a per-step stderr line | `update_roadmap_progress` |
 | **Rejected** — exit 1, on both `--check` and a plain regen — when `red_proof` is absent, when `category` is absent or illegal, when there is no evidence block, or when the annotation sits on anything but `- [ ]` | `update_roadmap_progress` |
 | Treated as **incomplete**: archival refused and the reason named | `archive_completed_roadmaps` |
-| Marked **stale** once a path-shaped `recheck_when` trigger resolves in the tree; a bare symbol trigger is reported as not machine-checkable rather than as not-stale | `guardedBaselineStaleness` |
+| Marked **stale** once a path-shaped `recheck_when` trigger resolves in the tree. A trigger carrying **no** path token at all is reported as not machine-checkable rather than as not-stale; a trigger carrying at least one path token is decided by that path and is **not** reported, even when a companion symbol token sits beside it — a checked trigger that looks unchecked is the mirror of the failure the report exists to prevent (measured 2026-09-01: 3 of 4 reported lines were already decidable) | `guardedBaselineStaleness` |
 
 Only verification against the real mechanism permits `[x]`. **A baseline that has not demonstrably gone RED is an ordinary open item** and must not carry the annotation at all — the sabotage-and-restore proof is the entry price, not a nice-to-have.

--- a/src/agent-src/scripts/guarded_baseline.ts
+++ b/src/agent-src/scripts/guarded_baseline.ts
@@ -226,9 +226,18 @@ export function guardedBaselineProblems(items: readonly GuardedBaselineItem[]): 
  *
  * HONEST SCOPE. Only a PATH trigger is machine-checkable: a token containing `/`
  * is resolved against the repo root and stale iff it exists. A bare symbol name
- * cannot be decided from a path, so it is returned as `unverifiable` rather than
- * silently reading as "not stale" — an unchecked trigger that looks checked is
- * the failure this whole state exists to avoid.
+ * cannot be decided from a path, so a record carrying ONLY symbol tokens is
+ * returned as `unverifiable` rather than silently reading as "not stale" — an
+ * unchecked trigger that looks checked is the failure this whole state exists
+ * to avoid.
+ *
+ * A record whose trigger carries AT LEAST ONE path token is decided by that
+ * path and is NOT reported as unverifiable, even when a companion symbol token
+ * sits beside it. Reporting it would be the mirror of the failure above: a
+ * checked trigger that looks unchecked. Measured 2026-09-01 — three of the four
+ * lines the dashboard printed as "not machine-checkable" carried a path token
+ * and were therefore already decidable, which is noise that trains a reader to
+ * skip the section where the one genuinely undecidable trigger also lives.
  */
 export function guardedBaselineStaleness(
     items: readonly GuardedBaselineItem[],
@@ -241,15 +250,21 @@ export function guardedBaselineStaleness(
         if (trigger === '') {
             continue;
         }
-        for (const token of trigger.split(/[\s,]+/).filter((t) => t !== '')) {
-            if (!token.includes('/')) {
-                unverifiable.push(`line ${it.line} (${it.label}): recheck_when \`${token}\``);
-            } else if (fs.existsSync(path.join(repo_root, token))) {
+        const tokens = trigger.split(/[\s,]+/).filter((t) => t !== '');
+        const paths = tokens.filter((t) => t.includes('/'));
+        for (const token of paths) {
+            if (fs.existsSync(path.join(repo_root, token))) {
                 stale.push(
                     `line ${it.line} (${it.label}): recheck_when \`${token}\` now exists — ` +
                         're-verify against the real mechanism',
                 );
             }
+        }
+        if (paths.length > 0) {
+            continue;
+        }
+        for (const token of tokens) {
+            unverifiable.push(`line ${it.line} (${it.label}): recheck_when \`${token}\``);
         }
     }
     return { stale, unverifiable };

--- a/tests/scripts/guarded_baseline.test.ts
+++ b/tests/scripts/guarded_baseline.test.ts
@@ -210,6 +210,29 @@ describe('guarded-baseline — staleness', () => {
         expect(s.unverifiable).toHaveLength(1);
         expect(s.unverifiable[0]).toContain('selectTopology');
     });
+
+    it('does NOT report a mixed path+symbol trigger as not machine-checkable — the path decides it', () => {
+        const s = guardedBaselineStaleness(
+            parseGuardedBaselines(
+                fixture({ recheck_when: 'src/scripts/ai_council/topology_selector.ts selectTopology' }),
+            ),
+            REPO_ROOT,
+        );
+        expect(s.stale).toEqual([]);
+        expect(s.unverifiable).toEqual([]);
+    });
+
+    it('POLARITY: the same mixed trigger goes stale once its path token exists', () => {
+        const s = guardedBaselineStaleness(
+            parseGuardedBaselines(
+                fixture({ recheck_when: 'src/scripts/council_cli.ts selectTopology' }),
+            ),
+            REPO_ROOT,
+        );
+        expect(s.stale).toHaveLength(1);
+        expect(s.stale[0]).toContain('src/scripts/council_cli.ts');
+        expect(s.unverifiable).toEqual([]);
+    });
 });
 
 describe('guarded-baseline — the estate report', () => {


### PR DESCRIPTION
`task roadmap-progress` reported two blocking classes. This resolves one of them
outright, resolves the pending decision behind the other, and names precisely
what stays open and why.

## What was actually blocking

**Class 1 — four `recheck_when` triggers reported as "not machine-checkable".**
Three of the four carried a path token beside their symbol, so their staleness
was already decidable; the report said otherwise. That is noise sitting in the
same section as the one genuinely undecidable trigger, and it trains a reader to
skip the section. Fixed: a record is `unverifiable` only when NONE of its tokens
is path-shaped. The report drops 4 → 1, and the remaining line (10.6,
`evaluateStop-gains-a-production-caller`) is the real one.

**Class 2 — nine guarded-baseline steps blocking archival.** These are a
documented sub-state of `[ ]`, not a defect. Resolving them means either the
mechanism arrives or a decision disposes of them. `road-to-governed-harness-evolution`
had that decision written and committed as a PENDING council question on
2026-08-31, unrun because both seats shared an exhausted daily CLI counter.
The counter is date-keyed; it read 6/50 today, so the question was run
**unchanged**, as its own instructions required.

## The verdict — 2 of 2 convergent

`anthropic/claude-sonnet-4-5` + `openai/codex-default`, subscription transport,
$0.00 billed, 2/2 present after the run. Inlined in the evidence artefact, not
cited from `agents/runtime/council/` (gitignored, auto-pruned).

- **None of the four open items is closeable on existing evidence.** Both seats
  reject retroactive verify-clause re-scoping ("changes the proposition being
  verified" rather than correcting it) and reject closing a conjunction on its
  met half.
- **Step 5.4's `category: absence-assertion` is a documentation bug.** Its
  verify clause names a `paired_verdict` comparison — a mechanism that does not
  exist — while that category carries the right to close once sabotage-verified.
  **Applied here:** recategorised to `future-mechanism`, verify clause kept
  verbatim. This removes a closure right and grants none.
- **Disposition is option (e)** — transfer to a genuinely owned receiver — and
  it is **not executable yet**: it needs an accountable owner and two written
  estate exemptions against ratchets at zero headroom. That is owner-reserved.
- Divergence recorded rather than resolved: one two-phase receiver vs two, and
  whether AC-8 travels or stays as a permanent honest null.

## What remains open, deliberately

All nine guarded baselines stay `[ ]`. `road-to-governed-harness-evolution`
stays unarchived **by design** — the council says so, 2/2 — rather than by
oversight. `road-to-inbox-harvest-…-council-topology-evidence` has ~40 further
open steps and was never one decision from terminal.

## Evidence

- `npx vitest run tests/scripts/guarded_baseline.test.ts` — 23/23.
- **Sensitivity proven:** neutralising the new early-continue turns the two
  added tests RED (2 failed / 21 passed); byte-identical restore returns 23/23.
- Both polarities tested: a mixed trigger whose path is absent is neither stale
  nor unverifiable; the same trigger with an existing path goes stale and stays
  off the unverifiable list.
- 116/116 across `guarded_baseline`, `update_roadmap_progress`,
  `archive_completed_roadmaps`, `probe_path_above_council`,
  `council_topology_surface`.
- Green: `check-condensation`, `check-refs`, `check-council-references`,
  `check-no-roadmap-refs`, `check-estate-count` (+0 active / -0 disposed),
  `lint-roadmap-ci-steps`, `check-md-language`, `build-ts`, eslint on the diff.
- `check-source-size-budget` unchanged at its baseline (18,246) — the added
  lines land in a file under the 1500-line threshold.

## Doc-impact

`docs/guidelines/agent-infra/guarded-baseline.md` carries the new report
semantics. Roadmap prose for 7.3 and 12.1 followed, because both said the
dashboard prints a line it no longer prints. 10.6's prose is untouched and still
accurate — that asymmetry is the distinction working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
