### PR TITLE
roadmap: transfer the four governed-harness obligations to an owned receiver, and archive the source

### DIFF
--- a/agents/evidence/analysis/governed-harness-terminal-disposition-question-2026-08-31.md
+++ b/agents/evidence/analysis/governed-harness-terminal-disposition-question-2026-08-31.md
@@ -2,7 +2,30 @@
 
 # Governed harness evolution — the terminal-disposition question, asked and ANSWERED
 
-**Status: ANSWERED 2026-09-01. Verdict below; the question follows it verbatim.**
+**Status: ANSWERED AND EXECUTED 2026-09-01. Verdict below; the question
+follows it verbatim.**
+
+**What happened after the verdict, recorded here because the question body
+below still describes the pre-transfer world and would otherwise read as
+current.** The owner accepted the convergent disposition — option (e), a
+transfer to an owned receiver — and authorised its estate cost on the same
+day. All four obligations moved whole and unweakened to
+`agents/roadmaps/road-to-governed-evidence-production.md`, with every
+`verify:` clause carried verbatim and every source item marked `[-]`
+TRANSFERRED rather than `[x]`. `road-to-governed-harness-evolution` thereby
+reached 0 open, 0 deferred and 0 guarded baselines, and is now at
+`agents/roadmaps/archive/road-to-governed-harness-evolution.md`. Every path
+the question body names for that roadmap is therefore an ARCHIVE path now.
+
+**Where the executed transfer departed from the seats, in the two places it
+did.** The cheapest-first ordering obligation sits in the receiver's metered
+phase rather than its deterministic one — the anthropic seat's illustrative
+list said otherwise, but the criterion both seats named puts it there, since
+`assertCheapestFirst` polices the order of metered tier attempts. And AC-8
+travelled rather than staying as a permanent honest null: the seats diverged,
+and the source file's own definition of `[-]` (TRANSFERRED, never met and
+never dropped) plus AC-9's existing disposition settle it without the agent
+choosing a side.
 
 This was the AI-council question for the four items that remain open on
 `road-to-governed-harness-evolution`. It was committed as an artefact so the

--- a/agents/evidence/reviews/governed-evidence-receiver.findings.md
+++ b/agents/evidence/reviews/governed-evidence-receiver.findings.md
@@ -1,0 +1,5 @@
+<!-- evidence-type: review -->
+
+# Completion review — governed evidence receiver
+
+**Skipped:** no code surface for this completion — the diff is a roadmap transfer, an archive move and two prose records; no .ts, no test and no config changed, scope 7a88346cb1e308ec911c27603f8c844ae847c36ce56311508ad24d4090d70341, declared 2026-09-01

--- a/agents/roadmaps/archive/road-to-consolidation-lineage-integrity.md
+++ b/agents/roadmaps/archive/road-to-consolidation-lineage-integrity.md
@@ -254,7 +254,7 @@ about it, and it moved while these very corrections were being written.
 
       **Met**, and both halves are exercised on real data rather than only on
       fixtures. `missing-parent` fired on
-      `agents/roadmaps/road-to-governed-harness-evolution.md` during development
+      `agents/roadmaps/archive/road-to-governed-harness-evolution.md` during development
       — a declared parent that exists nowhere in the repository, which is 2.2's
       stated shape; `omitted-sibling` reproduces the four census rows. Both are
       pinned by tests, and the estate surface keeps `missing-parent` while

--- a/agents/roadmaps/archive/road-to-governed-harness-evolution.md
+++ b/agents/roadmaps/archive/road-to-governed-harness-evolution.md
@@ -1031,8 +1031,16 @@ once.
 > outcome per case, expected-vs-observed is recorded against stable case ids at
 > that point — not before, and not as an empty file that looks like a carrier.
 
-- [ ] <!-- roadmap-status: guarded-baseline -->
-      **4.1 Cascade cheap to expensive, abort on the first hard failure.** The
+- [-] **4.1 Cascade cheap to expensive, abort on the first hard failure.** The
+      **TRANSFERRED 2026-09-01 to `road-to-governed-evidence-production`**, on the
+      terminal-disposition AI council of the same day, 2 of 2 convergent. `[-]`
+      means TRANSFERRED — never met and never dropped. The obligation moved
+      verbatim and unweakened, including the `verify:` clause, and the discharged
+      half below is reproduced there as already-proven context rather than being
+      re-credited. The `guarded-baseline` annotation is removed with the move: it
+      is a state about an OPEN step's evidence, and this step is no longer open
+      here. Its evidence block is kept below as the historical record of what was
+      proven, and when.
       **GUARDED BASELINE 2026-08-31 — the deterministic prefix is built, wired
       and RED-proven; the box stays `[ ]` because the twelve-stage form is not.**
 
@@ -1715,8 +1723,16 @@ once.
       **The judge stays optional**, as the step says: `buildSplitPipeline`
       (`:330`) returns `judge: null` when none is configured, and the three role
       prompts are produced regardless.
-- [ ] <!-- roadmap-status: guarded-baseline -->
-      **5.4 An LLM proposer must beat the deterministic one to survive.** On at
+- [-] **5.4 An LLM proposer must beat the deterministic one to survive.** On at
+      **TRANSFERRED 2026-09-01 to `road-to-governed-evidence-production`**, on the
+      terminal-disposition AI council of the same day, 2 of 2 convergent. `[-]`
+      means TRANSFERRED — never met and never dropped. The obligation moved
+      verbatim and unweakened, including the `verify:` clause, and the discharged
+      half below is reproduced there as already-proven context rather than being
+      re-credited. The `guarded-baseline` annotation is removed with the move: it
+      is a state about an OPEN step's evidence, and this step is no longer open
+      here. Its evidence block is kept below as the historical record of what was
+      proven, and when.
       **GUARDED BASELINE 2026-08-31 — the comparison cannot be run because there
       is no second arm, and the fallback clause is now ENFORCED instead of
       merely written.**
@@ -1823,7 +1839,16 @@ once.
       is a STATED default at the conservative end of `lint_originality`'s range,
       not a measured optimum; `revisit-if` a screening run rejects a proposal a
       curator then re-adds by hand, or admits one a human calls a duplicate.
-- [ ] <!-- roadmap-status: guarded-baseline --> **5.6 Cheap proposer models first, and track evolution ROI.**
+- [-] **5.6 Cheap proposer models first, and track evolution ROI.**
+      **TRANSFERRED 2026-09-01 to `road-to-governed-evidence-production`**, on the
+      terminal-disposition AI council of the same day, 2 of 2 convergent. `[-]`
+      means TRANSFERRED — never met and never dropped. The obligation moved
+      verbatim and unweakened, including the `verify:` clause, and the discharged
+      half below is reproduced there as already-proven context rather than being
+      re-credited. The `guarded-baseline` annotation is removed with the move: it
+      is a state about an OPEN step's evidence, and this step is no longer open
+      here. Its evidence block is kept below as the historical record of what was
+      proven, and when.
       `from-skipped-parent`, and this one is self-undercutting in the master:
       its own cross-critique faults both parents as cost-blind and answers with
       a hard budget cap, while dropping the only cost-*reduction* mechanism both
@@ -2762,7 +2787,20 @@ once.
       archived roadmap, and a cost model is not the three-arm experiment 6.1
       names. The "before any new retrieval component exists" half is satisfied
       only vacuously, since 6.3 has not started. What closes it is 6.1.
-- [ ] AC-8 — Programme success and failure criteria from 0.7 were committed
+- [-] AC-8 — Programme success and failure criteria from 0.7 were committed
+      **TRANSFERRED 2026-09-01 to `road-to-governed-evidence-production` as AC-4**,
+      on the terminal-disposition AI council of the same day. The two seats
+      DIVERGED on this one item — the anthropic seat would have kept it here as a
+      permanent honest null, on the ground that AC-8 is *this* programme's
+      acceptance criterion and transferring it obscures that the programme did not
+      meet it. **The tree settles the divergence rather than the agent.** `[-]` is
+      defined in this very file as TRANSFERRED, never met and never dropped, and
+      AC-9 directly below already carries that disposition for the same reason. So
+      `[-]` records non-satisfaction rather than obscuring it, which is exactly
+      the property the anthropic objection asked for. This criterion's own closing
+      sentence, written 2026-08-31 and unedited, already named the receiver class:
+      *"a first candidate run under a metered backend, which belongs to whichever
+      roadmap lifts the live-harness park — not to this one."*
       before the first candidate run, and the run report carries an
       evolution-ROI figure.
       **RE-AUDITED 2026-08-31 after 5.6 landed: still OPEN, and the reason

--- a/agents/roadmaps/road-to-governed-evidence-production.md
+++ b/agents/roadmaps/road-to-governed-evidence-production.md
@@ -1,0 +1,191 @@
+---
+complexity: structural
+status: ready
+execution:
+  mode: phase-checkpoints
+estate_growth_exempt: "Grows open_blockers 29 -> 30 and nothing else. Measured with check_estate_count on this change, not predicted: active_roadmaps 3 (floor 3, +0), later_roadmaps 75 (floor 75, +0), skill_count 299 (+0), skill_description_tokens 11455 (+0), concern_count 55 (+0). The active count is at its floor because this change archives road-to-governed-harness-evolution in the same commit — one in, one out, so no offset is claimed and none is needed. The single new blocker is metered-backend-park, and it is a blocker that ALREADY EXISTED as an unnamed constraint: the 5.2 evaluator-independence park of the archived roadmap held four obligations without ever appearing in the blocker count, so the +1 makes a standing constraint countable rather than adding a new one. The alternative is to write Phase 2 with no blocker, which would leave two steps looking workable while a recorded council decision forbids them - a silent block instead of a counted one."
+---
+# Road to governed evidence production
+
+> **Source:** the terminal-disposition AI council of 2026-09-01, 2 of 2
+> convergent (`anthropic/claude-sonnet-4-5` + `openai/codex-default`,
+> subscription transport, nothing billed), recorded in full at
+> `agents/evidence/analysis/governed-harness-terminal-disposition-question-2026-08-31.md`.
+> That council was asked what to do with the four items that remained open on
+> `road-to-governed-harness-evolution`, and it answered: none is closeable on
+> existing evidence, no `verify:` clause may be retroactively re-scoped, no
+> conjunction may close on its met half, and the disposition is a transfer to a
+> receiver with an accountable owner. **This file is that receiver.** The owner
+> accepted it and authorised the estate cost on 2026-09-01.
+
+## Goal
+
+The four evidence obligations the governed-harness programme could not
+discharge are owned here, whole and unweakened, and each is either met against
+the real mechanism or still visibly open — never closed on the half that was
+already true. When this is finished, an activation receipt is produced by an
+independent producer rather than inferred from a deterministic proxy, and a
+proposer that costs money has been compared against the deterministic one in a
+paired run rather than in an argument.
+
+## Why the phases split where they do
+
+Both seats named the same criterion, and it is a **trust boundary rather than a
+convenience**: the 5.2 evaluator-independence park of the source roadmap forbids
+a live model harness, so work that needs no metered call is executable now and
+work that needs one is not. Phase 1 is the executable half. Phase 2 is blocked
+by the `metered-backend-park` blocker below and stays open until an owner lifts
+it.
+
+**One deliberate deviation from the anthropic seat's illustrative list, named
+rather than absorbed.** That seat placed the ordering-guard obligation (item 3's
+pending conjunct) in the deterministic phase. By the criterion both seats
+actually named, it belongs in Phase 2: `assertCheapestFirst` polices the order
+in which *metered* proposer tiers are attempted, so a production caller for it
+cannot exist while no metered call does. The criterion is followed here in
+preference to the illustration, and the reader can see which was chosen.
+
+## Phase 1 — Deterministic evidence, executable under the park
+
+- [ ] **1.1 Produce activation receipts from an independent, append-only
+      producer, so the evaluation cascade's receipt-bearing stages have a
+      subject.**
+      Transferred whole from `road-to-governed-harness-evolution` step 4.1 —
+      *"Cascade cheap to expensive, abort on the first hard failure."*
+      verify: a candidate failing the cheapest stage consumes no model call, and
+      the stage list can produce the Phase 1 classification.
+      **Already discharged at transfer, reproduced so nothing is re-derived and
+      nothing is re-credited.** `src/scripts/_lib/evaluation_cascade.ts` is a
+      six-stage deterministic prefix (`schema-validity → path-ownership →
+      holdout-disclosure → budget → near-duplicate → metric-verdict`) that
+      aborts on the first hard failure; `model_calls` is the literal type `0` on
+      every path, so the first conjunct follows from the type rather than from a
+      counter. It is wired into the real runner (`evolution_lab.ts` `verbRun`)
+      and was RED-proven on 2026-08-31 by letting the prefix assign
+      `activation`, then by unwiring the cascade from the runner.
+      **What is still open is the second conjunct.** The Phase 1 classification
+      is the four-value `content | activation | adherence | unknown`, and the
+      prefix may assign only `content` and `unknown` — `activation` and
+      `adherence` are excluded by construction, because assigning either from a
+      deterministic proxy manufactures evidence. The receipt SCHEMA exists and
+      the CLASSIFIER exists; the PRODUCER does not, and nothing writes an
+      `activation` object into an audit line.
+      **Why this is Phase 1 and not Phase 2:** producing a receipt requires
+      observing real activation, which the park does not forbid. It forbids a
+      live model harness.
+
+- [ ] **1.2 Settle the twelve-stage enumeration before treating the stage
+      semantics as decided.**
+      Carried from the same step's unconverged half. An AI council round of
+      2026-08-31 returned `REVISE`, degraded at 1 of 2 seats: keep the decided
+      twelve-stage arity, but do not treat the stage semantics as settled until
+      the receipt trust boundary and the evidence-cost contract are explicit.
+      Running the same seat twice produced two materially different twelve-stage
+      enumerations, which is why the enumeration is recorded as unconverged
+      rather than as decided.
+      verify: one enumeration is committed, and a second independent pass
+      reproduces it rather than proposing a different twelve.
+
+- [ ] **1.3 State the receipt trust boundary and the evidence-cost contract
+      before the producer writes its first receipt.**
+      The 2026-08-31 `REVISE` names these two as the precondition for 1.2, and
+      1.1 cannot be reviewed without them: a receipt producer that is not
+      independent of the thing it observes reproduces the proxy problem one
+      layer up.
+      verify: both are written down as falsifiable claims, and 1.1's producer
+      design cites them rather than restating them.
+
+## Phase 2 — Experimental evidence, blocked on the metered-backend park
+
+Every step here is held by `metered-backend-park`. None of them may be worked
+before that blocker is resolved, and none of them may be closed by substituting
+a fixture for a run.
+
+- [ ] **2.1 An LLM proposer must beat the deterministic one to survive.**
+      Transferred whole from `road-to-governed-harness-evolution` step 5.4.
+      verify: the comparison is a paired_verdict run, not an argument.
+      **Already discharged at transfer:** the step's written fallback —
+      *"Otherwise the deterministic path stays"* — is mechanically enforced.
+      `tests/scripts/proposer_survival_bar.test.ts` asserts no transport import,
+      no subprocess spawn, no API host and no key env var across the proposer
+      and its dependency, so an LLM proposer cannot silently become the default.
+      RED-proven 2026-08-31 by adding a `fetch` to an API host inside the
+      proposer module; byte-identical restore returned green.
+      **What is still open is the comparison itself.** A paired verdict needs
+      two arms and `src/scripts/_lib/llm_candidate_proposer.ts` does not exist;
+      `src/scripts/_lib/candidate_proposer.ts` is the only proposer in the tree
+      and is deterministic by construction.
+      **The verify clause is carried verbatim and was NOT re-scoped.** Both
+      seats rejected re-scoping it to match the absence guard: that changes the
+      proposition being verified rather than correcting it. The source step's
+      `category` was corrected to `future-mechanism` in the same movement, which
+      removed a closure right and granted none.
+
+- [ ] **2.2 Cheap proposer models first, and track evolution ROI.**
+      Transferred whole from `road-to-governed-harness-evolution` step 5.6.
+      verify: the ROI figure appears in every run report, and a cheaper model is
+      tried before an expensive one on each defect class.
+      **Already discharged at transfer, with a production caller:**
+      `buildRunReport` (`src/scripts/_lib/evolution_roi.ts:363`) refuses a
+      report whose evolution-ROI figure is absent or carries an unknown kind,
+      and `evolution_lab.ts:865` calls it on the one path a run completes on.
+      Both halves RED-proven, 28/28 green.
+      **What is still open is the ordering conjunct.** The guard
+      `assertCheapestFirst` (`evolution_roi.ts:191`) exists and is exercised in
+      both polarities, and it has **zero production callers** — it polices a
+      population of zero, because nothing in the tree makes a metered proposer
+      call. A check that scans a population of zero exits green while looking
+      like coverage, which is why this is open rather than closed.
+
+## Blockers
+
+### blocker: metered-backend-park
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** Phase 2 (2.1, 2.2) and AC-2
+- **What to do:** pick exactly one — (a) resolve the 5.2 evaluator-independence
+  decision of 2026-08-25 so a metered backend is admitted for candidate
+  evaluation under stated independence conditions, and record the amendment; or
+  (b) leave the park standing and leave Phase 2 open, which keeps AC-2
+  unsatisfiable and is a legitimate terminal state for this file; or (c) narrow
+  the park to permit a metered *proposer* while still forbidding a metered
+  *evaluator*, if the independence objection turns out to bind only the
+  evaluating side.
+- **Recommendation:** (b) until someone needs Phase 2's answer. The park does
+  not rest on cost — token spend was explicitly pre-authorised when it was
+  decided — it rests on evaluator independence, and nothing has changed about
+  that argument. Reopening it to unblock a roadmap would be the
+  benefit-blocked-by-a-lock case reversed: the lock is the finding.
+- **If you do nothing:** Phase 2 stays open indefinitely and AC-2 is never met.
+  The obligations remain visible and owned rather than dropped, which is the
+  outcome the transfer was for; nothing silently reads as satisfied.
+- **Resolved when:** the 5.2 decision carries a recorded amendment naming which
+  metered calls are admitted and under what independence conditions, or this
+  blocker is closed with (b) as the recorded disposition.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-09-01 | reviewer: claude/host -->
+
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | A receipt producer that observes the thing it reports on | implementation | 1.1's producer is written against the same module that classifies the failure, so the receipt inherits the proxy problem the cascade's `PREFIX_ASSIGNABLE_FAMILIES` exclusion exists to prevent — one layer up, where it is harder to see | 1.3 requires the trust boundary to be written as a falsifiable claim BEFORE the producer is designed, and 1.1 must cite it rather than restate it | Phase 1 — Deterministic evidence, executable under the park |
+| 2 | Phase 2 closes on a fixture instead of a run | product | A paired-verdict harness is built, exercised over recorded fixtures, and 2.1 is closed on it — the substitution the source roadmap caught twice, arriving here with the obligation | The Phase 2 preamble forbids closing on a fixture, and 2.1's verify clause is carried verbatim so the word `run` cannot quietly become `case` | Phase 2 — Experimental evidence, blocked on the metered-backend park |
+| 3 | This file becomes a parking lot | product | Four obligations arrive, nothing is worked, and the file's existence reads as the problem being handled — the artificial-owner failure both seats warned about | Phase 1 is executable on the day of transfer with no blocker above it, so a file with zero movement is a visible fact rather than an excusable one | Phase 1 — Deterministic evidence, executable under the park |
+| 4 | The transferred evidence is re-credited | implementation | A later reader takes the discharged-at-transfer paragraphs as this roadmap's own work and counts the same sabotage proof twice | Every discharged half names the source step and the date it was proven, and no transferred step carries a `guarded-baseline` annotation of its own — the guards belong to the source file's record | Phase 2 — Experimental evidence, blocked on the metered-backend park |
+
+## Acceptance Criteria
+
+- [ ] AC-1 — An activation receipt exists that was written by a producer
+      independent of the classifier, and the evaluation cascade's stage list can
+      assign all four Phase 1 families rather than two.
+- [ ] AC-2 — A paired-verdict comparison between a metered proposer and the
+      deterministic one has been run, and its result — in either direction —
+      is recorded. Held by `metered-backend-park`.
+- [ ] AC-3 — `assertCheapestFirst` has at least one production caller, so the
+      ordering it polices governs a real population rather than an empty one.
+- [ ] AC-4 — Programme success and failure criteria were committed before the
+      first candidate run, and the run report carries an evolution-ROI figure.
+      Transferred whole from `road-to-governed-harness-evolution` AC-8. Its
+      shape half is met — `buildRunReport` refuses a report without the figure —
+      and its subject half needs the run, which needs the park lifted. `[-]` on
+      the source means TRANSFERRED, never met and never dropped.


### PR DESCRIPTION
Executes the disposition the 2026-09-01 terminal-disposition council resolved
(2/2 convergent) and PR #1786 recorded. The owner accepted the receiver and
authorised its estate cost.

## What moved

New: `agents/roadmaps/road-to-governed-evidence-production.md` — two phases split
on the trust boundary both seats named, not on convenience. Phase 1 needs no
metered call and is executable under the 5.2 evaluator-independence park today.
Phase 2 needs one and is held by a new `metered-backend-park` blocker.

| Source | Receiver | Obligation |
|---|---|---|
| 4.1 | 1.1 | activation-receipt producer (`verify` carried verbatim) |
| 5.4 | 2.1 | paired-verdict proposer comparison |
| 5.6 | 2.2 | cheapest-first ordering |
| AC-8 | AC-4 | criteria committed before the first candidate run |

Every source item is `[-]` **TRANSFERRED**, never `[x]`: both seats read a
parent `[x]` over a transferred conjunct as a record implying the conjunction
passed. Each `guarded-baseline` annotation is removed with its move — that state
is defined on an OPEN step — and each evidence block stays below it as the
historical record of what was proven and when. The discharged halves are
reproduced in the receiver as already-proven context, each naming its source
step and proof date so the same sabotage run cannot be counted twice.

## Two deviations, named rather than absorbed

**The ordering obligation sits in Phase 2, not Phase 1.** The anthropic seat's
illustrative list put it in the deterministic phase; by the criterion *both*
seats named it belongs in the metered one, because `assertCheapestFirst` polices
the order in which metered proposer tiers are attempted, so a production caller
cannot exist while no metered call does. The criterion wins over the
illustration, and the roadmap says which was chosen.

**AC-8 travels rather than staying as a permanent honest null.** The seats
diverged here. The tree settles it rather than the agent: `[-]` is defined in
that very file as TRANSFERRED — never met and never dropped — AC-9 directly
below already carries that disposition, and AC-8's own closing sentence from
2026-08-31 already named the receiver class (*"belongs to whichever roadmap lifts
the live-harness park — not to this one"*). So `[-]` records non-satisfaction
rather than obscuring it, which is exactly what the anthropic objection asked
for.

## Archival, and why it is one commit

`road-to-governed-harness-evolution` reaches **0 open, 0 deferred, 0 guarded
baselines** and is archived in the same commit. The dashboard pre-commit gate
requires that atomicity — the flips cannot be split from the `git mv`.

## Estate, measured rather than predicted

- `active_roadmaps` **3 (floor 3, +0)** — one in, one out, so no offset is
  claimed and none is needed.
- `open_blockers` **29 → 30 (+1)** — claimed in the new file's frontmatter with
  the gate's own readings. That blocker makes a constraint countable that
  already held four obligations invisibly; the alternative is a Phase 2 whose
  steps look workable while a recorded council decision forbids them.
- `later_roadmaps` 75 (+0), `skill_count` 299 (+0),
  `skill_description_tokens` 11455 (+0), `concern_count` 55 (+0).
- Gate verdict: `+1 active / -1 disposed`, growth authorised, estate within its
  ratchet.

## Evidence

Green: all seven roadmap gates (`lint_plan_risk_register`,
`lint_roadmap_blockers` incl. decidability, `check_roadmap_trackable`,
`lint_roadmap_ci_steps`, `lint_empty_roadmaps`, `lint_roadmap_family_cap`,
`lint_roadmap_complexity`), `check-estate-count`, `check-archive-index` (INDEX.md
and index.json both fresh), `check-refs`, `check-no-roadmap-refs`,
`check-gate-coverage`, `check-condensation`, `lint-evidence-artifacts`,
`check-completion-review`.

The dashboard now reports 3 roadmaps and one remaining "not machine-checkable"
line — 10.6, the only genuinely undecidable trigger in the estate.

## Doc-impact

The terminal-disposition evidence artefact described the pre-transfer world and
would have read as current. It now records that the disposition was executed,
that every path it names for that roadmap is an archive path, and both
deviations above. Completion review is skipped by declaration: 0 code paths of 5
changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
