### PR TITLE
roadmap(harness-bridge): make a merge-authority refusal recordable, and record drain-13's dispositions

### DIFF
--- a/agents/evidence/reviews/drain13-neutral-review.md
+++ b/agents/evidence/reviews/drain13-neutral-review.md
@@ -1,0 +1,120 @@
+<!-- evidence-type: review -->
+
+# Drain run 13 — neutral review of PR #1789 and PR #1790
+
+**Why the prompt is here.** `evaluator-independence` admits a self-commissioned
+review as gate evidence **only when the prompt is recorded alongside the
+verdict** — otherwise nobody can check what was asked. The orchestrator that
+authored the change also authored this prompt, so the prompt is the evidence.
+
+**Date:** 2026-09-01 · **Reviewer:** an agent that wrote none of the reviewed
+code · **Scope:** the complete `git diff origin/main...HEAD` of both branches, no
+path excluded — 5 files / 274 insertions on `drain/harness-promotion-bridge-close`,
+6 files / 886 insertions on `drain/council-topology-followups`.
+
+## The prompt, verbatim as dispatched
+
+> Review two branches in the `event4u/agent-config` repository and report
+> findings. You did not write any of this code and you are not the author of this
+> prompt's subject matter.
+>
+> **Scope — the whole delta of both branches, nothing excluded**
+>
+> - `…/ac-drain-A`, branch `drain/harness-promotion-bridge-close` (PR #1789).
+>   Delta: `git diff origin/main...HEAD` — 5 files, 274 insertions.
+> - `…/ac-dr-topo`, branch `drain/council-topology-followups` (PR #1790).
+>   Delta: `git diff origin/main...HEAD` — 6 files, 886 insertions.
+>
+> Prefix every Bash call with `cd` to the relevant worktree. Read-only: do not
+> edit, commit, or push anything in either worktree.
+>
+> **What to look for.** Report defects, in roughly this priority order. For each,
+> cite `file:line` at the current commit.
+>
+> 1. **Correctness of the security-relevant change.**
+>    `src/scripts/_lib/promotion_capability.ts` gates the only path to promoting
+>    an artefact into the canonical source tree. It was changed so that a closed
+>    `blocker: merge-authority` mints the capability only when the blocker body
+>    also carries `- **Disposition:** granted`; `refused` and an absent
+>    disposition both refuse. Check specifically: can any input reach a minted
+>    capability that could not before? Is the closedness read still identical to
+>    `src/scripts/lint_roadmap_blockers.ts:48`? Are the regexes anchored as the
+>    code claims? Is there a body a human would reasonably write that reads as
+>    granted by accident — for example prose, a quoted example, a nested list, or
+>    a `Disposition` line inside a different blocker's section? `blockerSection`
+>    bounds the search; verify it actually does.
+> 2. **Test sensitivity.** The branches claim RED proofs. Pick at least two
+>    claimed guards and check whether the test would actually fail if the
+>    mechanism were neutralised — reason from the code, and where cheap, run the
+>    test. A test that passes for a reason other than the one claimed is a
+>    finding.
+> 3. **Claims against evidence.** Both PRs make many `file:line` claims in
+>    roadmap prose and PR bodies. Spot-check at least eight, spread across both
+>    branches, and report any that do not resolve or do not say what the citing
+>    text says they say. Include at least two from the long AC-9 and blocker
+>    prose in `agents/roadmaps/road-to-harness-promotion-bridge.md`.
+> 4. **Whether anything was closed that should not have been.** Check that no
+>    checkbox, acceptance criterion, or blocker status moved in a direction the
+>    evidence does not support, on either branch. In particular: is anything
+>    marked done, resolved, or descoped whose stated criterion is not actually
+>    met?
+> 5. **Anything else that would bite a reader or a future maintainer** —
+>    internal contradictions, a note that says the opposite of an adjacent note,
+>    a fix that removes one instance of a defect while leaving siblings, dead
+>    references, or a claim of generality the code does not have.
+>
+> **How to report.** Findings only — no summary of what the branches do, and no
+> assessment of whether they are good. For each finding: the file:line, one
+> sentence stating the defect, and a concrete failure scenario (inputs or state →
+> wrong outcome). Rank most severe first.
+>
+> If you find nothing in a category, say so for that category. **An empty
+> findings list is an acceptable and expected outcome if the code is clean — do
+> not manufacture findings to appear thorough, and do not soften a real one.**
+> Equally, do not withhold a finding because the change looks careful elsewhere.
+>
+> Do not write any file. Report back in your final message.
+
+**Note on the prompt's own defect.** Its item 1 cites
+`lint_roadmap_blockers.ts:48` as the closedness read. That is wrong — `:48` is
+the required-field-presence regex, `:193` is the closedness one — and the
+reviewer caught it as finding 4. The prompt is reproduced unaltered rather than
+corrected, because a prompt edited after the fact is not the prompt that was
+answered.
+
+## Verdict — 11 findings, 9 on #1789 and 2 on #1790
+
+The reviewer's own headline: *"no input mints that could not mint before — the
+disposition reads sit strictly after the closedness guard clause, so the new mint
+set is a proper subset of the old one … The defects are elsewhere."* Findings 1-3
+then show that the pre-existing surface was larger than the change assumed, and
+that the change enlarged one part of it.
+
+| # | Branch | Finding | Disposition |
+|---|---|---|---|
+| 1 | #1789 | `blockerSection` did not strip fenced code, so a fenced EXAMPLE of the grant syntax minted while the live `Status` read `open` | **FIXED** + pinned + RED-proven |
+| 2 | #1789 | `DISPOSITION_GRANTED_RE` ended in `\b`, so `granted/refused (pick one)` and three other hedges minted | **FIXED** + pinned + RED-proven |
+| 3 | #1789 | the heading search accepted any `#{2,4} blocker:` anywhere in the file, so a `####` history heading could out-vote the real entry | **FIXED** + pinned + RED-proven |
+| 4 | #1789 | roadmap `:821` cited `lint_roadmap_blockers.ts:48`, a field-presence regex, not `:193` | **FIXED** |
+| 5 | #1789 | the roadmap crossed the documented 1000-line structural cap, silently — no gate enforces it | **NOTED + stub**, not split |
+| 6 | #1789 | the section terminator fired inside fenced code and missed h5/h6 | **FIXED** (fence strip + `#{1,6}`) |
+| 7 | #1789 | four stale statements still asserted the pre-change condition | **FIXED** |
+| 8 | #1789 | `lint_promotion_paths.ts:615` re-derived the polarity `isRefusingStatus` exists to own | **FIXED** |
+| 9 | #1789 | of the three new tests, one passed byte-identically on pre-change code and pinned nothing new | **KEPT, annotated** — it pins that closedness and direction are read independently, which findings 1 and 3 make load-bearing |
+| 10 | #1790 | the dossier's line citations were invalidated by the same PR's own corrections | **FOLLOW-UP** — #1790 is merged |
+| 11 | #1790 | two bare `file:line` ranges name no file, and one range starts on the wrong note | **FOLLOW-UP** — #1790 is merged |
+
+**Categories the reviewer found clean, recorded because a null is a result.**
+Claims-against-evidence on #1790: 22 citations resolved, all correct, including
+an independent recomputation of the 38 = 24 + 2 + 12 partition and the 43-inbound
+census. Improper closure on both branches: none — no checkbox, acceptance
+criterion, `status:` field or blocker moved anywhere in either delta.
+
+## What this review changes about the run's own claims
+
+The PR body for #1789 originally called the change *"strictly stricter in every
+direction"*. That was true of the disposition read in isolation and false of the
+module as shipped: findings 1 and 3 are pre-existing holes in `blockerSection`
+that the new `Disposition` line made materially easier to trip, because a
+disposition line is far likelier to appear in a `What to do:` example than a
+`Status` line ever was. The claim is corrected rather than defended.

--- a/agents/evidence/reviews/drain13-neutral-review.md
+++ b/agents/evidence/reviews/drain13-neutral-review.md
@@ -1,4 +1,4 @@
-<!-- evidence-type: review -->
+<!-- evidence-type: original-review -->
 
 # Drain run 13 — neutral review of PR #1789 and PR #1790
 

--- a/agents/roadmaps/road-to-harness-promotion-bridge.md
+++ b/agents/roadmaps/road-to-harness-promotion-bridge.md
@@ -818,8 +818,9 @@ owner adopts 1A verbatim:
   **DISPOSITION FIELD — added 2026-09-01, and it is why a refusal is now
   representable at all.** `src/scripts/_lib/promotion_capability.ts` no longer
   treats `Status: resolved` as a grant. Closedness is still read with the same
-  literal `src/scripts/lint_roadmap_blockers.ts:48` uses, so this blocker's open
-  state cannot diverge from the repository's reading of it; the **direction** is
+  literal `src/scripts/lint_roadmap_blockers.ts:193` uses — over the same
+  fence-stripped, `## Blockers`-scoped text — so this blocker's open state cannot
+  diverge from the repository's reading of it; the **direction** is
   read separately from a `- **Disposition:**` line, and only `granted` mints.
   `refused` is a first-class closed state, and a blocker closed with neither word
   reads as `resolved-unclassified` and refuses. The change is strictly stricter
@@ -829,6 +830,33 @@ owner adopts 1A verbatim:
   (`tests/scripts/lint_promotion_paths.test.ts` § *a blocker CLOSED AS REFUSED
   does not mint* and § *a blocker closed WITHOUT a disposition fails closed*),
   and a byte-identical restore returns 25/25 green.
+
+  **HARDENED 2026-09-01 after a neutral review of this very change found three
+  ways it could still mint against a blocker whose live `Status` is `open`.** The
+  review was commissioned over the whole delta with a prompt that stated no
+  expected outcome; its prompt and verdict are committed together at
+  `agents/evidence/reviews/drain13-neutral-review.md`. All three are now fixed
+  and each is pinned by its own test, RED-proven individually.
+
+  - **A fenced EXAMPLE of the syntax was read as the live value.** The
+    `What to do:` field exists to tell a maintainer which line to write, so a
+    fenced block showing `- **Disposition:** granted` is the likeliest content in
+    a real blocker — and it minted while `Status: open` sat two lines above it.
+    `lint_roadmap_blockers.ts:137` strips fenced code before its own read and
+    this module did not, which falsified the "cannot diverge" claim rather than
+    supporting it. Both now strip.
+  - **`granted` was matched as a PREFIX.** The regex ended in `\b`, so
+    `granted/refused (pick one)` — a half-written template — and
+    `granted-NOT, this is a refusal` both minted. `granted` must now be the
+    whole value.
+  - **The heading search was unscoped.** Any `#{2,4} blocker: merge-authority`
+    anywhere in the file won, so a `####` heading in a history section could
+    carry a status the repository's own gate never sees. The search is now
+    confined to `## Blockers` and to `###`, exactly as the gate is.
+
+  The three shared literals are copied rather than imported (that module is a CLI
+  gate with load-time side effects) and a test pins the copies byte-equal, so the
+  no-divergence claim is now checked rather than asserted.
 - **Owner:** maintainer
 - **Blocks:** Phase 0 step 0.8, and by consequence every promotion step in
   Phase 7.

--- a/agents/roadmaps/road-to-harness-promotion-bridge.md
+++ b/agents/roadmaps/road-to-harness-promotion-bridge.md
@@ -368,6 +368,25 @@ descopeable, and the run that looked at it says so rather than moving it.**
   § Blockers → `What to do`. Nothing else. There is no intermediate state and
   no partial credit; `[~]` is the accurate mark and it stays.
 
+**RE-CONFIRMED 2026-09-01 (drain run 13) — 0.8 STAYS `[~]`, and the reason is
+now stronger rather than merely repeated.** This run put the (b) argument to the
+council and got **1A — refuse, 2/2 convergent**; it is not executing that
+verdict, and the full disclosure of why sits in § Blockers under **RE-ATTEMPTED
+2026-09-01**. Two independent reasons keep the mark where it is even if a later
+owner adopts 1A verbatim:
+
+- **The step is a transferred step, and the Resume condition's refusal branch
+  binds it.** That branch reads: do not weaken, cancel, retire, or **mark
+  complete** any transferred step or acceptance criterion, if the owner refuses
+  or otherwise does not grant the authority. So even a settled refusal does not
+  turn 0.8 `[x]` — refusal is precisely the branch that forbids it. Only a
+  **grant** would let this step close by being satisfied, and a grant is
+  unavailable per the Hard Floor.
+- **Nothing was silently made closeable.** The `Disposition` field added to the
+  blocker this run makes a refusal *recordable* without minting the promotion
+  capability. It does not make 0.8 closeable, and it is not to be read as
+  progress toward closing it.
+
 ## Phase 7 — Promotion bridge and the lifecycle after it
 
 > **Every step below is gated twice and may not be entered on either gate
@@ -750,6 +769,66 @@ descopeable, and the run that looked at it says so rather than moving it.**
     path to being met. Recorded here because the `What to do` list below prices
     (a), (b) and (c) as if they were symmetric for this file, and for AC-9 they
     are not.
+
+  **RE-ATTEMPTED 2026-09-01 (drain run 13), AND THE ATTEMPT IS DISCLOSED AS A
+  PROCEDURAL DEFECT RATHER THAN AS A RESULT. The question for (b) WAS put to the
+  council, it returned a verdict, and this run is NOT executing it.** The
+  paragraphs above are unchanged and still govern; this one records what
+  happened so a later reader is not told a cleaner story than the true one.
+
+  - **What was put.** A drain run carrying a human maintainer's standing
+    instruction — *"every open question, decision, or blocker is answered by the
+    AI Council — never by me; the council's recorded decision substitutes for
+    user sign-off"* — put ADR-239 § Decision 3 to the council as its Question 1,
+    with the granting direction explicitly marked unavailable. AI council
+    2026-09-01, `anthropic/claude-sonnet-4-5` + `openai/codex-default`, 2 rounds,
+    deep, peer-review, blind chairman, quorum **2/2 present, needed 1 —
+    concluded**, subscription transport, `billable=0`, `$0.0000`. Verdict
+    **1A — refuse preauthorized merge authority, 2/2 convergent**, both seats on
+    the ground that refusal strengthens rather than lowers the floor. The openai
+    seat added a scoping the record should keep: refusal would bind
+    **preauthorized** authority only and must not be written so as to prohibit
+    ordinary same-turn human confirmation.
+  - **Why it was put anyway, stated plainly: the lock was not evaluated before
+    the question was written.** `decision-revisit-gate` step 2 requires a lock to
+    be read before it is cited or bypassed, and this run wrote and dispatched
+    Question 1 before reaching this blocker's `revisit-if` paragraphs. That is
+    the defect. It is recorded here rather than in a summary because this is
+    where the next reader will look.
+  - **Why the verdict is NOT executed.** Two reasons, and the second is the
+    load-bearing one. First, the release condition is still not cleanly fired:
+    the paragraph above reserves (b) until *"a human either answers it or
+    explicitly asks for the (b) argument to be put"*, and a standing instruction
+    to route all blockers to the council is not the same speech act as asking for
+    **this** argument — and from inside a session the two are not
+    distinguishable from the 2026-09-01 agent-issued instruction the record
+    already refused. Second, and independently: **writing the refusal into
+    ADR-239 § Decision 3 is settling ADR-239 § Decision 3**, which is the act the
+    reservation names, in either direction. The seats' reasoning for 1A is sound
+    and is preserved above; what a council may not do is perform the amendment.
+  - **What this run did instead, and it is not nothing.** It found and fixed the
+    defect that would have made a refusal *unrecordable*. See the
+    **DISPOSITION FIELD** note below: `Status: resolved` was the only closed
+    token this repository recognises, and `readMergeAuthorityStatus` read it as a
+    GRANT — so settling this blocker in the refusing direction would have minted
+    the capability the refusal refuses. That trap is now closed, and closing it
+    is strictly floor-strengthening, which is council-decidable. The blocker
+    itself **stays `open`**.
+
+  **DISPOSITION FIELD — added 2026-09-01, and it is why a refusal is now
+  representable at all.** `src/scripts/_lib/promotion_capability.ts` no longer
+  treats `Status: resolved` as a grant. Closedness is still read with the same
+  literal `src/scripts/lint_roadmap_blockers.ts:48` uses, so this blocker's open
+  state cannot diverge from the repository's reading of it; the **direction** is
+  read separately from a `- **Disposition:**` line, and only `granted` mints.
+  `refused` is a first-class closed state, and a blocker closed with neither word
+  reads as `resolved-unclassified` and refuses. The change is strictly stricter
+  in every direction — a body that minted before must now say `granted` — so it
+  cannot widen the capability. RED-proven: collapsing the two disposition reads
+  back to the pre-split `return 'resolved'` fails exactly the two new pole tests
+  (`tests/scripts/lint_promotion_paths.test.ts` § *a blocker CLOSED AS REFUSED
+  does not mint* and § *a blocker closed WITHOUT a disposition fails closed*),
+  and a byte-identical restore returns 25/25 green.
 - **Owner:** maintainer
 - **Blocks:** Phase 0 step 0.8, and by consequence every promotion step in
   Phase 7.
@@ -875,6 +954,37 @@ descopeable, and the run that looked at it says so rather than moving it.**
       either: it makes (b) permanently impossible, at which point AC-9's
       disposition becomes an owner decision in its own right rather than an
       automatic descope.
+      **FOURTH AUDIT 2026-09-01 (drain run 13) — STILL `[ ]`, and this run
+      establishes the one fact three prior audits left open: this roadmap
+      CANNOT ARCHIVE while AC-9 is unmet, and that is a property of the
+      repository rather than a judgement.** *AI council 2026-09-01
+      (`anthropic/claude-sonnet-4-5` + `openai/codex-default`, 2 rounds, deep,
+      peer-review, blind chairman, quorum 2/2 present, needed 1 — concluded,
+      subscription transport, `billable=0`, `$0.0000`) — Question 2: the seats
+      SPLIT, anthropic **2A** and openai **2B**, and BOTH attached the same
+      condition.* anthropic: if archive semantics conventionally imply success,
+      choose 2B instead. openai: the proposal provides no repository rule
+      showing that an active roadmap with an unmet acceptance criterion may
+      enter the archive, and that fact must be demonstrated first.
+      **The condition was then checked against the tree, and it decides the
+      split as 2B.** `src/agent-src/scripts/archive_completed_roadmaps.ts:14-16`
+      states the criterion — a roadmap that has reached `count_open == 0` and
+      `count_deferred == 0` is complete — and `:562-563` is the predicate that
+      enforces it. `count_open` comes from `count_checkboxes`
+      (`src/agent-src/scripts/update_roadmap_progress.ts:323`) over `CHECKBOX_RE`
+      (`:81`), a whole-file `/gm` regex with **no section filter**: an
+      `- [ ] AC-9` line under `## Acceptance Criteria` is counted exactly like
+      an unfinished step. There is no `terminal-incomplete` disposition in the
+      archiver and no flag that supplies one. So the archive gate is not an
+      opinion this run formed; it is a mechanism, and it refuses.
+      **Consequence, recorded as the disposition: this roadmap stays ACTIVE.**
+      It is not archived, not descoped, and not marked complete. Its executable
+      work is finished and verified; its acceptance is not, and the file remains
+      the visible carrier of that difference. Both seats also warned in Question
+      5 against exactly the framing this paragraph refuses — openai named 2A's
+      unsupported assertion that the roadmap may archive with AC-9 unmet as the
+      run's principal manufactured-closure risk, and it is declined here rather
+      than argued with.
 
 ## Provenance
 

--- a/agents/roadmaps/stubs/road-to-promotion-bridge-size-and-citation-repairs.md
+++ b/agents/roadmaps/stubs/road-to-promotion-bridge-size-and-citation-repairs.md
@@ -1,0 +1,64 @@
+---
+complexity: lightweight
+status: stub
+---
+
+# Road to the promotion-bridge size split and the topology citation repairs
+
+Three defects a neutral review found on 2026-09-01 that were **not** fixed in the
+change that surfaced them, each for a stated reason. Full review, including the
+prompt it was commissioned with, at
+[`../../evidence/reviews/drain13-neutral-review.md`](../../evidence/reviews/drain13-neutral-review.md).
+
+## 1. `road-to-harness-promotion-bridge.md` is over the structural line cap
+
+`src/agent-src/templates/roadmaps.md:28` caps a declared `complexity: structural`
+roadmap at **1000 lines** — *"if larger, split into multiple files"*. The file
+crossed it during drain run 13 (927 → 1065) and is the only active roadmap over
+the cap.
+
+**Why nothing caught it:** `lint_roadmap_complexity.ts:50` carries only
+`LIGHTWEIGHT_LINE_CAP = 600`. The structural cap is documented and ungated, so
+the crossing was silent — which is the more interesting half of this item.
+
+**Why it was not fixed in the same change.** Splitting is a restructuring of a
+governance record whose Resume condition reserves weakening, cancelling,
+retiring and completing its transferred steps to the owner, and whose two open
+items are both owner-reserved. A split performed by the same run that wrote most
+of the added lines is the shape `preservation-guard` exists to catch. It also
+cannot be done well while `blocker: merge-authority` is open, because the natural
+cut line is Phase 7, which is the part the blocker governs.
+
+**What closes it:** either a split the owner accepts, or a gate for the
+structural cap so the next crossing is not silent — and the gate is the cheaper
+half, independent of the split.
+
+## 2. The topology dossier's line citations were invalidated by its own PR
+
+`agents/evidence/analysis/topology-followups-disposition-evidence-2026-09-01.md`
+pins every citation to commit `468eeefc7` and says so. PR #1790 then executed the
+corrections the dossier recommended, which added 30 lines to the receiver and
+13-26 to each stub — so a reader in the working tree following e.g. "Receiver
+`:144-145`" now lands on a checkbox rather than the sentence being quoted.
+
+Disclosed in principle by the commit pin, undisclosed as a consequence. Fix by
+adding a second column of current-tree line numbers, or by stating the offset
+once at the head of the citation list.
+
+## 3. Two bare `file:line` ranges name no file
+
+- `stubs/road-to-council-topology-instrumentation.md:164-166` — the Group 3
+  forbidden-claims section cites `1B.1` at `:865-883` and `1B.4` at `:978-984`
+  with no file; the archived-parent path appears only in the Group 2 section
+  sixty lines above.
+- `stubs/road-to-provider-leakage-bench-execution.md:128-131` — the 3.4 range
+  `:1270-1296` starts on a pre-existing 2026-08-30 note rather than on the
+  `[~]` block it cites (which begins at `:1282`) and ends mid-sentence.
+
+Both are in files already merged to `main` via #1790, so they need their own
+change rather than an amendment.
+
+## Not in scope
+
+Anything about the `merge-authority` blocker, step 0.8, or AC-9. Those are
+owner-reserved and are recorded in the roadmap itself.

--- a/agents/roadmaps/stubs/road-to-promotion-bridge-size-and-citation-repairs.md
+++ b/agents/roadmaps/stubs/road-to-promotion-bridge-size-and-citation-repairs.md
@@ -1,6 +1,6 @@
 ---
 complexity: lightweight
-status: stub
+review_by: 2027-03-31
 ---
 
 # Road to the promotion-bridge size split and the topology citation repairs

--- a/src/scripts/_lib/promotion_capability.ts
+++ b/src/scripts/_lib/promotion_capability.ts
@@ -24,7 +24,7 @@
  * ## This module creates no promotion path
  *
  * It performs no filesystem write, no transition, and no promotion. It mints an
- * opaque token and refuses to mint one while the blocker is open. The carried
+ * opaque token, and refuses unless the blocker reads GRANTED. The carried
  * condition requires the enforcement to land *before or in* the first commit
  * that creates a promotion path; this is the enforcement, and it arrives with no
  * path attached.
@@ -47,7 +47,17 @@ const _HERE = fileURLToPath(import.meta.url);
 /** `src/scripts/_lib/` → repo root. */
 export const CAPABILITY_REPO_ROOT = path.resolve(path.dirname(_HERE), '..', '..', '..');
 
-/** The blocker whose open state makes this capability unobtainable. */
+/**
+ * The three literals `lint_roadmap_blockers` uses to find a blocker, copied so
+ * the two readers cannot drift: `:37`, `:38` and `:39` there. They are literals
+ * rather than an import because that module is a CLI gate with side effects at
+ * load; `tests/scripts/lint_promotion_paths.test.ts` pins them equal.
+ */
+const FENCED_CODE_RE = /^[ \t]*```[^\n]*\n[\s\S]*?^[ \t]*```[ \t]*$/gm;
+const BLOCKERS_SECTION_RE = /^##[ \t]+Blockers[ \t]*$/im;
+const NEXT_H2_RE = /^##[ \t]+\S/m;
+
+/** The blocker whose disposition decides whether this capability is obtainable. */
 export const MERGE_AUTHORITY_BLOCKER_ID = 'merge-authority';
 
 /** The roadmap that owns the blocker entry, repo-relative. */
@@ -116,13 +126,45 @@ export function isRefusingStatus(s: BlockerStatus): boolean {
  * is "no". Anything else, including an absent line, reads as
  * `resolved-unclassified` and refuses.
  */
-const DISPOSITION_GRANTED_RE = /^-[ \t]*\*\*Disposition:\*\*[ \t]*granted\b/im;
-const DISPOSITION_REFUSED_RE = /^-[ \t]*\*\*Disposition:\*\*[ \t]*refused\b/im;
+const DISPOSITION_GRANTED_RE = /^-[ \t]*\*\*Disposition:\*\*[ \t]*granted[ \t]*$/im;
+const DISPOSITION_REFUSED_RE = /^-[ \t]*\*\*Disposition:\*\*[ \t]*refused[ \t]*(?:$|[-—:.,(])/im;
 
-/** Extract the `### blocker: <id>` section body from a roadmap's text. */
+/**
+ * Blank out fenced code, preserving line count.
+ *
+ * The same transform `lint_roadmap_blockers.ts:137` applies before its own read,
+ * and applying it here is what makes the "cannot diverge" claim true rather than
+ * merely intended. Without it a fenced EXAMPLE of the syntax — which is exactly
+ * what a `What to do:` field contains, since that field's job is to tell a
+ * maintainer which line to write — is read as the live value.
+ */
+function stripFencedCode(text: string): string {
+    return text.replace(FENCED_CODE_RE, (m) => '\n'.repeat((m.match(/\n/g) ?? []).length));
+}
+
+/**
+ * Extract the `### blocker: <id>` section body from a roadmap's text.
+ *
+ * Scoped and stripped to match `lint_roadmap_blockers` exactly: fenced code is
+ * blanked first, the search is confined to the `## Blockers` section, and only a
+ * `###` heading opens a blocker. A `#### blocker: merge-authority` under some
+ * other section is not a blocker to the linter and must not be one here either —
+ * otherwise a history note could carry a status the repository's own gate does
+ * not see.
+ */
 export function blockerSection(markdown: string, id: string): string | null {
-    const lines = markdown.split('\n');
-    const head = new RegExp(`^#{2,4}\\s+blocker:\\s*${id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*$`, 'i');
+    const stripped = stripFencedCode(markdown);
+    const sectionMatch = BLOCKERS_SECTION_RE.exec(stripped);
+    if (sectionMatch === null) {
+        return null;
+    }
+    const sectionStart = sectionMatch.index + sectionMatch[0].length;
+    const rest = stripped.slice(sectionStart);
+    const h2 = NEXT_H2_RE.exec(rest);
+    const scoped = rest.slice(0, h2 ? h2.index : undefined);
+
+    const lines = scoped.split('\n');
+    const head = new RegExp(`^###\\s+blocker:\\s*${id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*$`, 'i');
     let start = -1;
     for (let i = 0; i < lines.length; i += 1) {
         if (head.test(lines[i] as string)) {
@@ -135,7 +177,11 @@ export function blockerSection(markdown: string, id: string): string | null {
     }
     const out: string[] = [];
     for (let i = start; i < lines.length; i += 1) {
-        if (/^#{1,4}\s/.test(lines[i] as string)) {
+        // `#{1,6}` rather than `#{1,4}`: an h5/h6 sub-heading ends the section
+        // too. With the old bound a `##### ` line matched nothing (greedy 4 then
+        // requiring `\s`, backtracking into `#`), so everything after it bled
+        // into the body.
+        if (/^#{1,6}\s/.test(lines[i] as string)) {
             break;
         }
         out.push(lines[i] as string);
@@ -191,9 +237,10 @@ export class PromotionCapabilityUnobtainableError extends Error {
 }
 
 /**
- * The token. Holding one means the blocker was resolved AND a human was named.
+ * The token. Holding one means the blocker reads GRANTED AND a human was named.
  *
- * Deliberately opaque: `blockerStatusAtGrant` is a LITERAL type, so a caller
+ * Deliberately opaque: `blockerStatusAtGrant` is a LITERAL type — its value
+ * `'resolved'` is the status enum's GRANTED member, not merely "closed" — so a caller
  * cannot construct a value of this shape with any other status, and there is no
  * exported constructor other than {@link acquirePromotionCapability}.
  */

--- a/src/scripts/_lib/promotion_capability.ts
+++ b/src/scripts/_lib/promotion_capability.ts
@@ -66,16 +66,58 @@ export const REPO_SOURCE_ROOT = 'src';
 /**
  * Blocker states, as the roadmap gate reads them.
  *
- * `resolved` is the ONLY value that is not a refusal, and it is matched with the
- * same literal `lint_roadmap_blockers.ts:193` uses, so a blocker this repository
- * calls open and a blocker this module calls open cannot diverge.
+ * `resolved` is the ONLY value that is not a refusal. The literal that decides
+ * *closedness* is the same one `lint_roadmap_blockers.ts:193` uses, so a blocker
+ * this repository calls open and a blocker this module calls open cannot
+ * diverge — but closedness alone is no longer sufficient to mint, and the reason
+ * is a defect this module used to carry.
+ *
+ * ## Why `Status: resolved` is not, by itself, a grant
+ *
+ * `blocker: merge-authority` asks *"is preauthorized merge authority granted or
+ * refused?"*, and its own `What to do` offers BOTH directions. But `resolved` is
+ * the only closed token this repository recognises, so before this change the
+ * two directions were indistinguishable here: settling the blocker in the
+ * **refusing** direction — writing down that unattended promotion is forbidden —
+ * would have set `Status: resolved` and thereby MINTED the capability that
+ * performs unattended promotion. The refusal would have granted the thing it
+ * refused.
+ *
+ * That is the same failure ADR-239 Decision 3 names from the other side, where
+ * an authorization read out of agent-writable state *"would let the agent
+ * consent on the user's behalf — which is the thing the abort exists to prevent,
+ * reimplemented as a feature"*. Here the consent would have been synthesised out
+ * of a bookkeeping token rather than out of runtime state, which is worse: no
+ * one would have written the word "granted" anywhere.
+ *
+ * So the closed blocker must additionally carry an explicit **disposition**, and
+ * only one of its values mints. This is strictly stricter than the previous
+ * behaviour in every direction — a body that granted before and still grants
+ * must now say so — so it cannot widen the capability, only narrow it.
  */
-export type BlockerStatus = 'resolved' | 'open' | 'blocker-absent' | 'roadmap-unreadable';
+export type BlockerStatus =
+    | 'resolved'
+    | 'refused'
+    | 'resolved-unclassified'
+    | 'open'
+    | 'blocker-absent'
+    | 'roadmap-unreadable';
 
 /** Every status except `resolved`. Named so callers do not re-derive the polarity. */
 export function isRefusingStatus(s: BlockerStatus): boolean {
     return s !== 'resolved';
 }
+
+/**
+ * The disposition line a CLOSED `merge-authority` blocker must carry.
+ *
+ * `granted` is the only value that mints. `refused` is a first-class closed
+ * state — the blocker is answered and no longer blocks archival, and the answer
+ * is "no". Anything else, including an absent line, reads as
+ * `resolved-unclassified` and refuses.
+ */
+const DISPOSITION_GRANTED_RE = /^-[ \t]*\*\*Disposition:\*\*[ \t]*granted\b/im;
+const DISPOSITION_REFUSED_RE = /^-[ \t]*\*\*Disposition:\*\*[ \t]*refused\b/im;
 
 /** Extract the `### blocker: <id>` section body from a roadmap's text. */
 export function blockerSection(markdown: string, id: string): string | null {
@@ -120,8 +162,20 @@ export function readMergeAuthorityStatus(repoRoot: string = CAPABILITY_REPO_ROOT
         return 'blocker-absent';
     }
     // The same literal `lint_roadmap_blockers.ts:193` matches. `resolved` is the
-    // only closed token this repository recognises.
-    return /^-[ \t]*\*\*Status:\*\*[ \t]*resolved/im.test(body) ? 'resolved' : 'open';
+    // only closed token this repository recognises — so closedness is read with
+    // that literal and NOTHING else, and the grant/refuse direction is then read
+    // separately from the body's own `Disposition` line. See the BlockerStatus
+    // docblock for why a closed blocker is not automatically a grant.
+    if (!/^-[ \t]*\*\*Status:\*\*[ \t]*resolved/im.test(body)) {
+        return 'open';
+    }
+    if (DISPOSITION_REFUSED_RE.test(body)) {
+        return 'refused';
+    }
+    if (DISPOSITION_GRANTED_RE.test(body)) {
+        return 'resolved';
+    }
+    return 'resolved-unclassified';
 }
 
 /** Raised when the capability cannot be minted. There is no way around it. */
@@ -155,9 +209,12 @@ export interface PromotionCapability {
  * Two conjuncts, both required, checked in this order so the message names the
  * governance reason first:
  *
- *   1. `blocker: merge-authority` reads `resolved` in the live roadmap. While it
- *      reads anything else — including "the roadmap is missing" — the capability
- *      is unobtainable, which is the property the council's route 1 specified.
+ *   1. `blocker: merge-authority` reads `resolved` in the live roadmap — which
+ *      now means BOTH `Status: resolved` AND `Disposition: granted`. While it
+ *      reads anything else — including "the roadmap is missing", "the blocker was
+ *      closed as refused" and "the blocker was closed without saying which" — the
+ *      capability is unobtainable, which is the property the council's route 1
+ *      specified.
  *   2. A NAMED human approver. Empty, whitespace-only and absent are refused, so
  *      the cheapest way to satisfy the gate stays "name someone".
  *
@@ -171,8 +228,9 @@ export function acquirePromotionCapability(
     if (isRefusingStatus(status)) {
         throw new PromotionCapabilityUnobtainableError(
             status,
-            'promotion into canonical agent-config is gated on an OPEN, owner-reserved blocker ' +
-                '(ADR-239 Decision 3). No flag, environment variable or argument lifts it.',
+            'promotion into canonical agent-config is gated on the owner-reserved blocker ' +
+                '(ADR-239 Decision 3), which does not read as GRANTED. No flag, environment ' +
+                'variable or argument lifts it.',
         );
     }
     if (approval.approver.trim() === '' || approval.approvedAt.trim() === '') {

--- a/src/scripts/lint_promotion_paths.ts
+++ b/src/scripts/lint_promotion_paths.ts
@@ -94,6 +94,7 @@ import {
     PromotionCapabilityUnobtainableError,
     REPO_SOURCE_ROOT,
     acquirePromotionCapability,
+    isRefusingStatus,
     readMergeAuthorityStatus,
 } from './_lib/promotion_capability.js';
 
@@ -612,7 +613,7 @@ export function evaluate(root: string = REPO_ROOT, ledger?: GateLedger): Evaluat
     // a blocker closed as `refused`, or closed without saying which, is a
     // refusing status here exactly like an open one.
     const status = readMergeAuthorityStatus(root);
-    if (status !== 'resolved') {
+    if (isRefusingStatus(status)) {
         let refused = false;
         try {
             acquirePromotionCapability({ approver: 'gate probe', approvedAt: '1970-01-01' }, root);

--- a/src/scripts/lint_promotion_paths.ts
+++ b/src/scripts/lint_promotion_paths.ts
@@ -606,8 +606,11 @@ export function evaluate(root: string = REPO_ROOT, ledger?: GateLedger): Evaluat
         else ledger?.complete(rel);
     }
 
-    // R0 — the capability must be unobtainable while the blocker is open. Called,
-    // not read: a text match would pass over a refusal edited into a no-op.
+    // R0 — the capability must be unobtainable unless the blocker reads GRANTED.
+    // Called, not read: a text match would pass over a refusal edited into a
+    // no-op. `resolved` now means `Status: resolved` AND `Disposition: granted`;
+    // a blocker closed as `refused`, or closed without saying which, is a
+    // refusing status here exactly like an open one.
     const status = readMergeAuthorityStatus(root);
     if (status !== 'resolved') {
         let refused = false;
@@ -621,7 +624,7 @@ export function evaluate(root: string = REPO_ROOT, ledger?: GateLedger): Evaluat
                 rule: 'R0',
                 file: 'src/scripts/_lib/promotion_capability.ts',
                 line: 1,
-                what: 'capability obtainable while the blocker is open',
+                what: 'capability obtainable while the blocker does not read granted',
                 text: `blocker status ${status}, yet acquirePromotionCapability() returned a token`,
             });
         }

--- a/tests/scripts/governed_harness_no_live_harness.test.ts
+++ b/tests/scripts/governed_harness_no_live_harness.test.ts
@@ -39,7 +39,31 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
-const ROADMAP = path.join(REPO, 'agents', 'roadmaps', 'road-to-governed-harness-evolution.md');
+/**
+ * The roadmap this scan reads, wherever it currently lives.
+ *
+ * It was `agents/roadmaps/…` when this test was written and it is
+ * `agents/roadmaps/archive/…` now: PR #1788 archived it, and CI went red on both
+ * OSes because this constant kept pointing at the active path. The archiver DOES
+ * rewrite inbound references — `agents/roadmaps/<x>.md` →
+ * `agents/roadmaps/archive/<x>.md` across tracked files
+ * (`src/agent-src/scripts/archive_completed_roadmaps.ts:15-17`) — but it matches
+ * a literal path, and this one was assembled from separate `path.join`
+ * arguments, so there was no literal for it to see.
+ *
+ * Resolving active-then-archive fixes the break and removes the whole class:
+ * the next archival of this file cannot red the scan again. The final `??` keeps
+ * the ENOENT pointing at the active path, which is the more useful message when
+ * the file is genuinely gone rather than moved.
+ *
+ * Half B is unaffected — it scans `src/**\/*.ts` headers and, as the header note
+ * above says, is the half that keeps working after the roadmap closes.
+ */
+const ROADMAP_CANDIDATES = [
+    path.join(REPO, 'agents', 'roadmaps', 'road-to-governed-harness-evolution.md'),
+    path.join(REPO, 'agents', 'roadmaps', 'archive', 'road-to-governed-harness-evolution.md'),
+];
+const ROADMAP = ROADMAP_CANDIDATES.find((p) => existsSync(p)) ?? (ROADMAP_CANDIDATES[0] as string);
 const PARK = path.join(
     REPO,
     'agents',

--- a/tests/scripts/lint_promotion_paths.test.ts
+++ b/tests/scripts/lint_promotion_paths.test.ts
@@ -6,7 +6,7 @@
 // with an asserted denominator, that a collapsed population fails instead of
 // exiting green, that the allowlists are exactly what the header claims, and
 // that the guarded capability is unobtainable while the blocker is open.
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { readFileSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -216,12 +216,18 @@ describe('R3 — candidate-derived writes into the canonical source tree', () =>
 
 // --- § R0 — the capability is unobtainable unless the blocker reads GRANTED ---
 
-/** Write a throwaway roadmap carrying just the `merge-authority` blocker body. */
+/**
+ * Write a throwaway roadmap carrying just the `merge-authority` blocker body.
+ *
+ * The `## Blockers` wrapper is not decoration: the reader is scoped to that
+ * section exactly as `lint_roadmap_blockers` is, so a bare `###` heading with no
+ * section around it is correctly invisible.
+ */
 function writeBlocker(dir: string, body: string): void {
     mkdirSync(join(dir, 'agents', 'roadmaps'), { recursive: true });
     writeFileSync(
         join(dir, 'agents', 'roadmaps', 'road-to-harness-promotion-bridge.md'),
-        `### blocker: merge-authority\n\n${body}`,
+        `## Blockers\n\n### blocker: merge-authority\n\n${body}`,
     );
 }
 
@@ -238,7 +244,10 @@ describe('the guarded capability', () => {
         try {
             expect(readMergeAuthorityStatus(dir)).toBe('roadmap-unreadable');
             mkdirSync(join(dir, 'agents', 'roadmaps'), { recursive: true });
-            writeFileSync(join(dir, 'agents', 'roadmaps', 'road-to-harness-promotion-bridge.md'), '# nothing here\n');
+            writeFileSync(
+                join(dir, 'agents', 'roadmaps', 'road-to-harness-promotion-bridge.md'),
+                '## Blockers\n\n# nothing here\n',
+            );
             expect(readMergeAuthorityStatus(dir)).toBe('blocker-absent');
             expect(() => acquirePromotionCapability({ approver: 'A Human', approvedAt: '2026-08-31' }, dir))
                 .toThrow(PromotionCapabilityUnobtainableError);
@@ -300,6 +309,101 @@ describe('the guarded capability', () => {
         }
     });
 
+    // --- the three minting defects a neutral review of this change found -----
+    //
+    // All three were in the FIRST version of the grant/refuse split and all three
+    // let the capability mint against a blocker whose live `Status` is `open`.
+    // They are pinned here rather than only fixed, because each is the kind of
+    // body a maintainer writes on purpose.
+
+    it('a FENCED example of the grant syntax is not the live value', () => {
+        // The `What to do:` field exists to tell a maintainer which line to
+        // write, so a fenced example of exactly that line is the most likely
+        // content in a real blocker — and it sat above a live `Status: open`.
+        const dir = mkdtempSync(join(tmpdir(), 'promo-cap-fence-'));
+        try {
+            writeBlocker(
+                dir,
+                '- **Status:** open\n' +
+                    '- **What to do:** to grant, write exactly:\n\n' +
+                    '```markdown\n' +
+                    '- **Status:** resolved\n' +
+                    '- **Disposition:** granted\n' +
+                    '```\n',
+            );
+            expect(readMergeAuthorityStatus(dir)).toBe('open');
+            expect(() => acquirePromotionCapability({ approver: 'A Human', approvedAt: '2026-09-01' }, dir))
+                .toThrow(PromotionCapabilityUnobtainableError);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it('a blocker heading OUTSIDE `## Blockers`, or below `###`, is not the blocker', () => {
+        // `lint_roadmap_blockers` only sees `###` headings inside `## Blockers`.
+        // A `#### blocker: merge-authority` in a history section must not carry a
+        // status the repository's own gate cannot see.
+        const dir = mkdtempSync(join(tmpdir(), 'promo-cap-scope-'));
+        try {
+            mkdirSync(join(dir, 'agents', 'roadmaps'), { recursive: true });
+            writeFileSync(
+                join(dir, 'agents', 'roadmaps', 'road-to-harness-promotion-bridge.md'),
+                '## History\n\n' +
+                    '#### blocker: merge-authority\n\n' +
+                    '- **Status:** resolved\n' +
+                    '- **Disposition:** granted\n\n' +
+                    '## Blockers\n\n' +
+                    '### blocker: merge-authority\n\n' +
+                    '- **Status:** open\n',
+            );
+            expect(readMergeAuthorityStatus(dir)).toBe('open');
+            expect(() => acquirePromotionCapability({ approver: 'A Human', approvedAt: '2026-09-01' }, dir))
+                .toThrow(PromotionCapabilityUnobtainableError);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it('`granted` must be the WHOLE value — a hedge or a template does not mint', () => {
+        // The first version anchored with `\b`, which matches before any
+        // non-word character. A half-written template line was a live grant.
+        const hedges = [
+            'granted/refused (pick one)',
+            'granted?  — unclear, ask owner',
+            'granted. NOT for unattended use',
+            'granted-NOT, this is a refusal',
+        ];
+        for (const value of hedges) {
+            const dir = mkdtempSync(join(tmpdir(), 'promo-cap-hedge-'));
+            try {
+                writeBlocker(dir, `- **Status:** resolved\n- **Disposition:** ${value}\n`);
+                expect(readMergeAuthorityStatus(dir), value).toBe('resolved-unclassified');
+                expect(() => acquirePromotionCapability({ approver: 'A Human', approvedAt: '2026-09-01' }, dir))
+                    .toThrow(PromotionCapabilityUnobtainableError);
+            } finally {
+                rmSync(dir, { recursive: true, force: true });
+            }
+        }
+    });
+
+    it('the three section literals are byte-identical to the blocker gate\'s own', () => {
+        // The "cannot diverge" claim is only true while these agree. They are
+        // copied rather than imported (that module is a CLI gate with load-time
+        // side effects), so the copy is pinned instead of trusted.
+        const gate = readFileSync(join(REPO_ROOT, 'src', 'scripts', 'lint_roadmap_blockers.ts'), 'utf-8');
+        const cap = readFileSync(
+            join(REPO_ROOT, 'src', 'scripts', '_lib', 'promotion_capability.ts'),
+            'utf-8',
+        );
+        for (const name of ['FENCED_CODE_RE', 'BLOCKERS_SECTION_RE', 'NEXT_H2_RE']) {
+            const re = new RegExp(`^const ${name} = (.+);$`, 'm');
+            const inGate = re.exec(gate)?.[1];
+            const inCap = re.exec(cap)?.[1];
+            expect(inGate, `${name} missing from the blocker gate`).toBeTruthy();
+            expect(inCap, `${name} missing from the capability`).toBe(inGate);
+        }
+    });
+
     it('an OPEN blocker carrying a granted disposition still does not mint', () => {
         // Closedness and direction are read independently and BOTH must hold, so
         // a stray disposition line cannot pre-authorise an unanswered blocker.
@@ -315,7 +419,8 @@ describe('the guarded capability', () => {
     });
 
     it('blockerSection stops at the next heading', () => {
-        const md = '### blocker: a\n\n- **Status:** open\n\n### blocker: b\n\n- **Status:** resolved\n';
+        const md =
+            '## Blockers\n\n### blocker: a\n\n- **Status:** open\n\n### blocker: b\n\n- **Status:** resolved\n';
         expect(blockerSection(md, 'a')).toContain('open');
         expect(blockerSection(md, 'a')).not.toContain('resolved');
         expect(blockerSection(md, 'missing')).toBeNull();

--- a/tests/scripts/lint_promotion_paths.test.ts
+++ b/tests/scripts/lint_promotion_paths.test.ts
@@ -214,7 +214,17 @@ describe('R3 — candidate-derived writes into the canonical source tree', () =>
     });
 });
 
-// --- § R0 — the capability is unobtainable while the blocker is open ---------
+// --- § R0 — the capability is unobtainable unless the blocker reads GRANTED ---
+
+/** Write a throwaway roadmap carrying just the `merge-authority` blocker body. */
+function writeBlocker(dir: string, body: string): void {
+    mkdirSync(join(dir, 'agents', 'roadmaps'), { recursive: true });
+    writeFileSync(
+        join(dir, 'agents', 'roadmaps', 'road-to-harness-promotion-bridge.md'),
+        `### blocker: merge-authority\n\n${body}`,
+    );
+}
+
 
 describe('the guarded capability', () => {
     it('reads the live blocker as open, and refuses', () => {
@@ -237,21 +247,68 @@ describe('the guarded capability', () => {
         }
     });
 
-    it('still demands a NAMED human once the blocker reads resolved', () => {
+    it('still demands a NAMED human once the blocker reads resolved AND granted', () => {
         // The positive pole: without it, every assertion above would pass on a
         // function that refuses unconditionally and could never be satisfied.
         const dir = mkdtempSync(join(tmpdir(), 'promo-cap-ok-'));
         try {
-            mkdirSync(join(dir, 'agents', 'roadmaps'), { recursive: true });
-            writeFileSync(
-                join(dir, 'agents', 'roadmaps', 'road-to-harness-promotion-bridge.md'),
-                '### blocker: merge-authority\n\n- **Status:** resolved — settled by the owner\n',
-            );
+            writeBlocker(dir, '- **Status:** resolved — settled by the owner\n- **Disposition:** granted\n');
             expect(readMergeAuthorityStatus(dir)).toBe('resolved');
             expect(() => acquirePromotionCapability({ approver: '   ', approvedAt: '2026-08-31' }, dir))
                 .toThrow(/NAMED human approver/);
             const cap = acquirePromotionCapability({ approver: 'A Human', approvedAt: '2026-08-31' }, dir);
             expect(cap.blockerStatusAtGrant).toBe('resolved');
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    // --- the grant/refuse split ---------------------------------------------
+    //
+    // `resolved` is the only closed token this repository recognises, so before
+    // this split a REFUSAL of preauthorized merge authority — the direction the
+    // AI council of 2026-09-01 chose 2/2 — could only be recorded by writing
+    // `Status: resolved`, which minted the capability the refusal refuses. These
+    // three cases pin the two poles and the ambiguous middle. Delete the
+    // `Disposition` reads in `promotion_capability.ts` and the first two fail.
+
+    it('a blocker CLOSED AS REFUSED does not mint — the refusal is not a grant', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'promo-cap-refused-'));
+        try {
+            writeBlocker(
+                dir,
+                '- **Status:** resolved — settled 2026-09-01\n' +
+                    '- **Disposition:** refused — preauthorized merge authority is NOT granted\n',
+            );
+            expect(readMergeAuthorityStatus(dir)).toBe('refused');
+            expect(() => acquirePromotionCapability({ approver: 'A Human', approvedAt: '2026-09-01' }, dir))
+                .toThrow(PromotionCapabilityUnobtainableError);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it('a blocker closed WITHOUT a disposition fails closed rather than granting', () => {
+        const dir = mkdtempSync(join(tmpdir(), 'promo-cap-unclassified-'));
+        try {
+            writeBlocker(dir, '- **Status:** resolved — settled by the owner\n');
+            expect(readMergeAuthorityStatus(dir)).toBe('resolved-unclassified');
+            expect(() => acquirePromotionCapability({ approver: 'A Human', approvedAt: '2026-09-01' }, dir))
+                .toThrow(PromotionCapabilityUnobtainableError);
+        } finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it('an OPEN blocker carrying a granted disposition still does not mint', () => {
+        // Closedness and direction are read independently and BOTH must hold, so
+        // a stray disposition line cannot pre-authorise an unanswered blocker.
+        const dir = mkdtempSync(join(tmpdir(), 'promo-cap-open-grant-'));
+        try {
+            writeBlocker(dir, '- **Status:** open\n- **Disposition:** granted\n');
+            expect(readMergeAuthorityStatus(dir)).toBe('open');
+            expect(() => acquirePromotionCapability({ approver: 'A Human', approvedAt: '2026-09-01' }, dir))
+                .toThrow(PromotionCapabilityUnobtainableError);
         } finally {
             rmSync(dir, { recursive: true, force: true });
         }


### PR DESCRIPTION
## What this is

Drain run 13, roadmap 1 of 3: `road-to-harness-promotion-bridge`.

**This PR does not complete the roadmap and does not archive it.** It ships one
real defect fix, and it records three dispositions — including a procedural
defect this run committed. The roadmap stays active, and the reason it stays
active is now a mechanism rather than a judgement.

## The defect this fixes

`blocker: merge-authority` asks whether preauthorized merge authority is
**granted or refused**, and its own `What to do` offers both directions. But
`resolved` is the only closed token this repository recognises, and
`readMergeAuthorityStatus` (`src/scripts/_lib/promotion_capability.ts`) read that
token as a **grant**.

So settling the blocker in the refusing direction — writing down that unattended
promotion is forbidden — would have set `Status: resolved` and thereby minted
`acquirePromotionCapability`, the capability that performs unattended promotion.
**The refusal would have granted the thing it refused, and nobody would have had
to write the word "granted" anywhere.** That is the failure ADR-239 § Decision 3
names from the other side (`docs/decisions/ADR-239-drain-command-surface-and-merge-authority.md:79-95`),
arriving through a bookkeeping token instead of through runtime state.

**The fix.** Closedness is still read with the same literal
`src/scripts/lint_roadmap_blockers.ts:48` uses, so this blocker's open state
cannot diverge from the repository's reading of it. The *direction* is now read
separately from a `- **Disposition:**` line: `granted` is the only value that
mints, `refused` is a first-class closed state, and a closed blocker carrying
neither reads as `resolved-unclassified` and refuses. **This was originally claimed as "strictly stricter in every direction". A
neutral review showed that was true of the disposition read in isolation and
false of the module as shipped — see the section below.** The claim is corrected
rather than defended.

**RED-proof.** Collapsing the two disposition reads back to the pre-split
`return 'resolved'` fails exactly two tests and nothing else:

```
× the guarded capability > a blocker CLOSED AS REFUSED does not mint
× the guarded capability > a blocker closed WITHOUT a disposition fails closed
  Tests  2 failed | 23 passed (25)
```

Byte-identical restore returns `Tests 25 passed (25)`. A third new test pins that
closedness and direction are read independently, so a stray `Disposition: granted`
on an **open** blocker still does not mint.

## Council record

AI council 2026-09-01, `anthropic/claude-sonnet-4-5` + `openai/codex-default`,
2 rounds, deep, peer-review, blind chairman, quorum **2/2 present, needed 1 —
concluded**, subscription transport, `billable=0`, `$0.0000`.

| Q | Question | Verdict |
|---|---|---|
| 1 | Disposition of `blocker: merge-authority` | **1A — refuse preauthorized merge authority, 2/2 convergent.** openai scoped it: refusal binds *preauthorized* authority only and must not prohibit ordinary same-turn human confirmation. |
| 2 | Disposition of AC-9 | **SPLIT** — anthropic 2A, openai 2B, both attaching the **same** condition. |
| 5 | Is the delegation manufacturing closure? | **Yes** — openai named "2A's unsupported assertion that the roadmap may archive with AC-9 unmet" as the principal risk. |

## What this run did NOT do, and why

**The 1A verdict is recorded and NOT executed.** Two reasons, disclosed in the
roadmap at the blocker rather than in a summary:

1. The tree carries a live lock reserving the (b) argument until *"a human either
   answers it or explicitly asks for the (b) argument to be put"*. A standing
   instruction to route all blockers to the council is not that speech act, and
   from inside a session it is not distinguishable from the agent-issued
   instruction the 2026-09-01 record already refused.
2. Independently: **writing the refusal into ADR-239 § Decision 3 is settling
   ADR-239 § Decision 3**, which is the act the reservation names, in *either*
   direction. The seats' reasoning for 1A is sound and is preserved; what a
   council may not do is perform the amendment.

**Disclosed defect:** this run wrote and dispatched Question 1 **before** reading
the lock, which is a `decision-revisit-gate` step-2 miss. It is recorded in the
roadmap where the next reader will look, not hidden in a run summary.

## Dispositions recorded

- **`blocker: merge-authority` — stays `open`.** Not closed in either direction.
- **Step 0.8 — stays `[~]`.** The Resume condition's refusal branch forbids
  marking a *transferred* step complete, so even a settled refusal would not
  close it; only a grant would, and a grant is unavailable per the Hard Floor.
- **AC-9 — stays `[ ]`, and the roadmap stays ACTIVE.** The council's Q2 split
  hinged on one empirical question both seats named: does this repository admit
  an archive with an unmet acceptance criterion? **It does not.**
  `src/agent-src/scripts/archive_completed_roadmaps.ts:14-16` states the
  criterion (`count_open == 0` and `count_deferred == 0`) and `:562-563` enforces
  it; `count_open` comes from `count_checkboxes`
  (`src/agent-src/scripts/update_roadmap_progress.ts:323`) over `CHECKBOX_RE`
  (`:81`), a whole-file `/gm` regex with **no section filter** — so an
  `- [ ] AC-9` line under `## Acceptance Criteria` counts exactly like an
  unfinished step. There is no `terminal-incomplete` disposition in the archiver
  and no flag that supplies one. The condition therefore decides the split as
  **2B**, and it is a mechanism, not this run's opinion.

## Honest nulls

- AC-9 is **not met** and is not claimed to be. Its closing chain needs a real
  promotion by a named human, which is unobtainable while the blocker is open —
  `./scripts-run src/scripts/lint_promotion_paths` reports `blocker status: open`
  at exit 0 over 2863 files.
- No acceptance criterion moved. No checkbox moved. Nothing was descoped.

## Gates

`lint_roadmap_blockers` · `lint_roadmap_complexity` · `lint_roadmap_ci_steps` ·
`check_roadmap_trackable` · `check_no_roadmap_refs` · `lint_empty_roadmaps` ·
`lint_roadmap_later_disposition` · `check_estate_count` · `check_references` ·
`lint_evidence_artifacts` · `check_gate_coverage` · `lint_promotion_paths`
(2863 files) — all green. `task typecheck-ts` clean.
Tests: `lint_promotion_paths` 25/25, plus `promotion_evidence`, `evolution_lab`,
`candidate_record`, `promotion_review` — 108/108.


## Also in this PR: a pre-existing red on `main`, fixed

Not caused by this branch — the file was byte-identical to `origin/main` before
the fix commit.

`tests/scripts/governed_harness_no_live_harness.test.ts` failed to **collect**
with `ENOENT ... agents/roadmaps/road-to-governed-harness-evolution.md`, taking
Node Tests shard 4/4 down on both `ubuntu-latest` and `macos-latest`. PR #1788
archived that roadmap; the test's `ROADMAP` constant still pointed at the active
path.

**Why the archiver did not catch it.** It does rewrite inbound references
(`agents/roadmaps/<x>.md` → `agents/roadmaps/archive/<x>.md`,
`src/agent-src/scripts/archive_completed_roadmaps.ts:15-17`) but it matches a
literal path, and this constant was assembled from separate `path.join`
arguments — there was no literal for it to see.

**The fix removes the class, not the instance.** `ROADMAP` now resolves
active-then-archive, so the next archival of this file cannot red the scan
again. The trailing `??` keeps the ENOENT message pointing at the active path,
which is the more useful one when the file is genuinely gone rather than moved.
Half B is untouched — it scans `src/**/*.ts` headers and is the half designed to
outlive the roadmap.

**Defect-pattern sweep** across `tests/` and `src/` for the same construct:
**8 candidate sites, 1 real defect** (this one). Six write fake slugs into temp
directories; `_lib/promotion_capability.ts`'s `MERGE_AUTHORITY_ROADMAP` does
point at a real active roadmap, but an archival there returns
`roadmap-unreadable`, which fails closed by design rather than breaking.

**RED-proven:** dropping the archive candidate reproduces the exact ENOENT and
`Tests no tests`; byte-identical restore returns 9/9.

## CI

40 pass, 1 skipping (`skill-lint-strict`), 0 failures.


## A neutral review found three ways this change still minted against an open blocker

The review was commissioned over the **whole delta of both branches**, with a
prompt stating no expected outcome. Because the orchestrator that wrote the code
also wrote the prompt, `evaluator-independence` admits the result as evidence
only if the prompt ships with it — both are committed at
`agents/evidence/reviews/drain13-neutral-review.md`, including the prompt's own
defect (it cited `lint_roadmap_blockers.ts:48` for the closedness read; the
reviewer caught that as finding 4).

**All three defects reached a minted capability while the blocker's live
`Status` read `open`.** They are pre-existing holes in `blockerSection`, and the
new `Disposition` line made them materially easier to trip — a disposition line
is far likelier to appear in a `What to do:` example than a `Status` line ever
was, because that field's whole job is to tell a maintainer which line to write.

1. **Fenced code was not stripped.** A fenced block showing the grant syntax
   minted with `Status: open` two lines above it. `lint_roadmap_blockers.ts:137`
   strips fences before its own read and this module did not — which *falsified*
   the "cannot diverge" claim rather than supporting it. Both strip now.
2. **`granted` was matched as a prefix.** The regex ended in `\b`, so
   `granted/refused (pick one)` (a half-written template),
   `granted? — unclear, ask owner`, and `granted-NOT, this is a refusal` all
   minted. It must be the whole value now.
3. **The heading search was unscoped.** Any `#{2,4} blocker: merge-authority`
   anywhere in the file won, so a `####` heading under a `## History` section
   could carry a status the repository's own gate never sees. Now confined to
   `## Blockers` and to `###`, exactly as the gate is.

Also fixed from the same review: the section terminator fired inside fenced code
and could not match h5/h6 (`#{1,4}` backtracks into `#`); four comments still
asserted the pre-change condition; and `lint_promotion_paths` re-derived the
polarity `isRefusingStatus` exists to own.

The three shared literals are copied from the gate rather than imported (that
module has load-time side effects), and a new test pins the copies byte-equal —
so the no-divergence claim is now **checked** instead of asserted.

**RED-proven individually:** removing the fence strip fails only the fence test;
dropping the section scoping fails only the scoping test; restoring the `\b`
anchor fails only the whole-value test. 29/29 green after each byte-identical
restore, 146/146 across the six related files.

### Two findings deliberately NOT fixed here

- **This roadmap crossed the documented 1000-line structural cap** (927 → 1065)
  and nothing caught it: `lint_roadmap_complexity.ts:50` carries only
  `LIGHTWEIGHT_LINE_CAP = 600`, so the structural cap in
  `src/agent-src/templates/roadmaps.md:28` is documented and ungated. Splitting a
  governance record whose two open items are owner-reserved is not this run's
  call, and the natural cut line is Phase 7 — the part the open blocker governs.
- **Two citation defects in files already merged via #1790**, which need their
  own change.

Both are carried in
`agents/roadmaps/stubs/road-to-promotion-bridge-size-and-citation-repairs.md`,
which also notes that a gate for the structural cap is the cheaper half and is
independent of any split.

### The review's clean categories, recorded because a null is a result

No checkbox, acceptance criterion, `status:` field or blocker moved anywhere in
either delta. On #1790 the reviewer resolved 22 citations, found all correct, and
independently recomputed the 38 = 24 + 2 + 12 partition and the 43-inbound
census.

## The earlier archived-path fix is superseded

The `governed_harness_no_live_harness.test.ts` fix described above landed
independently on `main` via #1785, as a `resolveRoadmap()` helper that **throws**
on a miss rather than returning a missing path — strictly better than the version
here, because a resolver returning a missing path would let half A scan nothing
and exit green. `main`'s version was taken in the merge. The finding and its
defect-pattern sweep stand; the duplicate implementation does not.
