### PR TITLE
roadmap(governed-evidence): close Phase 1, narrow the metered park, build Phase 2's arm and record its execution refusal

### DIFF
--- a/agents/evidence/analysis/governed-evidence-phase1-open-questions.md
+++ b/agents/evidence/analysis/governed-evidence-phase1-open-questions.md
@@ -1,3 +1,5 @@
+<!-- evidence-type: analysis -->
+
 # Governed-evidence Phase 1 and 2 — open questions
 
 Written by the session that executed `road-to-governed-evidence-production`

--- a/agents/evidence/analysis/governed-evidence-phase1-open-questions.md
+++ b/agents/evidence/analysis/governed-evidence-phase1-open-questions.md
@@ -1,0 +1,126 @@
+# Governed-evidence Phase 1 and 2 — open questions
+
+Written by the session that executed `road-to-governed-evidence-production`
+Phase 1 (steps 1.1-1.3) and the BUILD half of Phase 2 (step 2.1's arm), on
+2026-09-01. Each entry is a fork the tree could not settle, with the options and
+this session's recommendation. Nothing here is a decision.
+
+## OQ-1 — who freezes the execution protocol
+
+**Status:** resolved in practice by splitting the document; recorded because the
+two instructions this session received disagreed, and a later reader should see
+which was followed and why.
+
+**The disagreement.** The roadmap's own Phase 2 preamble, condition 2, says the
+session that freezes the execution protocol must be independent of the one that
+authored the arm. The task instruction for this session assigned deliverable 3
+— *freeze the execution protocol, in writing, BEFORE anything is captured* — to
+the session that also built the arm. Both cannot hold as stated.
+
+**What the underlying lock actually says.**
+`agents/roadmaps/later/road-to-routing-assurance-live-floors.md:49-52`: *"an
+independent session (not the one that authored the corpus) freezes the execution
+protocol — model/provider version, prompts, sampling, retry and exclusion policy
+— BEFORE capturing any baseline"*. The second seat's reason names the discretion
+being guarded against: *"model version, retries, exclusions and aggregation
+would all have been discretionary choices made by the session under
+evaluation"* (`:41-43`).
+
+**How this session split it, and the discriminator it used.** Not
+freeze-versus-not-freeze, but **is this clause a description or a choice**:
+
+- A clause that DESCRIBES the arm's code — endpoint, dated model ids, sampling,
+  the byte-exact prompts, the retry walk, the output contract — cannot favour an
+  outcome, and nobody but the author can write it accurately. Filled.
+- A clause DERIVED from a constant committed before the arm existed — the pair
+  count from `max_candidates`, the stopping rule from `ALPHA` and
+  `MIN_DISCORDANT`, the corpus from a stated byte-wise enumeration — is a
+  computation, not a preference. Filled, with the derivation shown.
+- A clause that is a genuine CHOICE with an outcome-relevant degree of freedom —
+  the paired outcome metric and its aggregation — is exactly what the park
+  reserves. Left UNSET and marked as Session B's, in
+  `docs/contracts/metered-proposer-protocol.md` § The one slot this document
+  leaves open.
+
+**Recommendation.** Keep the split. If the coordinator intended the whole
+document to be this session's, the metric slot is the one clause to re-assign
+rather than the whole file — filling it here would put the session under
+evaluation in charge of the number that decides its own arm, which is the single
+thing the park exists to prevent.
+
+**What would falsify the split:** a reading of the park under which describing
+one's own code counts as a discretionary choice. This session could not
+construct one — a description is checkable against the code it describes, and a
+wrong description is a defect rather than a bias.
+
+## OQ-2 — the `high` tier has no dated model id in this tree
+
+**Status:** open, and deliberately failing closed.
+
+`TIER_MODEL.high` is `null`, so `modelForTier('high')` throws. No dated
+`claude-opus-4-1-*` id exists anywhere in this repository, and a floating alias
+in a frozen protocol is not frozen.
+
+`high` is reachable only through an `execution_failed` escalation
+(`_lib/evolution_roi.ts:109`), so a run with no transport error never reaches
+it; a run that does hit one gets a loud refusal naming what to pin.
+
+**Options.** (a) Leave it refused, and let a run that needs `high` stop — the
+current state. (b) Pin a dated id, recording where it came from, and note it in
+the protocol. (c) Remove `high` from the `execution_failed` ladder, which is an
+edit to a constant this session does not own.
+
+**Recommendation.** (a) until a run actually needs it. A refusal that names its
+own remedy costs one aborted run; a guessed date costs a protocol that reads
+frozen and is not.
+
+## OQ-3 — nothing scans the metered arm for a live-harness construct
+
+**Status:** open, named rather than closed, and NOT a gap this session should
+close by editing someone else's gate.
+
+`tests/scripts/governed_harness_no_live_harness.test.ts` half B owns every `.ts`
+under `src/` whose text contains the slug `road-to-governed-harness-evolution`
+and applies a live-harness pattern set to it. The metered arm belongs to
+`road-to-governed-evidence-production`, whose park was narrowed on 2026-09-01 to
+permit exactly a metered proposer, so that scan should NOT cover it: extending it
+would enforce a lock a council has since narrowed.
+
+The consequence is real all the same — no standing scan now asserts that a model
+endpoint stays out of the metered arm's other files.
+`tests/scripts/llm_candidate_proposer.test.ts` closes it for this arm with a
+containment assertion (exactly one file in the arm's own closure may carry a
+model endpoint, and it is the transport), but that assertion is local to three
+named paths rather than a tree-wide scan.
+
+**Options.** (a) Leave the local containment assertion, and widen it if the arm
+grows more files. (b) Add a second slug-keyed scan for
+`road-to-governed-evidence-production` with a pattern set that PERMITS the
+transport and forbids everything else. (c) Nothing.
+
+**Recommendation.** (a) now, (b) if the metered arm grows past three files. (b)
+today would be a gate over a population of three, which is the shape this
+roadmap already refuses elsewhere.
+
+## OQ-4 — `assertCheapestFirst` had no falsifiable red until the resume path existed
+
+**Status:** resolved during the build; recorded because the first design shipped
+an unfalsifiable guard and a reader should see how it was caught.
+
+The first version called `assertCheapestFirst` on an attempt list the walk built
+entirely from `nextTier` per class. That list cannot be out of order by
+construction, so the guard's red was not producible through the caller — the
+same defect `_lib/candidate_proposer.ts:343-347` records for an output sort it
+deleted for exactly this reason.
+
+Found by running the sabotage: sharing one spent-map across classes did not make
+the guard fire, it made the ladder exhaust early and throw somewhere else.
+
+Closed by giving the arm a `priorAttempts` parameter for a budget-aborted run's
+history — untrusted caller input, validated by the same guard. An inconsistent
+history now reds, and removing the guard call reds that case, so the call is
+load-bearing rather than decorative.
+
+**What is still true:** over an EMPTY `priorAttempts` the guard still cannot
+fire. It is defence-in-depth on the fresh path and a real gate on the resume
+path, and the module says so where the call is.

--- a/agents/evidence/drain-run-summary.md
+++ b/agents/evidence/drain-run-summary.md
@@ -251,3 +251,151 @@ roadmap's own text reserved to the owner, an evidence record born stale, and two
 over-claims about what the council had said. All fixed, each with a commit ref.
 That review is the reason this summary can be read as evidence rather than as a
 report about itself.
+
+---
+
+# Drain run 13 — 2026-09-01
+
+A second autonomous drain run, on the tree the run above left behind. Same
+standing instruction: every open question, decision or blocker goes to the AI
+council rather than to the maintainer, and the council's recorded decision
+substitutes for owner sign-off.
+
+## Scope
+
+Recomputed from the tree, not from the seed queue — the seed named 36 roadmaps
+and **three** were active at `origin/main` @ `468eeefc7`. Two of the three are
+the ones run 12 left open; the third, `road-to-governed-evidence-production`, is
+the receiver run 12's successor created.
+
+**The active directory is NOT empty at the end of this run, and that is the
+recorded outcome rather than a shortfall.** All three files remain, each for a
+reason that is written down and falsifiable.
+
+## Pull requests
+
+| PR | Roadmap | Outcome | State |
+|---|---|---|---|
+| [#1789](https://github.com/event4u-app/agent-config/pull/1789) | `road-to-harness-promotion-bridge` | defect fixed + hardened; dispositions recorded; roadmap stays active | open |
+| [#1790](https://github.com/event4u-app/agent-config/pull/1790) | `road-to-council-topology-evidence-followups` | triggers verified, 4 faithfulness repairs; deliberately not drained | **merged** |
+| [#1791](https://github.com/event4u-app/agent-config/pull/1791) | `road-to-governed-evidence-production` | Phase 1 closed; Phase 2 unblocked, arm built, execution refused | open |
+
+`#1785` (a run-12 leftover for an already-archived roadmap) was merged by a human
+during this run. It was not touched by this run and is out of its scope.
+
+## Council decisions — one session, five questions
+
+AI council 2026-09-01: `anthropic/claude-sonnet-4-5` + `openai/codex-default`,
+2 rounds, deep, peer-review, blind chairman, quorum **2/2 present, needed 1 —
+concluded**, subscription transport, `billable=0`, **`$0.0000`**.
+
+| Q | Question | Verdict | Executed? |
+|---|---|---|---|
+| 1 | ADR-239 § Decision 3 / `blocker: merge-authority` | **1A refuse, 2/2** | **NO** — see below |
+| 2 | AC-9's disposition | **SPLIT 2A/2B**, both on one shared condition | resolved as **2B** from the tree |
+| 3 | `blocker: metered-backend-park` | **3B narrow to a proposer, 2/2** | **YES** |
+| 4 | the topology receiver's disposition | **4A leave as draft receiver, 2/2** | **YES** |
+| 5 | is the delegation manufacturing closure? | **YES**, one risk named | risk declined |
+
+**Q1's verdict was obtained and deliberately not executed, and the run discloses
+its own procedural defect for having asked.** The tree carries a live lock
+reserving that argument until *"a human either answers it or explicitly asks for
+the (b) argument to be put"*, and the question was written and dispatched before
+that lock was read — a `decision-revisit-gate` step-2 miss. Independently of the
+lock, writing the refusal into ADR-239 **is** settling ADR-239, which the
+reservation names in either direction. Disclosed in
+`road-to-harness-promotion-bridge.md` § Blockers, where the next reader looks.
+
+**Q2's split was resolved by a fact, not by picking a side.** Both seats
+conditioned their answer on the same question — does this repository admit an
+archive with an unmet acceptance criterion? It does not:
+`archive_completed_roadmaps.ts:14-16,562-563` gates on `count_open == 0`, counted
+by a whole-file `/gm` regex with no section filter, so `- [ ] AC-9` counts like
+an unfinished step. There is no `terminal-incomplete` disposition and no flag
+that supplies one.
+
+**Q3 was taken only after reading the actual lock, which corrected the
+blocker's own provenance.** The blocker cited *"the 5.2 evaluator-independence
+decision"*; step 5.2 only defers, and the reasoning lives in
+`agents/roadmaps/later/road-to-routing-assurance-live-floors.md:20-52`. Two facts
+there decide it: the park states its own authority as *"council-decidable, not
+owner-reserved"* (`:44-47`), and its objection is *"evaluating an artifact you
+authored"*, explicitly not cost (`:27-33`).
+
+## Descopes
+
+**None.** Nothing was descoped, cancelled, weakened, or marked complete on any of
+the three roadmaps in this run.
+
+## Terminal blocks, and what clears each
+
+| Item | Block | Clears when |
+|---|---|---|
+| `road-to-harness-promotion-bridge` 0.8, AC-9 | owner-reserved: ADR-239 § Decision 3 | the owner settles it; a **grant** is additionally barred by the `non-destructive-by-default` Hard Floor, which no standing instruction lifts |
+| `road-to-governed-evidence-production` 2.1, 2.2, AC-2, AC-3, AC-4 | host execution refusal on a session authorised to make paid API calls | a human runs the frozen protocol, or authorises a spending session |
+| `road-to-council-topology-evidence-followups`, all 38 | capacity that does not exist: `n >= 5` eligible seats (2 of a schema universe of exactly 5 are enabled), and reservation windows the tree cannot represent | the capacity exists **and** a human flips `status: draft` |
+
+The middle row is the one that moved. Phase 2 was held by a governance lock; it
+is now held by an environment-scoped refusal, which is falsifiable and cheap to
+clear. The run did **not** retry that refusal — the same shape is on record one
+roadmap over, where a run *"stopped rather than rephrasing its way past a safety
+refusal, which would have been the reservation defeated by persistence."*
+
+## What the run actually shipped
+
+- **A real security defect and its hardening.** `Status: resolved` was the only
+  closed token this repository recognises and the promotion capability read it as
+  a **grant** — so recording a *refusal* of preauthorized merge authority would
+  have minted the capability that performs unattended promotion. A neutral review
+  then found **three further ways** the fixed version still minted against a
+  blocker whose live status was `open` (a fenced example read as the live value,
+  `granted` matched as a prefix so a half-written template minted, and an
+  unscoped heading search). All four fixed, each pinned by its own test, each
+  RED-proven individually.
+- **Phase 1 of the governed-evidence receiver, closed on real evidence** — an
+  independent append-only activation-receipt producer that imports no evaluation
+  module (so its trust boundary holds by construction), a falsifiable trust
+  boundary and evidence-cost contract, and a twelve-stage enumeration that is
+  *computed* from committed arrays and reproduced by a second route.
+- **A metered proposer arm whose role constraint is structural** — six forbidden
+  roles each made unavailable by the type or the shape rather than by intention;
+  a scoring key is a build error.
+- **28 RED proofs across the run**, every one restored byte-identically. Three of
+  them found real defects instead of confirming health: an unfalsifiable
+  `assertCheapestFirst` guard, a vacuous test stub that made an ordering
+  assertion meaningless, and a hand-written family list that was the wrong
+  complement.
+- **A pre-existing red on `main`, diagnosed and swept.** PR #1788 archived a
+  roadmap without updating a test's hardcoded path, failing collection and taking
+  Node Tests shard 4/4 down on both OSes. Defect-pattern sweep: 8 candidate
+  sites, 1 real defect. Fixed independently on `main` via #1785 with a stricter
+  resolver; that version was taken.
+
+## Honest nulls
+
+- **No metered model call was made by any session in this run.** Zero requests to
+  any provider API, including no wiring probe — that would itself be a capture by
+  the park's own reasoning. The metered transport's live path is unexercised.
+- **No measurement was taken for any of the 38 topology items and none is
+  claimed.** Zero of them turned out to be already satisfied.
+- **`adherence` is reachable through the evaluation cascade's stage list but from
+  no shipped observer**, because no evidence source is admitted for it. Named in
+  the step rather than papered over.
+- **No tree-wide scan covers the new metered arm**; containment is asserted
+  locally over three paths. Recorded as an open question.
+- **The two prior councils' rulings were not overturned.** Where this run
+  disagreed with a recorded lock it said so and left the lock standing.
+
+## Open questions left for a human
+
+1. ADR-239 § Decision 3 — grant or refuse preauthorized merge authority. The
+   council's reasoning for refusal is recorded and unexecuted.
+2. Whether to run the frozen metered-proposer protocol, and who freezes its one
+   deliberately-unset slot (the paired outcome metric and its aggregation).
+3. Whether `road-to-council-topology-evidence-followups` should be flipped to
+   `ready` — its header reserves that to a human.
+4. Whether the ungated 1000-line structural roadmap cap should get a gate.
+   `road-to-harness-promotion-bridge` crossed it silently in this run.
+5. Whether the unguarded-removal exposure on the topology receiver — 38
+   obligations resting on a file no gate protects — warrants a standing
+   validator.

--- a/agents/roadmaps/road-to-governed-evidence-production.md
+++ b/agents/roadmaps/road-to-governed-evidence-production.md
@@ -149,7 +149,7 @@ preference to the illustration, and the reader can see which was chosen.
       widening the key list to admit one safe case would have weakened the floor
       for all three producers.
 
-- [x] **1.2 Settle the twelve-stage enumeration before treating the stage
+- [ ] **1.2 Settle the twelve-stage enumeration before treating the stage
       semantics as decided.**
       Carried from the same step's unconverged half. An AI council round of
       2026-08-31 returned `REVISE`, degraded at 1 of 2 seats: keep the decided
@@ -160,50 +160,6 @@ preference to the illustration, and the reader can see which was chosen.
       rather than as decided.
       verify: one enumeration is committed, and a second independent pass
       reproduces it rather than proposing a different twelve.
-      **CLOSED 2026-09-01, and the enumeration is COMPUTED rather than
-      proposed.** A third proposal would have been a third answer. What settles
-      an enumeration that two proposals disagreed on is removing proposal from
-      the process: `src/scripts/_lib/cascade_stage_enumeration.ts:87` derives
-      `TWELVE_STAGES` from two committed arrays — `CASCADE_STAGES` and the
-      ladder's `RECEIPT_STAGES` (`activation_ladder.ts:58`, itself derived from
-      `LADDER_RUNGS`) — by one stated ordering rule, stable-sorted on the
-      evidence each stage needs. Nobody's judgement is in the output, and
-      changing it requires changing an array, which is a visible diff rather than
-      a differently-worded reply.
-      **The twelve**, published as a machine-checked table in
-      `docs/contracts/evaluation-cascade-stages.md`: `schema-validity`,
-      `path-ownership`, `holdout-disclosure`, `budget`, `near-duplicate`, then
-      the six receipt stages `receipt-eligible` … `receipt-adhered`, then
-      `metric-verdict`. E9's condition is met literally — activation/delivery
-      and adherence are each their own stage. The statistical stage is LAST,
-      which is where the two prior enumerations disagreed, and the reason is the
-      ordering rule rather than taste: measurement is the only evidence class
-      that requires trials to have been run.
-      **The second pass is independent in ROUTE, not in author, and that is the
-      point rather than a hedge.** A second author is a second proposal, and two
-      proposals is the state that produced the `REVISE`. Route A imports the two
-      arrays; route B (`tests/scripts/twelve_stage_enumeration.test.ts`) reads
-      the same two source FILES as text, regex-extracts the stage names, reads
-      the evidence classes from the published contract table, re-applies the
-      ordering rule itself, and never reads `TWELVE_STAGES` except for the final
-      comparison. It reproduces the committed twelve exactly.
-      **What the reproduction does NOT establish, stated so it is not read as
-      more.** Both routes read the same two arrays, so neither is evidence that
-      the arrays hold the right rungs or the right stage set. Those are E4 and
-      E9, both already decided; reopening either is a decision-revisit matter.
-      **One further check derives the ordering rule from BEHAVIOUR**, not from
-      the table: the position at which `runCascade` first reads each
-      `CascadeInput` field must rise with the evidence-class rank, so a stage
-      reordered in the body without its class being updated reds.
-      **RED-proofs, 2026-09-01, each restored byte-identically and re-verified by
-      SHA-256:**
-      7. hand-edited `TWELVE_STAGES` to a different order: **1 failed** — route B
-         never reads that constant, which is exactly the property the failure
-         mode needed. Restored.
-      8. changed one class in the contract table only: **2 failed**. Restored.
-      9. added a seventh rung in code without the table: **4 failed**. Restored.
-      10. hoisted a read of `input.receipt` above the budget stage: **1 failed**
-          on the behavioural ordering check. Restored, 6/6.
 
 - [x] **1.3 State the receipt trust boundary and the evidence-cost contract
       before the producer writes its first receipt.**

--- a/agents/roadmaps/road-to-governed-evidence-production.md
+++ b/agents/roadmaps/road-to-governed-evidence-production.md
@@ -263,6 +263,52 @@ bind every step below:
 
 The fixture prohibition above is unchanged and is not weakened by any of this.
 
+**EXECUTION HALF ATTEMPTED AND REFUSED BY THE HARNESS, 2026-09-01 (drain run
+13). Recorded rather than worked around, and NOT retried.**
+
+The build half of Phase 2 landed in this branch: the metered arm
+(`src/scripts/_lib/llm_candidate_proposer.ts`), its transport
+(`src/scripts/_lib/llm_proposer_transport.ts`), the entry point
+(`src/scripts/llm_propose.ts`, dry by default) and the frozen execution protocol
+(`docs/contracts/metered-proposer-protocol.md`). **No metered call was made by
+that session — zero requests to any provider API**, which is the state the park's
+un-park procedure requires of the authoring session.
+
+The execution half was then dispatched to a **fresh, independent session** —
+which is the park's own requirement at
+`agents/roadmaps/later/road-to-routing-assurance-live-floors.md:49-52`, *"an
+independent session (not the one that authored the corpus) freezes the execution
+protocol … BEFORE capturing any baseline"*. That dispatch was **refused by the
+host harness's safety classifier** before the session started, because it would
+have been authorised to make real paid API calls.
+
+**Why it was not retried, and this is the load-bearing part.** The identical
+shape is already on the record one roadmap over:
+`road-to-harness-promotion-bridge.md` § `blocker: merge-authority` documents an
+autonomous run whose question *"was refused twice by the harness's own safety
+classifier before reaching any seat"*, and notes that the run *"stopped rather
+than rephrasing its way past a safety refusal, which would have been the
+reservation defeated by persistence."* The same reasoning binds here. A softened
+re-prompt that got the same work past the same classifier would be persistence,
+not authorisation — and the maintainer's pre-authorisation of token spend is not
+the classifier's to be argued with by an agent.
+
+**What this changes about Phase 2's state, precisely.** The block is no longer
+governance. `metered-backend-park` is narrowed and a metered proposer is
+admitted; the arm exists, the protocol is frozen, and the independence split is
+designed rather than hypothetical. What remains is a **harness execution
+refusal**, which is falsifiable and environment-scoped: it clears the moment a
+human runs the frozen protocol themselves, or authorises a session that may
+spend. Nothing here is closed on a fixture, and 2.1's verify clause — *"the
+comparison is a paired_verdict run, not an argument"* — is carried unweakened.
+
+**One protocol slot is deliberately UNSET and must stay that way until the
+executing session closes it: the paired outcome metric and its aggregation.**
+The build session left it open because the park names aggregation among the
+choices a session under evaluation must not make for itself. Whoever executes
+freezes it in writing FIRST, in its own commit, before any capture. A metric
+chosen after seeing a result is a tuned metric.
+
 - [ ] **2.1 An LLM proposer must beat the deterministic one to survive.**
       Transferred whole from `road-to-governed-harness-evolution` step 5.4.
       verify: the comparison is a paired_verdict run, not an argument.

--- a/agents/roadmaps/road-to-governed-evidence-production.md
+++ b/agents/roadmaps/road-to-governed-evidence-production.md
@@ -149,7 +149,7 @@ preference to the illustration, and the reader can see which was chosen.
       widening the key list to admit one safe case would have weakened the floor
       for all three producers.
 
-- [ ] **1.2 Settle the twelve-stage enumeration before treating the stage
+- [x] **1.2 Settle the twelve-stage enumeration before treating the stage
       semantics as decided.**
       Carried from the same step's unconverged half. An AI council round of
       2026-08-31 returned `REVISE`, degraded at 1 of 2 seats: keep the decided
@@ -160,6 +160,50 @@ preference to the illustration, and the reader can see which was chosen.
       rather than as decided.
       verify: one enumeration is committed, and a second independent pass
       reproduces it rather than proposing a different twelve.
+      **CLOSED 2026-09-01, and the enumeration is COMPUTED rather than
+      proposed.** A third proposal would have been a third answer. What settles
+      an enumeration that two proposals disagreed on is removing proposal from
+      the process: `src/scripts/_lib/cascade_stage_enumeration.ts:87` derives
+      `TWELVE_STAGES` from two committed arrays — `CASCADE_STAGES` and the
+      ladder's `RECEIPT_STAGES` (`activation_ladder.ts:58`, itself derived from
+      `LADDER_RUNGS`) — by one stated ordering rule, stable-sorted on the
+      evidence each stage needs. Nobody's judgement is in the output, and
+      changing it requires changing an array, which is a visible diff rather than
+      a differently-worded reply.
+      **The twelve**, published as a machine-checked table in
+      `docs/contracts/evaluation-cascade-stages.md`: `schema-validity`,
+      `path-ownership`, `holdout-disclosure`, `budget`, `near-duplicate`, then
+      the six receipt stages `receipt-eligible` … `receipt-adhered`, then
+      `metric-verdict`. E9's condition is met literally — activation/delivery
+      and adherence are each their own stage. The statistical stage is LAST,
+      which is where the two prior enumerations disagreed, and the reason is the
+      ordering rule rather than taste: measurement is the only evidence class
+      that requires trials to have been run.
+      **The second pass is independent in ROUTE, not in author, and that is the
+      point rather than a hedge.** A second author is a second proposal, and two
+      proposals is the state that produced the `REVISE`. Route A imports the two
+      arrays; route B (`tests/scripts/twelve_stage_enumeration.test.ts`) reads
+      the same two source FILES as text, regex-extracts the stage names, reads
+      the evidence classes from the published contract table, re-applies the
+      ordering rule itself, and never reads `TWELVE_STAGES` except for the final
+      comparison. It reproduces the committed twelve exactly.
+      **What the reproduction does NOT establish, stated so it is not read as
+      more.** Both routes read the same two arrays, so neither is evidence that
+      the arrays hold the right rungs or the right stage set. Those are E4 and
+      E9, both already decided; reopening either is a decision-revisit matter.
+      **One further check derives the ordering rule from BEHAVIOUR**, not from
+      the table: the position at which `runCascade` first reads each
+      `CascadeInput` field must rise with the evidence-class rank, so a stage
+      reordered in the body without its class being updated reds.
+      **RED-proofs, 2026-09-01, each restored byte-identically and re-verified by
+      SHA-256:**
+      7. hand-edited `TWELVE_STAGES` to a different order: **1 failed** — route B
+         never reads that constant, which is exactly the property the failure
+         mode needed. Restored.
+      8. changed one class in the contract table only: **2 failed**. Restored.
+      9. added a seventh rung in code without the table: **4 failed**. Restored.
+      10. hoisted a read of `input.receipt` above the budget stage: **1 failed**
+          on the behavioural ordering check. Restored, 6/6.
 
 - [x] **1.3 State the receipt trust boundary and the evidence-cost contract
       before the producer writes its first receipt.**

--- a/agents/roadmaps/road-to-governed-evidence-production.md
+++ b/agents/roadmaps/road-to-governed-evidence-production.md
@@ -244,6 +244,25 @@ Every step here is held by `metered-backend-park`. None of them may be worked
 before that blocker is resolved, and none of them may be closed by substituting
 a fixture for a run.
 
+**NARROWED 2026-09-01 — the phase is enterable for a metered PROPOSER only, and
+the two-session split is part of the discharge rather than a nicety.** See
+`blocker: metered-backend-park` → **NARROWED 2026-09-01** for the council record,
+the corrected provenance of the lock, and the role constraint. Three conditions
+bind every step below:
+
+1. **Role, not label.** A metered call may **generate** candidate text. It may
+   not score, rank, filter, select between, or supply any input to the verdict
+   for the arms being compared — whatever the module is called.
+2. **Independent session.** The park's un-park procedure requires the session
+   that freezes the execution protocol and captures results to be independent of
+   the one that authored the arm. A single session doing both is not a
+   discharge, however green the run.
+3. **Protocol frozen first, in writing** — model/provider version, prompts,
+   sampling, retry policy, exclusion policy — before any capture. A protocol
+   written after a result is a tuned protocol.
+
+The fixture prohibition above is unchanged and is not weakened by any of this.
+
 - [ ] **2.1 An LLM proposer must beat the deterministic one to survive.**
       Transferred whole from `road-to-governed-harness-evolution` step 5.4.
       verify: the comparison is a paired_verdict run, not an argument.
@@ -294,6 +313,69 @@ a fixture for a run.
   the park to permit a metered *proposer* while still forbidding a metered
   *evaluator*, if the independence objection turns out to bind only the
   evaluating side.
+
+  **NARROWED 2026-09-01 (drain run 13) — option (c) TAKEN. A metered PROPOSER is
+  admitted; a metered EVALUATOR remains forbidden.** *AI council 2026-09-01
+  (`anthropic/claude-sonnet-4-5` + `openai/codex-default`, 2 rounds, deep,
+  peer-review, blind chairman, quorum 2/2 present, needed 1 — concluded,
+  subscription transport, `billable=0`, `$0.0000`) — Question 3: **3B, 2/2
+  convergent.***
+
+  **The lock was read before it was narrowed, and the read corrected this
+  entry's own provenance.** This blocker calls the constraint *"the 5.2
+  evaluator-independence decision of 2026-08-25"*. Step 5.2 of the archived
+  parent (`agents/roadmaps/archive/road-to-governed-harness-evolution.md:1632`)
+  in fact says only *"Keep the live-floors park intact. No live harness."* and
+  **defers** to a different file. The real lock is
+  `agents/roadmaps/later/road-to-routing-assurance-live-floors.md:20-52`, and it
+  is that file — not 5.2 — that carries the evaluator-independence reasoning. The
+  shorthand was accurate in substance and wrong about where the reasoning lives;
+  a later reader following this entry to 5.2 would have found a one-line pointer
+  and no argument.
+
+  **Two facts from the real lock decide this narrowing, and neither was
+  available from the shorthand.**
+
+  - **Authority is not owner-reserved.** The park states it outright: *"Both
+    seats: council-decidable, not owner-reserved. The parent's cut line
+    pre-authorises exactly this disposition, the move is reversible, it creates
+    no external commitment, and the preservation test passes"*
+    (`:44-47`). So a council may narrow it. This is the opposite of the
+    `merge-authority` blocker on `road-to-harness-promotion-bridge`, which is
+    owner-reserved in both directions — the two must not be reasoned about
+    together.
+  - **The objection is about evaluating what you authored, not about spending.**
+    *"Cost was explicitly not the objection — token spend was pre-authorised. The
+    objection is evaluator independence"*, sharpened by one seat to *"it's about
+    evaluating an artifact you authored"* (`:27-33`). A metered **proposer**
+    generates an arm; it decides nothing. The evaluator for 2.1 is
+    `decidePairedVerdict` (`src/scripts/_lib/paired_verdict.ts:126`), which is
+    deterministic and whose decision constants — `ALPHA` (`:51`) and
+    `MIN_DISCORDANT` (`:78`) — were committed before any arm existed and cannot
+    be tuned to a result. So the narrowing does not touch the thing the park
+    protects.
+
+  **The narrowing constrains ROLES, not provider labels** — openai's refinement,
+  adopted verbatim in substance: *"a 'proposer' that ranks, filters, or supplies
+  the controlling verdict could effectively become an evaluator and defeat the
+  independence boundary."* Admitted: a metered call that **generates** candidate
+  text. Still forbidden: a metered call that scores, ranks, filters, selects
+  between, or supplies any input to the verdict for the arms being compared —
+  whatever it is named.
+
+  **The park's own un-park procedure binds and is NOT waived.** It requires *"an
+  independent session (not the one that authored the corpus)"* to freeze the
+  execution protocol — model/provider version, prompts, sampling, retry and
+  exclusion policy — **before** capturing any baseline (`:49-52`). Applied here:
+  the session that builds the metered proposer arm may not also run the
+  comparison. Phase 2 is therefore executed as a two-session split, and a
+  single-session run of 2.1 is not a discharge of it however green it comes back.
+
+  **What this does NOT do.** It does not un-park
+  `road-to-routing-assurance-live-floors.md`, whose steps need a live *routing*
+  harness and are untouched. It does not admit a metered evaluator anywhere. It
+  does not relax `tests/scripts/governed_harness_no_live_harness.test.ts`, which
+  polices the archived parent's own tree and is not this roadmap's gate.
 - **Recommendation:** (b) until someone needs Phase 2's answer. The park does
   not rest on cost — token spend was explicitly pre-authorised when it was
   decided — it rests on evaluator independence, and nothing has changed about

--- a/agents/roadmaps/road-to-governed-evidence-production.md
+++ b/agents/roadmaps/road-to-governed-evidence-production.md
@@ -47,7 +47,7 @@ preference to the illustration, and the reader can see which was chosen.
 
 ## Phase 1 — Deterministic evidence, executable under the park
 
-- [ ] **1.1 Produce activation receipts from an independent, append-only
+- [x] **1.1 Produce activation receipts from an independent, append-only
       producer, so the evaluation cascade's receipt-bearing stages have a
       subject.**
       Transferred whole from `road-to-governed-harness-evolution` step 4.1 —
@@ -73,8 +73,83 @@ preference to the illustration, and the reader can see which was chosen.
       **Why this is Phase 1 and not Phase 2:** producing a receipt requires
       observing real activation, which the park does not forbid. It forbids a
       live model harness.
+      **CLOSED 2026-09-01 — the producer exists, it writes, and the exclusion is
+      gone.** Three artefacts, and each one names the gap it filled:
+      (a) `src/scripts/_lib/activation_receipt_producer.ts` — the producer.
+      `EVIDENCE_SOURCES` (`:65`) is a closed three-value set, each with a shipped
+      observer; `buildActivationReceipt` (`:115`) refuses an unadmitted source
+      and refuses an admitted source speaking about another source's rung;
+      `appendActivationLine` (`:317`) uses `appendFileSync` and nothing else;
+      `UNOBSERVED_RUNGS` (`:76`) makes the coverage gap enumerable data rather
+      than prose. It imports no evaluation module, so TB-1 holds by construction
+      rather than by care.
+      (b) `src/scripts/activation_receipt.ts` — the PRODUCTION CALLER, because a
+      library nothing calls has no coverage. It observes three rungs from three
+      real surfaces (`src/` for `eligible`, `dist/discovery/discovery-manifest.json`
+      for `selected`, a host tree for `projected`) and appends one audit-log-v1
+      line carrying an `activation` object (`:238`).
+      (c) the receipt-bearing stages in `evaluation_cascade.ts`:
+      `CascadeInput.receipt` (`:268`), the stage block (`:381`),
+      `RECEIPT_ASSIGNABLE_FAMILIES` (`:141`) and `familyForStage` made total over
+      both halves (`:187`).
+      **The first conjunct still holds and was re-checked, not assumed.**
+      `model_calls` is still the literal `0` on every path, receipt aborts
+      included.
+      **The second conjunct — the stage list can produce the Phase 1
+      classification.** `PREFIX_ASSIGNABLE_FAMILIES` (`:116`) is UNCHANGED at
+      `['content','unknown']`: widening it was never the fix, and a later edit
+      that widens it reds. What changed is that the prefix is one half of the
+      stage list instead of all of it. `runCascade` reaches each of the four
+      families, asserted one test per family, and three of the four —
+      `content`, `activation`, `unknown` — are reachable from REAL filesystem
+      observation rather than from a fixture: `activation_receipt --rule
+      commit-policy` reports `family=activation` because that rule is authored
+      and selected but not projected into `.claude/rules/`, and that is an
+      observation of the tree, not an inference about a candidate.
+      **The coverage gap, named rather than absorbed.** `adhered` has no admitted
+      evidence source, so the shipped producer cannot emit that rung and a real
+      receipt is ABSENT there — which the ladder reads as `unknown` and keeps out
+      of every denominator. The `adherence` family is therefore reachable through
+      the stage list but not yet from any shipped observer. That is a COVERAGE
+      fact about observers, not a stage-list fact, and AC-1's own wording is what
+      settles which of the two this step owed: *"the stage list can ASSIGN all
+      four Phase 1 families rather than two."* Admitting a fourth source with no
+      observer behind it would have made the gap invisible instead of closing it,
+      which is the population-of-zero failure 2.2 stays open on.
+      **A defect the tests caught before the roadmap could record it.**
+      `RECEIPT_ASSIGNABLE_FAMILIES` was first hand-written as the prefix's
+      complement, `['activation','adherence','unknown']`. That is wrong: the
+      `eligible` rung's family is `content`, so a receipt stage can assign
+      `content` too. It is derived from `LADDER` now, and the assertion that
+      caught it is kept.
+      **RED-proofs, 2026-09-01, each restored byte-identically and re-verified by
+      SHA-256** (`tests/scripts/activation_receipt_producer.test.ts`,
+      `tests/scripts/cascade_receipt_stages.test.ts`):
+      1. TB-2 — defaulted every unobserved rung to `not-reached`: **2 failed**,
+         including the real-CLI case. Restored, 21/21.
+      2. TB-3 — removed the source/rung mismatch refusal: **1 failed**. Restored.
+      3. TB-4 — `appendFileSync` to `writeFileSync`: **2 failed** (the behavioural
+         two-line case and the structural scan). Restored.
+      4. EC-1 — added `fetch('https://api.anthropic.com/...')` to the producer:
+         **1 failed**. Restored.
+      5. the wiring — disabled the receipt block in `runCascade`: **4 failed**,
+         `activation` and `adherence` both unreachable. Restored, 9/9.
+      6. the exclusion — let a PREFIX stage assign `activation`: **4 failed**,
+         two of them pre-existing assertions from step 4.1, which is the check
+         that the old guarantee is still guarded. Restored.
+      Restore verified green: 67/67 across the five touched test files,
+      `tsc -p tsconfig.scripts.json --noEmit` clean.
+      **Doc-impact.** `docs/contracts/audit-log-v1.md` said the compile-time
+      privacy floor binds "two shipped producers" and that a third would be
+      caught by nothing. There are three now and the third carries the same
+      guard, so the count, the § Producer table and the `activation` field row
+      were corrected in the same change. The guard's bluntness is recorded there
+      too: the ladder's `reason` field is a `FREE_FORM_KEYS` member, so the
+      producer's input field is `precedence_reason` and is mapped on emission —
+      widening the key list to admit one safe case would have weakened the floor
+      for all three producers.
 
-- [ ] **1.2 Settle the twelve-stage enumeration before treating the stage
+- [x] **1.2 Settle the twelve-stage enumeration before treating the stage
       semantics as decided.**
       Carried from the same step's unconverged half. An AI council round of
       2026-08-31 returned `REVISE`, degraded at 1 of 2 seats: keep the decided
@@ -85,8 +160,52 @@ preference to the illustration, and the reader can see which was chosen.
       rather than as decided.
       verify: one enumeration is committed, and a second independent pass
       reproduces it rather than proposing a different twelve.
+      **CLOSED 2026-09-01, and the enumeration is COMPUTED rather than
+      proposed.** A third proposal would have been a third answer. What settles
+      an enumeration that two proposals disagreed on is removing proposal from
+      the process: `src/scripts/_lib/cascade_stage_enumeration.ts:87` derives
+      `TWELVE_STAGES` from two committed arrays — `CASCADE_STAGES` and the
+      ladder's `RECEIPT_STAGES` (`activation_ladder.ts:58`, itself derived from
+      `LADDER_RUNGS`) — by one stated ordering rule, stable-sorted on the
+      evidence each stage needs. Nobody's judgement is in the output, and
+      changing it requires changing an array, which is a visible diff rather than
+      a differently-worded reply.
+      **The twelve**, published as a machine-checked table in
+      `docs/contracts/evaluation-cascade-stages.md`: `schema-validity`,
+      `path-ownership`, `holdout-disclosure`, `budget`, `near-duplicate`, then
+      the six receipt stages `receipt-eligible` … `receipt-adhered`, then
+      `metric-verdict`. E9's condition is met literally — activation/delivery
+      and adherence are each their own stage. The statistical stage is LAST,
+      which is where the two prior enumerations disagreed, and the reason is the
+      ordering rule rather than taste: measurement is the only evidence class
+      that requires trials to have been run.
+      **The second pass is independent in ROUTE, not in author, and that is the
+      point rather than a hedge.** A second author is a second proposal, and two
+      proposals is the state that produced the `REVISE`. Route A imports the two
+      arrays; route B (`tests/scripts/twelve_stage_enumeration.test.ts`) reads
+      the same two source FILES as text, regex-extracts the stage names, reads
+      the evidence classes from the published contract table, re-applies the
+      ordering rule itself, and never reads `TWELVE_STAGES` except for the final
+      comparison. It reproduces the committed twelve exactly.
+      **What the reproduction does NOT establish, stated so it is not read as
+      more.** Both routes read the same two arrays, so neither is evidence that
+      the arrays hold the right rungs or the right stage set. Those are E4 and
+      E9, both already decided; reopening either is a decision-revisit matter.
+      **One further check derives the ordering rule from BEHAVIOUR**, not from
+      the table: the position at which `runCascade` first reads each
+      `CascadeInput` field must rise with the evidence-class rank, so a stage
+      reordered in the body without its class being updated reds.
+      **RED-proofs, 2026-09-01, each restored byte-identically and re-verified by
+      SHA-256:**
+      7. hand-edited `TWELVE_STAGES` to a different order: **1 failed** — route B
+         never reads that constant, which is exactly the property the failure
+         mode needed. Restored.
+      8. changed one class in the contract table only: **2 failed**. Restored.
+      9. added a seventh rung in code without the table: **4 failed**. Restored.
+      10. hoisted a read of `input.receipt` above the budget stage: **1 failed**
+          on the behavioural ordering check. Restored, 6/6.
 
-- [ ] **1.3 State the receipt trust boundary and the evidence-cost contract
+- [x] **1.3 State the receipt trust boundary and the evidence-cost contract
       before the producer writes its first receipt.**
       The 2026-08-31 `REVISE` names these two as the precondition for 1.2, and
       1.1 cannot be reviewed without them: a receipt producer that is not
@@ -94,6 +213,30 @@ preference to the illustration, and the reader can see which was chosen.
       layer up.
       verify: both are written down as falsifiable claims, and 1.1's producer
       design cites them rather than restating them.
+      **CLOSED 2026-09-01. `docs/contracts/activation-receipt-trust-boundary.md`**
+      — four trust-boundary claims (TB-1 no evaluation input decides a rung
+      STATE; TB-2 an unobserved rung is absent, never negative; TB-3 every state
+      names an admitted source, and an admitted source with no shipped observer
+      is itself a refutation; TB-4 append, never rewrite) and three
+      evidence-cost claims (EC-1 zero model calls; EC-2 no receipt stage runs
+      before the free prefix; EC-3 a missing observation is never bought).
+      **Falsifiable in the literal sense the verify clause asks for:** each claim
+      states the observation that would REFUTE it, and each refuting observation
+      is one a test can make. They are not decorative — the test file asserts
+      each claim by its id and each assertion is written as the contract's own
+      refutation, so a reader checks the test against the claim rather than
+      against a paraphrase.
+      **Cited, not restated, by 1.1.** The producer's header
+      (`src/scripts/_lib/activation_receipt_producer.ts:9-30`) carries a table
+      mapping each claim id to the line of code that binds it, and the contract
+      is the only place the claims are written. Both directions were RED-proven
+      — see 1.1.
+      **TB-1 was sharpened while writing 1.1, and the sharpening is recorded
+      because it changes what the claim forbids.** The first draft forbade a rung
+      being "derived from a candidate record", which would have forbidden a
+      caller naming WHICH artefact a receipt is about. Subject and state are now
+      separated explicitly: the subject is an input and decides nothing; the
+      state is evidence and may come only from an admitted source.
 
 ## Phase 2 — Experimental evidence, blocked on the metered-backend park
 
@@ -175,9 +318,20 @@ a fixture for a run.
 
 ## Acceptance Criteria
 
-- [ ] AC-1 — An activation receipt exists that was written by a producer
+- [x] AC-1 — An activation receipt exists that was written by a producer
       independent of the classifier, and the evaluation cascade's stage list can
       assign all four Phase 1 families rather than two.
+      **MET 2026-09-01 by step 1.1.** First half: `activation_receipt --rule
+      <id>` appends a real line, and the test asserts the append against the real
+      repository rather than a fixture. The ledger is local-only by contract
+      (`audit-log-v1.md` § File location — "MAY be gitignored in consumer
+      projects"), so "exists" rests on a reproducible write, not on a committed
+      artefact; a committed receipt is not a thing this contract permits. Second
+      half: `PREFIX_ASSIGNABLE_FAMILIES` stays at two and the stage list spans
+      four, asserted one test per family. The `adhered` rung has no shipped
+      observer, so the `adherence` family is reachable through the stage list and
+      not yet from real evidence — a coverage gap named in 1.1 rather than
+      counted here.
 - [ ] AC-2 — A paired-verdict comparison between a metered proposer and the
       deterministic one has been run, and its result — in either direction —
       is recorded. Held by `metered-backend-park`.

--- a/agents/roadmaps/road-to-governed-evidence-production.md
+++ b/agents/roadmaps/road-to-governed-evidence-production.md
@@ -282,6 +282,46 @@ The fixture prohibition above is unchanged and is not weakened by any of this.
       proposition being verified rather than correcting it. The source step's
       `category` was corrected to `future-mechanism` in the same movement, which
       removed a closure right and granted none.
+      **SESSION A — THE BUILD HALF LANDED 2026-09-01. THE STEP STAYS `[ ]`, AND
+      that is the design rather than a shortfall.** The park's un-park procedure
+      requires the session that freezes the protocol and captures results to be
+      independent of the one that authored the arm
+      (`agents/roadmaps/later/road-to-routing-assurance-live-floors.md:49-52`),
+      so a single session doing both is not a discharge however green it comes
+      back. This session built the arm and made **zero metered calls**.
+      **The second arm now exists**, which was the whole of what 2.1 was blocked
+      on — *"a paired verdict needs two arms and
+      `src/scripts/_lib/llm_candidate_proposer.ts` does not exist"*:
+      (a) `src/scripts/_lib/llm_candidate_proposer.ts` — the arm. Same
+      `DefectObservation` input, same `CandidateRecord` output, same id function
+      and same input ordering as the deterministic arm, so the two are
+      comparable pair-wise over one input.
+      (b) `src/scripts/_lib/llm_proposer_transport.ts` — the only file in the
+      arm's closure carrying a model endpoint. Dated model ids only; the `high`
+      tier is `null` and REFUSES, because no dated `claude-opus-4-1-*` id exists
+      in this tree and a floating alias in a frozen protocol is not frozen.
+      (c) `src/scripts/llm_propose.ts` — the entry point, dry by default.
+      `--confirm` is the only path that spends, and it has never been taken.
+      **The role constraint is structural, not intentional.** A metered call may
+      generate text and nothing else, and six separate mechanisms make the other
+      roles unavailable rather than discouraged: the port's result type carries
+      `text` and `model` only and a `NoDecisionField` compile-time assert turns
+      any scoring key into a BUILD ERROR; the port takes one request and returns
+      one result, so it cannot express a batch or a comparison; one record per
+      observation is asserted at the return; an unsatisfiable observation THROWS
+      instead of being dropped, so the output can never be a subset; output
+      order is `byteCompare` over the INPUT using the deterministic arm's own
+      comparator; and the arm imports no verdict module. One test per mechanism.
+      **Escalation is decided by a deterministic refusal, never by the model.**
+      The first attempt runs on `reason_unknown`, whose ladder is exactly
+      `['lite']`; a refusal is classified into a `PathologyWhy` from the refusal
+      itself and the walk continues on that class's cheapest untried rung. The
+      retry stops at the FIRST contract-valid generation — it never holds two
+      valid generations and no code path can express choosing between them.
+      **What has NOT happened:** no metered call, no capture, no comparison. The
+      transport's live path is unexercised; its request shape is proven by
+      `describeRequest` and a unit test over the description, and every
+      behavioral test uses a stubbed generator.
 
 - [ ] **2.2 Cheap proposer models first, and track evolution ROI.**
       Transferred whole from `road-to-governed-harness-evolution` step 5.6.
@@ -298,6 +338,26 @@ The fixture prohibition above is unchanged and is not weakened by any of this.
       population of zero, because nothing in the tree makes a metered proposer
       call. A check that scans a population of zero exits green while looking
       like coverage, which is why this is open rather than closed.
+      **UPDATED 2026-09-01 — the caller now exists; the live population does
+      not.** `proposeCandidatesWithModel`
+      (`src/scripts/_lib/llm_candidate_proposer.ts:369`) calls
+      `assertCheapestFirst` over the attempts the walk actually made, and
+      `plannedAttempts` (`:429`) calls it over the dry-run plan, which
+      `llm_propose` reaches with no spend. So "zero production callers" is no
+      longer true. What is still true is that no LIVE run has produced attempts,
+      so the ordering has not yet governed a spent population — see AC-3.
+      **A defect found and closed during the build, recorded because the first
+      version shipped an unfalsifiable guard.** The walk builds attempts from
+      `nextTier` per class, so an out-of-order list is unconstructible and the
+      guard's red was NOT producible through the caller — the same defect
+      `_lib/candidate_proposer.ts:343-347` records for an output sort it deleted
+      for exactly this reason. Found by running the sabotage: sharing one
+      spent-map across classes did not make the guard fire, it exhausted the
+      ladder early and threw elsewhere. Closed by the `priorAttempts` parameter
+      — a budget-aborted run's history is UNTRUSTED caller input validated by
+      the same guard, so an inconsistent history reds and removing the guard
+      call reds that case. Over an empty history the guard is still
+      defence-in-depth, and the module says so at the call.
 
 ## Blockers
 
@@ -419,6 +479,20 @@ The fixture prohibition above is unchanged and is not weakened by any of this.
       is recorded. Held by `metered-backend-park`.
 - [ ] AC-3 — `assertCheapestFirst` has at least one production caller, so the
       ordering it polices governs a real population rather than an empty one.
+      **HALF MET 2026-09-01, and left `[ ]` on the half that is not.** The
+      caller exists and is on the executable path: `proposeCandidatesWithModel`
+      calls it over the attempts a run actually made, and `plannedAttempts`
+      calls it over the dry-run plan, which `llm_propose` reaches without
+      spending. The guard is also falsifiable now — an inconsistent resumed
+      history is refused, and removing the call reds that case.
+      **What is not met is the criterion's purpose clause.** The populations
+      that exist today are the all-`lite` dry plan, in which no ordering
+      decision arises, and test populations under a stubbed generator. Neither
+      is a spent population, so the ordering has not yet governed one.
+      **No further code is needed to close it** — Session B's first metered run
+      produces the population, and the caller is already there to police it.
+      Checking it now would be closing on the half that was already true, which
+      is the failure this whole file was transferred to prevent.
 - [ ] AC-4 — Programme success and failure criteria were committed before the
       first candidate run, and the run report carries an evolution-ROI figure.
       Transferred whole from `road-to-governed-harness-evolution` AC-8. Its

--- a/docs/contracts/activation-receipt-trust-boundary.md
+++ b/docs/contracts/activation-receipt-trust-boundary.md
@@ -1,0 +1,181 @@
+---
+stability: beta
+keep-beta-until: 2026-11-30
+roadmap_ref: road-to-governed-evidence-production.md
+---
+
+# Activation-receipt trust boundary and evidence-cost contract
+
+**Purpose.** State, as falsifiable claims, (a) what makes an activation receipt
+independent of the thing it reports on, and (b) what a receipt is allowed to
+cost. Written under `road-to-governed-evidence-production` step 1.3, whose
+verify clause requires both to be written down before a producer writes its
+first receipt, and requires step 1.1's producer to **cite** them rather than
+restate them.
+
+**Scope.** Governs the producer of the optional `activation` object on an
+audit-log-v1 line ([`audit-log-v1.md`](audit-log-v1.md) § Field semantics), the
+receipt shape in
+[`src/scripts/_lib/activation_ladder.ts`](../../src/scripts/_lib/activation_ladder.ts),
+and the receipt-bearing stages of the evaluation cascade
+([`src/scripts/_lib/evaluation_cascade.ts`](../../src/scripts/_lib/evaluation_cascade.ts)).
+Does **not** define the ladder's rungs, its families, or the aggregation rule —
+those are the ladder module's, and duplicating them here would create a second
+source of truth for the same enum.
+
+## Why this exists — the failure it is written against
+
+The deterministic cascade excludes `activation` and `adherence` from
+`PREFIX_ASSIGNABLE_FAMILIES` because assigning either from a deterministic proxy
+manufactures evidence: a holdout leak is not an observation that activation
+failed. A receipt producer removes that exclusion — and if the producer reads
+the same inputs the classifier reads, the proxy problem returns one layer up,
+where it is harder to see. That is
+`road-to-governed-evidence-production` § Risk Register row 1, and every claim
+below is written so that a reader can check whether it has happened.
+
+Each claim states the observation that would **refute** it. A claim whose
+refuting observation cannot be made is not a claim in this contract.
+
+## Trust-boundary claims
+
+### TB-1 — The producer reads no evaluation input
+
+> **Claim.** No rung STATE written by the producer is a function of a candidate
+> record, a cascade stage outcome, a metric vector, or a promotion verdict.
+
+**Refuted by:** an import edge from the producer module to
+`_lib/evaluation_cascade.ts`, `_lib/candidate_record.ts`,
+`_lib/evaluation_vector.ts` or `_lib/paired_verdict.ts`; or any producer code
+path whose emitted `RungState` is a function of a value obtained from one of
+them.
+
+**Subject and state are separated deliberately, and the word `STATE` is
+load-bearing.** *Which* artifact a receipt is about is an INPUT — a caller may
+name it from anywhere, including from a candidate record, and doing so decides
+nothing. *Whether* a rung was reached is EVIDENCE, and it may come only from an
+admitted source under TB-3. A contract that forbade the subject too would forbid
+producing a receipt about a candidate at all, which is not the failure being
+guarded against: the proxy problem is a state inferred from the evaluator's own
+judgement, never a name passed across a function boundary.
+
+**Why an import edge is the refuting observation and not a proxy for one.** The
+producer's only inputs are its declared observations; if it imports no
+evaluation module, there is no value from the evaluation side it could read.
+The direction is deliberately one-way: the cascade MAY import the producer's
+receipt type, because consuming a receipt is not the same as producing one.
+
+### TB-2 — An unobserved rung is absent, never negative
+
+> **Claim.** A rung for which the producer holds no observation is omitted from
+> the receipt. It is never written as `not-reached`, and never as `reached`.
+
+**Refuted by:** a receipt in which a rung carries `not-reached` while the
+producer's observation set names no observation for that rung; equivalently, a
+`ladderRate` denominator that grows when a rung goes unobserved.
+
+This is the same absent-versus-empty distinction audit-log-v1 already draws for
+`skills_applied`, and it exists for the same reason: a reader that folds "not
+recorded" into "recorded, and negative" inflates every downstream rate by
+exactly the capture gap.
+
+### TB-3 — Every observation names an admitted evidence source
+
+> **Claim.** Every rung state carries an `evidence_source` drawn from a closed,
+> committed set, and each admitted source is a surface the producer can read
+> without consulting the evaluation side.
+
+**Refuted by:** a receipt carrying an `evidence_source` outside the committed
+set; or an admitted source whose reader imports an evaluation module (which
+would also refute TB-1); or an admitted source with no shipped observer, which
+makes the set describe a capability that does not exist.
+
+**The last clause is a real constraint and it costs coverage.** An adherence
+observation would need a source that reads what a reply actually did. No such
+source is admitted today, so the producer cannot emit the `adhered` rung, and
+real receipts therefore read `unknown` at that rung rather than claiming
+adherence either way. Admitting a source with no observer would make the
+coverage gap invisible instead of closing it — the same "check that scans a
+population of zero exits green" failure the roadmap flags for
+`assertCheapestFirst`.
+
+### TB-4 — Receipts append; they never rewrite
+
+> **Claim.** The producer only appends lines. A correction is a new line with
+> `type=supersede` naming the prior `id`, per audit-log-v1 § Append-only
+> invariant.
+
+**Refuted by:** a producer code path that opens an audit file in a mode other
+than append, that truncates one, or that emits a line reusing an existing `id`
+without `type=supersede`.
+
+## Evidence-cost claims
+
+### EC-1 — Producing a receipt costs zero model calls
+
+> **Claim.** The producer and its dependency closure contain no transport
+> import, no network call, no subprocess spawn, and no API-key environment read.
+
+**Refuted by:** any of those four appearing in the producer module or in a
+module it imports. This is the same shape as the survival-bar assertion in
+`tests/scripts/proposer_survival_bar.test.ts`, and it is checkable by reading
+source rather than by counting calls at runtime — a counter can be wrong about
+a call that did not happen on the path under test.
+
+**Consequence, stated so it cannot be read as narrower than it is.** Receipt
+production is admissible under the `metered-backend-park` blocker. The park
+forbids a live model harness; it does not forbid observing a filesystem.
+
+### EC-2 — No receipt-bearing stage runs before the free prefix
+
+> **Claim.** In the committed stage enumeration, every receipt-bearing stage has
+> a higher index than every stage of the deterministic prefix that precedes the
+> measurement stage.
+
+**Refuted by:** a committed enumeration in which a `receipt-*` stage index is
+lower than the index of `schema-validity`, `path-ownership`,
+`holdout-disclosure`, `budget` or `near-duplicate`.
+
+The cascade's ordering rule is cheapest-first and abort-on-first-failure. A
+receipt is cheap, but it is not free of *precondition*: classifying how far an
+artifact climbed is meaningless for a candidate that is not even well-formed, so
+the receipt stages sit after the record-only and plan-only stages and before the
+measurement stage, whose evidence is the most expensive to obtain.
+
+### EC-3 — A missing observation is never bought
+
+> **Claim.** When an evidence source yields nothing for a rung, the producer
+> records absence. It does not trigger work to obtain the observation.
+
+**Refuted by:** a producer code path that, on a missing observation, calls an
+observer a second time, spawns a process, or performs any I/O beyond the read
+that already returned nothing.
+
+**Why this is separate from EC-1.** EC-1 forbids a *model* call. EC-3 forbids
+the cheaper version of the same mistake: a producer that quietly escalates from
+observing to investigating, whose cost is unbounded even though no token is
+spent. `unknown` is the intended output of a missing observation, not a
+degraded one.
+
+## What this contract does not claim
+
+- **It does not claim coverage.** Every claim above is about the producer's
+  discipline; none asserts that any particular rung is observable today. The
+  shipped observer set and the rungs it leaves unobserved are recorded in the
+  producer module, where they can change without amending this contract.
+- **It does not claim the receipt is correct.** An observer that reads the wrong
+  file produces a wrong receipt that satisfies TB-1 through TB-4. Observer
+  correctness is each observer's own test's problem.
+- **It does not gate the classifier.** `classifyFailure` is unchanged by this
+  contract and keeps its own short-circuit-on-unknown rule.
+
+## Cross-references
+
+- Receipt shape, rungs, families, aggregation:
+  [`src/scripts/_lib/activation_ladder.ts`](../../src/scripts/_lib/activation_ladder.ts).
+- The line the receipt rides on, and the absent-versus-empty rule TB-2 mirrors:
+  [`audit-log-v1.md`](audit-log-v1.md).
+- The prefix exclusion this contract makes it safe to lift:
+  [`src/scripts/_lib/evaluation_cascade.ts`](../../src/scripts/_lib/evaluation_cascade.ts).
+- Privacy floor the producer's input type is bound by:
+  [`audit-log-v1.md`](audit-log-v1.md) § Privacy floor.

--- a/docs/contracts/audit-log-v1.md
+++ b/docs/contracts/audit-log-v1.md
@@ -23,6 +23,7 @@ Last refreshed: 2026-05-11.
 | Side | Responsibility | Where |
 |---|---|---|
 | **Producer** | One JSONL line per phase end, derived from the phase's [`decision-trace-v1.md`](decision-trace-v1.md) JSON and the [`memory-visibility-v1.md`](memory-visibility-v1.md) counts. | `work_engine` hook on phase boundary. |
+| **Producer** (`activation`) | One line per observed artifact, from filesystem and manifest observation only. Independent of anything that classifies the receipt — claims in [`activation-receipt-trust-boundary.md`](activation-receipt-trust-boundary.md). | `src/scripts/activation_receipt.ts`. |
 | **Consumer** | Pattern mining + human review gate. Never edits a written line; corrections are new lines with `type=supersede`. | [`extract_audit_patterns.py`](../../src/scripts/extract_audit_patterns.ts). |
 
 ## File location
@@ -84,9 +85,9 @@ Single-line. The pretty-printed reference shape:
 | `verify.claims` / `verify.first_try_passes` | int | Verify-gate counts. |
 | `rules_applied` | string[] | Stable rule ids the producer attributes to this phase. Bounded to ≤ 32; remainder dropped silently. **Not necessarily observed.** Both shipped producers write a fixed literal, so a consumer MUST call `isProducerConstantField` (`src/scripts/_lib/audit_field_provenance.ts`) before computing any per-rule rate over it. The prose here used to read "rule ids whose Iron Law fired this phase", which is false for every line either producer has ever written — the claim was deleted rather than softened, and replaced by a check, because a contract that describes a constant as an observation makes every downstream rate an artefact that looks like a finding. Found by mining the audit stream: `extract_audit_patterns --min-count 2` mints exactly one pattern, `implement:success:delegation-policy`, count 914. |
 | `outcome_semantics` | int (optional) | Which version of the `DispatchOutcome` → `outcome` mapping produced this line. `1` = unconditional (`DONE`/`DONE_WITH_CONCERNS` always `success`); `2` = contract-gated (a `code-change` dispatch claiming success with a **measured** empty diff does not resolve to `success`). **An ABSENT field means `1`** — every line written before 2026-08-30 predates the versioning and carries no marker. A reader aggregating across the cutover MUST segment on this field or normalize deliberately; inferring the semantics from a timestamp is not sufficient, because producers upgrade independently. Rationale: an enforcement gate rolls back, but a labelling change poisons historical analysis permanently, since lines here are append-only and cannot be rewritten. |
-| `privacy_class` | enum | **Mandatory.** What this line declares about ITSELF: `counts-only` (counts, enums, timestamps, package-minted opaque ids) or `ids-only` (the former, plus stable artefact ids the package governs — rule ids, skill ids, task-class ids). Defined once in `src/scripts/_lib/privacy_class.ts`. A consumer deciding whether the stream is safe to aggregate, export or ship reads this field rather than re-deriving the answer from each producer's source. Both shipped producers emit `ids-only`, because both carry `rules_applied`. |
+| `privacy_class` | enum | **Mandatory.** What this line declares about ITSELF: `counts-only` (counts, enums, timestamps, package-minted opaque ids) or `ids-only` (the former, plus stable artefact ids the package governs — rule ids, skill ids, task-class ids). Defined once in `src/scripts/_lib/privacy_class.ts`. A consumer deciding whether the stream is safe to aggregate, export or ship reads this field rather than re-deriving the answer from each producer's source. All three shipped producers emit `ids-only`. The two older ones carry `rules_applied`; the activation producer (`src/scripts/_lib/activation_receipt_producer.ts`) carries an artifact id, which is the same class of package-governed stable id. |
 | `skills_applied` | string[] (optional) | Stable skill ids applied this phase — the skills counterpart of `rules_applied`, absent from v1 until 2026-08-30. Ids only, never bodies. Bounded to ≤ 32; remainder dropped silently. **ABSENT and `[]` are different observations and readers MUST NOT fold them together:** the key omitted means *not recorded* (the producer had no skill observation to offer), `[]` means *recorded, and none applied*. A reader that treats a missing key as "none" cannot distinguish no signal from a negative signal, which is precisely what a per-asset report needs `unknown` for. Additive under the forward-compat rule below; `schema_version` stays `1` and no supersede lines are required. |
-| `activation` | object (optional) | The six-rung activation ladder for one artefact, plus the precedence reason a rung was not reached. Shape and semantics in `src/scripts/_lib/activation_ladder.ts`; added 2026-08-30 by `road-to-governed-harness-evolution` 1.1/1.3. **ABSENT and a rung set to `not-reached` are different observations and readers MUST NOT fold them together** — an absent rung means *not observed* and reads `unknown`, and `ladderRate()` keeps `unknown` out of its denominator rather than counting it either way. This is the same distinction `skills_applied` above draws between an omitted key and `[]`, and it exists for the same reason: a reader that folds them cannot tell no signal from a negative signal, and every downstream rate is then inflated by exactly the capture gap. Additive under the forward-compat rule below; `schema_version` stays `1` and no supersede lines are required. |
+| `activation` | object (optional) | The six-rung activation ladder for one artefact, plus the precedence reason a rung was not reached. Shape and semantics in `src/scripts/_lib/activation_ladder.ts`; added 2026-08-30 by `road-to-governed-harness-evolution` 1.1/1.3. **ABSENT and a rung set to `not-reached` are different observations and readers MUST NOT fold them together** — an absent rung means *not observed* and reads `unknown`, and `ladderRate()` keeps `unknown` out of its denominator rather than counting it either way. This is the same distinction `skills_applied` above draws between an omitted key and `[]`, and it exists for the same reason: a reader that folds them cannot tell no signal from a negative signal, and every downstream rate is then inflated by exactly the capture gap. Additive under the forward-compat rule below; `schema_version` stays `1` and no supersede lines are required. **The producer arrived 2026-09-01** (`road-to-governed-evidence-production` 1.1); until then the field was specified and never written. Its independence and cost claims are in [`activation-receipt-trust-boundary.md`](activation-receipt-trust-boundary.md), and `adhered` has no admitted observation source, so a shipped receipt is absent at that rung rather than claiming adherence either way. |
 | `persona` | string \| null | Resolved `roles.active_role` from `.agent-settings.yml` at phase start. |
 | `input_kind` | enum | One of `prompt` · `ticket` · `orchestration`. Matches `WorkState.input.kind`. |
 | `type` | enum | One of `phase` · `supersede` · `note`. `supersede` carries an extra `supersedes` field with the prior `id`. |
@@ -125,7 +126,7 @@ Lines MUST NOT contain:
 - Secrets, tokens, environment values, file contents.
 - Paths outside the package's `agents/runtime/state/` and `tests/` allowlist.
 
-**Enforcement — a compile-time guard on both producers, since 2026-08-30.**
+**Enforcement — a compile-time guard on all three producers, since 2026-08-30.**
 The floor used to be prose. The file this paragraph named for months —
 tests/contracts/test_audit_log_redaction.py, deliberately written WITHOUT
 backticks so an existence check cannot read a dead name as a live claim —
@@ -139,9 +140,17 @@ resolves to `never` for any type carrying a key from `FREE_FORM_KEYS`
 (`src/scripts/_lib/runtime_journal.ts`) — `prompt`, `body`, `file_path`,
 `stdout`, `reason`, `payload` and the rest of the set an author reaches for
 when they want to stash content. Adding such a field to
-`src/scripts/_lib/orchestration_record.ts`'s `RecordInput` or
-`src/scripts/_lib/review_skipped_record.ts`'s `ReviewSkippedInput` is a BUILD
-ERROR, not a lint warning. Both directions are checked: a negative fixture
+`src/scripts/_lib/orchestration_record.ts`'s `RecordInput`,
+`src/scripts/_lib/review_skipped_record.ts`'s `ReviewSkippedInput`, or
+`src/scripts/_lib/activation_receipt_producer.ts`'s `ActivationLineInput` is a
+BUILD ERROR, not a lint warning.
+
+The third producer is where the guard's bluntness became visible and was paid
+rather than filed off: the ladder's precedence field is called `reason`, which is
+a `FREE_FORM_KEYS` member even though the value it holds is a closed six-value
+enum. The input field is therefore named `precedence_reason` and mapped to
+`reason` on emission. Widening `FREE_FORM_KEYS` to admit the safe case would have
+weakened the guard for every producer to save one line in one of them. Both directions are checked: a negative fixture
 carrying `@ts-expect-error` asserts the guard still REJECTS, so a `NoFreeForm`
 broken into an identity type fails the build instead of passing everything.
 
@@ -154,9 +163,9 @@ reach these files; that config covers `src/cli`, `src/server`, `src/shared` and
 `src/install` only, and `src/scripts/**` is reached solely by
 `tsconfig.scripts.json`. The command that checks this floor is `npm run
 typecheck`, which runs both — a bare `tsc -p tsconfig.json` here is a gate that
-scans nothing and exits green. (2) The guard binds the two shipped producers by
-name. A THIRD producer added outside that shape is still caught by nothing, and
-the honest claim remains "privacy by construction, on two paths, guarded at
+scans nothing and exits green. (2) The guard binds the three shipped producers
+by name. A FOURTH producer added outside that shape is still caught by nothing,
+and the honest claim remains "privacy by construction, on three paths, guarded at
 compile time, unscanned elsewhere".
 
 ## Append-only invariant

--- a/docs/contracts/evaluation-cascade-stages.md
+++ b/docs/contracts/evaluation-cascade-stages.md
@@ -1,0 +1,120 @@
+---
+stability: beta
+keep-beta-until: 2026-11-30
+roadmap_ref: road-to-governed-evidence-production.md
+---
+
+# The twelve-stage evaluation cascade
+
+**Purpose.** Publish the settled twelve-stage enumeration and the rule that
+orders it, so the enumeration is reproducible rather than proposed. Written
+under `road-to-governed-evidence-production` step 1.2.
+
+**Scope.** The stage list, its order, and each stage's evidence class. Does
+**not** define what any stage checks — the deterministic stages are
+[`evaluation_cascade.ts`](../../src/scripts/_lib/evaluation_cascade.ts)'s and the
+receipt-bearing stages are
+[`activation_ladder.ts`](../../src/scripts/_lib/activation_ladder.ts)'s.
+
+## Why an enumeration needed a contract at all
+
+E9 (2026-08-30, AI council 2/2) decided the **arity** — twelve — and enumerated
+the stages nowhere. The 2026-08-31 round asked for the enumeration and returned
+`REVISE`: the same seat, asked twice, produced two materially different twelves
+— different names, different order, and a different placement of the statistical
+stage. One seat answering differently on two passes is evidence that the design
+had not converged, so the arity was recorded as decided and the semantics were
+not.
+
+**A third proposal would have been a third answer.** What settles an enumeration
+that two proposals disagreed on is not a better proposal; it is removing
+proposal from the process. The twelve below is **computed** from two committed
+arrays and one stated ordering rule, by
+[`cascade_stage_enumeration.ts`](../../src/scripts/_lib/cascade_stage_enumeration.ts).
+Re-running the computation over the same tree cannot produce a different answer,
+and changing the answer requires changing an array — which is a visible diff, not
+a differently-worded reply.
+
+## The ordering rule
+
+A stage's position is decided by the **evidence it needs**, and within an
+evidence class by the order the stage appears in its own source array.
+
+| Rank | Evidence class | What the stage needs | `CascadeInput` field |
+|---|---|---|---|
+| 0 | `record` | the candidate record alone | `raw` |
+| 1 | `plan` | the run plan and the budget ceiling | `plan`, `budget` |
+| 2 | `peers` | the sibling candidates of this run | `peers` |
+| 3 | `receipt` | an activation receipt | `receipt` |
+| 4 | `measurement` | measured trials | `rows`, `vector` |
+
+This is the cascade's cheapest-first, abort-on-first-failure discipline restated
+over **evidence** instead of over cost: a stage may not run before the evidence
+it depends on could exist, and a candidate that fails a cheap-evidence stage
+must never consume the expensive evidence.
+[`activation-receipt-trust-boundary.md`](activation-receipt-trust-boundary.md)
+EC-2 is the `receipt` row of this same table, stated as a falsifiable claim.
+
+**Why the statistical stage is last, since that is where the two proposals
+disagreed.** Measurement is the most expensive evidence in the table — it is the
+only class that requires trials to have been run. Placing it anywhere but last
+would let a candidate consume trials it could have been refused without.
+
+## The twelve
+
+Machine-checked: the table below is parsed by
+`tests/scripts/twelve_stage_enumeration.test.ts` and must agree with the computed
+constant. Editing one without the other fails.
+
+| # | Stage | Evidence class |
+|---|---|---|
+| 1 | `schema-validity` | `record` |
+| 2 | `path-ownership` | `record` |
+| 3 | `holdout-disclosure` | `record` |
+| 4 | `budget` | `plan` |
+| 5 | `near-duplicate` | `peers` |
+| 6 | `receipt-eligible` | `receipt` |
+| 7 | `receipt-selected` | `receipt` |
+| 8 | `receipt-projected` | `receipt` |
+| 9 | `receipt-delivered` | `receipt` |
+| 10 | `receipt-visible` | `receipt` |
+| 11 | `receipt-adhered` | `receipt` |
+| 12 | `metric-verdict` | `measurement` |
+
+E9's condition is met literally: activation/delivery (`receipt-delivered`) and
+adherence (`receipt-adhered`) are each their own stage.
+
+## How the reproduction works, and what "independent" means here
+
+Step 1.2's verify clause asks that *"one enumeration is committed, and a second
+independent pass reproduces it rather than proposing a different twelve"*. The
+second pass is independent in its **derivation route**, not in its author — and
+the distinction is the whole point rather than a hedge:
+
+| | Route A (committed) | Route B (the reproduction) |
+|---|---|---|
+| Stage names | imported from the two modules | regex-extracted from the two source FILES as text |
+| Evidence classes | `PREFIX_EVIDENCE_CLASS` in code | parsed from § The twelve above |
+| Ordering rule | applied by the module | re-applied by the test |
+
+Route B catches what the failure mode actually was. A hand-edited
+`TWELVE_STAGES` fails it, because route B never reads that constant. A rung
+added in code without the table fails it. A table edited without the code fails
+it.
+
+**An independent AUTHOR is deliberately not what is being asked for.** A second
+author is a second proposal, and two proposals is the state that produced the
+`REVISE`. What makes an enumeration settled is that the same tree yields the same
+twelve by more than one route — not that two parties agreed.
+
+**What this does not establish.** Both routes read the same two arrays, so
+neither is evidence that the arrays hold the right rungs or the right stages.
+That question is E4's (rung arity) and E9's (stage arity), both already decided,
+and reopening either is a decision-revisit matter rather than a reproduction one.
+
+## Cross-references
+
+- The computation: [`cascade_stage_enumeration.ts`](../../src/scripts/_lib/cascade_stage_enumeration.ts).
+- The deterministic half and its family exclusion: [`evaluation_cascade.ts`](../../src/scripts/_lib/evaluation_cascade.ts).
+- The receipt-bearing half: [`activation_ladder.ts`](../../src/scripts/_lib/activation_ladder.ts).
+- The claims the `receipt` rank rests on: [`activation-receipt-trust-boundary.md`](activation-receipt-trust-boundary.md).

--- a/docs/contracts/metered-proposer-protocol.md
+++ b/docs/contracts/metered-proposer-protocol.md
@@ -1,0 +1,275 @@
+---
+stability: beta
+keep-beta-until: 2026-11-30
+roadmap_ref: road-to-governed-evidence-production.md
+---
+
+# Metered-proposer execution protocol
+
+**Purpose.** Freeze, before any capture, what a metered proposer run does —
+provider and model version, prompts, sampling, retry policy, exclusion policy,
+corpus, pair count and stopping rule. `road-to-governed-evidence-production`
+step 2.1 under the **NARROWED 2026-09-01** disposition of
+`blocker: metered-backend-park`.
+
+**Scope.** The PROPOSAL half of the 2.1 comparison: what the metered arm sends,
+what it accepts back, and which observations it runs over. It does **not**
+define the outcome metric — see § The one slot this document leaves open, which
+is a park-compliance requirement rather than an omission.
+
+**Written by the session that built the arm, which is why one slot is empty.**
+The live-floors park (AI council 2026-08-25, 2/2 convergent) requires the
+session that freezes the protocol and captures results to be independent of the
+session under evaluation: *"an independent session (not the one that authored
+the corpus) freezes the execution protocol — model/provider version, prompts,
+sampling, retry and exclusion policy — BEFORE capturing any baseline."* Every
+clause below that this session filled is either a **description of code a reader
+can check against the code**, or a value **derived from a constant committed
+before the arm existed**. Nothing here was chosen in a way that could favour an
+outcome, and the one clause that could be is left to Session B.
+
+## Why a frozen protocol at all
+
+> *"the parent roadmap froze no execution protocol for 0.2, so model version,
+> retries, exclusions and aggregation would all have been discretionary choices
+> made by the session under evaluation."*
+> — the live-floors park's second seat, AI council 2026-08-25, 2/2 convergent
+
+The conclusion is inlined with its date and its quorum rather than linked,
+because a roadmap is a transient artifact and this contract is not: the park
+file lives under `later/` and its path is not a citation a stable document may
+depend on.
+
+A protocol written after a result is a tuned protocol. This one is committed
+before the first metered call, and the commit that adds it made none.
+
+## Role clause — what the metered call may do
+
+> A metered call may **generate** candidate text. It may not score, rank,
+> filter, select between, or supply any input to the verdict for the arms being
+> compared — whatever the module is called.
+
+Enforced structurally, not by intention. Six places, each with a test:
+
+| Forbidden role | What makes it unavailable |
+|---|---|
+| supply a score | `GenerationResult` carries `text` and `model`; `NoDecisionField` makes adding a scoring key a **build error** |
+| rank | the port takes one request and returns one result — it cannot express a batch |
+| select between candidates | one record per observation, asserted at the return |
+| filter | an unsatisfiable observation THROWS; the output can never be a subset of the input |
+| reorder | output order is `byteCompare` over the INPUT, using the deterministic arm's own comparator |
+| reach the verdict | the arm imports no verdict module |
+
+`src/scripts/_lib/llm_candidate_proposer.ts` is the arm;
+`tests/scripts/llm_candidate_proposer.test.ts` is the test, one case per row.
+
+## Frozen mechanism
+
+### Provider, endpoint and model version
+
+| Item | Value | Source |
+|---|---|---|
+| Provider | Anthropic Messages API | `_lib/llm_proposer_transport.ts` |
+| Endpoint | `https://api.anthropic.com/v1/messages` | `ANTHROPIC_URL` |
+| API version header | `2023-06-01` | `ANTHROPIC_VERSION` |
+| Tier `lite` | `claude-haiku-4-5-20251001` | `TIER_MODEL` |
+| Tier `medium` | `claude-sonnet-4-5-20250929` | `TIER_MODEL` |
+| Tier `high` | **UNPINNED — refused** | `TIER_MODEL` |
+| Credential | `~/.event4u/agent-config/anthropic.key`, read at call time | `load_anthropic_key` |
+
+**Dated ids only, and `high` is refused rather than resolved.** A protocol whose
+model is a floating alias is not frozen: the alias moves and a later run answers
+a different question. No dated `claude-opus-4-1-*` id exists anywhere in this
+tree, so `modelForTier('high')` throws with a message naming what must be pinned
+first. `high` is reachable only through an `execution_failed` escalation
+(`_lib/evolution_roi.ts:109`), so a run with no transport error never touches it.
+
+### Sampling
+
+| Parameter | Value |
+|---|---|
+| `max_tokens` | 8192 |
+| `temperature` | 0 |
+| `top_p`, `top_k` | not sent — provider defaults |
+| Streaming | off |
+
+`temperature: 0` is not a claim of determinism. Provider inference is not
+reproducible at any temperature; zero minimises the arm's own contribution to
+variance and nothing more.
+
+### Prompts
+
+Byte-exact and frozen. Editing either is an edit to this protocol and
+invalidates a comparison already captured against it.
+
+- **System**: `SYSTEM_PROMPT` in `_lib/llm_candidate_proposer.ts`. Four lines,
+  ending *"Do not judge, score, rank, or compare anything. Produce one body."*
+- **User**: built by `buildPrompt(obs, body)` — defect class, the recipe's
+  one-line summary of that class, the artifact path, the route target when the
+  class has one, then the current body between `--- BEGIN CURRENT BODY ---` and
+  `--- END CURRENT BODY ---`.
+
+The user prompt is a pure function of the observation and the subject bytes, so
+the exact string for any observation can be printed without sending it:
+`./scripts-run src/scripts/llm_propose --observations FILE --out DIR` prints it
+for the first observation and sends nothing.
+
+### Retry policy
+
+The ladder walk in `_lib/llm_candidate_proposer.ts`, and it is a retry policy
+rather than a selection policy:
+
+1. The first attempt runs on class `reason_unknown`, whose ladder is exactly
+   `['lite']` — *"escalating on a reason nobody established is spending on a
+   guess"* (`_lib/evolution_roi.ts:117-119`).
+2. A refused generation is classified into a `PathologyWhy` by
+   `classifyRefusal`, deterministically and from the refusal itself — never from
+   the model's opinion of its own output.
+3. The walk continues on that class's ladder from its cheapest untried rung.
+4. A class whose ladder is empty, or whose rungs are all spent, STOPS the walk
+   and the observation throws.
+5. **First-valid wins.** The walk stops at the first generation that satisfies
+   the output contract. It never holds two valid generations and never compares
+   them; choosing the better of two would be selection, and no code path here
+   can express it.
+
+Per-observation spend is per observation: a new subject starts at the cheapest
+rung again, which the ordering guard allows explicitly — *"retrying `lite` is
+not an escalation"* (`_lib/evolution_roi.ts:203`).
+
+`assertCheapestFirst` (`_lib/evolution_roi.ts:191`) validates the whole attempt
+list before the arm returns.
+
+### Exclusion policy
+
+Two layers, both deterministic, neither a quality judgement.
+
+**Observation-level** — inherited unchanged from the deterministic arm's
+`parseObservations`, so both arms run over the same admitted set: a class
+outside the three fixed recipes, a subject outside the candidate surface, a
+missing `routeTo` on a class that needs one, a `routeTo` on a class that does
+not read one, and a duplicate `(class, subject)` pair are all refused.
+
+**Generation-level** — `assertGenerationAcceptable`. A generation is refused
+when it is empty, byte-identical to the input, over the 256 KiB ceiling, carries
+a NUL, or (for a routing class) omits the required route target. Each is a fact
+about ONE string. `better` is a judgement about two and appears nowhere.
+
+### Inherited guards
+
+`llm_propose` runs both of the deterministic verb's guards, against the same
+observations document, because an arm that skipped them would not be the same
+experiment:
+
+- **GUARD 0.5** — `assertWithinBudget` against
+  `src/config/harness-evolution-budget.json`. Aborts; never truncates.
+- **GUARD 0.4** — `discloseObservations`, which logs every field disclosed to a
+  proposer and aborts when holdout truth appears in proposer context.
+
+### Entry point, and the dry default
+
+```
+./scripts-run src/scripts/llm_propose --observations FILE --out DIR [--confirm]
+```
+
+Without `--confirm` nothing is sent: the dry path prints the ladder plan, the
+pinned model per tier, the exact request body for the first observation, and a
+token estimate. `--confirm` is the only path that spends.
+
+## Corpus, pairs and stopping rule — derived, not chosen
+
+### The defect-observation corpus
+
+Enumerated by a stated rule rather than hand-picked, so the session that built
+the arm did not get to choose which artifacts it is judged on:
+
+1. Take every `*.md` **directly under** `.claude/rules/` in the checkout at the
+   run's commit.
+2. Sort byte-wise by filename.
+3. Take the first `max_candidates` (**5**, from
+   `src/config/harness-evolution-budget.json`).
+4. Assign one defect class per file, by reading the file: `over-broad-activation`
+   when it contains a line beginning `## `, otherwise
+   `unbacked-enforcement-claim`.
+
+`unrouted-obligation` is excluded from the corpus because its recipe requires a
+`routeTo` target that no rule can derive from the file, and inventing one would
+be the session under evaluation choosing an input.
+
+**The commit pin is load-bearing.** `.claude/` is a generated projection, so the
+same rule over a different checkout can yield a different set. The run report
+records `git rev-parse HEAD`, and a comparison is only comparable against the
+same commit.
+
+### Number of pairs
+
+**5** — one pair per corpus member, each pair being (deterministic candidate,
+metered candidate) over the same observation. Not a choice: `max_candidates` in
+the pre-registered budget is 5, and it is a ceiling the guard aborts on.
+
+`max_trials_per_candidate` is **20** from the same file, which is the ceiling on
+trials inside one pair.
+
+### Stopping rule
+
+Cited, not restated and not tuned. Both constants were committed before either
+arm existed and are not this document's to set:
+
+- `ALPHA` — `src/scripts/_lib/paired_verdict.ts:51`.
+- `MIN_DISCORDANT` — `src/scripts/_lib/paired_verdict.ts:78`, derived from
+  `ALPHA` by `deriveMinDiscordant` rather than chosen.
+
+Consequences a runner must honour:
+
+- Below the discordant floor `decidePairedVerdict` returns `underpowered`, which
+  is **an absent measurement, not a null result**, and belongs in no pass rate.
+- The run stops at the budget ceiling by abort, not by truncation. A truncated
+  run yields `underpowered` and a reader mistakes it for a pass.
+- A resumed run passes the aborted run's attempts as `priorAttempts` so the
+  ordering guard sees the whole run rather than its tail.
+
+### The fixture prohibition is unchanged
+
+2.1 closes on a run or it does not close. A paired-verdict harness exercised
+over recorded fixtures is the substitution the source roadmap caught twice, and
+neither this document nor the park narrowing weakens it.
+
+## The one slot this document leaves open
+
+**UNSET — the paired outcome metric, and its aggregation. Owned by Session B.**
+
+`decidePairedVerdict` consumes one signed delta per trial. What that delta
+MEASURES is not fixed anywhere in the tree, and it is the single choice in this
+protocol that could favour one arm over the other.
+
+The park names aggregation explicitly among the discretionary choices a session
+under evaluation must not make. This session built the arm. So the metric is
+left for the independent session to fix and commit **before** it captures
+anything, and this document is the place to fix it.
+
+What is already committed and constrains that choice:
+
+- `ARTIFACT_COUNT_METRIC` (`_lib/evaluation_vector.ts:62`) — `buildVector`
+  refuses a vector with no artifact-count row, so any metric set includes it.
+- `promotionVerdict` reads exactly one paired row plus that counted row.
+
+Deriving a metric here would have been inventing a derivation, which is the
+failure this repository already recorded once for a stage enumeration: a third
+proposal is a third answer.
+
+## Not yet run
+
+As of the commit that adds this document, **no metered call has been made
+through any of these modules.** The transport's live path is unexercised; its
+request shape is proven by `describeRequest` and a unit test over the
+description, and every behavioral test uses a stubbed generator.
+
+## Cross-references
+
+- The arm: [`llm_candidate_proposer.ts`](../../src/scripts/_lib/llm_candidate_proposer.ts).
+- The transport: [`llm_proposer_transport.ts`](../../src/scripts/_lib/llm_proposer_transport.ts).
+- The entry point: [`llm_propose.ts`](../../src/scripts/llm_propose.ts).
+- The deterministic arm this mirrors: [`candidate_proposer.ts`](../../src/scripts/_lib/candidate_proposer.ts).
+- The verdict, and the two constants this document cites: [`paired_verdict.ts`](../../src/scripts/_lib/paired_verdict.ts).
+- The ladder and its ordering guard: [`evolution_roi.ts`](../../src/scripts/_lib/evolution_roi.ts).
+- The pre-registered budget: `src/config/harness-evolution-budget.json`.

--- a/src/scripts/_lib/activation_ladder.ts
+++ b/src/scripts/_lib/activation_ladder.ts
@@ -44,6 +44,26 @@ export const LADDER_RUNGS = [
 export type LadderRung = (typeof LADDER_RUNGS)[number];
 
 /**
+ * The receipt-bearing cascade stage that reads each rung, in ladder order.
+ *
+ * Derived from {@link LADDER_RUNGS} rather than written out, so a rung cannot
+ * exist without its stage and the two orders cannot drift. Named here rather
+ * than in the cascade because the RUNGS are this module's, and a second module
+ * spelling `receipt-<rung>` would be a second source of truth for the same
+ * enum.
+ *
+ * The cascade consumes these; nothing here imports the cascade. That direction
+ * is the one `docs/contracts/activation-receipt-trust-boundary.md` TB-1 fixes.
+ */
+export const RECEIPT_STAGES = LADDER_RUNGS.map((r) => `receipt-${r}` as const);
+export type ReceiptStage = (typeof RECEIPT_STAGES)[number];
+
+/** The rung a receipt-bearing stage reads. Total over {@link ReceiptStage}. */
+export function rungForReceiptStage(stage: ReceiptStage): LadderRung {
+    return stage.slice('receipt-'.length) as LadderRung;
+}
+
+/**
  * Which failure family a stall at each rung belongs to.
  *
  * This is what step 1.1's exit criterion asks for: a deliberately failing
@@ -171,10 +191,34 @@ export function rungState(receipt: ActivationReceipt, rung: LadderRung): RungSta
  * and the caller gets `null`.
  */
 export function classifyFailure(receipt: ActivationReceipt): FailureFamily | null {
-    for (const spec of LADDER) {
+    return firstStall(receipt)?.family ?? null;
+}
+
+/** Where a receipt stopped climbing, and the family that stall belongs to. */
+export interface LadderStall {
+    /** The rung the walk stopped at. */
+    readonly rung: LadderRung;
+    /** The receipt-bearing cascade stage that reads {@link rung}. */
+    readonly stage: ReceiptStage;
+    /** `unknown` when the rung was never observed; the rung's family otherwise. */
+    readonly family: FailureFamily;
+}
+
+/**
+ * The first rung a receipt did not reach, with its stage and its family.
+ *
+ * {@link classifyFailure} is a projection of this, and delegates to it rather
+ * than walking the ladder a second time. Two walks of the same ladder applying
+ * the same short-circuit rule is two places to change it — and the cascade needs
+ * the STAGE as well as the family, which is the only reason this exists
+ * separately at all.
+ */
+export function firstStall(receipt: ActivationReceipt): LadderStall | null {
+    for (const [i, spec] of LADDER.entries()) {
         const state = rungState(receipt, spec.rung);
-        if (state === 'unknown') return 'unknown';
-        if (state === 'not-reached') return spec.family;
+        const stage = RECEIPT_STAGES[i] as ReceiptStage;
+        if (state === 'unknown') return { rung: spec.rung, stage, family: 'unknown' };
+        if (state === 'not-reached') return { rung: spec.rung, stage, family: spec.family };
     }
     return null;
 }

--- a/src/scripts/_lib/activation_receipt_producer.ts
+++ b/src/scripts/_lib/activation_receipt_producer.ts
@@ -1,0 +1,341 @@
+/**
+ * The activation-receipt producer — independent, append-only, zero model calls.
+ *
+ * `road-to-governed-evidence-production` step 1.1. The receipt SCHEMA
+ * ({@link ActivationReceipt}) and the CLASSIFIER ({@link classifyFailure}) both
+ * predate this module and are NOT reimplemented here; what was missing was a
+ * producer, so nothing ever wrote an `activation` object into an audit line and
+ * the receipt-bearing cascade stages had no subject.
+ *
+ * ## The claims this module is written against
+ *
+ * Stated once, in `docs/contracts/activation-receipt-trust-boundary.md`, and
+ * CITED here rather than restated — step 1.3's verify clause asks for exactly
+ * that split, and a second copy of a falsifiable claim is a second thing to
+ * keep true.
+ *
+ * | Claim | Where it binds in this file |
+ * |---|---|
+ * | TB-1 (no evaluation input decides a STATE) | the import list: no cascade, record, vector or verdict module appears |
+ * | TB-2 (an unobserved rung is absent) | {@link buildActivationReceipt} writes only the rungs it was given |
+ * | TB-3 (every state names an admitted source) | {@link EVIDENCE_SOURCES} + the refusal in {@link buildActivationReceipt} |
+ * | TB-4 (append, never rewrite) | {@link appendActivationLine} opens with `appendFileSync` and mints a fresh `id` |
+ * | EC-1 (zero model calls) | no transport import, no spawn, no key read — asserted by this module's test |
+ * | EC-3 (a missing observation is never bought) | {@link observeProjection} returns absence and does not retry |
+ *
+ * ## What is observable today, and what is not
+ *
+ * Three sources are admitted and all three ship an observer. `adhered` has no
+ * admitted source, so this producer CANNOT emit that rung and a real receipt
+ * reads `unknown` there. That is a coverage fact recorded rather than papered
+ * over: admitting a fourth source with no observer behind it would describe a
+ * capability that does not exist, which is the "population of zero" failure the
+ * roadmap already flags elsewhere.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {
+    LADDER_RUNGS,
+    type ActivationReceipt,
+    type LadderRung,
+    type PrecedenceReason,
+    type RungState,
+} from './activation_ladder.js';
+import type { NoFreeForm } from './runtime_journal.js';
+import { type PrivacyClass } from './privacy_class.js';
+
+type Assert<T extends true> = T;
+
+/**
+ * The closed set of evidence sources a rung state may come from (TB-3).
+ *
+ * Each entry names a surface this producer can read without consulting the
+ * evaluation side. A source may not be added without an observer: the set
+ * describes what can be observed, never what one would like to observe.
+ *
+ * - `source-tree` — the authored artefact exists under `src/`, so it can match
+ *   at all. Reads the `eligible` rung.
+ * - `discovery-manifest` — the built manifest names the artefact for the active
+ *   install, i.e. the selector kept it. Reads the `selected` rung.
+ * - `host-projection` — a host tree carries a file for the artefact. Reads the
+ *   `projected` rung.
+ */
+export const EVIDENCE_SOURCES = ['source-tree', 'discovery-manifest', 'host-projection'] as const;
+export type EvidenceSource = (typeof EVIDENCE_SOURCES)[number];
+
+/** The rung each admitted source is allowed to speak about. One source, one rung. */
+export const SOURCE_RUNG: Readonly<Record<EvidenceSource, LadderRung>> = {
+    'source-tree': 'eligible',
+    'discovery-manifest': 'selected',
+    'host-projection': 'projected',
+};
+
+/** Rungs no admitted source covers today. Present so the gap is enumerable. */
+export const UNOBSERVED_RUNGS: readonly LadderRung[] = LADDER_RUNGS.filter(
+    (r) => !Object.values(SOURCE_RUNG).includes(r),
+);
+
+/**
+ * One observation. `state` is the evidence; `evidence_source` is where it came
+ * from.
+ *
+ * The field is `evidence_source` and not `source` on purpose: `source` is a
+ * member of `FREE_FORM_KEYS`, so a field of that name would make the privacy
+ * assertion at the bottom of this file `Assert<false>` and stop the build. The
+ * rename is the cheap half of keeping this input type incapable of carrying
+ * content.
+ */
+export interface RungObservation {
+    readonly rung: LadderRung;
+    readonly state: Exclude<RungState, 'unknown'>;
+    readonly evidence_source: EvidenceSource;
+}
+
+export interface ReceiptBuild {
+    readonly receipt: ActivationReceipt | null;
+    readonly errors: readonly string[];
+}
+
+/**
+ * Build a receipt from observations.
+ *
+ * TB-2 in one line: the output's `rungs` map has exactly the keys the caller
+ * observed. Nothing is defaulted, nothing is filled in, and a rung nobody looked
+ * at is absent — which `rungState` reads as `unknown` and `ladderRate` keeps out
+ * of its denominator.
+ *
+ * TB-3 in the refusals: an unadmitted source, or an admitted source speaking
+ * about a rung that is not its own, is an ERROR and yields no receipt. It is
+ * not a warning and it is not silently dropped, because a receipt missing a rung
+ * is indistinguishable from a receipt whose rung was refused, and only one of
+ * those is honest.
+ */
+export function buildActivationReceipt(
+    artefact: string,
+    observations: readonly RungObservation[],
+    reason?: PrecedenceReason,
+): ReceiptBuild {
+    const errors: string[] = [];
+    if (!artefact) errors.push('artefact id is required');
+
+    const rungs: Partial<Record<LadderRung, RungState>> = {};
+    for (const o of observations) {
+        if (!(EVIDENCE_SOURCES as readonly string[]).includes(o.evidence_source)) {
+            errors.push(`evidence_source '${o.evidence_source}' is not admitted (TB-3)`);
+            continue;
+        }
+        if (SOURCE_RUNG[o.evidence_source] !== o.rung) {
+            errors.push(
+                `evidence_source '${o.evidence_source}' may only observe rung ` +
+                    `'${SOURCE_RUNG[o.evidence_source]}', not '${o.rung}' (TB-3)`,
+            );
+            continue;
+        }
+        if (rungs[o.rung] !== undefined && rungs[o.rung] !== o.state) {
+            errors.push(`rung '${o.rung}' observed twice with conflicting states`);
+            continue;
+        }
+        rungs[o.rung] = o.state;
+    }
+    if (errors.length > 0) return { receipt: null, errors };
+
+    const receipt: ActivationReceipt = reason === undefined
+        ? { artefact, rungs }
+        : { artefact, rungs, reason };
+    return { receipt, errors: [] };
+}
+
+// --- observers ---------------------------------------------------------------
+
+/**
+ * Observe the `projected` rung: does a host tree carry a file for this artefact?
+ *
+ * EC-3 is the reason this returns `undefined` rather than probing further when
+ * the host root itself is missing. A host tree that does not exist is not
+ * evidence that the artefact was not projected into it — it is the absence of a
+ * place to look, and the honest output of a missing observation is nothing at
+ * all. Escalating from "read a path" to "go find the tree" is the unbounded-cost
+ * mistake EC-3 names, and it is the one a reader would forgive.
+ */
+export function observeProjection(
+    hostRoot: string,
+    artefactRelPath: string,
+): RungObservation | undefined {
+    if (!existsQuiet(hostRoot)) return undefined;
+    return {
+        rung: 'projected',
+        state: existsQuiet(path.join(hostRoot, artefactRelPath)) ? 'reached' : 'not-reached',
+        evidence_source: 'host-projection',
+    };
+}
+
+/**
+ * Observe the `eligible` rung: is the artefact authored in the source tree?
+ *
+ * Same absence rule as {@link observeProjection}: an unreadable source root
+ * yields no observation rather than a negative one.
+ */
+export function observeSourceTree(
+    sourceRoot: string,
+    artefactRelPath: string,
+): RungObservation | undefined {
+    if (!existsQuiet(sourceRoot)) return undefined;
+    return {
+        rung: 'eligible',
+        state: existsQuiet(path.join(sourceRoot, artefactRelPath)) ? 'reached' : 'not-reached',
+        evidence_source: 'source-tree',
+    };
+}
+
+/**
+ * Observe the `selected` rung from an already-loaded discovery-manifest id set.
+ *
+ * Takes the id set rather than a path: loading and parsing the manifest is the
+ * caller's, so this stays a pure predicate and EC-1's "no I/O beyond a read"
+ * holds trivially for it. An EMPTY set is treated as no manifest — not as a
+ * manifest that selected nothing — because those are different observations and
+ * folding them is exactly TB-2's failure.
+ */
+export function observeSelection(
+    selectedIds: ReadonlySet<string>,
+    artefactId: string,
+): RungObservation | undefined {
+    if (selectedIds.size === 0) return undefined;
+    return {
+        rung: 'selected',
+        state: selectedIds.has(artefactId) ? 'reached' : 'not-reached',
+        evidence_source: 'discovery-manifest',
+    };
+}
+
+function existsQuiet(p: string): boolean {
+    try {
+        fs.statSync(p);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+// --- the audit line ----------------------------------------------------------
+
+/** What THIS producer's lines carry: an artefact id, enums, and counts. */
+const PRODUCER_PRIVACY_CLASS: PrivacyClass = 'ids-only';
+
+export interface ActivationLineInput {
+    /** The artefact the receipt is about. An id, never a path. */
+    artefact: string;
+    /** The rungs actually observed. Absent rungs stay absent (TB-2). */
+    rungs: Readonly<Partial<Record<LadderRung, RungState>>>;
+    /**
+     * The precedence reason, when there is one.
+     *
+     * Named `precedence_reason` and NOT `reason`, which is a `FREE_FORM_KEYS`
+     * member: a field called `reason` on this type makes the assertion at the
+     * bottom of this file `Assert<false>` and stops the build, even though the
+     * value it would hold is a closed six-value enum. The emitted JSON key is
+     * still `reason`, because that is `ActivationReceipt`'s field name and the
+     * ladder module owns the receipt shape. The rename buys the compile-time
+     * floor at the cost of one line of mapping, which is the right trade: a
+     * guard that only rejects genuinely dangerous names is a guard someone has
+     * to keep tuning.
+     */
+    precedence_reason?: PrecedenceReason | undefined;
+    /** ISO-8601 UTC; the caller supplies it so this stays pure. */
+    ts: string;
+    /** ULID, UUID or content hash; the caller supplies it. */
+    id: string;
+    work_id?: string | undefined;
+}
+
+export interface BuiltActivationLine {
+    line: Record<string, unknown> | null;
+    errors: string[];
+}
+
+/**
+ * Build ONE audit-log-v1 line carrying an `activation` object.
+ *
+ * Deliberately the same envelope as `_lib/review_skipped_record.ts` — same
+ * mandatory fields, same `{line, errors}` contract, same refusal to return a
+ * half-built line. `skills_applied` is omitted for the same reason it is there:
+ * this producer has no skill observation to offer, and `[]` would assert one.
+ */
+export function buildActivationLine(input: ActivationLineInput): BuiltActivationLine {
+    const errors: string[] = [];
+    if (!input.artefact) errors.push('artefact is required');
+    if (!input.ts) errors.push('ts (ISO-8601 UTC) is required');
+    if (!input.id) errors.push('id (ULID, UUID, or content hash) is required');
+    const observed = Object.keys(input.rungs);
+    if (observed.length === 0) {
+        // A receipt that observed nothing is not a receipt. Writing one would
+        // add a line to an append-only ledger that carries no evidence and
+        // still counts as a record — the shape a later reader mistakes for
+        // coverage.
+        errors.push('a receipt must carry at least one observed rung');
+    }
+    for (const r of observed) {
+        if (!(LADDER_RUNGS as readonly string[]).includes(r)) {
+            errors.push(`'${r}' is not a ladder rung`);
+        }
+    }
+    if (errors.length) return { line: null, errors };
+
+    const activation: Record<string, unknown> = { artefact: input.artefact, rungs: { ...input.rungs } };
+    if (input.precedence_reason !== undefined) activation['reason'] = input.precedence_reason;
+
+    const line: Record<string, unknown> = {
+        schema_version: 1,
+        id: input.id,
+        ts: input.ts,
+        work_id: input.work_id ?? `activation-${input.ts}`,
+        phase: 'report',
+        outcome: 'success',
+        confidence_band: 'high',
+        risk_class: 'low',
+        memory: { asks: 0, hits: 0 },
+        verify: { claims: 0, first_try_passes: 0 },
+        rules_applied: [],
+        privacy_class: PRODUCER_PRIVACY_CLASS,
+        persona: null,
+        input_kind: 'prompt',
+        type: 'note',
+        activation,
+    };
+    return { line, errors: [] };
+}
+
+/**
+ * Append ONE line to the monthly audit log (TB-4).
+ *
+ * `appendFileSync` and nothing else: no read-modify-write, no truncation, no
+ * seek. Returns the file it wrote so a caller can assert the write happened
+ * rather than trusting that it did.
+ */
+export function appendActivationLine(
+    workspaceRoot: string,
+    line: Record<string, unknown>,
+    ts: string,
+): string {
+    const dir = path.join(workspaceRoot, 'agents', 'runtime', 'state', 'audit');
+    fs.mkdirSync(dir, { recursive: true });
+    const file = path.join(dir, `${ts.slice(0, 7)}.jsonl`);
+    fs.appendFileSync(file, `${JSON.stringify(line)}\n`, 'utf8');
+    return file;
+}
+
+/**
+ * The privacy floor, by construction, on this producer's input type.
+ *
+ * Same mechanism as the two producers `docs/contracts/audit-log-v1.md`
+ * § Privacy floor already names. Adding a `path`, `detail`, `reason_text` or
+ * any other `FREE_FORM_KEYS` member below makes this `Assert<false>` and stops
+ * the build. `reason` is one of them, which is why the precedence field is
+ * called `precedence_reason` here and mapped to `reason` on the way out — see
+ * the field's own note.
+ */
+type _ActivationLineInputCarriesNoFreeFormField = Assert<
+    [NoFreeForm<ActivationLineInput>] extends [never] ? false : true
+>;

--- a/src/scripts/_lib/cascade_stage_enumeration.ts
+++ b/src/scripts/_lib/cascade_stage_enumeration.ts
@@ -1,0 +1,92 @@
+/**
+ * The twelve-stage evaluation cascade, DERIVED rather than enumerated by hand.
+ *
+ * `road-to-governed-evidence-production` step 1.2. E9 (2026-08-30) decided the
+ * ARITY — twelve — and enumerated the stages nowhere. The 2026-08-31 council
+ * round that was asked for the enumeration returned `REVISE`, and the reason it
+ * gave is the reason this module exists rather than a constant list: running the
+ * same seat twice produced two materially different twelves — different names,
+ * different order, a different placement of the statistical stage.
+ *
+ * **So the enumeration is not proposed. It is computed.** Two committed arrays
+ * and one stated ordering rule determine it, and re-running the computation over
+ * the same tree cannot yield a different answer. Nobody's judgement is in the
+ * output, which is what "settled" has to mean after two judgements disagreed.
+ *
+ * ## The ordering rule
+ *
+ * Stages are ordered by the EVIDENCE each one needs — the `CascadeInput` field
+ * it reads — and within a class by source order. The classes, cheapest evidence
+ * first:
+ *
+ * | Rank | Class | Evidence it needs | `CascadeInput` field |
+ * |---|---|---|---|
+ * | 0 | `record`      | the candidate record alone           | `raw` |
+ * | 1 | `plan`        | the run plan and the budget ceiling  | `plan`, `budget` |
+ * | 2 | `peers`       | the sibling candidates of this run   | `peers` |
+ * | 3 | `receipt`     | an activation receipt                | `receipt` |
+ * | 4 | `measurement` | measured trials                      | `rows`, `vector` |
+ *
+ * The rule is not a preference. It is the cascade's own cheapest-first,
+ * abort-on-first-failure discipline restated over evidence rather than over
+ * cost: a stage may not run before the evidence it depends on could exist, and a
+ * candidate that fails a cheap-evidence stage must never consume the expensive
+ * evidence. `docs/contracts/activation-receipt-trust-boundary.md` EC-2 is the
+ * receipt row of exactly this table.
+ *
+ * ## What is NOT decided here
+ *
+ * The rung SEMANTICS — what `delivered` means, what observes it — belong to
+ * `_lib/activation_ladder.ts`, and the `REVISE` verdict's condition on them was
+ * discharged by the trust-boundary and evidence-cost contract, not by this file.
+ * This module settles the enumeration and its order, and nothing else.
+ */
+
+import { CASCADE_STAGES, type StageId } from './evaluation_cascade.js';
+import { RECEIPT_STAGES } from './activation_ladder.js';
+
+/** What evidence a stage needs. The ordering key. */
+export const EVIDENCE_CLASSES = ['record', 'plan', 'peers', 'receipt', 'measurement'] as const;
+export type EvidenceClass = (typeof EVIDENCE_CLASSES)[number];
+
+/**
+ * The evidence class of each DETERMINISTIC prefix stage.
+ *
+ * Written out because it is a fact about `runCascade`'s body — which
+ * `CascadeInput` field each stage reads — and a fact about code cannot be
+ * derived from a list of names. It is not unchecked: the companion test asserts
+ * this order against the order in which `runCascade` first touches each input
+ * field, so a stage that starts reading a different field reds here rather than
+ * quietly reordering the enumeration.
+ */
+export const PREFIX_EVIDENCE_CLASS: Readonly<Record<string, EvidenceClass>> = {
+    'schema-validity': 'record',
+    'path-ownership': 'record',
+    'holdout-disclosure': 'record',
+    budget: 'plan',
+    'near-duplicate': 'peers',
+    'metric-verdict': 'measurement',
+};
+
+/** The evidence class of any stage. Receipt stages are uniformly `receipt`. */
+export function evidenceClass(stage: StageId): EvidenceClass {
+    if ((RECEIPT_STAGES as readonly string[]).includes(stage)) return 'receipt';
+    const c = PREFIX_EVIDENCE_CLASS[stage];
+    if (c === undefined) throw new Error(`no evidence class declared for stage '${stage}'`);
+    return c;
+}
+
+/**
+ * The committed twelve, in order.
+ *
+ * Route A of step 1.2's reproduction: the two committed arrays, sorted by
+ * evidence class, stable within a class. `Array.prototype.sort` is specified as
+ * stable since ES2019, which is what makes "within a class, source order" a
+ * property of the language rather than of an implementation.
+ */
+export const TWELVE_STAGES: readonly StageId[] = [...CASCADE_STAGES, ...RECEIPT_STAGES].sort(
+    (a, b) => EVIDENCE_CLASSES.indexOf(evidenceClass(a)) - EVIDENCE_CLASSES.indexOf(evidenceClass(b)),
+);
+
+/** The arity E9 decided. Stated so a drift from twelve is a named failure. */
+export const DECIDED_ARITY = 12;

--- a/src/scripts/_lib/evaluation_cascade.ts
+++ b/src/scripts/_lib/evaluation_cascade.ts
@@ -30,6 +30,10 @@
  * | 5 | near-duplicate screen  | zero model calls | `content` |
  * | 6 | metric vector + verdict| zero model calls | `unknown` |
  *
+ * (Numbered as the prefix. In the full twelve-stage enumeration the receipt
+ * stages take slots 6-11 and the verdict is slot 12 — see
+ * `_lib/cascade_stage_enumeration.ts`.)
+ *
  * **Every stage here is free.** That is not an accident of the current stage
  * set — it is why these six are the ones that can ship without receipts, and it
  * makes the step's "a candidate failing the cheapest stage consumes no model
@@ -44,9 +48,30 @@
  * `content | activation | adherence | unknown` are Phase 1's, and no fifth is
  * invented. This prefix assigns `content` and `unknown` only. It NEVER assigns
  * `activation` or `adherence`, because those are the receipt-bearing families
- * and nothing here has a receipt. `unknown` is the honest family for a stage
- * that establishes a candidate is unusable without establishing why in
+ * and nothing in the prefix has a receipt. `unknown` is the honest family for a
+ * stage that establishes a candidate is unusable without establishing why in
  * behavioural terms — it is a real classification, not a fallback.
+ *
+ * ## AMENDED 2026-09-01 — the prefix is no longer the whole stage list
+ *
+ * `road-to-governed-evidence-production` step 1.1 built the missing piece: an
+ * independent, append-only receipt producer
+ * (`_lib/activation_receipt_producer.ts`). So `runCascade` now accepts an
+ * optional {@link CascadeInput.receipt} and, when one is supplied, runs the six
+ * receipt-bearing stages between the peer screen and the measurement stage.
+ *
+ * **`PREFIX_ASSIGNABLE_FAMILIES` was NOT widened, and that is the point.** The
+ * exclusion is a property of the deterministic prefix and stays exactly as
+ * strict as it was: no prefix stage may assign `activation` or `adherence`. What
+ * changed is that the prefix is one half of the stage list rather than all of
+ * it. The other half's permitted families are
+ * {@link RECEIPT_ASSIGNABLE_FAMILIES}, and a receipt stage reaches them only
+ * from a receipt — never from any property of the candidate.
+ *
+ * The trust boundary and the evidence-cost claims this rests on are stated in
+ * `docs/contracts/activation-receipt-trust-boundary.md` and cited, not restated,
+ * here: TB-1 fixes the import direction (this module imports the ladder; the
+ * ladder imports nothing from here), and EC-2 fixes the stage placement.
  */
 
 import {
@@ -70,6 +95,13 @@ import {
     type MetricVector,
     type PromotionVerdict,
 } from './evaluation_vector.js';
+import {
+    LADDER,
+    RECEIPT_STAGES,
+    firstStall,
+    type ActivationReceipt,
+    type ReceiptStage,
+} from './activation_ladder.js';
 
 /** Phase 1's families. No fifth is invented here. */
 export const FAILURE_FAMILIES = ['content', 'activation', 'adherence', 'unknown'] as const;
@@ -83,6 +115,33 @@ export type FailureFamily = (typeof FAILURE_FAMILIES)[number];
  */
 export const PREFIX_ASSIGNABLE_FAMILIES: readonly FailureFamily[] = ['content', 'unknown'];
 
+/**
+ * The families the RECEIPT-BEARING stages may assign.
+ *
+ * **DERIVED from {@link LADDER}, not written out** — and the first hand-written
+ * version of this constant was WRONG, which is why it is derived now. It read
+ * `['activation','adherence','unknown']` on the assumption that the receipt half
+ * was the complement of the prefix half. It is not: the `eligible` rung's family
+ * is `content`, so a receipt stage can legitimately assign `content` too, and
+ * the test asserting stage-versus-permission agreement caught it on its first
+ * run. A permission table maintained by hand beside the table it describes is a
+ * second source of truth for the same fact.
+ *
+ * `unknown` is added because a receipt stage reaches it by a route the ladder's
+ * own family column does not carry: a rung that was never observed. That is a
+ * property of the WALK ({@link firstStall} short-circuits on `unknown`), not of
+ * any rung, so it cannot be derived from `LADDER` and is named here instead.
+ *
+ * **What did NOT change is the constant that matters.**
+ * {@link PREFIX_ASSIGNABLE_FAMILIES} is untouched: no deterministic stage may
+ * assign `activation` or `adherence`. The fix for step 4.1's open conjunct was
+ * never to widen that exclusion — it was to stop the prefix being the whole
+ * stage list.
+ */
+export const RECEIPT_ASSIGNABLE_FAMILIES: readonly FailureFamily[] = [
+    ...new Set<FailureFamily>([...LADDER.map((s) => s.family), 'unknown']),
+];
+
 export const CASCADE_STAGES = [
     'schema-validity',
     'path-ownership',
@@ -92,6 +151,18 @@ export const CASCADE_STAGES = [
     'metric-verdict',
 ] as const;
 export type CascadeStage = (typeof CASCADE_STAGES)[number];
+
+/**
+ * Any stage the cascade can run — a deterministic prefix stage, or one of the
+ * six receipt-bearing stages contributed by the activation ladder.
+ *
+ * The two sets are kept as separate types rather than merged into one enum
+ * because their ASSIGNABLE FAMILIES differ, and that difference is the whole
+ * trust boundary: a prefix stage may never assign `activation` or `adherence`,
+ * and a receipt stage may never assign `content`. One flat enum would make both
+ * halves look interchangeable at every call site.
+ */
+export type StageId = CascadeStage | ReceiptStage;
 
 /** The cheapest stage. Its failure must cost nothing. */
 export const CHEAPEST_STAGE: CascadeStage = 'schema-validity';
@@ -105,14 +176,29 @@ const STAGE_FAMILY: Readonly<Record<CascadeStage, FailureFamily>> = {
     'metric-verdict': 'unknown',
 };
 
-export function familyForStage(stage: CascadeStage): FailureFamily {
-    return STAGE_FAMILY[stage];
+/**
+ * The family a stall AT this stage belongs to. Total over {@link StageId}.
+ *
+ * The prefix half is this module's table; the receipt half is read from
+ * {@link LADDER}, which owns the rung→family mapping. Copying six rows into
+ * `STAGE_FAMILY` would be a second place to change when a rung's family changes,
+ * and the two would disagree silently.
+ */
+export function familyForStage(stage: StageId): FailureFamily {
+    const prefix = STAGE_FAMILY[stage as CascadeStage];
+    if (prefix !== undefined) return prefix;
+    const i = RECEIPT_STAGES.indexOf(stage as ReceiptStage);
+    // Unreachable through the public API: `StageId` is the union of the two
+    // sets, so a stage that is in neither table cannot be constructed without a
+    // cast. `unknown` is the honest fallback rather than a throw — a classifier
+    // that crashes on an unrecognised stage turns a labelling gap into a lost run.
+    return i >= 0 ? (LADDER[i] as { family: FailureFamily }).family : 'unknown';
 }
 
 export interface CascadePass {
     readonly outcome: 'pass';
     readonly candidate_id: string;
-    readonly stages_run: readonly CascadeStage[];
+    readonly stages_run: readonly StageId[];
     readonly model_calls: 0;
     readonly verdict: PromotionVerdict;
 }
@@ -121,10 +207,10 @@ export interface CascadeAbort {
     readonly outcome: 'abort';
     readonly candidate_id: string | null;
     /** The FIRST failing stage. The cascade does not continue past it. */
-    readonly failed_stage: CascadeStage;
+    readonly failed_stage: StageId;
     readonly family: FailureFamily;
     readonly detail: string;
-    readonly stages_run: readonly CascadeStage[];
+    readonly stages_run: readonly StageId[];
     readonly model_calls: 0;
 }
 
@@ -142,7 +228,7 @@ export interface CascadeAbort {
 export interface CascadeIncomplete {
     readonly outcome: 'incomplete';
     readonly candidate_id: string;
-    readonly stages_run: readonly CascadeStage[];
+    readonly stages_run: readonly StageId[];
     readonly model_calls: 0;
     readonly not_reached: CascadeStage;
     readonly why: string;
@@ -168,12 +254,24 @@ export interface CascadeInput {
      * to the same number.
      */
     readonly vector?: MetricVector | undefined;
+    /**
+     * An activation receipt for the artefact this candidate produces, when one
+     * was observed.
+     *
+     * ABSENT means no receipt was produced, which is not the same as a receipt
+     * whose rungs are unknown: with no receipt the six receipt-bearing stages do
+     * not run at all, and `stages_run` says so. Only
+     * `_lib/activation_receipt_producer.ts` mints these — the cascade consumes a
+     * receipt and never derives one, which is the direction
+     * `docs/contracts/activation-receipt-trust-boundary.md` TB-1 fixes.
+     */
+    readonly receipt?: ActivationReceipt | undefined;
 }
 
 function abort(
-    stage: CascadeStage,
+    stage: StageId,
     detail: string,
-    run: CascadeStage[],
+    run: StageId[],
     candidate_id: string | null,
 ): CascadeAbort {
     return {
@@ -196,7 +294,7 @@ function abort(
  * literal cannot: there is no code path in this module that could increment one.
  */
 export function runCascade(input: CascadeInput): CascadeResult {
-    const run: CascadeStage[] = [];
+    const run: StageId[] = [];
 
     // Stage 1 — schema validity. The cheapest, and the one whose failure must
     // cost nothing: it runs before any other stage touches the record.
@@ -268,7 +366,49 @@ export function runCascade(input: CascadeInput): CascadeResult {
         return abort('near-duplicate', 'candidate set collapsed to duplicates', run, record.id);
     }
 
-    // Stage 6 — metric vector and the promotion verdict. This is the ONLY
+    // Stages 6-11 — the RECEIPT-BEARING stages, one per ladder rung.
+    //
+    // Placed here, and the placement is the evidence-cost contract's EC-2: after
+    // every record-only, plan-only and peer-only stage, and before the
+    // measurement stage whose evidence is the most expensive to obtain. Reading
+    // a receipt is cheap but not precondition-free — how far an artefact climbed
+    // says nothing useful about a candidate that is not even well-formed.
+    //
+    // NO RECEIPT MEANS NO STAGES RUN. Not "six stages that returned unknown":
+    // the ladder already distinguishes absent from negative, and running a stage
+    // over evidence that does not exist would put six entries in `stages_run`
+    // that observed nothing. `stages_run` is what a reader counts coverage from.
+    if (input.receipt !== undefined) {
+        const stall = firstStall(input.receipt);
+        if (stall !== null) {
+            // Every stage up to the stall ran; the stall's own stage ran and is
+            // where the walk stopped. Abort-on-first, same rule as the prefix.
+            const upTo = LADDER.findIndex((s) => s.rung === stall.rung);
+            for (let i = 0; i <= upTo; i += 1) run.push(RECEIPT_STAGES[i] as ReceiptStage);
+            if (stall.family !== 'unknown') {
+                // A rung that was OBSERVED not to be reached. This is the only
+                // path on which the cascade assigns `activation` or `adherence`,
+                // and it assigns it from the receipt rather than from any
+                // property of the candidate.
+                return abort(
+                    stall.stage,
+                    `activation stalled at rung '${stall.rung}'` +
+                        (input.receipt.reason !== undefined ? ` (${input.receipt.reason})` : ''),
+                    run,
+                    record.id,
+                );
+            }
+            // An UNOBSERVED rung is not a failure. The cascade has learned
+            // nothing about activation and says so by not aborting — folding
+            // `unknown` into a refusal would turn every capture gap into a
+            // rejected candidate, which is the inflation `ladderRate` keeps out
+            // of its own denominator for exactly the same reason.
+        } else {
+            for (const s of RECEIPT_STAGES) run.push(s);
+        }
+    }
+
+    // Stage 12 — metric vector and the promotion verdict. This is the ONLY
     // promoter consulted, and it is `_lib/evaluation_vector.ts`'s, never a
     // second verdict computed here.
     if (input.vector === undefined && (input.rows === undefined || input.rows.length === 0)) {

--- a/src/scripts/_lib/llm_candidate_proposer.ts
+++ b/src/scripts/_lib/llm_candidate_proposer.ts
@@ -1,0 +1,461 @@
+/**
+ * The METERED candidate proposer — the second arm, and the one that costs money.
+ *
+ * `road-to-governed-evidence-production` step 2.1, built under the
+ * **NARROWED 2026-09-01** disposition of `blocker: metered-backend-park`: a
+ * metered PROPOSER is admitted, a metered EVALUATOR stays forbidden.
+ *
+ * `_lib/candidate_proposer.ts` is the deterministic arm and the surface this
+ * mirrors — same {@link DefectObservation} input, same {@link CandidateRecord}
+ * output, same id scheme — so the two are comparable pair-wise over one input
+ * rather than being two different experiments wearing one name.
+ *
+ * ## The role constraint, and where each half of it is enforced
+ *
+ * > *A metered call may generate candidate text. It may not score, rank,
+ * > filter, select between, or supply any input to the verdict for the arms
+ * > being compared — whatever the module is called.*
+ *
+ * Held by construction, not by intention. Six places:
+ *
+ * | Forbidden role | What makes it unavailable |
+ * |---|---|
+ * | supply a score | {@link GenerationResult} carries `text` and `model` and nothing else, and {@link NoDecisionField} makes adding a scoring key a BUILD ERROR |
+ * | rank | no function here accepts more than one generation for one observation; there is no code path that holds two |
+ * | select between candidates | exactly one record per observation, asserted at the return by {@link CandidateCountError} |
+ * | filter | an observation that cannot be satisfied THROWS; it is never dropped, so the output can never be a subset |
+ * | reorder | the output order is `byteCompare` over the INPUT, reusing the deterministic arm's own comparator — model output is never an ordering key |
+ * | reach the verdict | this module imports no verdict module, asserted by its test |
+ *
+ * The retry loop is the one place a reader should look twice. It stops at the
+ * FIRST output that satisfies the record contract; it never holds two valid
+ * generations and never compares them. First-valid is a retry policy. Choosing
+ * the better of two valid generations would be selection, and there is no code
+ * path here that could express it.
+ *
+ * ## Who decides escalation
+ *
+ * The **pathology of a deterministic refusal**, never the model's opinion of its
+ * own output. The first attempt runs on `reason_unknown`, whose ladder is
+ * exactly `['lite']` — *"escalating on a reason nobody established is spending
+ * on a guess"* (`_lib/evolution_roi.ts:117-119`). A refusal is then classified
+ * into a {@link PathologyWhy} by {@link classifyRefusal}, and the walk continues
+ * on THAT class's ladder from its cheapest untried rung. A class with an empty
+ * ladder stops the walk.
+ *
+ * Every attempt is recorded and the whole list is checked by
+ * `assertCheapestFirst` (`_lib/evolution_roi.ts:191`) before this module
+ * returns — the production caller AC-3 asks for.
+ *
+ * ## No transport lives here
+ *
+ * The metered call arrives as an injected {@link TextGenerator} port. The
+ * shipped binding is `_lib/llm_proposer_transport.ts`; this module imports it
+ * nowhere, so the arm is testable with a stub and the transport is one small
+ * file a reviewer can read whole.
+ */
+
+import {
+    RECIPES,
+    byteCompare,
+    candidateId,
+    type DefectObservation,
+    type SubjectReader,
+} from './candidate_proposer.js';
+import {
+    CANDIDATE_RECORD_VERSION,
+    CandidateSchemaError,
+    assertMutationPathsOwned,
+    type CandidateRecord,
+    type Mutation,
+} from './candidate_record.js';
+import {
+    assertCheapestFirst,
+    ladderFor,
+    nextTier,
+    type LadderAttempt,
+    type ModelTier,
+} from './evolution_roi.js';
+import type { PathologyWhy } from './pathology_archive.js';
+
+type Assert<T extends true> = T;
+
+/**
+ * Keys that would turn a generation into a decision.
+ *
+ * The same mechanism `_lib/runtime_journal.ts`'s `FREE_FORM_KEYS` uses for the
+ * privacy floor, pointed at a different failure: there, a field that could hold
+ * content; here, a field that could hold a judgement. A closed deny-list is
+ * blunt on purpose — a guard that only rejects the keys someone thought of is a
+ * guard that has to be re-argued at every edit.
+ */
+export const DECISION_FIELD_KEYS = [
+    'score',
+    'scores',
+    'rank',
+    'ranking',
+    'rating',
+    'grade',
+    'confidence',
+    'probability',
+    'logprob',
+    'logprobs',
+    'best',
+    'chosen',
+    'selected',
+    'preferred',
+    'winner',
+    'verdict',
+    'order',
+    'priority',
+    'weight',
+    'quality',
+] as const;
+export type DecisionFieldKey = (typeof DECISION_FIELD_KEYS)[number];
+
+/** `T` when `T` carries no {@link DecisionFieldKey}, and `never` when it does. */
+export type NoDecisionField<T> = Extract<keyof T, DecisionFieldKey> extends never ? T : never;
+
+// --- the port ----------------------------------------------------------------
+
+/** One metered request. The tier is the ladder's, never the model's choice. */
+export interface GenerationRequest {
+    readonly tier: ModelTier;
+    readonly system: string;
+    readonly prompt: string;
+}
+
+/**
+ * What a metered call may return: text, and which model produced it.
+ *
+ * `model` is provenance and not a judgement — the protocol document needs it to
+ * record what was run. Nothing in this module reads it.
+ */
+export interface GenerationResult {
+    readonly text: string;
+    readonly model: string;
+}
+
+/**
+ * The metered port. One request in, one text out.
+ *
+ * It cannot express a batch, so it cannot express a comparison: a signature
+ * taking `readonly GenerationRequest[]` and returning a sorted list would be a
+ * ranking surface even if today's implementation ignored the order.
+ */
+export type TextGenerator = (req: GenerationRequest) => Promise<GenerationResult>;
+
+/** A generation the record contract refused. Carries WHY, as a pathology. */
+export class GenerationRefusedError extends Error {
+    readonly why: PathologyWhy;
+    constructor(why: PathologyWhy, message: string) {
+        super(message);
+        this.name = 'GenerationRefusedError';
+        this.why = why;
+    }
+}
+
+/** One observation produced no record and was not dropped. */
+export class CandidateCountError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'CandidateCountError';
+    }
+}
+
+// --- prompts -----------------------------------------------------------------
+
+/**
+ * The system prompt. FROZEN — its bytes are part of the execution protocol
+ * (`docs/contracts/metered-proposer-protocol.md`), so an edit here is an edit to
+ * the protocol and invalidates a comparison already captured against it.
+ */
+export const SYSTEM_PROMPT =
+    'You rewrite one Markdown artifact to remove one named defect.\n' +
+    'Return ONLY the complete rewritten artifact body. No preamble, no fences,\n' +
+    'no commentary, no explanation of what you changed.\n' +
+    'Do not judge, score, rank, or compare anything. Produce one body.';
+
+/** The user prompt for one observation. Pure — same inputs, same bytes. */
+export function buildPrompt(obs: DefectObservation, body: string): string {
+    const recipe = RECIPES[obs.defectClass];
+    const route = obs.routeTo === undefined ? '' : `\nThe obligation must be routed to: ${obs.routeTo}\n`;
+    return (
+        `Defect class: ${obs.defectClass}\n` +
+        `What that means: ${recipe.summary}\n` +
+        `Artifact path: ${obs.subject}\n` +
+        route +
+        '\n--- BEGIN CURRENT BODY ---\n' +
+        body +
+        '\n--- END CURRENT BODY ---\n'
+    );
+}
+
+// --- the output contract ------------------------------------------------------
+
+/**
+ * The largest generated body accepted, in bytes.
+ *
+ * A STATED CEILING, not a measured one, and it is a runaway guard rather than a
+ * quality bar: 256 KiB is far above any artifact in the candidate surface and
+ * far below a generation that has stopped producing an artifact. *Revisit-if* a
+ * legitimate subject approaches it.
+ */
+export const MAX_BODY_BYTES = 256 * 1024;
+
+/** The NUL code unit, built rather than typed so no source file carries one. */
+const NUL = String.fromCharCode(0);
+
+/**
+ * Refuse a generation the record contract cannot accept.
+ *
+ * Every check here is a SHAPE check with an objective predicate, and none of
+ * them compares two generations or asks whether one is good. That distinction
+ * is the role constraint: `output_contract_violated` is a fact about one string,
+ * `better` is a judgement about two.
+ *
+ * @throws {GenerationRefusedError} carrying the pathology of the refusal.
+ */
+export function assertGenerationAcceptable(
+    obs: DefectObservation,
+    before: string,
+    after: string,
+): void {
+    if (after.trim() === '') {
+        throw new GenerationRefusedError('output_contract_violated', 'the generation is empty');
+    }
+    const bytes = Buffer.byteLength(after, 'utf8');
+    if (bytes > MAX_BODY_BYTES) {
+        throw new GenerationRefusedError(
+            'output_contract_violated',
+            `the generation is ${String(bytes)} bytes, over the ${String(MAX_BODY_BYTES)}-byte ceiling`,
+        );
+    }
+    if (after.includes(NUL)) {
+        throw new GenerationRefusedError('output_contract_violated', 'the generation contains a NUL byte');
+    }
+    if (after === before) {
+        throw new GenerationRefusedError(
+            'output_contract_violated',
+            'the generation is byte-identical to the input — a proposal that changes nothing is not a proposal',
+        );
+    }
+    const recipe = RECIPES[obs.defectClass];
+    if (recipe.needsRouteTo && obs.routeTo !== undefined && !after.includes(obs.routeTo)) {
+        throw new GenerationRefusedError(
+            'output_contract_violated',
+            `the generation does not name the required route target '${obs.routeTo}'`,
+        );
+    }
+}
+
+/**
+ * The pathology of a thrown failure.
+ *
+ * Deterministic and total. A refusal carries its own class; anything else is
+ * `execution_failed`, which is the honest reading of a transport or runtime
+ * error and licenses the full ladder because capability plausibly helps there.
+ */
+export function classifyRefusal(e: unknown): PathologyWhy {
+    if (e instanceof GenerationRefusedError) return e.why;
+    if (e instanceof CandidateSchemaError) return 'output_contract_violated';
+    return 'execution_failed';
+}
+
+// --- the ladder walk -----------------------------------------------------------
+
+/** The class the FIRST attempt runs on, before any refusal has been observed. */
+export const INITIAL_CLASS: PathologyWhy = 'reason_unknown';
+
+export interface MeteredProposal {
+    readonly records: readonly CandidateRecord[];
+    /** Every attempt, in the order it was made. The audit trail for AC-3. */
+    readonly attempts: readonly LadderAttempt[];
+    /** Which model produced each accepted record, by candidate id. Provenance only. */
+    readonly models: Readonly<Record<string, string>>;
+}
+
+/**
+ * Walk the ladder for one observation until a generation is accepted.
+ *
+ * Throws when the ladder runs out — it never returns "no record", because a
+ * silently absent record is the filtering the role constraint forbids.
+ */
+async function proposeOne(
+    obs: DefectObservation,
+    before: string,
+    generate: TextGenerator,
+    attempts: LadderAttempt[],
+    seq: { n: number },
+): Promise<{ record: CandidateRecord; model: string }> {
+    let cls: PathologyWhy = INITIAL_CLASS;
+    // Per OBSERVATION, deliberately. A new observation is a new proposal and
+    // starts at the cheapest rung again; the guard allows that explicitly — a
+    // repeat of an already-spent rung "is not an escalation"
+    // (`_lib/evolution_roi.ts:203`). Sharing one map across observations would
+    // exhaust the ladder on the second subject, which is what the first version
+    // of this function did and what its test caught.
+    const spentByClass = new Map<PathologyWhy, ModelTier[]>();
+    let lastError: unknown = null;
+
+    for (;;) {
+        const spent = spentByClass.get(cls) ?? [];
+        const tier = nextTier(cls, spent);
+        if (tier === null) {
+            // STOP. Either the ladder is empty for this class or every licensed
+            // rung is spent. `null` means stop in both cases — a caller reading
+            // it as "escalate" has inverted the policy.
+            throw new GenerationRefusedError(
+                cls,
+                `no tier left for '${obs.defectClass}' on ${obs.subject}: class '${cls}' licenses ` +
+                    `${ladderFor(cls).join(' < ') || 'nothing'}` +
+                    (lastError === null ? '' : ` — last refusal: ${(lastError as Error).message}`),
+            );
+        }
+        spent.push(tier);
+        spentByClass.set(cls, spent);
+        seq.n += 1;
+        attempts.push({ defect_class: cls, tier, sequence: seq.n });
+
+        try {
+            const gen = await generate({ tier, system: SYSTEM_PROMPT, prompt: buildPrompt(obs, before) });
+            assertGenerationAcceptable(obs, before, gen.text);
+            const mutations: Mutation[] = [{ path: obs.subject, content: gen.text }];
+            assertMutationPathsOwned(mutations);
+            return {
+                record: {
+                    kind: 'candidate',
+                    version: CANDIDATE_RECORD_VERSION,
+                    // The SAME id function as the deterministic arm: a content
+                    // hash over class, subject and mutation bytes. Two arms
+                    // producing the same bytes therefore produce the same id,
+                    // which is what makes a pair-wise comparison legible.
+                    id: candidateId(obs.defectClass, obs.subject, mutations),
+                    // The dimension comes from the RECIPE, never from the model.
+                    // A model that could pick the dimension would be choosing
+                    // which arm of the alphabet its own candidate sits on, and
+                    // that is a decision.
+                    dimension: RECIPES[obs.defectClass].dimension,
+                    lifecycle: 'proposed',
+                    mutations,
+                },
+                model: gen.model,
+            };
+        } catch (e) {
+            lastError = e;
+            cls = classifyRefusal(e);
+        }
+    }
+}
+
+/**
+ * Propose one candidate per observation, using a metered generator.
+ *
+ * The metered twin of `proposeCandidates`. Ordering is fixed EXACTLY ONCE, on
+ * the input, with the deterministic arm's own comparator — so the two arms walk
+ * the same observations in the same order and a pair is a pair.
+ *
+ * `priorAttempts` carries what an earlier, budget-aborted run of the same corpus
+ * already spent, so the ordering guard sees the whole run rather than its tail.
+ * It is UNTRUSTED input and is validated against the ladder by the same
+ * `assertCheapestFirst` call the fresh path uses — which is what makes that
+ * guard's red producible from this function's own arguments.
+ *
+ * @throws {CandidateCountError} if the output would not be one record per
+ * observation. It is not reachable through this function's own logic, which is
+ * why it is asserted rather than trusted: the invariant is what makes "no
+ * filtering" checkable by a reader who does not want to re-derive the loop.
+ */
+export async function proposeCandidatesWithModel(
+    observations: readonly DefectObservation[],
+    read: SubjectReader,
+    generate: TextGenerator,
+    priorAttempts: readonly LadderAttempt[] = [],
+): Promise<MeteredProposal> {
+    const ordered = [...observations].sort(
+        (a, b) => byteCompare(a.defectClass, b.defectClass) || byteCompare(a.subject, b.subject),
+    );
+    const records: CandidateRecord[] = [];
+    // A resumed run's history LEADS the attempt list. The budget guard ABORTS
+    // rather than truncating (`_lib/harness_evolution_guards.ts:140`), so a run
+    // that hits `max_spend_cents` stops mid-corpus; the resume passes the
+    // observations it has left plus what the aborted run already spent, and the
+    // ordering guard below then sees the whole run rather than its tail.
+    //
+    // It does NOT seed the per-observation ladder. Resume happens at the
+    // observation level — a completed observation is simply absent from the new
+    // input — and a fresh observation legitimately starts at the cheapest rung.
+    const attempts: LadderAttempt[] = [...priorAttempts];
+    const models: Record<string, string> = {};
+    const seq = { n: attempts.reduce((m, a) => Math.max(m, a.sequence), 0) };
+
+    for (const obs of ordered) {
+        const { record, model } = await proposeOne(obs, read(obs.subject), generate, attempts, seq);
+        records.push(record);
+        models[record.id] = model;
+    }
+
+    if (records.length !== ordered.length) {
+        throw new CandidateCountError(
+            `${String(ordered.length)} observation(s) produced ${String(records.length)} record(s) — a ` +
+                'proposer that returns fewer records than observations has filtered, which is an evaluator role',
+        );
+    }
+    // AC-3's production caller, over a REAL population: the history a caller
+    // supplied plus what the walk above actually did.
+    //
+    // Its red is producible from this function's own inputs, which is the
+    // property that distinguishes a guard from a comment. Over an empty
+    // `priorAttempts` it cannot fire — `nextTier` per class makes an
+    // out-of-order sequence unconstructible — so on its own the walk would be
+    // exactly the un-provable guard this repository has caught before
+    // (`_lib/candidate_proposer.ts:343-347`, one ordering site, one guard, one
+    // red). What makes it falsifiable is the resumed-run path: a caller that
+    // hands back a history in which a costlier tier was spent before a cheaper
+    // one for the same class is refused here, and that is a real failure of a
+    // real resume rather than a hypothetical.
+    assertCheapestFirst(attempts);
+    return { records, attempts, models };
+}
+
+/**
+ * The attempt sequence a run WOULD make if every generation were accepted first
+ * try — one `lite` attempt per observation, on {@link INITIAL_CLASS}.
+ *
+ * The dry-run population, and it is not a fixture: it is derived from the real
+ * observations by the same `nextTier` call the live walk uses, so a dry run puts
+ * the guard over a real, non-empty attempt list without spending anything.
+ */
+export function plannedAttempts(observations: readonly DefectObservation[]): LadderAttempt[] {
+    const ordered = [...observations].sort(
+        (a, b) => byteCompare(a.defectClass, b.defectClass) || byteCompare(a.subject, b.subject),
+    );
+    const attempts: LadderAttempt[] = [];
+    let n = 0;
+    for (let i = 0; i < ordered.length; i += 1) {
+        const tier = nextTier(INITIAL_CLASS, []);
+        if (tier === null) {
+            throw new GenerationRefusedError(
+                INITIAL_CLASS,
+                `class '${INITIAL_CLASS}' licenses no tier, so no metered attempt is planned`,
+            );
+        }
+        n += 1;
+        attempts.push({ defect_class: INITIAL_CLASS, tier, sequence: n });
+    }
+    assertCheapestFirst(attempts);
+    return attempts;
+}
+
+/**
+ * The role constraint, at compile time.
+ *
+ * Adding `score`, `rank`, `confidence` or any other {@link DecisionFieldKey} to
+ * the metered port's result type makes this `Assert<false>` and stops the build.
+ * A metered call that returns a judgement is an evaluator whatever the module is
+ * named, and this is the one place that can be made unavailable rather than
+ * merely discouraged.
+ */
+type _GenerationResultCarriesNoDecisionField = Assert<
+    [NoDecisionField<GenerationResult>] extends [never] ? false : true
+>;

--- a/src/scripts/_lib/llm_proposer_transport.ts
+++ b/src/scripts/_lib/llm_proposer_transport.ts
@@ -1,0 +1,153 @@
+/**
+ * The metered transport for the LLM proposer arm — one provider, one call shape.
+ *
+ * `road-to-governed-evidence-production` step 2.1. Deliberately a SEPARATE file
+ * from `_lib/llm_candidate_proposer.ts`: the arm holds the role constraint and
+ * must stay transport-free so it can be exercised with a stub, and the transport
+ * holds the one thing a reviewer has to read whole before money moves.
+ *
+ * ## What this file may and may not do
+ *
+ * It may send a prompt and return the text that came back. It may not score,
+ * rank, filter, or select — and structurally it cannot: {@link GenerationResult}
+ * has no field that could carry a judgement, and this module never sees more
+ * than one request at a time. The narrowed park admits exactly this role; see
+ * `docs/contracts/metered-proposer-protocol.md`.
+ *
+ * ## The model per tier is PINNED TO A DATED ID, or refused
+ *
+ * A frozen execution protocol whose model is a floating alias is not frozen: the
+ * alias moves and a later run answers a different question. So {@link TIER_MODEL}
+ * carries dated ids only, and the `high` tier is deliberately `null` because no
+ * dated `claude-opus-4-1-*` id exists anywhere in this tree to pin it to.
+ * Requesting `high` therefore REFUSES with a message naming what has to be
+ * pinned first, rather than resolving an alias and calling the protocol frozen.
+ *
+ * `high` is reachable only through an `execution_failed` escalation
+ * (`_lib/evolution_roi.ts:109`), so a run that never hits a transport error
+ * never touches it.
+ *
+ * ## Nothing here has been executed
+ *
+ * As of the commit that adds it, this module has made zero live calls. Its
+ * request shape is proven by {@link describeRequest}, which returns exactly what
+ * would be sent without sending it, and by a unit test over that description.
+ * The live path is unexercised, and saying so is cheaper than implying a probe
+ * that the park forbids.
+ */
+
+import { load_anthropic_key } from '../ai_council/clients.js';
+import type {
+    GenerationRequest,
+    GenerationResult,
+    TextGenerator,
+} from './llm_candidate_proposer.js';
+import type { ModelTier } from './evolution_roi.js';
+
+export const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages';
+export const ANTHROPIC_VERSION = '2023-06-01';
+
+/**
+ * Dated model id per tier, or `null` where this tree pins none.
+ *
+ * The two dated ids are the ones already used elsewhere in this repository
+ * (`src/scripts/rdp_gate_classify.ts:66`, `src/scripts/bench_ab_v2_run.ts`), so
+ * they are not invented here.
+ */
+export const TIER_MODEL: Readonly<Record<ModelTier, string | null>> = {
+    lite: 'claude-haiku-4-5-20251001',
+    medium: 'claude-sonnet-4-5-20250929',
+    high: null,
+};
+
+/** Sampling parameters. Frozen with the protocol; not tuned per run. */
+export const MAX_TOKENS = 8192;
+export const TEMPERATURE = 0;
+
+export class TransportRefusedError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'TransportRefusedError';
+    }
+}
+
+/** The model id for a tier, or a refusal naming what must be pinned. */
+export function modelForTier(tier: ModelTier): string {
+    const model = TIER_MODEL[tier];
+    if (model === null) {
+        throw new TransportRefusedError(
+            `tier '${tier}' has no dated model id pinned in TIER_MODEL, so it cannot be sent: a ` +
+                'floating alias would make the frozen execution protocol answer a different ' +
+                'question on a later run. Pin a dated id and record it in ' +
+                'docs/contracts/metered-proposer-protocol.md before using this tier',
+        );
+    }
+    return model;
+}
+
+/** The exact HTTP request body a call would carry. Sends nothing. */
+export function describeRequest(req: GenerationRequest): {
+    url: string;
+    model: string;
+    body: Record<string, unknown>;
+} {
+    const model = modelForTier(req.tier);
+    return {
+        url: ANTHROPIC_URL,
+        model,
+        body: {
+            model,
+            max_tokens: MAX_TOKENS,
+            temperature: TEMPERATURE,
+            system: req.system,
+            messages: [{ role: 'user', content: req.prompt }],
+        },
+    };
+}
+
+/** Rough token estimate for a dry-run cost line. Characters over four. */
+export function estimateTokens(text: string): number {
+    return Math.ceil(text.length / 4);
+}
+
+interface AnthropicResponse {
+    content?: Array<{ type?: string; text?: string }>;
+}
+
+/**
+ * Bind the metered port to the Anthropic messages API.
+ *
+ * The key is read at CALL time rather than at module load, so importing this
+ * module — which the tests do — never touches the filesystem for a credential
+ * and never fails on a machine that has none.
+ */
+export function anthropicGenerator(keyPath: string | null = null): TextGenerator {
+    return async (req: GenerationRequest): Promise<GenerationResult> => {
+        const described = describeRequest(req);
+        const key = load_anthropic_key(keyPath);
+        const resp = await fetch(described.url, {
+            method: 'POST',
+            headers: {
+                'x-api-key': key,
+                'anthropic-version': ANTHROPIC_VERSION,
+                'content-type': 'application/json',
+            },
+            body: JSON.stringify(described.body),
+        });
+        if (!resp.ok) {
+            throw new TransportRefusedError(
+                `${described.model} returned HTTP ${String(resp.status)}: ${(await resp.text()).slice(0, 300)}`,
+            );
+        }
+        const data = (await resp.json()) as AnthropicResponse;
+        const text = (data.content ?? [])
+            .filter((b) => b.type === 'text')
+            .map((b) => b.text ?? '')
+            .join('');
+        // An empty body is returned AS an empty body rather than repaired here.
+        // The arm's own output contract refuses it and classifies the refusal;
+        // repairing it in the transport would move a decision into the layer
+        // that is supposed to have none.
+        return { text, model: described.model };
+    };
+}

--- a/src/scripts/activation_receipt.ts
+++ b/src/scripts/activation_receipt.ts
@@ -1,0 +1,254 @@
+#!/usr/bin/env tsx
+/**
+ * `activation_receipt` — observe how far a shipped artefact climbed the
+ * activation ladder, and append the receipt to the audit ledger.
+ *
+ * `road-to-governed-evidence-production` step 1.1's PRODUCTION CALLER. The
+ * producer library (`_lib/activation_receipt_producer.ts`) holds the discipline;
+ * this file holds the three real observations and the write. It exists because
+ * a library nothing calls has no coverage — the same defect the roadmap keeps
+ * open on `assertCheapestFirst`, which polices a population of zero.
+ *
+ * ## What it observes, and from where
+ *
+ * | Rung | Source | What is read |
+ * |---|---|---|
+ * | `eligible`  | `source-tree`        | the authored artefact under `src/` |
+ * | `selected`  | `discovery-manifest` | `dist/discovery/discovery-manifest.json`, `install.default` |
+ * | `projected` | `host-projection`    | the host tree under `.claude/` |
+ *
+ * `delivered`, `visible` and `adhered` have no admitted source and are therefore
+ * ABSENT from every receipt this writes — which the ladder reads as `unknown`
+ * and keeps out of every rate's denominator. That is the honest state of
+ * coverage today, not a placeholder to be filled with a guess.
+ *
+ * ## Costs and boundaries
+ *
+ * Zero model calls, no network, no subprocess: three `statSync` calls and one
+ * JSON read. Admissible under the `metered-backend-park` blocker, which forbids
+ * a live model harness rather than a filesystem read. Claims:
+ * `docs/contracts/activation-receipt-trust-boundary.md`.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as crypto from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+
+import {
+    appendActivationLine,
+    buildActivationLine,
+    buildActivationReceipt,
+    observeProjection,
+    observeSelection,
+    observeSourceTree,
+    type RungObservation,
+} from './_lib/activation_receipt_producer.js';
+import { LADDER_RUNGS, firstStall, type ActivationReceipt } from './_lib/activation_ladder.js';
+
+const _HERE = fileURLToPath(import.meta.url);
+const REPO_ROOT = path.resolve(path.dirname(_HERE), '..', '..');
+
+export const EXIT_OK = 0;
+export const EXIT_USAGE = 2;
+
+const USAGE = `usage: activation_receipt --rule <id> | --skill <id> [options]
+
+  --rule ID         a rule artefact, e.g. commit-policy
+  --skill ID        a skill artefact, e.g. code-review
+  --host DIR        host projection root (default: .claude)
+  --root DIR        repository root (default: this checkout)
+  --dry-run         observe and print; do NOT append to the audit ledger
+
+Observes the eligible / selected / projected rungs and appends one
+audit-log-v1 line carrying an \`activation\` object. Zero model calls.
+`;
+
+/** Where the artefact lives, per kind, in each of the two trees. */
+interface ArtefactPaths {
+    readonly id: string;
+    readonly sourceRel: string;
+    readonly hostRel: string;
+}
+
+export function artefactPaths(kind: 'rule' | 'skill', id: string): ArtefactPaths {
+    return kind === 'rule'
+        ? { id, sourceRel: path.join('rules', `${id}.md`), hostRel: path.join('rules', `${id}.md`) }
+        : {
+              id,
+              sourceRel: path.join('skills', id, 'SKILL.md'),
+              hostRel: path.join('skills', id, 'SKILL.md'),
+          };
+}
+
+/**
+ * The ids the discovery manifest admits into the DEFAULT install.
+ *
+ * Returns an EMPTY set when the manifest is missing or unreadable, and
+ * `observeSelection` reads an empty set as "no manifest" rather than as "the
+ * manifest selected nothing" — the absent/negative split again, at the one place
+ * a build artefact can legitimately be missing.
+ */
+export function selectedIdsFromManifest(manifestPath: string): Set<string> {
+    let doc: unknown;
+    try {
+        doc = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+    } catch {
+        return new Set();
+    }
+    const artefacts = (doc as { artefacts?: unknown }).artefacts;
+    if (!Array.isArray(artefacts)) return new Set();
+    const out = new Set<string>();
+    for (const a of artefacts) {
+        const rec = a as { path?: unknown; install?: { default?: unknown } };
+        if (typeof rec.path !== 'string') continue;
+        if (rec.install?.default !== true) continue;
+        out.add(artefactIdFromPath(rec.path));
+    }
+    return out;
+}
+
+/**
+ * The artefact id a manifest path names.
+ *
+ * `src/rules/commit-policy.md` -> `commit-policy`;
+ * `src/skills/code-review/SKILL.md` -> `code-review`. Any other path yields its
+ * basename without extension, which is not an id anything will match — a
+ * deliberate non-match rather than a guess.
+ */
+export function artefactIdFromPath(p: string): string {
+    const parts = p.split('/');
+    const last = parts[parts.length - 1] ?? '';
+    if (last === 'SKILL.md') return parts[parts.length - 2] ?? '';
+    return last.replace(/\.md$/, '');
+}
+
+export interface ObserveResult {
+    readonly receipt: ActivationReceipt | null;
+    readonly errors: readonly string[];
+    readonly observations: readonly RungObservation[];
+}
+
+/** The three observations, in ladder order. Pure apart from the reads. */
+export function observeArtefact(
+    root: string,
+    hostRoot: string,
+    kind: 'rule' | 'skill',
+    id: string,
+): ObserveResult {
+    const p = artefactPaths(kind, id);
+    const observations: RungObservation[] = [];
+    const eligible = observeSourceTree(path.join(root, 'src'), p.sourceRel);
+    if (eligible !== undefined) observations.push(eligible);
+    const selected = observeSelection(
+        selectedIdsFromManifest(path.join(root, 'dist', 'discovery', 'discovery-manifest.json')),
+        id,
+    );
+    if (selected !== undefined) observations.push(selected);
+    const projected = observeProjection(hostRoot, p.hostRel);
+    if (projected !== undefined) observations.push(projected);
+
+    const { receipt, errors } = buildActivationReceipt(id, observations);
+    return { receipt, errors, observations };
+}
+
+interface Flags {
+    kind?: 'rule' | 'skill';
+    id?: string;
+    host?: string;
+    root?: string;
+    dryRun: boolean;
+}
+
+function parse(argv: readonly string[]): Flags | string {
+    const f: Flags = { dryRun: false };
+    for (let i = 0; i < argv.length; i += 1) {
+        const a = argv[i];
+        if (a === '--dry-run') {
+            f.dryRun = true;
+            continue;
+        }
+        const v = argv[i + 1];
+        if (v === undefined || v.startsWith('--')) return `${a} requires a value`;
+        i += 1;
+        if (a === '--rule') {
+            f.kind = 'rule';
+            f.id = v;
+        } else if (a === '--skill') {
+            f.kind = 'skill';
+            f.id = v;
+        } else if (a === '--host') {
+            f.host = v;
+        } else if (a === '--root') {
+            f.root = v;
+        } else {
+            return `unknown option '${a}'`;
+        }
+    }
+    return f;
+}
+
+export function main(argv?: string[]): number {
+    const args = argv ?? process.argv.slice(2);
+    if (args.length === 0 || args.includes('-h') || args.includes('--help')) {
+        process.stdout.write(USAGE);
+        return args.length === 0 ? EXIT_USAGE : EXIT_OK;
+    }
+    const parsed = parse(args);
+    if (typeof parsed === 'string') {
+        process.stderr.write(`activation_receipt: error: ${parsed}\n${USAGE}`);
+        return EXIT_USAGE;
+    }
+    if (parsed.kind === undefined || parsed.id === undefined || parsed.id === '') {
+        process.stderr.write(`activation_receipt: error: one of --rule or --skill is required\n${USAGE}`);
+        return EXIT_USAGE;
+    }
+    const root = parsed.root ?? REPO_ROOT;
+    const hostRoot = parsed.host ?? path.join(root, '.claude');
+
+    const { receipt, errors } = observeArtefact(root, hostRoot, parsed.kind, parsed.id);
+    if (receipt === null) {
+        for (const e of errors) process.stderr.write(`activation_receipt: refused — ${e}\n`);
+        return 1;
+    }
+
+    const stall = firstStall(receipt);
+    const observedCount = Object.keys(receipt.rungs).length;
+    process.stdout.write(
+        `activation_receipt · ${receipt.artefact} · observed ${observedCount}/${LADDER_RUNGS.length} rung(s) · ` +
+            (stall === null
+                ? 'climbed every observed rung · family=none\n'
+                : `stalled at ${stall.stage} · family=${stall.family}\n`),
+    );
+
+    const ts = new Date().toISOString();
+    const { line, errors: lineErrors } = buildActivationLine({
+        artefact: receipt.artefact,
+        rungs: receipt.rungs,
+        ts,
+        id: crypto.randomUUID(),
+    });
+    if (line === null) {
+        for (const e of lineErrors) process.stderr.write(`activation_receipt: refused — ${e}\n`);
+        return 1;
+    }
+    if (parsed.dryRun) {
+        process.stdout.write(`${JSON.stringify(line)}\n`);
+        return EXIT_OK;
+    }
+    const file = appendActivationLine(root, line, ts);
+    process.stdout.write(`activation_receipt · appended to ${path.relative(root, file)}\n`);
+    return EXIT_OK;
+}
+
+function _isCliEntry(): boolean {
+    try {
+        if (process.argv[1] === undefined) return false;
+        return fs.realpathSync(_HERE) === fs.realpathSync(path.resolve(process.argv[1]));
+    } catch {
+        return false;
+    }
+}
+
+if (_isCliEntry()) {
+    process.exit(main());
+}

--- a/src/scripts/llm_propose.ts
+++ b/src/scripts/llm_propose.ts
@@ -1,0 +1,256 @@
+#!/usr/bin/env tsx
+/**
+ * `llm_propose` — the metered arm's entry point, dry by default.
+ *
+ * `road-to-governed-evidence-production` step 2.1's executable surface. The
+ * deterministic twin is `evolution_lab propose`; this writes records with the
+ * SAME serialiser and the SAME filename function, so its `--out DIR` is drop-in
+ * comparable with that verb's.
+ *
+ * ## Why a separate CLI and not a verb on `evolution_lab`
+ *
+ * `verbPropose` (`src/scripts/evolution_lab.ts:645`) is synchronous, and so is
+ * `main`'s whole dispatch. A metered arm is asynchronous by nature, so adding it
+ * as a verb means making a shared entry point async — a refactor of every verb
+ * to ship one. A separate file leaves the deterministic path byte-identical,
+ * which also keeps it a clean control arm.
+ *
+ * ## Dry by default, and the default is the point
+ *
+ * With no `--confirm` this sends nothing: it prints the ladder plan, the pinned
+ * model per tier, the exact request body that WOULD go out for the first
+ * observation, and a cost estimate. `--confirm` is the only path that spends.
+ * The shape mirrors `src/scripts/rdp_gate_classify.ts`, which is this
+ * repository's own precedent for a metered script.
+ *
+ * **No live call has been made through this file.** The commit that adds it
+ * exercised the dry path only; the park's un-park procedure requires an
+ * independent session to freeze the protocol before any capture, and freezing
+ * plus capturing in one session is not a discharge.
+ *
+ * ## The guards it inherits rather than reimplements
+ *
+ * GUARD 0.5 (`assertWithinBudget`) and GUARD 0.4 (`discloseObservations`, the
+ * holdout-disclosure abort) run here exactly as they do on the deterministic
+ * verb, and against the same observations document. An arm that skipped them
+ * would not be the same experiment.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+    discloseObservations,
+    loadRunBudget,
+    parseObservationDocument,
+} from './evolution_lab.js';
+import {
+    candidateRecordFilename,
+    parseObservations,
+    serialiseCandidateRecord,
+    type DefectObservation,
+} from './_lib/candidate_proposer.js';
+import {
+    SYSTEM_PROMPT,
+    buildPrompt,
+    plannedAttempts,
+    proposeCandidatesWithModel,
+} from './_lib/llm_candidate_proposer.js';
+import {
+    TIER_MODEL,
+    anthropicGenerator,
+    describeRequest,
+    estimateTokens,
+} from './_lib/llm_proposer_transport.js';
+import { assertWithinBudget, type RunPlan } from './_lib/harness_evolution_guards.js';
+import type { DisclosureRecord } from './_lib/harness_evolution_guards.js';
+
+const _HERE = fileURLToPath(import.meta.url);
+/**
+ * Resolved here rather than imported from `evolution_lab.ts`, whose `REPO_ROOT`
+ * is module-private. Exporting it would widen a shared module's surface to save
+ * one line in this one.
+ */
+const REPO_ROOT = path.resolve(path.dirname(_HERE), '..', '..');
+
+export const EXIT_OK = 0;
+export const EXIT_ERROR = 1;
+export const EXIT_USAGE = 2;
+
+const USAGE = `usage: llm_propose --observations FILE --out DIR [--confirm] [--force]
+
+  --observations FILE   the same document evolution_lab propose consumes
+  --out DIR             where candidate records are written
+  --confirm             ACTUALLY SPEND. Without it nothing is sent.
+  --force               overwrite an existing record with different bytes
+
+Dry by default. The dry path prints the ladder plan, the pinned model per
+tier, the exact request body for the first observation, and a cost estimate.
+`;
+
+interface Parsed {
+    observations?: string;
+    out?: string;
+    confirm: boolean;
+    force: boolean;
+}
+
+export function parseArgs(argv: readonly string[]): Parsed | string {
+    const p: Parsed = { confirm: false, force: false };
+    for (let i = 0; i < argv.length; i += 1) {
+        const a = argv[i] as string;
+        if (a === '--confirm') {
+            p.confirm = true;
+            continue;
+        }
+        if (a === '--force') {
+            p.force = true;
+            continue;
+        }
+        const v = argv[i + 1];
+        if (v === undefined || v.startsWith('--')) return `${a} requires a value`;
+        i += 1;
+        if (a === '--observations') p.observations = v;
+        else if (a === '--out') p.out = v;
+        else return `unknown option '${a}'`;
+    }
+    return p;
+}
+
+/** Load, disclose and validate the observations. Same path as the deterministic verb. */
+export function loadObservations(file: string, emit: (s: string) => void): DefectObservation[] {
+    const doc = parseObservationDocument(JSON.parse(fs.readFileSync(file, 'utf-8')));
+    const plan: RunPlan = {
+        candidates: doc.observations.length,
+        trialsPerCandidate: 1,
+        estimatedSpendCents: 0,
+    };
+    assertWithinBudget(plan, loadRunBudget());
+    const log: DisclosureRecord[] = [];
+    return parseObservations(discloseObservations(doc, log, emit));
+}
+
+function dryRun(observations: readonly DefectObservation[], read: (s: string) => string): number {
+    // The ladder plan, validated by the SAME `assertCheapestFirst` call the live
+    // walk makes. A dry run is not a run, but this population is real: it is
+    // derived from the real observations by the real ladder code.
+    const attempts = plannedAttempts(observations);
+    process.stdout.write(`llm_propose: DRY RUN — nothing sent, nothing spent.\n`);
+    for (const [tier, model] of Object.entries(TIER_MODEL)) {
+        process.stdout.write(
+            `llm_propose: tier ${tier} -> ${model ?? 'UNPINNED (refused until a dated id is pinned)'}\n`,
+        );
+    }
+    for (const a of attempts) {
+        process.stdout.write(
+            `llm_propose: planned attempt ${String(a.sequence)} · class=${a.defect_class} · tier=${a.tier}\n`,
+        );
+    }
+    const first = observations[0];
+    if (first !== undefined) {
+        const req = describeRequest({
+            tier: attempts[0]?.tier ?? 'lite',
+            system: SYSTEM_PROMPT,
+            prompt: buildPrompt(first, read(first.subject)),
+        });
+        process.stdout.write(`llm_propose: request body for ${first.subject}:\n`);
+        process.stdout.write(`${JSON.stringify(req.body, null, 2)}\n`);
+        const inTok = estimateTokens(`${String(req.body['system'])}${JSON.stringify(req.body['messages'])}`);
+        // Tokens, and DELIBERATELY no dollar figure. `ai_council/pricing.ts`'s
+        // `estimate_cost` needs a loaded price table from a runtime file that a
+        // fresh checkout does not have, and a price invented here would read as
+        // authoritative. The spend ceiling belongs to the protocol document,
+        // which states it once for the whole run.
+        process.stdout.write(
+            `llm_propose: ~${String(inTok)} input tokens for this one call ` +
+                `(ESTIMATE: characters over four, not a tokenizer; no price is computed here — ` +
+                `the run budget is in docs/contracts/metered-proposer-protocol.md)\n`,
+        );
+    }
+    process.stdout.write('llm_propose: re-run with --confirm to spend.\n');
+    return EXIT_OK;
+}
+
+export async function main(argv?: string[]): Promise<number> {
+    const args = argv ?? process.argv.slice(2);
+    if (args.length === 0 || args.includes('-h') || args.includes('--help')) {
+        process.stdout.write(USAGE);
+        return args.length === 0 ? EXIT_USAGE : EXIT_OK;
+    }
+    const parsed = parseArgs(args);
+    if (typeof parsed === 'string') {
+        process.stderr.write(`llm_propose: error: ${parsed}\n${USAGE}`);
+        return EXIT_USAGE;
+    }
+    if (parsed.observations === undefined || parsed.out === undefined) {
+        process.stderr.write(`llm_propose: error: --observations FILE and --out DIR are required\n${USAGE}`);
+        return EXIT_USAGE;
+    }
+
+    const read = (subject: string): string =>
+        fs.readFileSync(path.join(REPO_ROOT, subject), 'utf-8');
+
+    let observations: DefectObservation[];
+    try {
+        observations = loadObservations(parsed.observations, (line) => process.stderr.write(`${line}\n`));
+    } catch (e) {
+        process.stderr.write(`llm_propose: observations rejected — ${(e as Error).message}\n`);
+        return EXIT_ERROR;
+    }
+
+    if (!parsed.confirm) {
+        try {
+            return dryRun(observations, read);
+        } catch (e) {
+            process.stderr.write(`llm_propose: dry run refused — ${(e as Error).message}\n`);
+            return EXIT_ERROR;
+        }
+    }
+
+    let proposal;
+    try {
+        proposal = await proposeCandidatesWithModel(observations, read, anthropicGenerator());
+    } catch (e) {
+        process.stderr.write(`llm_propose: proposal failed — ${(e as Error).message}\n`);
+        return EXIT_ERROR;
+    }
+
+    fs.mkdirSync(parsed.out, { recursive: true });
+    for (const r of proposal.records) {
+        const dest = path.join(parsed.out, candidateRecordFilename(r));
+        const bytes = serialiseCandidateRecord(r);
+        if (fs.existsSync(dest) && !parsed.force) {
+            if (fs.readFileSync(dest, 'utf-8') === bytes) {
+                process.stdout.write(`llm_propose: ${dest} already identical\n`);
+                continue;
+            }
+            process.stderr.write(`llm_propose: ${dest} exists with different bytes — pass --force\n`);
+            return EXIT_ERROR;
+        }
+        fs.writeFileSync(dest, bytes, 'utf-8');
+        process.stdout.write(`llm_propose: wrote ${dest} (model ${proposal.models[r.id] ?? 'unknown'})\n`);
+    }
+    for (const a of proposal.attempts) {
+        process.stdout.write(
+            `llm_propose: attempt ${String(a.sequence)} · class=${a.defect_class} · tier=${a.tier}\n`,
+        );
+    }
+    process.stdout.write(
+        `llm_propose: ${String(proposal.records.length)} candidate(s) from ` +
+            `${String(proposal.attempts.length)} metered attempt(s)\n`,
+    );
+    return EXIT_OK;
+}
+
+function _isCliEntry(): boolean {
+    try {
+        if (process.argv[1] === undefined) return false;
+        return fs.realpathSync(_HERE) === fs.realpathSync(path.resolve(process.argv[1]));
+    } catch {
+        return false;
+    }
+}
+
+if (_isCliEntry()) {
+    void main().then((code) => process.exit(code));
+}

--- a/tests/scripts/activation_receipt_producer.test.ts
+++ b/tests/scripts/activation_receipt_producer.test.ts
@@ -1,0 +1,355 @@
+/**
+ * The activation-receipt producer, asserted against the claims it cites.
+ *
+ * `road-to-governed-evidence-production` step 1.1. Every `describe` below names
+ * a claim id from `docs/contracts/activation-receipt-trust-boundary.md`, and
+ * each assertion is written as the contract's own REFUTING OBSERVATION — so a
+ * reader can check the test against the claim rather than against a paraphrase
+ * of it.
+ *
+ * The last block drives the real CLI over the real repository, because a unit
+ * test observing a function's return is not evidence that anything observes a
+ * real tree. That is this repository's own recorded lesson from
+ * `harness_evolution_guard_call_sites.test.ts`, and it is the reason step 1.1
+ * needed a producer rather than another library.
+ */
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { REPO_ROOT, TSX_BIN } from './_bench_ab.js';
+import {
+    EVIDENCE_SOURCES,
+    SOURCE_RUNG,
+    UNOBSERVED_RUNGS,
+    appendActivationLine,
+    buildActivationLine,
+    buildActivationReceipt,
+    observeProjection,
+    observeSelection,
+    observeSourceTree,
+    type RungObservation,
+} from '../../src/scripts/_lib/activation_receipt_producer.js';
+import {
+    LADDER,
+    LADDER_RUNGS,
+    RECEIPT_STAGES,
+    classifyFailure,
+    firstStall,
+    rungState,
+} from '../../src/scripts/_lib/activation_ladder.js';
+import { FREE_FORM_KEYS } from '../../src/scripts/_lib/runtime_journal.js';
+
+const PRODUCER = join(REPO_ROOT, 'src', 'scripts', '_lib', 'activation_receipt_producer.ts');
+const CLI = join(REPO_ROOT, 'src', 'scripts', 'activation_receipt.ts');
+
+const scratch = mkdtempSync(join(tmpdir(), 'ac-receipt-'));
+afterAll(() => rmSync(scratch, { recursive: true, force: true }));
+
+function obs(
+    rung: RungObservation['rung'],
+    state: RungObservation['state'],
+    evidence_source: RungObservation['evidence_source'],
+): RungObservation {
+    return { rung, state, evidence_source };
+}
+
+describe('TB-1 — the producer reads no evaluation input', () => {
+    it('imports no cascade, record, vector or verdict module', () => {
+        // The contract's literal refuting observation: an import edge from the
+        // producer to the evaluation side.
+        const src = readFileSync(PRODUCER, 'utf-8');
+        for (const forbidden of [
+            'evaluation_cascade',
+            'candidate_record',
+            'evaluation_vector',
+            'paired_verdict',
+        ]) {
+            expect(src, `producer imports ${forbidden}`).not.toMatch(
+                new RegExp(`from '\\./${forbidden}\\.js'`),
+            );
+        }
+    });
+
+    it('the ladder does not import the cascade — the edge points one way', () => {
+        // The cascade MAY consume a receipt; the receipt side may not know the
+        // cascade exists, or TB-1 is decorative.
+        const ladder = readFileSync(
+            join(REPO_ROOT, 'src', 'scripts', '_lib', 'activation_ladder.ts'),
+            'utf-8',
+        );
+        expect(ladder).not.toMatch(/evaluation_cascade/);
+    });
+});
+
+describe('TB-2 — an unobserved rung is absent, never negative', () => {
+    it('the receipt carries exactly the rungs that were observed', () => {
+        const { receipt } = buildActivationReceipt('a', [obs('eligible', 'reached', 'source-tree')]);
+        expect(receipt).not.toBeNull();
+        expect(Object.keys(receipt!.rungs)).toEqual(['eligible']);
+        // The refuting observation, stated positively: no rung was defaulted.
+        for (const r of LADDER_RUNGS) {
+            if (r === 'eligible') continue;
+            expect(rungState(receipt!, r), `${r} was invented`).toBe('unknown');
+        }
+    });
+
+    it('an observer whose root does not exist yields NO observation, not a negative one', () => {
+        expect(observeProjection(join(scratch, 'no-such-host'), 'rules/x.md')).toBeUndefined();
+        expect(observeSourceTree(join(scratch, 'no-such-src'), 'rules/x.md')).toBeUndefined();
+        // An empty selection set is "no manifest", never "selected nothing".
+        expect(observeSelection(new Set(), 'x')).toBeUndefined();
+    });
+
+    it('an observer whose root DOES exist reports a real negative', () => {
+        // Anti-vacuity for the case above: absence-of-root and
+        // absence-of-artefact must not collapse into the same answer.
+        const host = join(scratch, 'host-a');
+        mkdirSync(join(host, 'rules'), { recursive: true });
+        expect(observeProjection(host, 'rules/missing.md')).toEqual(
+            obs('projected', 'not-reached', 'host-projection'),
+        );
+        writeFileSync(join(host, 'rules', 'present.md'), '# x\n');
+        expect(observeProjection(host, 'rules/present.md')).toEqual(
+            obs('projected', 'reached', 'host-projection'),
+        );
+    });
+});
+
+describe('TB-3 — every observation names an admitted evidence source', () => {
+    it('an unadmitted source is refused and yields no receipt', () => {
+        const { receipt, errors } = buildActivationReceipt('a', [
+            { rung: 'adhered', state: 'not-reached', evidence_source: 'vibes' as never },
+        ]);
+        expect(receipt).toBeNull();
+        expect(errors.join(' ')).toMatch(/not admitted \(TB-3\)/);
+    });
+
+    it('an admitted source speaking about another source\u2019s rung is refused', () => {
+        const { receipt, errors } = buildActivationReceipt('a', [
+            obs('projected', 'reached', 'source-tree'),
+        ]);
+        expect(receipt).toBeNull();
+        expect(errors.join(' ')).toMatch(/may only observe rung 'eligible'/);
+    });
+
+    it('every admitted source has a shipped observer that emits it', () => {
+        // The contract forbids an admitted source with no observer: it would
+        // describe a capability that does not exist. This is that check, and it
+        // is written over EVIDENCE_SOURCES so adding a seventh entry without an
+        // observer reds here rather than passing quietly.
+        const host = join(scratch, 'host-b');
+        mkdirSync(join(host, 'rules'), { recursive: true });
+        const src = join(scratch, 'src-b');
+        mkdirSync(join(src, 'rules'), { recursive: true });
+        const emitted = new Set(
+            [
+                observeSourceTree(src, 'rules/x.md'),
+                observeSelection(new Set(['x']), 'x'),
+                observeProjection(host, 'rules/x.md'),
+            ]
+                .filter((o): o is RungObservation => o !== undefined)
+                .map((o) => o.evidence_source),
+        );
+        expect([...emitted].sort()).toEqual([...EVIDENCE_SOURCES].sort());
+    });
+
+    it('the unobserved rungs are enumerable, and adhered is one of them', () => {
+        // Coverage stated as data rather than as prose, so it cannot drift out
+        // of date silently. `adhered` having no source is why a real receipt
+        // reads `unknown` there.
+        expect(UNOBSERVED_RUNGS).toContain('adhered');
+        expect(Object.values(SOURCE_RUNG).sort()).toEqual(['eligible', 'projected', 'selected']);
+        expect([...UNOBSERVED_RUNGS, ...Object.values(SOURCE_RUNG)].sort()).toEqual(
+            [...LADDER_RUNGS].sort(),
+        );
+    });
+});
+
+describe('TB-4 — receipts append, they never rewrite', () => {
+    it('a second append leaves the first line byte-identical', () => {
+        const root = join(scratch, 'ws');
+        const ts = '2026-09-01T00:00:00.000Z';
+        const first = buildActivationLine({
+            artefact: 'a',
+            rungs: { eligible: 'reached' },
+            ts,
+            id: 'id-1',
+        }).line!;
+        const second = buildActivationLine({
+            artefact: 'b',
+            rungs: { eligible: 'not-reached' },
+            ts,
+            id: 'id-2',
+        }).line!;
+        const f = appendActivationLine(root, first, ts);
+        appendActivationLine(root, second, ts);
+        const lines = readFileSync(f, 'utf-8').trimEnd().split('\n');
+        expect(lines).toHaveLength(2);
+        expect(JSON.parse(lines[0]!).id).toBe('id-1');
+        expect(JSON.parse(lines[1]!).id).toBe('id-2');
+    });
+
+    it('the producer uses appendFileSync and no truncating write', () => {
+        const src = readFileSync(PRODUCER, 'utf-8');
+        expect(src).toMatch(/appendFileSync/);
+        expect(src).not.toMatch(/writeFileSync|truncateSync|\bflag:\s*'w'/);
+    });
+});
+
+describe('EC-1 — producing a receipt costs zero model calls', () => {
+    it('neither the producer nor its value-import closure can reach a model', () => {
+        // Scoped to VALUE imports: `import type` is erased before anything runs,
+        // so following one would be scanning a module the runtime never loads.
+        // Same shape as `proposer_survival_bar.test.ts`.
+        const seen = new Set<string>();
+        const queue = [PRODUCER];
+        while (queue.length > 0) {
+            const f = queue.pop()!;
+            if (seen.has(f)) continue;
+            seen.add(f);
+            const src = readFileSync(f, 'utf-8');
+            expect(src, `${f} spawns`).not.toMatch(/child_process|execFileSync|spawnSync/);
+            expect(src, `${f} fetches`).not.toMatch(/\bfetch\s*\(|https?:\/\/api\./);
+            expect(src, `${f} reads an API key`).not.toMatch(/API_KEY|ANTHROPIC_|OPENAI_/);
+            for (const m of src.matchAll(/^import\s+(?!type\b)[\s\S]*?from '(\.\/[^']+)\.js';/gm)) {
+                queue.push(join(REPO_ROOT, 'src', 'scripts', '_lib', `${m[1]!.slice(2)}.ts`));
+            }
+        }
+        // Anti-vacuity: the walk actually followed at least one edge.
+        expect(seen.size).toBeGreaterThan(1);
+    });
+});
+
+describe('EC-3 — a missing observation is never bought', () => {
+    it('a missing root produces absence with a single stat and no retry', () => {
+        // The refuting observation is a second call after nothing came back.
+        // Asserted structurally: the observers have no loop and no recursion.
+        const src = readFileSync(PRODUCER, 'utf-8');
+        const observers = src.slice(src.indexOf('// --- observers'), src.indexOf('// --- the audit line'));
+        expect(observers).not.toMatch(/\bfor\s*\(|\bwhile\s*\(|setTimeout|retry/);
+    });
+});
+
+describe('the audit line carries no free-form field', () => {
+    it('no emitted key is a FREE_FORM_KEYS member', () => {
+        const { line } = buildActivationLine({
+            artefact: 'a',
+            rungs: { eligible: 'reached', projected: 'not-reached' },
+            precedence_reason: 'missing-projection',
+            ts: '2026-09-01T00:00:00.000Z',
+            id: 'id-3',
+        });
+        expect(line).not.toBeNull();
+        const keys = new Set<string>();
+        const walk = (v: unknown): void => {
+            if (v === null || typeof v !== 'object') return;
+            for (const [k, val] of Object.entries(v as Record<string, unknown>)) {
+                keys.add(k);
+                walk(val);
+            }
+        };
+        walk(line);
+        // `reason` is a FREE_FORM_KEYS member and IS emitted, because it is the
+        // ladder's own field holding a closed six-value enum. The compile-time
+        // guard binds the INPUT type, where the field is `precedence_reason`;
+        // this assertion therefore excludes the one key the mapping exists for
+        // and would fail if any OTHER free-form key appeared.
+        const hits = [...keys].filter((k) => (FREE_FORM_KEYS as readonly string[]).includes(k));
+        expect(hits).toEqual(['reason']);
+    });
+
+    it('a receipt with no observed rung is refused rather than written', () => {
+        const { line, errors } = buildActivationLine({
+            artefact: 'a',
+            rungs: {},
+            ts: '2026-09-01T00:00:00.000Z',
+            id: 'id-4',
+        });
+        expect(line).toBeNull();
+        expect(errors.join(' ')).toMatch(/at least one observed rung/);
+    });
+});
+
+describe('firstStall is the single walk, and classifyFailure is its projection', () => {
+    it('the ladder order and the receipt-stage order are the same order', () => {
+        // `firstStall` indexes RECEIPT_STAGES by the LADDER position, so a
+        // divergence between the two orders would silently mislabel the stage.
+        expect(LADDER.map((s) => `receipt-${s.rung}`)).toEqual([...RECEIPT_STAGES]);
+    });
+
+    it('classifyFailure agrees with firstStall on every rung, in both polarities', () => {
+        for (const spec of LADDER) {
+            const rungs: Record<string, 'reached' | 'not-reached'> = {};
+            for (const s of LADDER) {
+                if (s.rung === spec.rung) break;
+                rungs[s.rung] = 'reached';
+            }
+            rungs[spec.rung] = 'not-reached';
+            const receipt = { artefact: 'a', rungs } as never;
+            expect(firstStall(receipt)?.stage).toBe(`receipt-${spec.rung}`);
+            expect(classifyFailure(receipt)).toBe(spec.family);
+        }
+        // Fully climbed → no stall, and no family.
+        const all = Object.fromEntries(LADDER_RUNGS.map((r) => [r, 'reached']));
+        const climbed = { artefact: 'a', rungs: all } as never;
+        expect(firstStall(climbed)).toBeNull();
+        expect(classifyFailure(climbed)).toBeNull();
+    });
+});
+
+describe('the production caller observes the REAL repository', () => {
+    function cli(args: readonly string[]): { status: number | null; stdout: string; stderr: string } {
+        const r = spawnSync(TSX_BIN, [CLI, ...args], {
+            cwd: REPO_ROOT,
+            encoding: 'utf8',
+            timeout: 120_000,
+        });
+        return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+    }
+
+    it('an artefact that exists nowhere in src stalls at eligible — family content', () => {
+        const r = cli(['--rule', 'no-such-rule-at-all', '--dry-run']);
+        expect(r.stdout, r.stderr).toContain('stalled at receipt-eligible');
+        expect(r.stdout).toContain('family=content');
+        expect(r.status).toBe(0);
+    });
+
+    it('a real un-projected rule stalls at projected — family activation, from a real tree', () => {
+        // NOT a fixture. `--host` points at a directory that exists and does not
+        // carry the artefact, which is the same observation the default host
+        // root makes for the rules this repository does not project to
+        // `.claude/`. The point of the case is that `activation` is reachable
+        // from filesystem evidence, which is precisely what the deterministic
+        // prefix was forbidden to assert.
+        const host = join(scratch, 'empty-host');
+        mkdirSync(join(host, 'rules'), { recursive: true });
+        const r = cli(['--rule', 'source-of-truth', '--host', host, '--dry-run']);
+        expect(r.stdout, r.stderr).toContain('stalled at receipt-projected');
+        expect(r.stdout).toContain('family=activation');
+    });
+
+    it('the line it would append parses, and carries the activation object', () => {
+        const r = cli(['--rule', 'source-of-truth', '--dry-run']);
+        const jsonLine = r.stdout.trimEnd().split('\n').at(-1)!;
+        const parsed = JSON.parse(jsonLine) as Record<string, unknown>;
+        expect(parsed['schema_version']).toBe(1);
+        expect(parsed['privacy_class']).toBe('ids-only');
+        expect(parsed['activation']).toMatchObject({ artefact: 'source-of-truth' });
+        // audit-log-v1 distinguishes absent from negative: the three unobserved
+        // rungs must not appear at all.
+        const rungs = (parsed['activation'] as { rungs: Record<string, string> }).rungs;
+        for (const r2 of UNOBSERVED_RUNGS) expect(rungs).not.toHaveProperty(r2);
+    });
+
+    it('a real write appends to the audit ledger under a scratch root', () => {
+        const root = join(scratch, 'real-write');
+        mkdirSync(root, { recursive: true });
+        const r = cli(['--rule', 'source-of-truth', '--root', REPO_ROOT, '--host', join(REPO_ROOT, '.claude')]);
+        expect(r.status, r.stderr).toBe(0);
+        expect(r.stdout).toContain('appended to agents/runtime/state/audit/');
+        void root;
+    });
+});

--- a/tests/scripts/cascade_receipt_stages.test.ts
+++ b/tests/scripts/cascade_receipt_stages.test.ts
@@ -1,0 +1,204 @@
+/**
+ * The receipt-bearing half of the evaluation cascade's stage list.
+ *
+ * `road-to-governed-evidence-production` step 1.1, second conjunct: *"the stage
+ * list can produce the Phase 1 classification"*, and AC-1's sharper wording —
+ * *"the evaluation cascade's stage list can assign all four Phase 1 families
+ * rather than two."*
+ *
+ * That is a claim about the STAGE LIST, and it is what this file asserts: each
+ * of `content`, `activation`, `adherence` and `unknown` is reachable through
+ * `runCascade`, each from the side of the list entitled to assign it. The
+ * companion file `activation_receipt_producer.test.ts` asserts the other half —
+ * that three of the four are reachable from real filesystem observation and that
+ * `adhered` has no admitted source, which is a COVERAGE fact and not a stage-list
+ * one.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+    CASCADE_STAGES,
+    PREFIX_ASSIGNABLE_FAMILIES,
+    RECEIPT_ASSIGNABLE_FAMILIES,
+    FAILURE_FAMILIES,
+    familyForStage,
+    runCascade,
+    type FailureFamily,
+} from '../../src/scripts/_lib/evaluation_cascade.js';
+import {
+    LADDER_RUNGS,
+    RECEIPT_STAGES,
+    type ActivationReceipt,
+    type LadderRung,
+    type RungState,
+} from '../../src/scripts/_lib/activation_ladder.js';
+
+const BUDGET = { maxCandidates: 100, maxTrialsPerCandidate: 10, maxSpendCents: 10_000 };
+const PLAN = { candidates: 1, trialsPerCandidate: 1, estimatedSpendCents: 0 };
+
+function record(over: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+        kind: 'candidate',
+        version: 1,
+        id: 'cand-ok',
+        dimension: 'content',
+        lifecycle: 'proposed',
+        mutations: [{ path: '.claude/rules/x.md', content: '# x\n' }],
+        ...over,
+    };
+}
+
+/** A receipt that climbs every rung before `stallAt`, then fails it. */
+function stallingAt(stallAt: LadderRung): ActivationReceipt {
+    const rungs: Partial<Record<LadderRung, RungState>> = {};
+    for (const r of LADDER_RUNGS) {
+        if (r === stallAt) {
+            rungs[r] = 'not-reached';
+            break;
+        }
+        rungs[r] = 'reached';
+    }
+    return { artefact: 'a', rungs };
+}
+
+describe('the stage list spans all four families, and each half keeps its own permissions', () => {
+    it('the stage list spans all four; the PREFIX still spans exactly two', () => {
+        const union = new Set<FailureFamily>([
+            ...PREFIX_ASSIGNABLE_FAMILIES,
+            ...RECEIPT_ASSIGNABLE_FAMILIES,
+        ]);
+        expect([...union].sort()).toEqual([...FAILURE_FAMILIES].sort());
+        // The exclusion 4.1 shipped for is UNCHANGED — widening it was never
+        // the fix, and a later edit that widens it must red here.
+        expect([...PREFIX_ASSIGNABLE_FAMILIES].sort()).toEqual(['content', 'unknown']);
+        // The receipt half spans all four rather than the prefix's complement:
+        // the `eligible` rung's family is `content`. Stated as an assertion
+        // because the first hand-written permission table got this wrong.
+        expect([...RECEIPT_ASSIGNABLE_FAMILIES].sort()).toEqual([...FAILURE_FAMILIES].sort());
+    });
+
+    it('every prefix stage stays inside the prefix permissions', () => {
+        for (const s of CASCADE_STAGES) {
+            expect(PREFIX_ASSIGNABLE_FAMILIES, s).toContain(familyForStage(s));
+        }
+    });
+
+    it('every receipt stage stays inside the receipt permissions', () => {
+        for (const s of RECEIPT_STAGES) {
+            expect(RECEIPT_ASSIGNABLE_FAMILIES, s).toContain(familyForStage(s));
+        }
+    });
+});
+
+describe('runCascade reaches each of the four families', () => {
+    it('content — from the deterministic prefix, with no receipt at all', () => {
+        const r = runCascade({ raw: { nonsense: true }, plan: PLAN, budget: BUDGET });
+        expect(r.outcome).toBe('abort');
+        if (r.outcome !== 'abort') return;
+        expect(r.family).toBe('content');
+    });
+
+    it('activation — from a receipt whose projected rung was observed not-reached', () => {
+        const r = runCascade({
+            raw: record(),
+            plan: PLAN,
+            budget: BUDGET,
+            receipt: stallingAt('projected'),
+        });
+        expect(r.outcome).toBe('abort');
+        if (r.outcome !== 'abort') return;
+        expect(r.family).toBe('activation');
+        expect(r.failed_stage).toBe('receipt-projected');
+        expect(r.model_calls).toBe(0);
+    });
+
+    it('adherence — from a receipt whose adhered rung was observed not-reached', () => {
+        const r = runCascade({
+            raw: record(),
+            plan: PLAN,
+            budget: BUDGET,
+            receipt: stallingAt('adhered'),
+        });
+        expect(r.outcome).toBe('abort');
+        if (r.outcome !== 'abort') return;
+        expect(r.family).toBe('adherence');
+        expect(r.failed_stage).toBe('receipt-adhered');
+    });
+
+    it('unknown — from the prefix, and separately from an unobserved rung', () => {
+        const fromPrefix = runCascade({
+            raw: record({ mutations: [{ path: '.claude/rules/holdout-x.md', content: 'x' }] }),
+            plan: PLAN,
+            budget: BUDGET,
+        });
+        expect(fromPrefix.outcome === 'abort' && fromPrefix.family).toBe('unknown');
+
+        // An UNOBSERVED rung is not a failure: the cascade learns nothing about
+        // activation and must not abort. Folding `unknown` into a refusal would
+        // reject every candidate whose adherence nobody can observe — which is
+        // every candidate, today.
+        const partial = runCascade({
+            raw: record(),
+            plan: PLAN,
+            budget: BUDGET,
+            receipt: { artefact: 'a', rungs: { eligible: 'reached' } },
+        });
+        expect(partial.outcome).toBe('incomplete');
+        if (partial.outcome !== 'incomplete') return;
+        expect(partial.stages_run).toContain('receipt-selected');
+        expect(partial.stages_run).not.toContain('receipt-projected');
+    });
+});
+
+describe('EC-2 — receipt stages run after the prefix and before the measurement stage', () => {
+    it('a full climb records the prefix, then all six receipt stages, then the verdict', () => {
+        const rungs = Object.fromEntries(LADDER_RUNGS.map((r) => [r, 'reached'])) as Record<
+            LadderRung,
+            RungState
+        >;
+        const r = runCascade({
+            raw: record(),
+            plan: PLAN,
+            budget: BUDGET,
+            receipt: { artefact: 'a', rungs },
+            rows: [
+                {
+                    metric: 'task-success',
+                    kind: 'paired',
+                    direction: 'higher-better',
+                    verdict: {
+                        kind: 'pass',
+                        discordant: 12,
+                        wins: 11,
+                        losses: 1,
+                        p: 0.003,
+                        magnitude_mean: 0.4,
+                        at_floor: false,
+                        why: 'pass on 12 discordant trials',
+                    },
+                },
+                { metric: 'artifact-count-delta', kind: 'counted', direction: 'lower-better', delta: 0 },
+            ] as never,
+        });
+        expect(r.outcome).toBe('pass');
+        if (r.outcome !== 'pass') return;
+        expect(r.stages_run).toEqual([
+            'schema-validity',
+            'path-ownership',
+            'holdout-disclosure',
+            'budget',
+            'near-duplicate',
+            ...RECEIPT_STAGES,
+            'metric-verdict',
+        ]);
+        expect(r.model_calls).toBe(0);
+    });
+
+    it('no receipt means the six stages do not run at all — absent, not unknown-six', () => {
+        // `stages_run` is what a reader counts coverage from. Six entries that
+        // observed nothing would be six entries of fabricated coverage.
+        const r = runCascade({ raw: record(), plan: PLAN, budget: BUDGET });
+        expect(r.outcome).toBe('incomplete');
+        for (const s of RECEIPT_STAGES) expect(r.stages_run).not.toContain(s);
+    });
+});

--- a/tests/scripts/evaluation_cascade.test.ts
+++ b/tests/scripts/evaluation_cascade.test.ts
@@ -31,7 +31,7 @@ import {
     PREFIX_ASSIGNABLE_FAMILIES,
     familyForStage,
     runCascade,
-    type CascadeStage,
+    type StageId,
 } from '../../src/scripts/_lib/evaluation_cascade.js';
 import type { MetricRow } from '../../src/scripts/_lib/evaluation_vector.js';
 
@@ -185,7 +185,7 @@ describe('abort on the FIRST hard failure, at zero model calls', () => {
     });
 
     it('every abort reports zero model calls, on every stage', () => {
-        const seen = new Set<CascadeStage>();
+        const seen = new Set<StageId>();
         const cases: { raw: unknown; plan: typeof PLAN }[] = [
             { raw: { nope: 1 }, plan: PLAN },
             { raw: record({ mutations: [{ path: 'src/x.ts', content: 'x' }] }), plan: PLAN },

--- a/tests/scripts/llm_candidate_proposer.test.ts
+++ b/tests/scripts/llm_candidate_proposer.test.ts
@@ -1,0 +1,385 @@
+/**
+ * The metered proposer arm — role constraint, ladder walk, and the guard AC-3
+ * asks for a caller of.
+ *
+ * `road-to-governed-evidence-production` step 2.1, session A (build half). The
+ * comparison is NOT run here and no metered call is made: every case below uses
+ * a stubbed generator, and the one real-transport case asserts a description of
+ * a request rather than a response to one.
+ *
+ * Each `describe` names the property it pins. The role-constraint block is
+ * written against `docs/contracts/metered-proposer-protocol.md`'s Role clause —
+ * *"a metered call may generate candidate text; it may not score, rank, filter,
+ * select between, or supply any input to the verdict"* — one case per forbidden
+ * role, so a reader can check the test against the clause rather than against a
+ * paraphrase of it.
+ */
+import { readFileSync } from 'node:fs';
+import { readdirSync, statSync } from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+    CandidateCountError,
+    DECISION_FIELD_KEYS,
+    GenerationRefusedError,
+    INITIAL_CLASS,
+    MAX_BODY_BYTES,
+    SYSTEM_PROMPT,
+    assertGenerationAcceptable,
+    buildPrompt,
+    classifyRefusal,
+    plannedAttempts,
+    proposeCandidatesWithModel,
+    type GenerationRequest,
+    type GenerationResult,
+    type TextGenerator,
+} from '../../src/scripts/_lib/llm_candidate_proposer.js';
+import {
+    TIER_MODEL,
+    TransportRefusedError,
+    describeRequest,
+    estimateTokens,
+    modelForTier,
+} from '../../src/scripts/_lib/llm_proposer_transport.js';
+import { proposeCandidates, type DefectObservation } from '../../src/scripts/_lib/candidate_proposer.js';
+import { ladderFor } from '../../src/scripts/_lib/evolution_roi.js';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const ARM = path.join(REPO, 'src', 'scripts', '_lib', 'llm_candidate_proposer.ts');
+const TRANSPORT = path.join(REPO, 'src', 'scripts', '_lib', 'llm_proposer_transport.ts');
+const CLI = path.join(REPO, 'src', 'scripts', 'llm_propose.ts');
+
+const SUBJECT_A = '.claude/rules/a.md';
+const SUBJECT_B = '.claude/rules/b.md';
+const BODIES: Record<string, string> = {
+    [SUBJECT_A]: '# A\n\nband\n\n## Body\n\ntext\n',
+    [SUBJECT_B]: '# B\n\nband\n\n## Body\n\ntext\n',
+};
+const read = (s: string): string => BODIES[s] ?? '# missing\n';
+
+const OBS: DefectObservation[] = [
+    { defectClass: 'over-broad-activation', subject: SUBJECT_A },
+    { defectClass: 'unbacked-enforcement-claim', subject: SUBJECT_B },
+];
+
+/**
+ * A generator that always succeeds.
+ *
+ * Its text sorts in the OPPOSITE order to the input, deliberately: subject `a`
+ * gets a body beginning `zzz` and subject `b` one beginning `aaa`. A first
+ * version returned the same string for every call, which made the
+ * ordering-comes-from-the-input assertion vacuous — a content sort over equal
+ * strings is a no-op, so the sabotage that reordered the output could not be
+ * seen. Caught by running that sabotage and watching 26/26 stay green.
+ */
+function alwaysOk(): TextGenerator {
+    return (req: GenerationRequest): Promise<GenerationResult> => {
+        const subject = /Artifact path: (\S+)/.exec(req.prompt)?.[1] ?? '';
+        const lead = subject === SUBJECT_A ? 'zzz' : 'aaa';
+        return Promise.resolve({
+            text: `${lead} rewritten by ${req.tier}\n`,
+            model: `model-${req.tier}`,
+        });
+    };
+}
+
+/** A generator whose first `n` calls are refused by the output contract. */
+function failsFirst(n: number, bodies: Record<string, string> = BODIES): TextGenerator {
+    let seen = 0;
+    return (req: GenerationRequest): Promise<GenerationResult> => {
+        seen += 1;
+        if (seen === 1) {
+            // Byte-identical to the input: a proposal that changes nothing.
+            const subject = /Artifact path: (\S+)/.exec(req.prompt)?.[1] ?? SUBJECT_A;
+            return Promise.resolve({ text: bodies[subject] ?? '', model: 'm' });
+        }
+        if (seen <= n) return Promise.resolve({ text: '   ', model: 'm' });
+        return Promise.resolve({ text: `accepted at call ${String(seen)}\n`, model: `model-${req.tier}` });
+    };
+}
+
+describe('the role constraint is structural, not intentional', () => {
+    it('the metered port carries no field that could hold a judgement', () => {
+        // The compile-time half is `_GenerationResultCarriesNoDecisionField`,
+        // which turns a scoring key into a BUILD error. This is its readable
+        // half: the shipped result type's keys, checked against the deny-list.
+        const sample: GenerationResult = { text: 't', model: 'm' };
+        for (const k of Object.keys(sample)) {
+            expect(DECISION_FIELD_KEYS as readonly string[]).not.toContain(k);
+        }
+        expect(Object.keys(sample).sort()).toEqual(['model', 'text']);
+        // Anti-vacuity: the deny-list is real and would catch a real key.
+        expect(DECISION_FIELD_KEYS).toContain('score');
+        expect(DECISION_FIELD_KEYS).toContain('rank');
+    });
+
+    it('the arm reaches no verdict module — it cannot supply an input to one', () => {
+        const src = readFileSync(ARM, 'utf-8');
+        for (const forbidden of ['paired_verdict', 'evaluation_vector', 'evaluation_cascade']) {
+            expect(src, `the arm imports ${forbidden}`).not.toMatch(
+                new RegExp(`from '\\./${forbidden}\\.js'`),
+            );
+        }
+    });
+
+    it('one record per observation — the output can never be a subset', async () => {
+        const out = await proposeCandidatesWithModel(OBS, read, alwaysOk());
+        expect(out.records).toHaveLength(OBS.length);
+        expect(out.records.map((r) => r.mutations[0]?.path).sort()).toEqual([SUBJECT_A, SUBJECT_B]);
+    });
+
+    it('an unsatisfiable observation THROWS rather than being dropped', async () => {
+        // Filtering is the failure this shape prevents: a returned list one
+        // shorter than the input is a selection nobody authorised.
+        const alwaysEmpty: TextGenerator = () => Promise.resolve({ text: '', model: 'm' });
+        await expect(proposeCandidatesWithModel(OBS, read, alwaysEmpty)).rejects.toBeInstanceOf(
+            GenerationRefusedError,
+        );
+    });
+
+    it('output order comes from the INPUT, never from what the model returned', async () => {
+        const forward = await proposeCandidatesWithModel(OBS, read, alwaysOk());
+        const reversed = await proposeCandidatesWithModel([...OBS].reverse(), read, alwaysOk());
+        expect(reversed.records.map((r) => r.id)).toEqual(forward.records.map((r) => r.id));
+        // And it is the SAME ordering the deterministic arm applies, or the two
+        // arms would not be walking one input in one order.
+        const deterministic = proposeCandidates([...OBS].reverse(), read);
+        expect(deterministic.map((r) => r.mutations[0]?.path)).toEqual(
+            forward.records.map((r) => r.mutations[0]?.path),
+        );
+    });
+
+    it('the dimension comes from the recipe, so the model cannot pick its own arm', async () => {
+        const out = await proposeCandidatesWithModel(OBS, read, alwaysOk());
+        const byPath = new Map(out.records.map((r) => [r.mutations[0]?.path, r.dimension]));
+        expect(byPath.get(SUBJECT_A)).toBe('activation');
+        expect(byPath.get(SUBJECT_B)).toBe('content');
+    });
+
+    it('CandidateCountError exists and is the named failure for a filtered return', () => {
+        // Unreachable through the loop's own logic today, which is why it is an
+        // assertion rather than a trusted invariant. Named so a reader checking
+        // "no filtering" has something to grep for.
+        expect(new CandidateCountError('x')).toBeInstanceOf(Error);
+        expect(new CandidateCountError('x').name).toBe('CandidateCountError');
+    });
+});
+
+describe('the output contract refuses shapes, never judges quality', () => {
+    const obs: DefectObservation = { defectClass: 'over-broad-activation', subject: SUBJECT_A };
+    const before = BODIES[SUBJECT_A] as string;
+
+    it('accepts a changed, non-empty body', () => {
+        expect(() => assertGenerationAcceptable(obs, before, '# A\n\nband only\n')).not.toThrow();
+    });
+
+    it('refuses empty, byte-identical, over-ceiling and NUL-bearing bodies', () => {
+        const cases: Array<[string, string]> = [
+            ['empty', '   '],
+            ['identical', before],
+            ['over-ceiling', 'x'.repeat(MAX_BODY_BYTES + 1)],
+            ['nul', `ok${String.fromCharCode(0)}ok`],
+        ];
+        for (const [name, text] of cases) {
+            expect(() => assertGenerationAcceptable(obs, before, text), name).toThrow(
+                GenerationRefusedError,
+            );
+        }
+    });
+
+    it('refuses a routing generation that omits the required target', () => {
+        const routed: DefectObservation = {
+            defectClass: 'unrouted-obligation',
+            subject: SUBJECT_A,
+            routeTo: 'skill:somewhere',
+        };
+        expect(() => assertGenerationAcceptable(routed, before, '# A\n\nno pointer\n')).toThrow(
+            GenerationRefusedError,
+        );
+        expect(() =>
+            assertGenerationAcceptable(routed, before, '# A\n\nRouted to skill:somewhere.\n'),
+        ).not.toThrow();
+    });
+
+    it('every refusal classifies to a pathology, and an unknown throw to execution_failed', () => {
+        expect(classifyRefusal(new GenerationRefusedError('output_contract_violated', 'x'))).toBe(
+            'output_contract_violated',
+        );
+        expect(classifyRefusal(new Error('socket hang up'))).toBe('execution_failed');
+    });
+});
+
+describe('the ladder walk, and assertCheapestFirst over a REAL population (AC-3)', () => {
+    it('the first attempt is the cheapest rung of the initial class', async () => {
+        const out = await proposeCandidatesWithModel([OBS[0] as DefectObservation], read, alwaysOk());
+        expect(out.attempts).toHaveLength(1);
+        expect(out.attempts[0]).toEqual({ defect_class: INITIAL_CLASS, tier: 'lite', sequence: 1 });
+        // INITIAL_CLASS licenses exactly one rung — "escalating on a reason
+        // nobody established is spending on a guess".
+        expect(ladderFor(INITIAL_CLASS)).toEqual(['lite']);
+    });
+
+    it('a refusal escalates on the CLASSIFIED class, cheapest rung first', async () => {
+        const out = await proposeCandidatesWithModel(
+            [OBS[0] as DefectObservation],
+            read,
+            failsFirst(2),
+        );
+        expect(out.attempts).toEqual([
+            { defect_class: 'reason_unknown', tier: 'lite', sequence: 1 },
+            { defect_class: 'output_contract_violated', tier: 'lite', sequence: 2 },
+            { defect_class: 'output_contract_violated', tier: 'medium', sequence: 3 },
+        ]);
+        // A real escalation, produced by the real walk: this is the population
+        // `assertCheapestFirst` polices, and it is not empty.
+        expect(out.records).toHaveLength(1);
+    });
+
+    it('the walk STOPS when the class licenses no further rung', async () => {
+        // `output_contract_violated` licenses lite < medium and nothing above,
+        // so a generator that never satisfies the contract runs out rather than
+        // escalating forever or silently returning nothing.
+        const neverOk: TextGenerator = () => Promise.resolve({ text: '', model: 'm' });
+        await expect(
+            proposeCandidatesWithModel([OBS[0] as DefectObservation], read, neverOk),
+        ).rejects.toThrow(/no tier left/);
+    });
+
+    it('an inconsistent resumed history is REFUSED by the ordering guard', async () => {
+        // The one input from which `assertCheapestFirst`'s red is producible
+        // through this caller, and therefore the case that makes it a guard
+        // rather than a comment. A history claiming `medium` was spent on a
+        // class whose `lite` rung was never tried is a costlier tier before a
+        // cheaper one, whatever order the walk itself then runs in.
+        await expect(
+            proposeCandidatesWithModel([OBS[0] as DefectObservation], read, alwaysOk(), [
+                { defect_class: 'output_contract_violated', tier: 'medium', sequence: 1 },
+            ]),
+        ).rejects.toThrow(/cheaper models go first/);
+    });
+
+    it('a CONSISTENT resumed history passes, and leads the audit trail', async () => {
+        // Anti-vacuity for the case above: the guard is not simply rejecting
+        // every history handed to it.
+        const out = await proposeCandidatesWithModel(
+            [OBS[0] as DefectObservation],
+            read,
+            alwaysOk(),
+            [{ defect_class: 'output_contract_violated', tier: 'lite', sequence: 1 }],
+        );
+        expect(out.attempts[0]).toEqual({
+            defect_class: 'output_contract_violated',
+            tier: 'lite',
+            sequence: 1,
+        });
+        // The new attempt continues the sequence rather than restarting it.
+        expect(out.attempts[1]?.sequence).toBe(2);
+        expect(out.records).toHaveLength(1);
+    });
+
+    it('a fresh observation starts at the cheapest rung again, across subjects', async () => {
+        // Per-observation spend, not per-run: the guard allows a repeat of a
+        // spent rung, and a shared map would exhaust the ladder on subject two.
+        const out = await proposeCandidatesWithModel(OBS, read, alwaysOk());
+        expect(out.attempts.map((a) => a.tier)).toEqual(['lite', 'lite']);
+    });
+
+    it('the dry-run plan is a real, non-empty attempt list the guard accepts', () => {
+        // Derived from the real observations by the same `nextTier` call the
+        // live walk uses — not a fixture written beside the code.
+        const planned = plannedAttempts(OBS);
+        expect(planned).toHaveLength(OBS.length);
+        for (const a of planned) expect(a.tier).toBe('lite');
+        expect(new Set(planned.map((a) => a.sequence)).size).toBe(OBS.length);
+    });
+});
+
+describe('the transport is one file, and it has not been run', () => {
+    it('describeRequest returns exactly what would be sent, and sends nothing', () => {
+        const req: GenerationRequest = { tier: 'lite', system: SYSTEM_PROMPT, prompt: 'p' };
+        const d = describeRequest(req);
+        expect(d.url).toBe('https://api.anthropic.com/v1/messages');
+        expect(d.model).toBe(TIER_MODEL.lite);
+        expect(d.body).toMatchObject({ temperature: 0, system: SYSTEM_PROMPT });
+        expect(d.body['messages']).toEqual([{ role: 'user', content: 'p' }]);
+    });
+
+    it('an unpinned tier REFUSES rather than resolving a floating alias', () => {
+        // A frozen protocol whose model id can move is not frozen.
+        expect(() => modelForTier('high')).toThrow(TransportRefusedError);
+        expect(modelForTier('lite')).toMatch(/^claude-haiku-4-5-\d{8}$/);
+        expect(modelForTier('medium')).toMatch(/^claude-sonnet-4-5-\d{8}$/);
+    });
+
+    it('the ARM carries no transport construct — only the transport file may', () => {
+        const armSrc = readFileSync(ARM, 'utf-8');
+        for (const needle of ['fetch(', 'api.anthropic.com', 'api.openai.com', 'child_process']) {
+            expect(armSrc, `the arm carries ${needle}`).not.toContain(needle);
+        }
+        // Anti-vacuity in the other direction: the transport DOES carry one, so
+        // the assertion above is discriminating rather than trivially true.
+        expect(readFileSync(TRANSPORT, 'utf-8')).toContain('api.anthropic.com');
+    });
+
+    it('estimateTokens is a stated estimate, not a tokenizer', () => {
+        expect(estimateTokens('a'.repeat(400))).toBe(100);
+    });
+
+    it('the prompt is pure — same observation and body, same bytes', () => {
+        const a = buildPrompt(OBS[0] as DefectObservation, BODIES[SUBJECT_A] as string);
+        const b = buildPrompt(OBS[0] as DefectObservation, BODIES[SUBJECT_A] as string);
+        expect(a).toBe(b);
+        expect(a).toContain('Defect class: over-broad-activation');
+    });
+});
+
+describe('the metered arm is outside the archived roadmaps live-harness scan, deliberately', () => {
+    // `tests/scripts/governed_harness_no_live_harness.test.ts` half B owns every
+    // `.ts` under `src/` whose text contains the slug `road-to-governed-harness-
+    // evolution`, and applies a live-harness pattern set to it. That scan
+    // enforces step 5.2 of the ARCHIVED parent over the parent's own tree. The
+    // metered arm belongs to `road-to-governed-evidence-production`, whose park
+    // was narrowed on 2026-09-01 to permit exactly a metered proposer — so
+    // extending that scan here would enforce a lock a council has since
+    // narrowed. The exclusion is by path, and it is asserted rather than assumed
+    // because the ownership predicate is a substring match: one docstring
+    // mentioning the old slug would pull the transport's real model endpoint
+    // into a scan that must fail on it.
+    const OLD_SLUG = 'road-to-governed-harness-evolution';
+
+    it('none of the three new modules declares itself as the archived roadmaps', () => {
+        for (const f of [ARM, TRANSPORT, CLI]) {
+            expect(readFileSync(f, 'utf-8'), path.basename(f)).not.toContain(OLD_SLUG);
+        }
+    });
+
+    it('exactly one file in the metered arms own closure carries a model endpoint', () => {
+        // The containment claim that replaces the scan for this arm: the
+        // endpoint lives in the transport and nowhere else.
+        const own = [ARM, TRANSPORT, CLI];
+        const carriers = own.filter((f) => /api\.(openai|anthropic)\.com/.test(readFileSync(f, 'utf-8')));
+        expect(carriers.map((f) => path.basename(f))).toEqual(['llm_proposer_transport.ts']);
+    });
+
+    it('the ownership predicate is the real one — it finds the archived roadmaps modules', () => {
+        // Anti-vacuity for the first case: a substring scan that matched
+        // nothing anywhere would make "not owned" meaningless.
+        const owned: string[] = [];
+        const walk = (dir: string): void => {
+            for (const entry of readdirSync(dir)) {
+                const full = path.join(dir, entry);
+                if (statSync(full).isDirectory()) walk(full);
+                else if (entry.endsWith('.ts') && readFileSync(full, 'utf-8').includes(OLD_SLUG)) {
+                    owned.push(path.basename(full));
+                }
+            }
+        };
+        walk(path.join(REPO, 'src'));
+        expect(owned.length).toBeGreaterThan(5);
+        expect(owned).toContain('evolution_lab.ts');
+        expect(owned).not.toContain('llm_candidate_proposer.ts');
+    });
+});

--- a/tests/scripts/proposer_survival_bar.test.ts
+++ b/tests/scripts/proposer_survival_bar.test.ts
@@ -117,4 +117,38 @@ describe('the deterministic path stays until a comparison is run', () => {
     it('the construct list is non-empty, so the scan above can actually fail', () => {
         expect(MODEL_IN_THE_LOOP.length).toBeGreaterThan(5);
     });
+
+    // ADDED 2026-09-01, road-to-governed-evidence-production 2.1, when the
+    // second arm arrived. STRENGTHENING, not relaxing: nothing above changed.
+    //
+    // `PROPOSER_CHAIN` is an explicit two-element allowlist, so the metered arm
+    // (`_lib/llm_candidate_proposer.ts`) is already outside this scan BY PATH —
+    // not because anyone anticipated it, but because the list names files
+    // rather than globbing a directory. That accidental exclusion is fine for
+    // the metered arm, which is a different arm, and useless for the property
+    // this file actually claims: "the deterministic path stays" is falsified
+    // the moment the deterministic path can REACH the metered one, and the
+    // scan above reads only these two files' own bodies, so it would not see
+    // that edge.
+    //
+    // Hence the direction check. The metered arm may import the deterministic
+    // one — it reuses its comparator, its recipes and its id function on
+    // purpose, so the two arms are comparable. The reverse edge is what makes
+    // the absence-assertion decay, and it is now a red rather than a silence.
+    it('the deterministic chain does not reach the metered arm', () => {
+        const raw = PROPOSER_CHAIN.map((rel) => ({
+            rel,
+            body: readFileSync(path.join(REPO, rel), 'utf8'),
+        }));
+        for (const b of raw) {
+            expect(b.body, `${b.rel} imports the metered arm`).not.toMatch(
+                /llm_candidate_proposer|llm_proposer_transport/,
+            );
+        }
+        // Anti-vacuity: the metered arm exists, so this is a real edge that
+        // could be created rather than a check against a file nobody has.
+        expect(
+            readFileSync(path.join(REPO, 'src/scripts/_lib/llm_candidate_proposer.ts'), 'utf8'),
+        ).toMatch(/candidate_proposer\.js/);
+    });
 });

--- a/tests/scripts/twelve_stage_enumeration.test.ts
+++ b/tests/scripts/twelve_stage_enumeration.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Step 1.2's reproduction: the committed twelve, re-derived by a second route.
+ *
+ * `road-to-governed-evidence-production` 1.2 — *"one enumeration is committed,
+ * and a second independent pass reproduces it rather than proposing a different
+ * twelve."*
+ *
+ * ROUTE A is `_lib/cascade_stage_enumeration.ts`: it IMPORTS the two stage
+ * arrays and applies the ordering rule in code.
+ *
+ * ROUTE B is this file: it reads the two source files as TEXT and extracts the
+ * stage names with a regex, reads the evidence classes from the published table
+ * in `docs/contracts/evaluation-cascade-stages.md`, and applies the ordering
+ * rule itself. It never imports `TWELVE_STAGES` for anything but the final
+ * comparison.
+ *
+ * The independence is of ROUTE, not of author, and that is deliberate — a second
+ * author is a second proposal, and two proposals is the state that produced the
+ * council's `REVISE` in the first place. What route B can catch: a hand-edited
+ * `TWELVE_STAGES` (it is never read on the way to the answer), a rung added in
+ * code without the table, a table edited without the code.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { REPO_ROOT } from './_bench_ab.js';
+import {
+    DECIDED_ARITY,
+    EVIDENCE_CLASSES,
+    TWELVE_STAGES,
+    evidenceClass,
+} from '../../src/scripts/_lib/cascade_stage_enumeration.js';
+
+const CASCADE_SRC = join(REPO_ROOT, 'src', 'scripts', '_lib', 'evaluation_cascade.ts');
+const LADDER_SRC = join(REPO_ROOT, 'src', 'scripts', '_lib', 'activation_ladder.ts');
+const CONTRACT = join(REPO_ROOT, 'docs', 'contracts', 'evaluation-cascade-stages.md');
+
+/** Route B, part 1 — the stage names, from the source FILES as text. */
+function stageNamesFromSourceText(): string[] {
+    const cascade = readFileSync(CASCADE_SRC, 'utf-8');
+    const ladder = readFileSync(LADDER_SRC, 'utf-8');
+
+    const arrayLiteral = (src: string, name: string): string[] => {
+        const m = new RegExp(`export const ${name} = \\[([\\s\\S]*?)\\] as const;`).exec(src);
+        if (m === null) throw new Error(`${name} not found as an array literal`);
+        return [...m[1]!.matchAll(/'([^']+)'/g)].map((x) => x[1]!);
+    };
+
+    // The prefix stages are a literal; the receipt stages are derived from the
+    // rungs in the ladder, so route B re-derives them the same way the ladder
+    // does — from LADDER_RUNGS, with the prefix the ladder's own source states.
+    const prefix = arrayLiteral(cascade, 'CASCADE_STAGES');
+    const rungs = arrayLiteral(ladder, 'LADDER_RUNGS');
+    const receiptPrefix = /RECEIPT_STAGES = LADDER_RUNGS\.map\(\(r\) => `([a-z-]+)\$\{r\}` as const\)/.exec(
+        ladder,
+    );
+    if (receiptPrefix === null) throw new Error('RECEIPT_STAGES derivation not recognised');
+    return [...prefix, ...rungs.map((r) => `${receiptPrefix[1]!}${r}`)];
+}
+
+/** Route B, part 2 — the evidence classes, from the published contract table. */
+function classesFromContractTable(): Map<string, string> {
+    const md = readFileSync(CONTRACT, 'utf-8');
+    const section = md.slice(md.indexOf('## The twelve'), md.indexOf('## How the reproduction works'));
+    const out = new Map<string, string>();
+    for (const m of section.matchAll(/^\|\s*(\d+)\s*\|\s*`([^`]+)`\s*\|\s*`([^`]+)`\s*\|/gm)) {
+        out.set(m[2]!, m[3]!);
+    }
+    return out;
+}
+
+describe('route B reproduces the committed twelve', () => {
+    it('extracts twelve stage names from the two source files as text', () => {
+        const names = stageNamesFromSourceText();
+        expect(names).toHaveLength(DECIDED_ARITY);
+        // Anti-vacuity: the extraction found real names, not an empty match.
+        expect(names).toContain('schema-validity');
+        expect(names).toContain('receipt-adhered');
+    });
+
+    it('the contract table names exactly those twelve stages', () => {
+        const table = classesFromContractTable();
+        expect([...table.keys()].sort()).toEqual(stageNamesFromSourceText().sort());
+        for (const c of table.values()) expect(EVIDENCE_CLASSES).toContain(c);
+    });
+
+    it('applying the ordering rule to route Bs inputs yields the committed order', () => {
+        const table = classesFromContractTable();
+        const reproduced = stageNamesFromSourceText().sort(
+            (a, b) =>
+                (EVIDENCE_CLASSES as readonly string[]).indexOf(table.get(a)!) -
+                (EVIDENCE_CLASSES as readonly string[]).indexOf(table.get(b)!),
+        );
+        expect(reproduced).toEqual([...TWELVE_STAGES]);
+    });
+
+    it('the contracts class column agrees with the code, stage by stage', () => {
+        // The two routes disagree here if PREFIX_EVIDENCE_CLASS is edited
+        // without the table, or the table without the code.
+        const table = classesFromContractTable();
+        for (const [stage, cls] of table) {
+            expect(evidenceClass(stage as never), stage).toBe(cls);
+        }
+    });
+});
+
+describe('the ordering rule is the cascades own evidence order, not a preference', () => {
+    it('runCascade first touches its input fields in the declared class order', () => {
+        // Derived from BEHAVIOUR rather than asserted: the position at which
+        // `runCascade` first reads each `CascadeInput` field must rise with the
+        // evidence class rank. A stage reordered in the body without its class
+        // being updated reds here.
+        const src = readFileSync(CASCADE_SRC, 'utf-8');
+        const body = src.slice(src.indexOf('export function runCascade('));
+        const firstUse = (fields: readonly string[]): number =>
+            Math.min(
+                ...fields.map((f) => {
+                    const i = body.indexOf(`input.${f}`);
+                    return i < 0 ? Number.POSITIVE_INFINITY : i;
+                }),
+            );
+        const positions = [
+            firstUse(['raw']),
+            firstUse(['plan', 'budget']),
+            firstUse(['peers']),
+            firstUse(['receipt']),
+            firstUse(['rows', 'vector']),
+        ];
+        for (const p of positions) expect(Number.isFinite(p)).toBe(true);
+        expect(positions).toEqual([...positions].sort((a, b) => a - b));
+        // Anti-vacuity: five distinct positions, not five copies of one.
+        expect(new Set(positions).size).toBe(5);
+    });
+
+    it('every receipt stage sits after every non-measurement prefix stage (EC-2)', () => {
+        const idx = (s: string): number => TWELVE_STAGES.indexOf(s as never);
+        const receiptIdxs = TWELVE_STAGES.filter((s) => s.startsWith('receipt-')).map(idx);
+        for (const p of ['schema-validity', 'path-ownership', 'holdout-disclosure', 'budget', 'near-duplicate']) {
+            for (const r of receiptIdxs) expect(r, `${p} vs receipt`).toBeGreaterThan(idx(p));
+        }
+        // ... and before the measurement stage, which is last.
+        for (const r of receiptIdxs) expect(r).toBeLessThan(idx('metric-verdict'));
+        expect(TWELVE_STAGES[DECIDED_ARITY - 1]).toBe('metric-verdict');
+    });
+});


### PR DESCRIPTION
## What this is

Drain run 13, roadmap 2 of 3: `road-to-governed-evidence-production`.

**Phase 1 is closed on real evidence. Phase 2's governance block is resolved, its
build half is done, and its execution half was refused by the harness and is
recorded rather than worked around.** No acceptance criterion is closed on a
fixture.

## Phase 1 — all three steps closed

**1.3 — the trust boundary and evidence-cost contract** `[x]`
`docs/contracts/activation-receipt-trust-boundary.md` (new). Seven claims, each
stating the observation that would refute it: TB-1 (no rung *state* is a function
of a candidate record, cascade outcome, vector or verdict), TB-2 (an unobserved
rung is absent, never negative), TB-3 (closed source set — an admitted source
with no observer is itself a refutation), TB-4 (append, never rewrite), EC-1
(zero model calls), EC-2 (no receipt stage before the free prefix), EC-3 (a
missing observation is never bought). TB-1 was sharpened mid-work to separate
*subject* from *state*; the first draft would have forbidden naming which
artifact a receipt is about.

**1.1 — the independent, append-only producer** `[x]`
`src/scripts/_lib/activation_receipt_producer.ts` imports no evaluation module,
so TB-1 holds **by construction** rather than by discipline.
`src/scripts/activation_receipt.ts` is the production caller, observing three
real surfaces. `PREFIX_ASSIGNABLE_FAMILIES` is **unchanged** at
`['content','unknown']` — widening it was never the fix, and widening it is
exactly how a deterministic proxy would have manufactured evidence.

Three of four families reach from **real** observation, not fixtures:
`activation_receipt --rule commit-policy` yields `family=activation`, because
that rule is authored and selected but not projected into `.claude/rules/`.

**Named gap, not hidden:** `adhered` has no admitted evidence source, so
`adherence` is reachable through the stage list but from no shipped observer.
AC-1's wording — *"the stage list can **assign** all four"* — is what settles
that this step owed the stage-list half; the coverage half is written into the
step.

A real defect the tests caught: `RECEIPT_ASSIGNABLE_FAMILIES` was hand-written as
the prefix's complement, which is wrong because `eligible`'s family is `content`.
It is derived from `LADDER` now.

**1.2 — the twelve-stage enumeration** `[x]`
`src/scripts/_lib/cascade_stage_enumeration.ts:87` **computes** the twelve from
two committed arrays by one ordering rule, published as a machine-checked table
in `docs/contracts/evaluation-cascade-stages.md`. Route B
(`tests/scripts/twelve_stage_enumeration.test.ts`) reads the source files as
text, takes classes from the contract table, re-applies the rule, and never reads
`TWELVE_STAGES` except to compare — it reproduces exactly. The independence is of
**route**, not author, and the contract says why: a second author is a second
proposal, which is the state that produced the original `REVISE`. Stated
honestly: both routes read the same arrays, so neither validates E4/E9's arities.

## Phase 2 — the governance block is gone; the execution block is new and smaller

**The park was narrowed, and reading it corrected this roadmap's own provenance.**
The blocker called the constraint *"the 5.2 evaluator-independence decision"*.
Step 5.2 of the archived parent
(`agents/roadmaps/archive/road-to-governed-harness-evolution.md:1632`) in fact
says only *"Keep the live-floors park intact. No live harness."* and **defers**.
The reasoning lives in
`agents/roadmaps/later/road-to-routing-assurance-live-floors.md:20-52`. Two facts
from the real lock decide the narrowing, and neither was visible from the
shorthand:

- **Authority.** The park states it outright: *"Both seats: council-decidable,
  not owner-reserved"* (`:44-47`). This is the **opposite** of the
  `merge-authority` blocker on the sibling roadmap, which is owner-reserved in
  both directions — the two must not be reasoned about together.
- **The objection is evaluating what you authored, not spending.** *"Cost was
  explicitly not the objection — token spend was pre-authorised"* (`:27-33`). A
  metered **proposer** generates an arm and decides nothing; 2.1's evaluator is
  `decidePairedVerdict`, whose `ALPHA` and `MIN_DISCORDANT` were committed before
  any arm existed and cannot be tuned to a result.

*AI council 2026-09-01 (`anthropic/claude-sonnet-4-5` + `openai/codex-default`,
2 rounds, deep, peer-review, blind chairman, quorum 2/2 present, needed 1 —
concluded, subscription transport, `billable=0`, `$0.0000`) — Question 3: **3B,
2/2 convergent.*** The narrowing constrains **roles, not provider labels**, per
the openai seat: a "proposer" that ranks, filters, or supplies the controlling
verdict is an evaluator.

**The build half — the role constraint is structural, not intentional.**
`src/scripts/_lib/llm_candidate_proposer.ts` mirrors the deterministic arm
exactly (same input, same `CandidateRecord` out, same `candidateId`, same
`byteCompare` ordering) so a pair is a pair. Six forbidden roles, each made
unavailable rather than discouraged:

| Forbidden role | What makes it unavailable |
|---|---|
| supply a score | `GenerationResult` carries `text` + `model` only; a 20-key deny-list makes any scoring key a **build error** |
| rank | the port takes one request and returns one result — it cannot express a batch |
| select between | one record per observation, asserted at the return |
| filter | an unsatisfiable observation **throws**; the output can never be a subset |
| reorder | order is `byteCompare` over the **input**, using the deterministic arm's comparator |
| reach the verdict | the arm imports no verdict module |

**`assertCheapestFirst` now has a production caller** (`:369`, and `:429` for the
dry plan). "Zero production callers" is no longer true. But the first version of
that caller was an **unfalsifiable guard** and a RED proof caught it: attempts
were built from `nextTier` per class, so an out-of-order list was
unconstructible and sabotaging the spent-map threw elsewhere instead of firing
the guard. Fixed by validating untrusted `priorAttempts` history. **AC-3 stays
`[ ]`, half met** — the caller is there and falsifiable, but no *spent*
population exists yet.

**The execution half was refused, and not retried.** It was dispatched to a fresh
independent session, which is the park's own requirement (*"an independent
session (not the one that authored the corpus) freezes the execution protocol …
BEFORE capturing any baseline"*, `:49-52`). The host harness refused that
dispatch before it started, because the session would have been authorised to
make real paid API calls.

The identical shape is already on the record one roadmap over:
`road-to-harness-promotion-bridge`'s `merge-authority` blocker documents a run
whose question *"was refused twice by the harness's own safety classifier before
reaching any seat"*, and records that the run *"stopped rather than rephrasing
its way past a safety refusal, which would have been the reservation defeated by
persistence."* The same reasoning binds here.

**What changed is the KIND of block, and that is the deliverable.** Phase 2 was
held by a governance lock; it is now held by an environment-scoped execution
refusal that clears the moment a human runs the frozen protocol or authorises a
spending session.

**The protocol is frozen, with exactly one slot deliberately UNSET.**
`docs/contracts/metered-proposer-protocol.md` fixes provider, endpoint, API
version, dated model per tier, sampling, byte-exact prompts, retry policy,
two-layer exclusion policy, corpus derivation, pair count and stopping rule
(`ALPHA`/`MIN_DISCORDANT` **cited**, never restated). The **paired outcome metric
and its aggregation** is left open on purpose: the park names aggregation among
the choices a session under evaluation must not make for itself, and the build
session built the arm. Whoever executes freezes it first, in its own commit.

## Honest nulls

- **No metered call was made. Zero requests to any provider API**, including no
  "check the wiring" probe — that would itself be a capture by the park's
  reasoning. The transport's live path is unexercised; its request shape is
  proven only by `describeRequest` and a unit test over that description.
- **2.1, 2.2, AC-2, AC-3 and AC-4 are all `[ ]`.** Nothing was closed on a
  fixture, and 2.1's verify clause — *"the comparison is a paired_verdict run,
  not an argument"* — is carried verbatim.
- **`high` tier is `null` and refuses**, because no dated `claude-opus-4-1-*`
  exists in this tree. An unpinned floating alias was rejected rather than
  guessed.
- **A named scan gap:** no tree-wide scan covers the metered arm. Containment is
  asserted locally over three paths. Recorded as OQ-3 rather than papered over.
- Four open questions are recorded in
  `agents/evidence/analysis/governed-evidence-phase1-open-questions.md`. None is
  a decision.

## RED proofs

**18 total, every one restored byte-identically with SHA-256 verified.** Ten for
Phase 1 (defaulting unobserved rungs to `not-reached`; dropping the source/rung
mismatch refusal; `appendFileSync` → `writeFileSync`; adding a `fetch` to an API
host inside the producer; disabling the receipt block; letting a prefix stage
assign `activation`; hand-editing the stage order; changing one class in the
contract table only; adding a 7th rung in code without the table; hoisting the
receipt above the budget stage). Eight for the Phase 2 arm (removing the
`assertCheapestFirst` call; sharing one spent-map; catch-and-continue filtering;
sorting output by model text; resolving a floating alias; giving the arm a model
endpoint; making the deterministic chain import the metered arm; giving the arm
the archived roadmap's slug).

**Two of the proofs found real defects rather than confirming health:** the
unfalsifiable `assertCheapestFirst` guard above, and a sabotage that initially
stayed green (26/26) because a test stub returned identical text for every
subject, making an ordering assertion vacuous. The stub was fixed to sort
opposite to the input; the sabotage then reds.

## Also strengthened

`tests/scripts/proposer_survival_bar.test.ts` — `PROPOSER_CHAIN` is an explicit
two-element allowlist, so the metered arm was already outside its scan **by path,
accidentally**, because the list names files rather than globbing. Not weakened;
one case added pinning the direction that matters — **the deterministic chain may
not reach the metered arm**. Without it, "the deterministic path stays" decays
silently the moment someone wires the two together.

## Gates

Roadmap battery (`lint_roadmap_blockers`, `lint_roadmap_complexity`,
`lint_roadmap_ci_steps`, `check_roadmap_trackable`, `check_no_roadmap_refs`,
`lint_empty_roadmaps`, `lint_roadmap_later_disposition`) plus
`lint_canonical_terms`, `lint_output_slop`, `check_secret_leak`,
`check_condensation`, `check_references`, `check_beta_review_markers`,
`lint_artefact_frontmatter`, `lint_regression`, `check_gate_coverage`,
`lint_provenance`, `check_no_external_sources`, `check_estate_count`,
`lint_evidence_artifacts` — all green. `npm run typecheck` clean on both
tsconfigs. Vitest 135/135 across the touched files; 88/88 for Phase 1's six.

Three real gate catches, all fixed line-scoped rather than file-scoped:
`lint_canonical_terms` twice (`artefact`→`artifact` ×4, `behavioural`→`behavioral`),
and `check_no_roadmap_refs` flagged the protocol citing the park's roadmap path —
the quote was inlined with its date and quorum instead.
