### PR TITLE
roadmap(governed-evidence): refuse the metered capture on validity, and repair six defects found proving it

### DIFF
--- a/agents/evidence/analysis/drain14-phase2-capture-readiness.md
+++ b/agents/evidence/analysis/drain14-phase2-capture-readiness.md
@@ -1,0 +1,456 @@
+# Drain 14 — Phase 2 metered-capture readiness
+
+Reconnaissance for `road-to-governed-evidence-production` Phase 2 (steps 2.1,
+2.2) and AC-2 / AC-3 / AC-4. Measured on branch `drain/governed-evidence-phase2`
+@ `b50b27281`, 2026-09-01.
+
+**Zero metered calls were made by this session.** `--confirm` was never passed;
+no request reached `https://api.anthropic.com`. Every figure below comes from
+the dry path, from stub generators, or from reading the tree.
+
+**Nothing in the protocol was frozen by this session either.** The UNSET slot at
+`docs/contracts/metered-proposer-protocol.md:239` is reported on, with options
+and evidence, and is left UNSET. Freezing it is a council decision.
+
+## 1. The observations document — does not exist, and cannot be committed
+
+`llm_propose --observations FILE` (`src/scripts/llm_propose.ts:82`) and
+`evolution_lab propose --observations FILE`
+(`src/scripts/evolution_lab.ts:401`) consume the same document through the same
+parser pair: `parseObservationDocument`
+(`src/scripts/evolution_lab.ts:279`) then `parseObservations`
+(`src/scripts/_lib/candidate_proposer.ts:232`).
+
+**No such document exists anywhere in the tree.** `git ls-files` matches no
+`observ*` JSON, and no script generates one. The protocol does not ship a
+document; it ships an enumeration RULE
+(`docs/contracts/metered-proposer-protocol.md:181-197`):
+
+1. every `*.md` **directly under** `.claude/rules/` at the run's commit;
+2. sorted byte-wise by filename;
+3. first `max_candidates` = **5** (`src/config/harness-evolution-budget.json`,
+   `budget.max_candidates`);
+4. class per file: `over-broad-activation` when the file contains a line
+   beginning `## `, otherwise `unbacked-enforcement-claim`.
+
+### FINDING 1a — the corpus is not reproducible from a commit
+
+`.claude/` is **gitignored in its entirety** (`.gitignore:157` pins
+`/.claude/rules/`), and `git ls-files .claude` returns 0 files. A fresh worktree
+of this branch has no `.claude/rules/` directory at all; this session had to run
+`./scripts-run src/scripts/condense --generate-tools` (the `task generate-tools`
+body, `taskfiles/content.yml:50`) to materialise it.
+
+The protocol already names the commit pin as load-bearing
+(`metered-proposer-protocol.md:199-202`). The measurement here is that the
+commit pin is **not sufficient**, for two separate reasons:
+
+- **The generator skips rules already installed at user scope.** The
+  `--generate-tools` run in this worktree printed
+  `ℹ️  .claude/rules: 101 rule(s) skipped — byte-identical twin already
+  installed at user scope`. `~/.claude/rules/` holds 104 `.md` files on this
+  machine. The projected set is therefore a function of the operator's
+  user-global install, not of the commit.
+- **A stale projection differs from a fresh one.** The main checkout at the same
+  HEAD (`b50b27281`) carries 15 `.md` under `.claude/rules/` with mtimes of
+  `Jul 5 2026`; the freshly generated worktree projection carries 13. The two
+  extra files (`package-ci-checks.md`, `size-enforcement.md`) exist in
+  `src/rules/` and are absent from both the fresh projection and the user-global
+  layer, so the stale copy is the outlier — but a runner who does not regenerate
+  would silently capture a different corpus.
+
+**Consequence for the capture.** The observations document must be produced by a
+recorded procedure that pins BOTH the commit AND the projection state, or the
+comparison is not re-runnable. Nothing in the tree does this today.
+
+### The document this session produced (from the stated rule, fresh projection)
+
+Written to `/tmp/dr14/observations.json` — deliberately **not** committed, since
+it is derived from a gitignored projection and committing it would freeze one
+machine's user-global state into the tree.
+
+| # | subject | defect class |
+|---|---|---|
+| 1 | `.claude/rules/augment-edit-discipline.md` | `unbacked-enforcement-claim` |
+| 2 | `.claude/rules/domain-adoption-policy.md` | `over-broad-activation` |
+| 3 | `.claude/rules/framework-neutrality-in-generic-skills.md` | `over-broad-activation` |
+| 4 | `.claude/rules/low-impact-corpus-privacy-floor.md` | `over-broad-activation` |
+| 5 | `.claude/rules/no-roadmap-references.md` | `over-broad-activation` |
+
+**5 `DefectObservation`s**, matching `max_candidates` exactly, so
+`assertWithinBudget` (`src/scripts/_lib/harness_evolution_guards.ts:140`) admits
+it and one more would abort. Subjects are inside the candidate surface
+(`CANDIDATE_OWNED_PATHS`, `src/scripts/_lib/candidate_record.ts:262`, tested by
+`isCandidateOwnedPath` at `:271`) because
+`.claude` is an owned head.
+
+**It can be produced without spending.** Generating `.claude/` touches only
+gitignored paths (`.claude`, `.cursor`, `.clinerules`, `.windsurfrules`,
+`GEMINI.md` are all untracked — `git ls-files` returns 0 for each), and
+`git status` stayed clean through the whole run.
+
+## 2. The dry path, end to end
+
+`./scripts-run src/scripts/llm_propose --observations /tmp/dr14/observations.json --out /tmp/dr14/metered`
+— exit 0, nothing sent.
+
+```
+disclosure: obs[0] field=defectClass class=proposer-visible
+disclosure: obs[0] field=subject class=proposer-visible
+… (one pair per observation, 10 lines: GUARD 0.4)
+llm_propose: DRY RUN — nothing sent, nothing spent.
+llm_propose: tier lite -> claude-haiku-4-5-20251001
+llm_propose: tier medium -> claude-sonnet-4-5-20250929
+llm_propose: tier high -> UNPINNED (refused until a dated id is pinned)
+llm_propose: planned attempt 1 · class=reason_unknown · tier=lite
+llm_propose: planned attempt 2 · class=reason_unknown · tier=lite
+llm_propose: planned attempt 3 · class=reason_unknown · tier=lite
+llm_propose: planned attempt 4 · class=reason_unknown · tier=lite
+llm_propose: planned attempt 5 · class=reason_unknown · tier=lite
+llm_propose: request body for .claude/rules/augment-edit-discipline.md:
+{
+  "model": "claude-haiku-4-5-20251001",
+  "max_tokens": 8192,
+  "temperature": 0,
+  "system": "You rewrite one Markdown artifact to remove one named defect.\nReturn ONLY the complete rewritten artifact body. No preamble, no fences,\nno commentary, no explanation of what you changed.\nDo not judge, score, rank, or compare anything. Produce one body.",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Defect class: unbacked-enforcement-claim\nWhat that means: the artefact reads as enforced while nothing can observe a violation\nArtifact path: .claude/rules/augment-edit-discipline.md\n\n--- BEGIN CURRENT BODY ---\n…\n--- END CURRENT BODY ---\n"
+    }
+  ]
+}
+llm_propose: ~275 input tokens for this one call (ESTIMATE: characters over four, not a tokenizer; …)
+llm_propose: re-run with --confirm to spend.
+```
+
+The pinned models match `TIER_MODEL`
+(`src/scripts/_lib/llm_proposer_transport.ts:57-61`) and the protocol table
+verbatim. `high` refuses rather than resolving, as specified.
+
+### Cost of the whole capture
+
+Computed with the arm's own `buildPrompt` + `describeRequest` + `estimateTokens`
+over all five observations (no request sent), priced from the repository's own
+committed table — `claude-haiku-4-5` at $1.00/MTok in, $5.00/MTok out,
+`src/scripts/ai_council/_default_prices.ts:29`, `LAST_UPDATED = '2026-05-14'`
+(`:16`).
+
+| subject | class | input tok | body tok |
+|---|---|---|---|
+| `.claude/rules/domain-adoption-policy.md` | `over-broad-activation` | 666 | 521 |
+| `.claude/rules/framework-neutrality-in-generic-skills.md` | `over-broad-activation` | 739 | 589 |
+| `.claude/rules/low-impact-corpus-privacy-floor.md` | `over-broad-activation` | 756 | 603 |
+| `.claude/rules/no-roadmap-references.md` | `over-broad-activation` | 798 | 650 |
+| `.claude/rules/augment-edit-discipline.md` | `unbacked-enforcement-claim` | 275 | 141 |
+| **total** | | **3,234** | **2,504** |
+
+- **Likely cost: $0.0158** — 3,234 in + 2,504 out (a full-body rewrite per call).
+- **Absolute worst case: $0.2080** — 3,234 in + 5 × `MAX_TOKENS` (8192) out
+  (`llm_proposer_transport.ts:64`). Unreachable in practice; the subject bodies
+  are 141–650 tokens.
+- Budget ceiling `max_spend_cents: 500` = **$5.00**. The capture uses **0.3 %**
+  of it at the likely figure and **4.2 %** at the worst case.
+
+Token counts are the arm's own `characters / 4` estimator
+(`llm_proposer_transport.ts:109-111`), not a tokenizer; treat them as ±25 %.
+Even a 4× miss stays two orders of magnitude under the ceiling.
+
+Retries would add cost only on a contract refusal, and `reason_unknown`'s ladder
+is exactly `['lite']` (`src/scripts/_lib/evolution_roi.ts:121`) — so an
+unclassified refusal STOPS rather than escalating. The only class licensing
+`high` is `execution_failed` (`evolution_roi.ts:111`), and `high` is unpinned and
+throws, so a transport error terminates the observation rather than spending
+more.
+
+### The deterministic control arm, over the same document
+
+`./scripts-run src/scripts/evolution_lab propose --observations /tmp/dr14/observations.json --out /tmp/dr14/deterministic`
+— exit 0, five records:
+
+```
+propose: wrote /tmp/dr14/deterministic/act-ca6e7ddb23f7.json
+propose: wrote /tmp/dr14/deterministic/act-d2ac06be9cf2.json
+propose: wrote /tmp/dr14/deterministic/act-58069c3c3910.json
+propose: wrote /tmp/dr14/deterministic/act-628dda0a3784.json
+propose: wrote /tmp/dr14/deterministic/con-bb51c1cce67f.json
+propose: 5 candidate(s)
+```
+
+### Drop-in comparability — verified, with one operational caveat
+
+Both arms write through the same two functions: `candidateRecordFilename` and
+`serialiseCandidateRecord` (`candidate_proposer.ts:400`, `:395`), called from
+`llm_propose.ts:220-221` and `evolution_lab.ts:688-698`. Both order the input
+with the same comparator (`byteCompare`, `candidate_proposer.ts:290`) at
+`candidate_proposer.ts:365-367` and `llm_candidate_proposer.ts:375-377`. Both
+build the id with the same `candidateId` and take `dimension` from `RECIPES`,
+never from the model (`llm_candidate_proposer.ts:328-337`).
+
+Verified by running the metered arm against a **stub** generator (zero spend):
+
+- with a stub returning exactly the deterministic recipe's output, the two arms
+  produce **byte-identical** record files with **identical filenames in
+  identical order** — 5 records each;
+- with a stub returning different text, the record key set, dimensions,
+  `lifecycle: 'proposed'` and the one-record-per-observation invariant all hold,
+  and the filenames diverge.
+
+**CAVEAT — do not pair by filename.** `candidateId`
+(`candidate_proposer.ts:322-337`) hashes the mutation CONTENT, so two arms that
+produce different text produce different ids and therefore different filenames.
+The pairing key for the comparison is `(defectClass, mutations[0].path)`, which
+is stable across arms. A runner that zips the two `--out` directories by sorted
+filename will mis-pair.
+
+## 3. The UNSET slot — what `decidePairedVerdict` actually consumes
+
+`docs/contracts/metered-proposer-protocol.md:237-258` leaves the **paired
+outcome metric and its aggregation** UNSET, owned by the executing session,
+citing `ARTIFACT_COUNT_METRIC` (`_lib/evaluation_vector.ts:62`) and
+`promotionVerdict` as the committed constraints.
+
+### The exact input type
+
+```ts
+export interface PairedInput {
+    /** One signed delta per trial. Positive favours the treatment. */
+    deltas: readonly number[];
+    /** Deltas within this of zero are ties and are excluded as concordant. */
+    tieEpsilon?: number;
+    alpha?: number;
+}
+```
+— `src/scripts/_lib/paired_verdict.ts:109-115`.
+
+**A discordant pair** is a delta with `|d| > tieEpsilon`
+(`paired_verdict.ts:130-132`): `wins = deltas.filter(d => d > eps).length`,
+`losses = deltas.filter(d => d < -eps).length`, `discordant = wins + losses`.
+`tieEpsilon` defaults to **0** (`:128`), so with an integer-valued metric only an
+exact tie is concordant.
+
+**Constants, verified at this commit:**
+
+- `ALPHA = 0.05` — `paired_verdict.ts:51`.
+- `MIN_DISCORDANT = 5` — `paired_verdict.ts:78`, derived by
+  `deriveMinDiscordant` (`:72-76`) as the smallest `n` with `0.5**n <= ALPHA`.
+  Confirmed by execution: `MIN_DISCORDANT = 5`.
+
+**So the metric must be:** a function producing **one signed scalar per trial**,
+sign-oriented so that positive favours the METERED arm (the treatment). The
+aggregation is then NOT free — `decidePairedVerdict` fixes it as the one-sided
+exact sign test over the discordant subset (`:156-183`). The two genuinely free
+parameters are (a) **what the scalar measures**, and (b) **what one trial is**.
+
+### FINDING 3a — the unit of a trial is the load-bearing half, and it is not stated
+
+The protocol calls the slot "the paired outcome metric, and its aggregation" and
+does not say whether one trial is one candidate PAIR or one (candidate, eval
+item) pair. The arithmetic makes the two answers completely different verdicts.
+Executed against the real module:
+
+| deltas | kind | discordant | p | at_floor |
+|---|---|---|---|---|
+| 5 pairs, metered sweeps 5-0 | `pass` | 5 | 0.0313 | **true** |
+| 5 pairs, 4-1 | `no-change` | 5 | 0.1875 | true |
+| 5 pairs, one tie (4-0) | **`underpowered`** | 4 | 1.0000 | false |
+| 5 pairs, 0-5 | `regression` | 5 | 0.0313 | true |
+| 25 trials, 20-5 | `pass` | 25 | 0.0020 | false |
+
+**If one trial = one candidate pair, the run is on a knife edge.** The corpus is
+5 (a budget ceiling, not a choice) and `MIN_DISCORDANT` is 5 (a derivation, not
+a choice). The two coincide. A single tie drops the run to `underpowered`; a
+single dissent drops it to `no-change`; only a perfect 5-0 sweep can pass, in
+either direction. `floorWarning` (`paired_verdict.ts:199`) fires on every
+outcome and says so verbatim: *"Raise the trial count rather than the
+expectation."* The protocol itself flags `at_floor` handling nowhere.
+
+**The budget file already argues for the other reading.**
+`src/config/harness-evolution-budget.json`,
+`why_these_numbers.max_trials_per_candidate`: *"20 leaves room above that floor
+for a corpus of 10 queries run in both orders (judge_hygiene.ts:5-9)"* — i.e. a
+trial is a (candidate × query × order) unit, giving up to 5 × 20 = 100 deltas.
+`src/scripts/_lib/judge_hygiene.ts:4-9` is the order-swap discipline that
+citation points at.
+
+Whoever freezes the slot must state the trial unit explicitly. It is not
+derivable from the protocol as written.
+
+### FINDING 3b — nothing in the tree computes a delta, for any metric
+
+`decidePairedVerdict` has exactly **one** production caller in `src/`:
+`directionVerdict` in `src/scripts/_lib/bench_ab_size_claim.ts:96-105`, on the
+A/B bench path, unrelated to the evolution lab.
+
+On the evolution-lab path, `MetricVector`s are **read off disk**, not computed:
+`evolution_lab.ts:762-766` parses `--vector FILE` through
+`parseMetricVectorJson` (`evolution_roi.ts:428`), which accepts a `PairedRow`
+carrying an already-decided `PairedVerdict` (`evaluation_vector.ts:64-69`,
+verdict kinds validated at `evolution_roi.ts:456`, `:489`). So the deltas — and
+therefore the metric — are an **operator-supplied input** today. No code path
+turns two candidate records into a delta.
+
+This is a build gap AC-2 sits behind, and it is larger than the slot: freezing
+the metric in writing does not by itself make a paired-verdict run possible.
+
+### Candidate metrics — pre-existing vs. fresh judgement
+
+**Available from pre-existing, committed material:**
+
+| Candidate | Where it already exists | What it would measure | Fitness |
+|---|---|---|---|
+| ±1 direction vector | `bench_ab_size_claim.ts:96-105` — the only committed construction of `deltas`, reconstructing counts into `[1,…,-1,…]` with default `tieEpsilon` | the SHAPE of the delta vector, not its content | This is a **precedent for the encoding**, not a metric. It settles (b)-adjacent questions and none of (a). |
+| `ARTIFACT_COUNT_METRIC` = `'artifact-count-delta'` | `evaluation_vector.ts:62` | signed change in artifact count | **Cannot be the paired metric.** `buildVector` requires it as a `CountedRow` (`:114-120`), and `promotionVerdict` blocks a vector whose only rows are counted (`:262-265`, `<no-paired-row>`). It is a mandatory companion row, not the outcome. |
+| Skill trigger-eval pass rate | 100 committed `src/skills/*/evals/triggers.json`, e.g. `src/skills/code-intelligence/evals/triggers.json` (10 queries, 5 should-trigger / 5 should-not) | per-query routing correctness before vs. after the mutation | **Does not cover this corpus.** Zero rules carry a `triggers.json`; the frozen corpus is five `.claude/rules/*.md`. The parent roadmap's "First cut" named `code-intelligence`, but the frozen corpus rule (`metered-proposer-protocol.md:181-197`) enumerates rules instead. The two do not line up. |
+
+**Fresh judgement calls — none of these has a constant in the tree:**
+
+1. **What the scalar measures** for a rule artifact. Candidates a runner might
+   reach for — token count, activation-precision on a hand-built query set,
+   an LLM-judged quality score — are all uncommitted, and the third is
+   **forbidden**: a metered call that supplies input to the verdict is the
+   evaluator role the narrowing still bars
+   (`road-to-governed-evidence-production.md:252-256`).
+2. **The unit of a trial** (Finding 3a).
+3. **`tieEpsilon`** — defaulted to 0 in code, never stated in the protocol.
+4. **`direction`** for the paired row (`'higher-better' | 'lower-better'`,
+   `evaluation_vector.ts:59`) and the metric's string name.
+5. **`artifactDeltaCeiling`** (`evaluation_vector.ts:215`, defaulted to 0 at `:238`). Both
+   recipes rewrite one existing file and add none, so 0 is satisfiable — but it
+   is a caller choice nobody has recorded.
+
+**Recommendation to the council (not a freeze):** the trial-unit question
+(3a) should be answered before the metric-content question, because the
+knife-edge at `n = 5` makes a per-pair metric arithmetically near-unpassable
+regardless of what it measures, and because the budget file's own reasoning
+already presumes the per-query unit.
+
+### FINDING 3c — the protocol's HEAD-recording claim is false at this commit
+
+`metered-proposer-protocol.md:199-202` states *"The run report records
+`git rev-parse HEAD`"*. `RunReport` (`evolution_roi.ts:329-335`) carries
+`run_id`, `candidates`, `trials_per_candidate`, `roi`, `ladder` — **no commit
+field**. `run_id` is built from candidate ids (`evolution_lab.ts:866-871`), not
+from HEAD. `grep -rn "rev-parse"` over `evolution_lab.ts`, `llm_propose.ts`,
+`evolution_roi.ts` and `llm_candidate_proposer.ts` returns **nothing**. And
+`llm_propose` writes no run report at all — `buildRunReport` is reached only from
+`evolution_lab run` (`evolution_lab.ts:866`).
+
+Given Finding 1a, this is the more serious half: the one field that would make a
+capture re-runnable is claimed and absent.
+
+### FINDING 3d — three line citations in the frozen protocol are off
+
+Cosmetic, but the protocol is a frozen contract that cites by line:
+
+| Protocol text | Cited | Actual |
+|---|---|---|
+| *"`high` is reachable only through an `execution_failed` escalation"* (`:85`) | `evolution_roi.ts:109` (`dependency_unavailable: []`) | `evolution_roi.ts:111` |
+| *"escalating on a reason nobody established is spending on a guess"* (`:124`) | `evolution_roi.ts:117-119` | `evolution_roi.ts:119-121` |
+| *"retrying `lite` is not an escalation"* (`:138`) | `evolution_roi.ts:203` (the empty-ladder error string) | `evolution_roi.ts:184-185` |
+
+Verified correct: `ALPHA` `:51`, `MIN_DISCORDANT` `:78`, `decidePairedVerdict`
+`:126`, `assertCheapestFirst` `evolution_roi.ts:191`, `ARTIFACT_COUNT_METRIC`
+`evaluation_vector.ts:62`, `assertWithinBudget`
+`harness_evolution_guards.ts:140`, `buildRunReport` `evolution_roi.ts:363`,
+`candidate_proposer.ts:343-347`, the park at
+`road-to-routing-assurance-live-floors.md:20-52`.
+
+## 4. Guards — 76/76 green
+
+`npx vitest run` over the four relevant files, on `b50b27281`:
+
+| file | tests | result |
+|---|---|---|
+| `tests/scripts/proposer_survival_bar.test.ts` | 5 | pass |
+| `tests/lib/paired_verdict.test.ts` | 17 | pass |
+| `tests/scripts/_lib/evolution_roi.test.ts` | 28 | pass |
+| `tests/scripts/llm_candidate_proposer.test.ts` | 26 | pass |
+| **total** | **76** | **4 files passed, 0 failed** |
+
+No test file matches `llm_propose` — the entry point has no test of its own; its
+behaviour is covered indirectly through the arm and the transport description.
+Stated as an observation, not a defect claim.
+
+`git status` was clean before and after. The run triggered
+`ensure-build-artefacts` for `dist/cli`, `dist/ui` and `dist/mcp` (all
+gitignored); no tracked file changed.
+
+## 5. AC-3 — the claim is true, with the line numbers naming declarations
+
+AC-3 (`road-to-governed-evidence-production.md:526-541`) says
+`assertCheapestFirst` now has production callers at
+`llm_candidate_proposer.ts:369` (`proposeCandidatesWithModel`) and `:429`
+(`plannedAttempts`).
+
+**Both verified at `b50b27281`:**
+
+- `:369` — `export async function proposeCandidatesWithModel(` ✓
+- `:429` — `export function plannedAttempts(observations: readonly DefectObservation[]): LadderAttempt[] {` ✓
+
+The cited numbers are the **function declarations**. The `assertCheapestFirst`
+CALLS are at `:417` (inside `proposeCandidatesWithModel`) and `:446` (inside
+`plannedAttempts`). Both functions are on an executable path:
+`llm_propose.ts:137` calls `plannedAttempts` on the dry path, and
+`llm_propose.ts:212` calls `proposeCandidatesWithModel` on `--confirm`. These are
+the only two production call sites in the tree.
+
+**AC-3's stated remaining gap is confirmed.** The dry run above produced exactly
+five attempts, all `class=reason_unknown · tier=lite`. Every attempt is on the
+cheapest rung of a one-rung ladder, so no ordering decision arises and the guard
+polices a population in which it cannot fire. The population is real and
+non-empty; it is not a SPENT population.
+
+### FINDING 5a — two comments in the tree still deny AC-3's half-met state
+
+- `src/scripts/_lib/evolution_roi.ts:188-190` — `assertCheapestFirst`'s own
+  docstring: *"NO LIVE SUBJECT. Nothing in this programme produces
+  `LadderAttempt`s today; see the header. This is a guard waiting for a harness,
+  and its unit test proves it fires rather than proving anything ran."* False at
+  this commit: `plannedAttempts` produces five on a dry run.
+- `src/scripts/activation_receipt.ts:10` — *"open on `assertCheapestFirst`, which
+  polices a population of zero."* Same drift.
+
+Doc drift only; reported, not fixed.
+
+## 6. What a later capture step still needs
+
+Ordered by what blocks what. Items 1–3 are decisions; 4 is code; 5 is the run.
+
+1. **Freeze the UNSET slot** — the metric, the trial unit (Finding 3a),
+   `tieEpsilon`, the metric name and direction. Council decision; must land in
+   its own commit before any capture (`road-to-governed-evidence-production.md:307-311`).
+2. **Decide the corpus-reproducibility question** (Finding 1a) — either pin the
+   projection procedure alongside the commit, or move the corpus to a tracked
+   surface. As it stands, two runs on the same commit can enumerate different
+   corpora.
+3. **Decide whether the protocol's HEAD claim is repaired or withdrawn**
+   (Finding 3c).
+4. **Build the delta producer** (Finding 3b). Nothing turns two candidate records
+   into deltas, and `evolution_lab run` expects vectors as an input file. AC-2
+   cannot be met by running `llm_propose --confirm` alone: that produces
+   candidates, not a verdict.
+5. **Run the capture.** ~$0.02, worst case ~$0.21, against a $5.00 ceiling. The
+   credential the transport reads at call time
+   (`~/.event4u/agent-config/anthropic.key`, via `load_anthropic_key`,
+   `src/scripts/ai_council/clients.ts:369`) is present on this machine; its
+   contents were not read.
+
+Step 5 is cheap and step 4 is not. The dollar cost was never the constraint —
+which is what the park said in 2026-08-25 (*"Cost was explicitly not the
+objection — token spend was pre-authorised"*,
+`road-to-routing-assurance-live-floors.md:27-28`) and is still true.
+
+## Honest nulls
+
+- **No metered call was made.** The transport's live path remains unexercised, as
+  `metered-proposer-protocol.md:260-265` states.
+- **No verdict was computed** over real candidates. The verdict table in § 3 is
+  the real `decidePairedVerdict` over synthetic delta vectors, to expose the
+  `n = 5` arithmetic. It measures nothing about either arm.
+- **The UNSET slot is still UNSET.** Options and evidence only.
+- **Whether the metered arm beats the deterministic one is unknown**, and nothing
+  here is evidence in either direction.
+- **The observations document is not committed** and the corpus is not pinned;
+  the five subjects above are this machine's projection on 2026-09-01, not a
+  reproducible corpus.

--- a/agents/evidence/analysis/drain14-phase2-capture-readiness.md
+++ b/agents/evidence/analysis/drain14-phase2-capture-readiness.md
@@ -35,7 +35,7 @@ document; it ships an enumeration RULE
 4. class per file: `over-broad-activation` when the file contains a line
    beginning `## `, otherwise `unbacked-enforcement-claim`.
 
-### FINDING 1a — the corpus is not reproducible from a commit
+### FINDING 1a (F-A) — the corpus is not reproducible from the COMMIT ALONE
 
 `.claude/` is **gitignored in its entirety** (`.gitignore:157` pins
 `/.claude/rules/`), and `git ls-files .claude` returns 0 files. A fresh worktree
@@ -64,6 +64,15 @@ commit pin is **not sufficient**, for two separate reasons:
 **Consequence for the capture.** The observations document must be produced by a
 recorded procedure that pins BOTH the commit AND the projection state, or the
 comparison is not re-runnable. Nothing in the tree does this today.
+
+**DOWNGRADED 2026-09-01 by the council, and the narrowing is load-bearing.** An
+earlier framing of this finding said the run produces *"a number nobody can
+reproduce"*. That is overreach and is withdrawn. What is Confirmed is narrower:
+the run is not reproducible **from the commit alone**. It is NOT established that
+reproduction is impossible from a captured manifest plus an environment
+snapshot — nobody has tried, and the council declined to grade an untried
+mechanism as impossible. Fixing this is owner-reserved by default (corpus
+contract), so no manifest was pinned this run.
 
 ### The document this session produced (from the stated rule, fresh projection)
 
@@ -147,6 +156,22 @@ committed table — `claude-haiku-4-5` at $1.00/MTok in, $5.00/MTok out,
 | `.claude/rules/augment-edit-discipline.md` | `unbacked-enforcement-claim` | 275 | 141 |
 | **total** | | **3,234** | **2,504** |
 
+**The arithmetic, shown rather than asserted** (the council graded the figures
+`inferred` when neither the table location nor the sum was given). Price source:
+`src/scripts/ai_council/_default_prices.ts:29`, the row
+`['anthropic', 'claude-haiku-4-5', 1.0, 5.0]` — dollars per million tokens, input
+then output, `LAST_UPDATED = '2026-05-14'` (`:16`). Token counts are the arm's own
+`estimateTokens` (`_lib/llm_proposer_transport.ts:109-111`), which is
+`Math.ceil(text.length / 4)` — a character proxy, not a tokenizer.
+
+```
+likely = 3234/1e6 * 1.00  +  2504/1e6 * 5.00
+       = 0.003234         +  0.012520          = $0.015754  -> $0.0158
+worst  = 3234/1e6 * 1.00  +  40960/1e6 * 5.00
+       = 0.003234         +  0.204800          = $0.208034  -> $0.2080
+where 40960 = 5 calls x MAX_TOKENS 8192 (_lib/llm_proposer_transport.ts:64)
+```
+
 - **Likely cost: $0.0158** — 3,234 in + 2,504 out (a full-body rewrite per call).
 - **Absolute worst case: $0.2080** — 3,234 in + 5 × `MAX_TOKENS` (8192) out
   (`llm_proposer_transport.ts:64`). Unreachable in practice; the subject bodies
@@ -179,7 +204,7 @@ propose: wrote /tmp/dr14/deterministic/con-bb51c1cce67f.json
 propose: 5 candidate(s)
 ```
 
-### Drop-in comparability — verified, with one operational caveat
+### Drop-in comparability — OBSERVED under a stub in this run, with a caveat
 
 Both arms write through the same two functions: `candidateRecordFilename` and
 `serialiseCandidateRecord` (`candidate_proposer.ts:400`, `:395`), called from
@@ -189,7 +214,47 @@ with the same comparator (`byteCompare`, `candidate_proposer.ts:290`) at
 build the id with the same `candidateId` and take `dimension` from `RECIPES`,
 never from the model (`llm_candidate_proposer.ts:328-337`).
 
-Verified by running the metered arm against a **stub** generator (zero spend):
+**The command, so the word is not doing the work.** A throwaway probe under
+`node_modules/.bin/tsx` imports both arms, parses `/tmp/dr14/observations.json`
+through `parseObservations`, and calls `proposeCandidatesWithModel` with two
+stub generators — one echoing `RECIPES[cls].rewrite(read(subject), '')`, one
+appending a marker comment — then compares `serialiseCandidateRecord` output
+against `proposeCandidates` over the same input. Nothing is sent.
+
+Output of that run, verbatim:
+
+```
+deterministic records: 5 | metered records: 5
+filenames det : act-ca6e7ddb23f7.json act-d2ac06be9cf2.json act-58069c3c3910.json act-628dda0a3784.json con-bb51c1cce67f.json
+filenames met : act-ca6e7ddb23f7.json act-d2ac06be9cf2.json act-58069c3c3910.json act-628dda0a3784.json con-bb51c1cce67f.json
+record ORDER identical: true
+BYTES identical (echo stub): true
+attempts: [{"defect_class":"reason_unknown","tier":"lite","sequence":1}, … x5]
+
+filenames met2: act-d4fee76891a6.json act-c9218ab7ebcd.json act-f9cddb25cf5e.json act-6fc3387e0019.json con-b4f67d4cc2b6.json
+same key set as det: true
+dimensions from RECIPE: true
+all lifecycle proposed: true
+one record per observation: true
+```
+
+Digests, `sha256`: probe output
+`9c23e72965e5f25726bf0e579c000ceb769eb712257cbe761c0a1adde5714d79`; observations
+document `4079965fbc97f167434cb37fec1d774100d6de437fcf8e9e6f9fb7b5052dbbe3`;
+concatenated deterministic records
+`5c1babdb2c28ba882e6f79d161862852fb59635bf203fe35a6fed1de0b41fef3`.
+
+**What the digests do and do not pin — the honest limit.** They pin THIS run's
+artefacts. Neither the probe nor the observations document is committed, and the
+observations document is derived from a gitignored projection, so the digest
+inherits F-A: another machine can re-run the same procedure and get a different
+observations document, hence different digests. The word in the heading is
+therefore **observed**, not **proven**. What is genuinely established is a code
+property, independent of the corpus: both arms call the same
+`candidateRecordFilename`, `serialiseCandidateRecord`, `byteCompare` and
+`candidateId`, at the line numbers cited above.
+
+Observed by running the metered arm against a **stub** generator (zero spend):
 
 - with a stub returning exactly the deterministic recipe's output, the two arms
   produce **byte-identical** record files with **identical filenames in
@@ -428,10 +493,11 @@ Ordered by what blocks what. Items 1–3 are decisions; 4 is code; 5 is the run.
    corpora.
 3. **Decide whether the protocol's HEAD claim is repaired or withdrawn**
    (Finding 3c).
-4. **Build the delta producer** (Finding 3b). Nothing turns two candidate records
-   into deltas, and `evolution_lab run` expects vectors as an input file. AC-2
-   cannot be met by running `llm_propose --confirm` alone: that produces
-   candidates, not a verdict.
+4. **Build the delta producer** (Finding 3b / F-C, Confirmed — see § 7). No
+   producer has been identified that turns two candidate records into deltas,
+   and `evolution_lab run` expects vectors as an input file. So running
+   `llm_propose --confirm` alone would not produce the comparison AC-2 asks
+   for: it produces candidates, not a verdict.
 5. **Run the capture.** ~$0.02, worst case ~$0.21, against a $5.00 ceiling. The
    credential the transport reads at call time
    (`~/.event4u/agent-config/anthropic.key`, via `load_anthropic_key`,
@@ -456,3 +522,251 @@ objection — token spend was pre-authorised"*,
 - **The observations document is not committed** and the corpus is not pinned;
   the five subjects above are this machine's projection on 2026-09-01, not a
   reproducible corpus.
+
+---
+
+# Addendum — council round 2, the repair pass, and the F-C trace
+
+Added 2026-09-01, same drain run, after the reconnaissance above was committed.
+**Still zero metered calls: `--confirm` was never passed and the `--confirm`
+path stays untaken permanently for this drain.**
+
+## 7. Council round 2 — QB, do not capture
+
+*AI council 2026-09-01 (drain run 14, round 2 on Phase 2), members
+`anthropic/claude-sonnet-4-5` + `openai/codex-default`, 2 rounds, depth deep,
+peer-review, blind chairman, quorum 2/2 present (needed 1) — concluded.
+Subscription transport, `billable=0`, `$0.0000`. Verdict **QB**, convergent.*
+Council artefacts are gitignored and auto-pruned, so the text is inlined and no
+path under `agents/runtime/council/` is cited.
+
+Ratio, one line: *"the current run lacks both a reproducibly fixed subject and
+an executable path to the required comparison. The low cost and green guards do
+not cure those validity failures."*
+
+### The four framings it graded, and what changed in this document
+
+| # | Framing put to the council | Grade | What this document now says |
+|---|---|---|---|
+| 1 | *"a number nobody can reproduce"* | **overreach — refused** | § 1 F-A now claims only "not reproducible **from the commit alone**", and says explicitly that reproduction from a captured manifest plus an environment snapshot is untried, not impossible. |
+| 2 | *"AC-2's artefact cannot be produced"* | **Inferred, too categorical** | Narrowed everywhere to **"no producer has been identified"**, and then Confirmed by the trace in § 8 — which still does not license the categorical form. |
+| 3 | *"comparability-proven"* | **unsupported — no command cited** | § 2 now carries the probe description, its verbatim output, three `sha256` digests, and a paragraph on what the digests do NOT pin. The heading says **observed**, not proven. |
+| 4 | the cost figures | **inferred — no table, no arithmetic** | § 2 now shows the price-table row with its file:line and `LAST_UPDATED`, and the two sums line by line. |
+
+One further unsupported claim, now cited: fixture-substitution **is** ranked #2
+in this roadmap's Risk Register — `road-to-governed-evidence-production.md`
+§ Risk Register, Rank 2, *"Phase 2 closes on a fixture instead of a run"*, risk
+type `product`.
+
+### The two direct rulings
+
+1. **Fixing F-A is owner-reserved by default.** Changing corpus membership or
+   selection semantics amends a frozen experimental subject. One seat allowed a
+   purely provenance-preserving pin of the *same* subjects *might* be
+   autonomous, but held the equivalence undemonstrated. **No manifest was
+   pinned.**
+2. **`underpowered` does not discharge AC-2.** A legitimate execution status,
+   not a directional result: it records that adjudication was unavailable.
+
+### Not done, deliberately
+
+No capture, not even diagnostic. The metric and the trial unit were **not**
+frozen — the council ruled the experimental definition must be frozen as a whole
+(estimand, trial unit, pairing, aggregation, independence assumptions, sign
+convention, `tieEpsilon`) and that is not this run's work. The corpus contract
+was not touched. AC-2, AC-3, AC-4 not closed; 2.1 and 2.2 not flipped.
+`metered-backend-park` not resolved; its narrowing stands and this run's block is
+downstream of it.
+
+## 8. F-C — the end-to-end trace. VERDICT: CONFIRMED, no producer identified
+
+The council graded F-C `Inferred` because the first report described
+`evolution_lab run` as consuming vectors without showing that no producer exists
+elsewhere. This is the search record it asked for. **A confirmed absence needs a
+search record, not a description**, so every command is given.
+
+**The acceptance criterion** — AC-2,
+`road-to-governed-evidence-production.md` § Acceptance Criteria: *"A
+paired-verdict comparison between a metered proposer and the deterministic one
+has been run, and its result — in either direction — is recorded."*
+
+**The input consumer** — `evolution_lab run --vector FILE`
+(`src/scripts/evolution_lab.ts:402`), which parses each file through
+`parseMetricVectorJson` (`_lib/evolution_roi.ts:452`) into `buildVector`
+(`_lib/evaluation_vector.ts:103`).
+
+**The candidate records** — `proposeCandidates`
+(`_lib/candidate_proposer.ts:361`) and `proposeCandidatesWithModel`
+(`_lib/llm_candidate_proposer.ts:369`). Both emit `CandidateRecord`, whose fields
+are `kind`, `version`, `id`, `dimension`, `lifecycle`, `mutations` — **no outcome
+field of any kind**.
+
+**The gap, stated precisely:** nothing reads two `CandidateRecord`s and emits a
+signed delta, a `PairedVerdict`, or a `MetricVector`.
+
+### The searches
+
+| # | Command | Result |
+|---|---|---|
+| S1 | `grep -rn --include='*.ts' "decidePairedVerdict(" src` | exactly one caller: `_lib/bench_ab_size_claim.ts:101` |
+| S2 | `grep -rn --include='*.ts' "kind: 'paired'" src` | 2 hits: the type declaration `_lib/evaluation_vector.ts:65`, and `_lib/evolution_roi.ts:536` |
+| S3 | `grep -rn --include='*.ts' "kind: 'counted'" src` | 2 hits: `_lib/evaluation_vector.ts:72`, `_lib/evolution_roi.ts:500` |
+| S4 | `grep -rn --include='*.ts' "candidate_id" src` | 30 hits across 9 files; none builds a metric vector — see the exclusions below |
+| S5 | `grep -rn -- "--vector" src tests docs` | declared at `evolution_lab.ts:402`; supplied only by tests |
+| S6 | `grep -rln --include='*.ts' "evaluation_vector" src tests` | 5 src files, all consumers or parsers |
+| S7 | `grep -rln --include='*.ts' "paired_verdict" src tests` | 6 src files; 4 mention it only in comments |
+| S8 | `sed -n '550,566p' tests/scripts/evolution_lab.test.ts` | the only vector ever fed to the verb is a **hand-authored verdict literal** |
+| S9 | `sed -n '410,445p' src/scripts/_lib/evaluation_cascade.ts` | takes `input.vector` **or** `input.rows` — both caller-supplied |
+| S10 | `grep -rln --exclude-dir={src,tests,node_modules,.git} "evaluation_vector\|decidePairedVerdict\|artifact-count-delta" .` | 6 files, all prose: two roadmaps, three contracts, this report |
+| S11 | `sed -n '325,345p' src/scripts/bench_ab_v2_stats.ts` | the one live verdict's population is **A/B bench task pairs**, not candidate records |
+| S12 | `grep -n "paired_verdict\|evaluation_vector"` over the four other importers | `paired_stats.ts`, `role_split.ts`, `harness_evolution_guards.ts`, `pathology_archive.ts` — comments only |
+
+### Every adapter checked, and why each is not the producer
+
+| Module | What it does | Why not a producer |
+|---|---|---|
+| `_lib/bench_ab_size_claim.ts:96-105` | the tree's ONLY `decidePairedVerdict` call; builds `deltas` as a ±1 direction vector | its input is `PairedContinuous` from the A/B bench report pipeline (`bench_ab_v2_stats.ts:325-344` — added lines and cognitive complexity per benchmark task pair). Different population; it never sees a `CandidateRecord`. |
+| `_lib/evolution_roi.ts:480-543` (`parseRow`) | the only `kind:'paired'` / `kind:'counted'` construction in `src/` | a **deserialiser**. It re-shapes and validates JSON read off disk; it computes nothing. |
+| `_lib/evaluation_cascade.ts:414-441` | stage 12, the promotion verdict | consumes `input.vector` or `input.rows`; both arrive from the caller. |
+| `_lib/regression_neighbourhood.ts:194` | builds a `NeighbourhoodReport` keyed by `candidate_id` | selects regression specs from a registry. No deltas, no verdict, `authored: 0` by construction. |
+| `_lib/minimality_tiebreak.ts` | breaks ties on tokens/artifacts | a tiebreak over already-decided candidates; emits a winner id, not a delta. |
+| `_lib/pathology_archive.ts` | retains one representative failure per class | says outright (`:12-15`) it is not a second verdict and never calls `promotionVerdict`. |
+| `_lib/promotion_evidence.ts`, `_lib/evaluator_promotion.ts` | parse and check promotion evidence | validators over supplied evidence. |
+| `_lib/paired_stats.ts`, `_lib/role_split.ts`, `_lib/harness_evolution_guards.ts` | stats primitives, role split, budget/disclosure guards | reference `paired_verdict` in prose only. |
+
+**Verdict: CONFIRMED — no producer identified.** Stated as the council requires:
+this is an absence established by a recorded search over this tree at this
+commit, not a proof that the artefact cannot be produced. Building one is
+straightforward and is item 4 of the ordered list in § 6; if a later reader finds
+a producer this trace missed, that is the better outcome and this section is
+where the correction belongs.
+
+## 9. The repair pass — what changed, and the two sweeps
+
+Four defects reported in § 1-5 as "reported not fixed" were repaired, on the
+grounds that each is wrong at this commit whatever the council decides.
+
+### F-D1 — the false provenance claim: WITHDRAWN, not implemented
+
+`docs/contracts/metered-proposer-protocol.md` § The defect-observation corpus
+claimed *"The run report records `git rev-parse HEAD`"*.
+
+**Option taken: withdraw.** Three reasons, in the order they decided it:
+
+1. Adding a commit field to `RunReport` would not make the sentence true for the
+   arm this protocol governs. `llm_propose` writes **no run report at all**;
+   `buildRunReport` is reached only from `evolution_lab run`
+   (`evolution_lab.ts:866`). The field would describe a document the capture
+   never emits — a second true-sounding claim replacing the first.
+2. A recorded commit would not be sufficient where it did land, because of F-A.
+   An automatic HEAD line would have made the corpus look pinned while it was
+   not, which is worse than no line.
+3. Emitting real provenance from `llm_propose` — commit plus the enumerated
+   subject list — is a change to the frozen mechanism, and per the council the
+   experimental definition is frozen as a whole. That belongs to whoever freezes
+   it, not to a repair of a false sentence.
+
+**What is lost, stated in the contract itself:** the protocol now claims no
+automatic provenance capture whatsoever. Comparability rests entirely on the
+operator recording, by hand and alongside the results, both the commit and the
+`.claude/` projection state — at minimum the five sorted subject filenames,
+because the commit alone does not determine them.
+
+### F-D2 — the citation sweep. Found 3 of 7 stale; then my own repair broke 11 more
+
+**Sweep A, the protocol document.** Extracted every `file:line` citation with
+`grep -o` rather than fixing only the three already noticed. **7 citations
+existed; 3 were stale; 3 fixed; 4 already correct** (`evolution_roi.ts:191`,
+`paired_verdict.ts:51`, `:78`, `evaluation_vector.ts:62`). The document's
+non-line-numbered factual claims were checked in the same pass and **all hold**:
+`ANTHROPIC_URL`, `ANTHROPIC_VERSION`, both dated model ids and the null `high`
+tier, `MAX_TOKENS` 8192, `TEMPERATURE` 0, the 256 KiB body ceiling
+(`MAX_BODY_BYTES`, `_lib/llm_candidate_proposer.ts:204`), `max_candidates` 5 and
+`max_trials_per_candidate` 20.
+
+**Sweep B, the tree, and it caught a defect Sweep A could not.** Grepping
+`evolution_roi\.ts:[0-9]` across the tree showed the same three stale citations
+**recurring in code** — `_lib/llm_candidate_proposer.ts:41` and `:295`, and
+`_lib/llm_proposer_transport.ts:27`. Fixing only the protocol would have left
+the identical defect in two shipped modules.
+
+**And then the repair created the drift it was fixing.** Correcting the comments
+in § 9's next item added lines to `evolution_roi.ts`, which shifted its own line
+numbers and silently falsified **every** citation into it. **11 live citations
+repaired** across four files: the frozen protocol (5), the active roadmap (2),
+`_lib/llm_candidate_proposer.ts` (3), `_lib/llm_proposer_transport.ts` (1).
+
+| anchor | old | new |
+|---|---|---|
+| `execution_failed` ladder | `:109` → `:111` | `:128` |
+| `reason_unknown` + comment | `:117-119` → `:119-121` | `:136-138` |
+| "retrying `lite` is not an escalation" | `:203` → `:184-185` | `:201-202` |
+| `assertCheapestFirst` declaration | `:191` | `:215` |
+| `RunReport` interface | `:329-335` | `:353-359` |
+| `buildRunReport` | `:363` | `:387` |
+
+**Deliberately NOT repaired — historical records.** The archived parent roadmap
+(`agents/roadmaps/archive/road-to-governed-harness-evolution.md`, 3 citations)
+and two prior analysis documents also cite shifted lines. An `analysis` artefact
+*"asserts what was true when it was written and is never re-bound"*
+(`docs/contracts/evidence-artifact-types.md:59`), so re-binding them would be
+the error, not the fix.
+
+**The structural finding this exposes, recorded rather than fixed.** A citation
+by line number into a file is falsified by any prose edit to that file, silently,
+with no gate that notices. This pass produced 11 such falsifications from four
+comment edits. That is a maintenance hazard in the citation convention itself,
+not a defect in any one document, and it is out of scope here — but a reader
+touching `evolution_roi.ts` should expect to re-sweep.
+
+### F-D3 — five comments denying a state the code has
+
+`assertCheapestFirst` gained two production callers when the metered arm landed.
+**The construct was grepped across the tree rather than assumed to be the two
+already reported. 5 sites matched, all corrected:**
+
+| site | was |
+|---|---|
+| `src/scripts/_lib/evolution_roi.ts` header | "The ladder is an ORDERING POLICY, and it has no live subject" |
+| `src/scripts/_lib/evolution_roi.ts` guard docstring | "NO LIVE SUBJECT. Nothing in this programme produces LadderAttempts today" |
+| `src/scripts/activation_receipt.ts` | "which polices a population of zero" |
+| `tests/scripts/_lib/evolution_roi.test.ts` file docstring | "nothing in this programme produces a LadderAttempt" |
+| `tests/scripts/_lib/evolution_roi.test.ts` describe name | "a guard with no live subject" |
+
+Each now states the **half**-met position and not more: callers exist and are on
+an executable path; no LIVE run has produced a spent population, so the ordering
+has not yet governed one, which is what AC-3 stays open on.
+
+**11 further tree matches were read and EXCLUDED**, with the reason: they
+describe different machinery and are true of it —
+`lint_promotion_paths.ts:42`/`:739`, `_lib/candidate_record.ts:178`,
+`_lib/activation_receipt_producer.ts:32`, `src/config/gate-coverage.yml:2362`,
+`docs/contracts/activation-receipt-trust-boundary.md:99`,
+`_lib/tier_budget_routing.ts:15`, `ai_council/leakage_patterns.ts:48`,
+`_lib/collector_supervision.ts:654`, `_lib/capture_rate.ts:37`,
+`hooks/skill_route_hook.ts:8`.
+
+### F-D4 — the roadmap's declaration-vs-call citations
+
+Step 2.2 and AC-3 cited `llm_candidate_proposer.ts:369` and `:429` as though
+they were the call sites. They are the function **declarations**; the
+`assertCheapestFirst` calls are at `:417` and `:446`. Both sites now name
+declaration and call, plus the entry points that reach them
+(`llm_propose.ts:137` dry, `:212` `--confirm`). **Factual repair only — AC-3
+stays `[ ]` and its verdict text is untouched.**
+
+## 10. Honest nulls, restated after the addendum
+
+- **No metered call was made, in either pass.** The transport's live path
+  remains unexercised.
+- **No verdict was computed over real candidates.** The `n = 5` table in § 3 is
+  the real `decidePairedVerdict` over synthetic delta vectors; it measures
+  nothing about either arm.
+- **The metric slot is still UNSET**, and per the council it must be frozen as a
+  whole rather than slot by slot.
+- **The corpus contract is untouched and no manifest was pinned** — owner-reserved.
+- **Whether the metered arm beats the deterministic one is unknown**, and
+  nothing in this document is evidence in either direction.
+- **F-C is a Confirmed absence over this tree, not an impossibility proof.**
+- **The comparability result is `observed` under a stub in this run**, and its
+  digests pin uncommitted artefacts derived from a gitignored projection.

--- a/agents/evidence/analysis/drain14-phase2-capture-readiness.md
+++ b/agents/evidence/analysis/drain14-phase2-capture-readiness.md
@@ -1,3 +1,5 @@
+<!-- evidence-type: analysis -->
+
 # Drain 14 — Phase 2 metered-capture readiness
 
 Reconnaissance for `road-to-governed-evidence-production` Phase 2 (steps 2.1,

--- a/agents/roadmaps/road-to-governed-evidence-production.md
+++ b/agents/roadmaps/road-to-governed-evidence-production.md
@@ -374,12 +374,12 @@ chosen after seeing a result is a tuned metric.
       verify: the ROI figure appears in every run report, and a cheaper model is
       tried before an expensive one on each defect class.
       **Already discharged at transfer, with a production caller:**
-      `buildRunReport` (`src/scripts/_lib/evolution_roi.ts:363`) refuses a
+      `buildRunReport` (`src/scripts/_lib/evolution_roi.ts:387`) refuses a
       report whose evolution-ROI figure is absent or carries an unknown kind,
       and `evolution_lab.ts:865` calls it on the one path a run completes on.
       Both halves RED-proven, 28/28 green.
       **What is still open is the ordering conjunct.** The guard
-      `assertCheapestFirst` (`evolution_roi.ts:191`) exists and is exercised in
+      `assertCheapestFirst` (`evolution_roi.ts:215`) exists and is exercised in
       both polarities, and it has **zero production callers** — it polices a
       population of zero, because nothing in the tree makes a metered proposer
       call. A check that scans a population of zero exits green while looking

--- a/agents/roadmaps/road-to-governed-evidence-production.md
+++ b/agents/roadmaps/road-to-governed-evidence-production.md
@@ -386,10 +386,18 @@ chosen after seeing a result is a tuned metric.
       like coverage, which is why this is open rather than closed.
       **UPDATED 2026-09-01 — the caller now exists; the live population does
       not.** `proposeCandidatesWithModel`
-      (`src/scripts/_lib/llm_candidate_proposer.ts:369`) calls
-      `assertCheapestFirst` over the attempts the walk actually made, and
-      `plannedAttempts` (`:429`) calls it over the dry-run plan, which
-      `llm_propose` reaches with no spend. So "zero production callers" is no
+      (declared `src/scripts/_lib/llm_candidate_proposer.ts:369`, calls
+      `assertCheapestFirst` at `:417`) polices the attempts the walk actually
+      made, and `plannedAttempts` (declared `:429`, calls it at `:446`) polices
+      the dry-run plan, which `llm_propose` reaches with no spend at `:137`;
+      `:212` is the `--confirm` path.
+      **CITATION REPAIR 2026-09-01 (drain run 14) — factual, not a change of
+      verdict.** This paragraph and AC-3 both cited `:369` and `:429` as though
+      they were the call sites. They are the function DECLARATIONS; the
+      `assertCheapestFirst` calls are twenty-odd lines into each body. Nothing
+      about the half-met state changes and no checkbox moves — a reader
+      following the old numbers landed on a signature and could not see the
+      call the criterion is about. So "zero production callers" is no
       longer true. What is still true is that no LIVE run has produced attempts,
       so the ordering has not yet governed a spent population — see AC-3.
       **A defect found and closed during the build, recorded because the first
@@ -527,9 +535,12 @@ chosen after seeing a result is a tuned metric.
       ordering it polices governs a real population rather than an empty one.
       **HALF MET 2026-09-01, and left `[ ]` on the half that is not.** The
       caller exists and is on the executable path: `proposeCandidatesWithModel`
-      calls it over the attempts a run actually made, and `plannedAttempts`
-      calls it over the dry-run plan, which `llm_propose` reaches without
-      spending. The guard is also falsifiable now — an inconsistent resumed
+      (declared `src/scripts/_lib/llm_candidate_proposer.ts:369`, calling
+      `assertCheapestFirst` at `:417`) polices the attempts a run actually made,
+      and `plannedAttempts` (declared `:429`, calling it at `:446`) polices the
+      dry-run plan, which `llm_propose` reaches without spending (`:137`). Both
+      pairs are the repaired citations — see step 2.2's CITATION REPAIR note;
+      the declaration lines were previously cited as if they were the calls. The guard is also falsifiable now — an inconsistent resumed
       history is refused, and removing the call reds that case.
       **What is not met is the criterion's purpose clause.** The populations
       that exist today are the all-`lite` dry plan, in which no ordering

--- a/agents/roadmaps/road-to-governed-evidence-production.md
+++ b/agents/roadmaps/road-to-governed-evidence-production.md
@@ -309,6 +309,123 @@ choices a session under evaluation must not make for itself. Whoever executes
 freezes it in writing FIRST, in its own commit, before any capture. A metric
 chosen after seeing a result is a tuned metric.
 
+**PHASE 2 — DRAIN RUN 14: CAPTURE REFUSED ON VALIDITY, NOT ON COST OR
+CLASSIFIER. 2026-09-01.**
+
+*AI council 2026-09-01 (drain run 14, round 2 on Phase 2), members
+`anthropic/claude-sonnet-4-5` + `openai/codex-default`, 2 rounds, depth deep,
+peer-review, blind chairman, quorum 2/2 present (needed 1) — concluded.
+Subscription transport, `billable=0`, `$0.0000`. Verdict **QB — do not
+capture**, convergent.* Its ratio in one line: *"the current run lacks both a
+reproducibly fixed subject and an executable path to the required comparison.
+The low cost and green guards do not cure those validity failures."*
+
+**This is NOT the same refusal as drain run 13, and the earlier framing is
+superseded on this point.** Drain 13 recorded a **harness classifier** refusal
+and called the block *"falsifiable and environment-scoped … it clears the moment
+a human runs the frozen protocol themselves, or authorises a session that may
+spend."* Drain 14 was authorised to spend and did not spend, because it found a
+different and stronger block. Measured this run: a live Anthropic key resolves in
+this environment (`~/.event4u/agent-config/anthropic.key`, read at call time by
+`load_anthropic_key`, `src/scripts/ai_council/clients.ts:369`), and the whole
+capture would cost **about two cents**. So neither cost nor the classifier is
+what stops it. What stops it is that the protocol's subject is not reproducible
+from a commit and the required comparison has no identified producer. A later
+reader must not count this as the same refusal twice.
+
+**Drain 14 made ZERO metered calls.** `--confirm` was never passed and no request
+reached any provider API. The dry path was exercised end to end and both arms
+were compared under a stubbed generator.
+
+**The four findings, with the COUNCIL's evidence grades — not the reporting
+session's.**
+
+- **F-A — the subject is not reproducible from the commit. `Confirmed`.**
+  `.claude/` is gitignored in its entirety (`.gitignore:157`; `git ls-files
+  .claude` returns 0), and the projection generator SKIPS any rule already
+  installed byte-identically at user scope. A fresh generation in a clean
+  worktree of this commit reported *"101 rule(s) skipped — byte-identical twin
+  already installed at user scope"* and produced 13 files where a stale
+  projection of the same HEAD held 15. **The narrow claim, and the council cut
+  the wider one:** this proves the run is not reproducible *from the commit
+  alone*. It does **not** prove reproduction is impossible from a captured
+  manifest plus an environment snapshot. "A number nobody can reproduce" was
+  graded overreach and is withdrawn.
+- **F-B — the trial unit is undefined, and the corpus sits exactly on the
+  discordant floor. `Confirmed`.** `decidePairedVerdict`
+  (`src/scripts/_lib/paired_verdict.ts:126`) consumes one signed delta per
+  trial and fixes the aggregation itself, so the free choices are what the
+  scalar measures and what one trial IS. The protocol says neither. At one
+  delta per candidate pair the corpus size (**5**, `max_candidates` in
+  `src/config/harness-evolution-budget.json`) equals `MIN_DISCORDANT` (**5**,
+  `_lib/paired_verdict.ts:78`), so one tie yields `underpowered`, one dissent
+  yields `no-change`, and only a 5-0 sweep can pass in either direction.
+- **F-C — no producer of a paired outcome delta has been identified.
+  `Confirmed` this run, by an end-to-end trace; it was `Inferred` when first
+  reported.** Twelve searches, recorded in
+  `agents/evidence/analysis/drain14-phase2-capture-readiness.md` § F-C. The
+  short form: the only `decidePairedVerdict` caller in `src/` is
+  `_lib/bench_ab_size_claim.ts:101`, whose population is A/B **bench** task
+  pairs (`bench_ab_v2_stats.ts:325-344`), not candidate records; the only
+  `kind: 'paired'` construction in `src/` is inside `parseRow`
+  (`_lib/evolution_roi.ts:536`), a **deserialiser**; `evolution_lab run
+  --vector` and `_lib/evaluation_cascade.ts:414-441` both take the vector as
+  **caller-supplied input**; and the only vector that has ever reached the verb
+  is a hand-authored verdict literal in a test
+  (`tests/scripts/evolution_lab.test.ts:550-560`). Nothing reads two
+  `CandidateRecord`s and emits a delta. **The claim is "no producer has been
+  identified", not "the artefact cannot be produced"** — the council refused the
+  categorical form and the refusal stands even now that the trace is done.
+- **F-D — the frozen protocol misdescribed itself. `clerical`, and repaired
+  this run.** Two halves. (1) It claimed *"The run report records `git
+  rev-parse HEAD`"*; `RunReport` (`_lib/evolution_roi.ts:353-359`) has no commit
+  field, `run_id` is built from candidate ids (`evolution_lab.ts:871`), and
+  `rev-parse` appears nowhere in the closure. The claim is **withdrawn** rather
+  than implemented — `llm_propose` writes no run report at all
+  (`buildRunReport` is reached only from `evolution_lab run`,
+  `evolution_lab.ts:866`), so the field would have described a document the
+  capture never emits, and F-A shows a recorded commit would not have been
+  sufficient anyway. What is lost is stated in the contract: the protocol now
+  claims **no** automatic provenance capture, and comparability rests on the
+  operator recording the commit AND the projection state by hand. (2) Three
+  stale line citations, repaired, plus eight more found by sweeping.
+
+**Two direct answers this run owes the file.**
+
+1. **Fixing F-A is owner-reserved by default.** Changing corpus membership or
+   selection semantics amends a frozen experimental subject. One council seat
+   allowed that a purely provenance-preserving pin of the *same* subjects
+   *might* be autonomous, but held the equivalence undemonstrated — so the
+   default binds and **no manifest was pinned this run**.
+2. **`underpowered` does not discharge AC-2.** It is a legitimate execution
+   status and it is not a directional result: it records that adjudication was
+   unavailable. A run that returns it has not produced the comparison AC-2 asks
+   for, in either direction.
+
+**What must happen before any capture means anything, in order.** No step here
+is started by this run.
+
+1. An **owner ruling on the corpus contract** — F-A's fix is owner-reserved.
+2. **Freeze the complete experimental definition as a whole**: estimand, trial
+   unit, pairing, aggregation, independence assumptions, sign convention and
+   `tieEpsilon`. The council ruled it is frozen entire or not at all, which
+   supersedes the one-slot framing above for the purpose of executing.
+3. **Prove the producer gap end to end** — done this run for the current tree
+   (F-C), and it must be re-established against whatever tree the capture runs
+   on.
+4. **Implement the producer and the provenance record.**
+5. **Repair citations and re-run the dry path from a FRESH CHECKOUT**, requiring
+   identical corpus identity. A dry run in a worktree that inherited a
+   projection is not that check.
+
+**Terminal state of drain run 14, stated as such rather than as a stall.** 2.1,
+2.2, AC-2, AC-3 and AC-4 all stay open. `metered-backend-park` is **not**
+resolved and its 2026-09-01 narrowing stands unchanged; the block recorded here
+is **downstream** of that narrowing, not a re-argument of it. Nothing was closed
+on a fixture, which is Rank 2 of this file's own Risk Register — *"Phase 2 closes
+on a fixture instead of a run"*, risk type `product` — and the paragraph above
+is what that mitigation looks like when it fires.
+
 - [ ] **2.1 An LLM proposer must beat the deterministic one to survive.**
       Transferred whole from `road-to-governed-harness-evolution` step 5.4.
       verify: the comparison is a paired_verdict run, not an argument.

--- a/docs/contracts/metered-proposer-protocol.md
+++ b/docs/contracts/metered-proposer-protocol.md
@@ -196,10 +196,53 @@ the arm did not get to choose which artifacts it is judged on:
 `routeTo` target that no rule can derive from the file, and inventing one would
 be the session under evaluation choosing an input.
 
-**The commit pin is load-bearing.** `.claude/` is a generated projection, so the
-same rule over a different checkout can yield a different set. The run report
-records `git rev-parse HEAD`, and a comparison is only comparable against the
-same commit.
+**The commit pin is load-bearing, and NOTHING CAPTURES IT.** `.claude/` is a
+generated projection, so the same rule over a different checkout can yield a
+different set.
+
+**CORRECTED 2026-09-01 — the claim this paragraph used to make is withdrawn.**
+It read *"The run report records `git rev-parse HEAD`, and a comparison is only
+comparable against the same commit."* The second clause is true and stays. The
+first was false when it was written and is false now: `RunReport`
+(`_lib/evolution_roi.ts:329-335`) has `run_id`, `candidates`,
+`trials_per_candidate`, `roi` and `ladder` and no commit field; `run_id` is
+built from candidate ids (`evolution_lab.ts:871`); and `rev-parse` appears
+nowhere in `evolution_lab.ts`, `llm_propose.ts`, `_lib/evolution_roi.ts` or
+`_lib/llm_candidate_proposer.ts`.
+
+**Withdrawn rather than implemented, and the reason is not effort.** Adding a
+commit field to `RunReport` would not make the sentence true for the arm this
+protocol governs: `llm_propose` writes **no run report at all** — it writes
+candidate records and prints attempts, and `buildRunReport` is reached only from
+`evolution_lab run` (`evolution_lab.ts:866`). The capture path therefore has no
+report for a commit to sit in, so the field would produce a second true-sounding
+claim about a document the capture never emits.
+
+And a recorded commit would not be sufficient even where it landed. `.claude/`
+is gitignored in its entirety (`.gitignore:157`, `git ls-files .claude` → 0), and
+the projection generator SKIPS any rule already installed byte-identically at
+user scope, so the corpus this section enumerates is a function of the
+operator's user-global layer as well as of the commit. Measured 2026-09-01: a
+fresh generation in a clean worktree of the capture commit reported *"101 rule(s)
+skipped — byte-identical twin already installed at user scope"* and produced 13
+files where a stale projection of the same HEAD held 15. An automatic HEAD line
+would have made that corpus look pinned while it was not, which is worse than no
+line at all.
+
+**What is lost by withdrawing.** This protocol now claims **no automatic
+provenance capture whatsoever**. Comparability rests entirely on the operator
+recording, by hand and alongside the results, BOTH the commit the capture ran
+from AND the state of the `.claude/` projection it enumerated — at minimum the
+sorted filenames of the five subjects, because the commit alone does not
+determine them. A capture that records neither is not re-runnable and its result
+is not comparable to any other run, and this document no longer implies
+otherwise.
+
+**What would close it properly** is provenance emitted by the capture path
+itself — the commit plus the enumerated subject list, written by `llm_propose`
+next to the records. That is a change to the frozen mechanism and therefore
+belongs to whoever freezes the remaining slot, not to a repair of a false
+sentence.
 
 ### Number of pairs
 

--- a/docs/contracts/metered-proposer-protocol.md
+++ b/docs/contracts/metered-proposer-protocol.md
@@ -82,7 +82,7 @@ model is a floating alias is not frozen: the alias moves and a later run answers
 a different question. No dated `claude-opus-4-1-*` id exists anywhere in this
 tree, so `modelForTier('high')` throws with a message naming what must be pinned
 first. `high` is reachable only through an `execution_failed` escalation
-(`_lib/evolution_roi.ts:109`), so a run with no transport error never touches it.
+(`_lib/evolution_roi.ts:111`), so a run with no transport error never touches it.
 
 ### Sampling
 
@@ -121,7 +121,7 @@ rather than a selection policy:
 
 1. The first attempt runs on class `reason_unknown`, whose ladder is exactly
    `['lite']` — *"escalating on a reason nobody established is spending on a
-   guess"* (`_lib/evolution_roi.ts:117-119`).
+   guess"* (`_lib/evolution_roi.ts:119-121`).
 2. A refused generation is classified into a `PathologyWhy` by
    `classifyRefusal`, deterministically and from the refusal itself — never from
    the model's opinion of its own output.
@@ -135,7 +135,7 @@ rather than a selection policy:
 
 Per-observation spend is per observation: a new subject starts at the cheapest
 rung again, which the ordering guard allows explicitly — *"retrying `lite` is
-not an escalation"* (`_lib/evolution_roi.ts:203`).
+not an escalation"* (`_lib/evolution_roi.ts:184-185`).
 
 `assertCheapestFirst` (`_lib/evolution_roi.ts:191`) validates the whole attempt
 list before the arm returns.

--- a/docs/contracts/metered-proposer-protocol.md
+++ b/docs/contracts/metered-proposer-protocol.md
@@ -82,7 +82,7 @@ model is a floating alias is not frozen: the alias moves and a later run answers
 a different question. No dated `claude-opus-4-1-*` id exists anywhere in this
 tree, so `modelForTier('high')` throws with a message naming what must be pinned
 first. `high` is reachable only through an `execution_failed` escalation
-(`_lib/evolution_roi.ts:111`), so a run with no transport error never touches it.
+(`_lib/evolution_roi.ts:128`), so a run with no transport error never touches it.
 
 ### Sampling
 
@@ -121,7 +121,7 @@ rather than a selection policy:
 
 1. The first attempt runs on class `reason_unknown`, whose ladder is exactly
    `['lite']` — *"escalating on a reason nobody established is spending on a
-   guess"* (`_lib/evolution_roi.ts:119-121`).
+   guess"* (`_lib/evolution_roi.ts:136-138`).
 2. A refused generation is classified into a `PathologyWhy` by
    `classifyRefusal`, deterministically and from the refusal itself — never from
    the model's opinion of its own output.
@@ -135,9 +135,9 @@ rather than a selection policy:
 
 Per-observation spend is per observation: a new subject starts at the cheapest
 rung again, which the ordering guard allows explicitly — *"retrying `lite` is
-not an escalation"* (`_lib/evolution_roi.ts:184-185`).
+not an escalation"* (`_lib/evolution_roi.ts:201-202`).
 
-`assertCheapestFirst` (`_lib/evolution_roi.ts:191`) validates the whole attempt
+`assertCheapestFirst` (`_lib/evolution_roi.ts:215`) validates the whole attempt
 list before the arm returns.
 
 ### Exclusion policy
@@ -204,7 +204,7 @@ different set.
 It read *"The run report records `git rev-parse HEAD`, and a comparison is only
 comparable against the same commit."* The second clause is true and stays. The
 first was false when it was written and is false now: `RunReport`
-(`_lib/evolution_roi.ts:329-335`) has `run_id`, `candidates`,
+(`_lib/evolution_roi.ts:353-359`) has `run_id`, `candidates`,
 `trials_per_candidate`, `roi` and `ladder` and no commit field; `run_id` is
 built from candidate ids (`evolution_lab.ts:871`); and `rev-parse` appears
 nowhere in `evolution_lab.ts`, `llm_propose.ts`, `_lib/evolution_roi.ts` or

--- a/src/scripts/_lib/evolution_roi.ts
+++ b/src/scripts/_lib/evolution_roi.ts
@@ -41,16 +41,33 @@
  * park intact and there is no live harness to evaluate against. A report that
  * says `unmeasured` is telling the truth about a run that measured nothing.
  *
- * ## The ladder is an ORDERING POLICY, and it has no live subject
+ * ## The ladder is an ORDERING POLICY, and its subject is HALF live
  *
  * "A cheaper model is tried before an expensive one" needs an attempt sequence
- * to police, and there is none: no step in this roadmap invokes a live routing
- * harness (5.2), and `tests/scripts/governed_harness_no_live_harness.test.ts`
- * holds that. So {@link assertCheapestFirst} is a guard proved to FIRE on a
- * synthetic out-of-order sequence, standing over a mechanism that does not yet
- * exist. That is stated here rather than implied, because a guard described as
- * if it were policing real traffic is the coverage inflation this tree's own
- * records name repeatedly.
+ * to police. **CORRECTED 2026-09-01 — one exists now.** This section used to
+ * say there was none and that {@link assertCheapestFirst} stood "over a
+ * mechanism that does not yet exist"; both became false when the metered arm
+ * landed. Two production callers in `_lib/llm_candidate_proposer.ts` produce
+ * {@link LadderAttempt}s: `proposeCandidatesWithModel` calls the guard at
+ * `:417` over the attempts a walk actually made, and `plannedAttempts` at
+ * `:446` over the dry-run plan. Both are reached from `llm_propose.ts` — `:212`
+ * on `--confirm`, `:137` on the dry path, which spends nothing.
+ *
+ * What has NOT happened is a LIVE run. Every population produced so far is
+ * either the dry plan — one `lite` rung per observation on `reason_unknown`, in
+ * which no ordering decision arises at all — or a test population under a
+ * stubbed generator. So the guard stands over a real, non-empty population and
+ * has still never governed a SPENT one, which is what
+ * `road-to-governed-evidence-production` AC-3 stays open on.
+ *
+ * Both halves are stated deliberately. A guard described as if it were policing
+ * real traffic is the coverage inflation this tree's own records name
+ * repeatedly — and a guard still described as policing nothing, after it has
+ * callers, is that same inflation inverted.
+ *
+ * The live-floors park is untouched by any of this: it forbids a live
+ * **routing** harness (5.2), `tests/scripts/governed_harness_no_live_harness.test.ts`
+ * still holds that, and a metered proposer is not one.
  *
  * What IS live is the plan: {@link buildRunReport} puts the per-class ladder
  * into every report, so the cheapest untried tier for each defect class is on
@@ -184,9 +201,16 @@ export interface LadderAttempt {
  * not already spent. A repeat of an already-spent rung is allowed — retrying
  * `lite` is not an escalation — but a jump is not.
  *
- * NO LIVE SUBJECT. Nothing in this programme produces {@link LadderAttempt}s
- * today; see the header. This is a guard waiting for a harness, and its unit
- * test proves it fires rather than proving anything ran.
+ * SUBJECT EXISTS; A SPENT POPULATION DOES NOT (corrected 2026-09-01). This
+ * paragraph used to read "NO LIVE SUBJECT. Nothing in this programme produces
+ * {@link LadderAttempt}s today", and that stopped being true when the metered
+ * arm landed: `_lib/llm_candidate_proposer.ts` produces them from two
+ * production callers — `proposeCandidatesWithModel` (`:417`) and
+ * `plannedAttempts` (`:446`), both reachable from `llm_propose.ts`. No LIVE run
+ * has produced attempts yet, so the ordering this polices has not governed a
+ * spent population; see the header, and AC-3 of
+ * `road-to-governed-evidence-production`. The unit test still proves the guard
+ * FIRES rather than proving anything ran.
  */
 export function assertCheapestFirst(attempts: readonly LadderAttempt[]): void {
     const byClass = new Map<DefectClass, LadderAttempt[]>();

--- a/src/scripts/_lib/llm_candidate_proposer.ts
+++ b/src/scripts/_lib/llm_candidate_proposer.ts
@@ -38,13 +38,13 @@
  * The **pathology of a deterministic refusal**, never the model's opinion of its
  * own output. The first attempt runs on `reason_unknown`, whose ladder is
  * exactly `['lite']` — *"escalating on a reason nobody established is spending
- * on a guess"* (`_lib/evolution_roi.ts:117-119`). A refusal is then classified
+ * on a guess"* (`_lib/evolution_roi.ts:136-138`). A refusal is then classified
  * into a {@link PathologyWhy} by {@link classifyRefusal}, and the walk continues
  * on THAT class's ladder from its cheapest untried rung. A class with an empty
  * ladder stops the walk.
  *
  * Every attempt is recorded and the whole list is checked by
- * `assertCheapestFirst` (`_lib/evolution_roi.ts:191`) before this module
+ * `assertCheapestFirst` (`_lib/evolution_roi.ts:215`) before this module
  * returns — the production caller AC-3 asks for.
  *
  * ## No transport lives here
@@ -292,7 +292,7 @@ async function proposeOne(
     // Per OBSERVATION, deliberately. A new observation is a new proposal and
     // starts at the cheapest rung again; the guard allows that explicitly — a
     // repeat of an already-spent rung "is not an escalation"
-    // (`_lib/evolution_roi.ts:203`). Sharing one map across observations would
+    // (`_lib/evolution_roi.ts:201-202`). Sharing one map across observations would
     // exhaust the ladder on the second subject, which is what the first version
     // of this function did and what its test caught.
     const spentByClass = new Map<PathologyWhy, ModelTier[]>();

--- a/src/scripts/_lib/llm_proposer_transport.ts
+++ b/src/scripts/_lib/llm_proposer_transport.ts
@@ -24,7 +24,7 @@
  * pinned first, rather than resolving an alias and calling the protocol frozen.
  *
  * `high` is reachable only through an `execution_failed` escalation
- * (`_lib/evolution_roi.ts:109`), so a run that never hits a transport error
+ * (`_lib/evolution_roi.ts:128`), so a run that never hits a transport error
  * never touches it.
  *
  * ## Nothing here has been executed

--- a/src/scripts/activation_receipt.ts
+++ b/src/scripts/activation_receipt.ts
@@ -6,8 +6,12 @@
  * `road-to-governed-evidence-production` step 1.1's PRODUCTION CALLER. The
  * producer library (`_lib/activation_receipt_producer.ts`) holds the discipline;
  * this file holds the three real observations and the write. It exists because
- * a library nothing calls has no coverage — the same defect the roadmap keeps
- * open on `assertCheapestFirst`, which polices a population of zero.
+ * a library nothing calls has no coverage — the same defect the roadmap kept
+ * open on `assertCheapestFirst`. **Corrected 2026-09-01:** that one is now half
+ * closed. `assertCheapestFirst` has two production callers in
+ * `_lib/llm_candidate_proposer.ts` (`:417`, `:446`), so it no longer polices a
+ * population of zero; what it still does not police is a SPENT population,
+ * which is what AC-3 stays open on.
  *
  * ## What it observes, and from where
  *

--- a/tests/scripts/_lib/evolution_roi.test.ts
+++ b/tests/scripts/_lib/evolution_roi.test.ts
@@ -12,12 +12,16 @@
  * assertion that the line reaches stdout lives in `evolution_lab.test.ts`,
  * beside the clone fixture it needs.
  *
- * The ladder half has NO live subject and this file does not pretend otherwise:
- * nothing in this programme produces a {@link LadderAttempt}, because step 5.2
- * keeps the live-floors park intact and there is no harness to make a metered
- * call. {@link assertCheapestFirst} is therefore proved to FIRE on synthetic
- * out-of-order sequences and to stay silent on in-order ones — a guard with a
- * proved polarity standing over a mechanism that does not exist yet.
+ * The ladder half HAS a subject now, and it is not a spent one (corrected
+ * 2026-09-01). This paragraph used to say "nothing in this programme produces a
+ * {@link LadderAttempt}"; `_lib/llm_candidate_proposer.ts` produces them from
+ * two production callers (`:417`, `:446`), so the "mechanism that does not
+ * exist yet" wording was false. What is still absent is a LIVE run: every
+ * population so far is the dry plan or a stub, so the ordering has not governed
+ * a spent one, and AC-3 of `road-to-governed-evidence-production` stays open on
+ * exactly that. {@link assertCheapestFirst} is proved here to FIRE on synthetic
+ * out-of-order sequences and to stay silent on in-order ones; that polarity
+ * proof is unchanged, and it was never a claim that anything ran.
  */
 import { describe, expect, it } from 'vitest';
 
@@ -209,7 +213,7 @@ describe('5.6 — the ladder is cheapest-first by construction', () => {
     });
 });
 
-describe('5.6 — assertCheapestFirst, a guard with no live subject', () => {
+describe('5.6 — assertCheapestFirst, a guard whose population is not yet a spent one', () => {
     const seq = (rows: ReadonlyArray<[string, ModelTier]>): LadderAttempt[] =>
         rows.map(([cls, tier], i) => ({
             defect_class: cls as LadderAttempt['defect_class'],


### PR DESCRIPTION
Phase 2 of `road-to-governed-evidence-production` stays open, and this PR records **why** with an evidence grade on every claim. **No metered call was made — `--confirm` was never taken.** Six factual defects found along the way are repaired.

## The headline correction: this is not drain 13's refusal again

Drain 13 recorded that its capture was refused by the *harness safety classifier*, and framed the block as environment-scoped: it *"clears the moment a human runs the frozen protocol themselves, or authorises a session that may spend."*

That framing is **superseded on this point**. A live Anthropic key resolves in this environment (`load_anthropic_key()` returns a 108-char key), and the dry path prices the whole capture at **$0.0158 likely / $0.2080 worst case** against a $5.00 pre-registered ceiling. Cost is not the block and the classifier is not the block. Neither is authority: this session did not author the arm, so it satisfies the park's independent-session test, and the council confirmed that (**1C**).

What stops it is **validity**. Stated so a later reader does not read this as the same refusal twice.

## The council record

AI council 2026-09-01 (drain run 14), members `anthropic/claude-sonnet-4-5` + `openai/codex-default`, 2 rounds each, depth deep, peer-review, blind chairman, quorum 2/2 — concluded. Subscription transport, `billable=0`, `$0.0000`. Round 1: **1C** (independent for capture, but the metric must be frozen outside the capturing session). Round 2 on the evidence below: **QB — do not capture**, convergent.

Its ratio: *"the current run lacks both a reproducibly fixed subject and an executable path to the required comparison. The low cost and green guards do not cure those validity failures."*

Council artefacts are gitignored and auto-pruned, so the text relied on is inlined rather than cited by path (`no-roadmap-references`).

**A round-1 proposal was verified and withdrawn.** One seat proposed committing `SIMPLE_MAJORITY_VOTE` with `ALPHA=0.60, MIN_DISCORDANT=2` as "pre-committed constants". `SIMPLE_MAJORITY_VOTE` **does not exist** anywhere in the tree; the real committed values are `ALPHA = 0.05` (`paired_verdict.ts:51`) and `MIN_DISCORDANT = 5` (`:78`, *derived* by `deriveMinDiscordant()` at `:72`, not chosen). The other seat had already graded it unsupported. Recorded so it cannot be picked up later as a decision.

## The four findings, carrying the council's grades — not ours

- **F-A · Confirmed — the corpus is not reproducible from a commit.** The protocol fixes its subject by enumerating the first 5 byte-sorted `*.md` under `.claude/rules/`. `.claude/` is gitignored end to end (`.gitignore:157`; `git ls-files .claude` → 0). Generating it reported *"101 rule(s) skipped — byte-identical twin already installed at user scope"*, so the set is a function of the operator's user-global install. Measured: the main checkout at this HEAD carries **15** rules where a fresh generation yields **13**. Two runs at one commit enumerate different corpora.
- **F-B · Confirmed — the experiment is undefined, and at the obvious reading it cannot pass.** The protocol never says what one delta represents. At one delta per candidate pair, corpus size (5) *equals* `MIN_DISCORDANT` (5): one tie → `underpowered`, one dissent → `no-change`, only a 5-0 sweep returns `pass`, and `floorWarning` fires on every outcome. The pre-registered budget assumes a different unit (`max_trials_per_candidate: 20`, citing a per-query source).
- **F-C · Confirmed by recorded search — no delta producer identified.** Twelve searches, commands and results recorded. The tree's only `decidePairedVerdict` caller (`bench_ab_size_claim.ts:101`) runs over A/B bench task pairs, not candidate records; the only `kind: 'paired'` construction in `src/` is inside a deserialiser (`evolution_roi.ts:536`); the only vector ever fed to `evolution_lab run` is a hand-authored literal in a test (`evolution_lab.test.ts:550-560`). Stated as an absence established by search at this commit, **not** an impossibility proof — the section names where a correction belongs if someone finds one.
- **F-D · Clerical.** Repaired below.

## Two direct rulings, applied

- **Fixing F-A is owner-reserved by default.** Changing corpus membership or selection semantics amends a frozen experimental subject. One seat allowed that a purely provenance-preserving pin of the *same* subjects *might* be autonomous but held the equivalence undemonstrated. **No manifest was pinned; the corpus contract is untouched.**
- **`underpowered` does not discharge AC-2.** It is a legitimate execution status, not a directional result — it records that adjudication was unavailable. AC-2 stays open.

## Four downgrades applied to our own prose

The council refused four framings as stated, and the refusals were written back rather than dropped: *"a number nobody can reproduce"* (F-A proves not-reproducible-**from-the-commit**, not impossible); *"AC-2's artefact cannot be produced"* (too categorical → "no producer identified"); *"comparability-proven"* (now **observed**, with the digests' own limitation stated); and the cost figures (arithmetic and the committed pricing table now shown). The unsupported risk-register claim now carries its citation — Rank 2, *"Phase 2 closes on a fixture instead of a run"*.

## Six repairs

**The protocol's false provenance claim was withdrawn, not implemented.** It claimed the run report records `git rev-parse HEAD`; `RunReport` has no commit field. Withdrawal was chosen because implementing it would have been theatre: **`llm_propose` writes no run report at all** — `buildRunReport` is reached only from `evolution_lab run` (`evolution_lab.ts:866`), so the field would describe a document the capture never emits. And per F-A an automatic HEAD line would make the corpus *look* pinned while it is not, which is worse than none. What is lost is stated in the contract: comparability now rests on the operator recording the commit **and** the five sorted subject filenames by hand.

**Citation sweeps.** Sweep A over the protocol: 7 citations, 3 stale, 3 fixed, 4 already correct. Sweep B over the tree caught what Sweep A structurally could not — the same three stale citations recurring in shipped code (`llm_candidate_proposer.ts:41`, `:295`, `llm_proposer_transport.ts:27`). Then the repair reproduced the defect it was fixing: adding comment lines to `evolution_roi.ts` shifted its numbering and silently falsified **11 further live citations** across four files, all repaired. Recorded as a structural hazard — a line citation is falsified by any prose edit to the cited file, and no gate notices.

**Comment sweep.** 5 sites asserted a state the code no longer has (*"NO LIVE SUBJECT"*, *"polices a population of zero"*); all 5 corrected to the half-met position and no further — callers exist on an executable path, no live run has produced a spent population. **11 further tree matches were read and excluded**, each named with its reason. AC-3's citations now name declaration **and** call site (`:369`/`:417`, `:429`/`:446`).

## Nothing was closed

2.1, 2.2, AC-2, AC-3 and AC-4 all stay open; checkbox state is unchanged at 4/9. `metered-backend-park` is not resolved — its narrowing stands and the block is now downstream of it. The metric and trial unit are not frozen. This is the honest terminal state of this run, not a stall, and the roadmap now carries the ordered list of what must happen before a capture means anything: owner ruling on the corpus contract → freeze the complete experimental definition → prove the producer gap end to end → build the producer and the provenance record → re-run the dry path from a fresh checkout requiring identical corpus identity.

## Verification

Re-run independently by the orchestrator rather than adopted from the subagent's report: **85/85 tests green** across `proposer_survival_bar` (5), `paired_verdict` (17), `evolution_roi` (28), `llm_candidate_proposer` (26), `governed_harness_no_live_harness` (9). Gates exit 0: `lint_roadmap_blockers` · `lint_roadmap_complexity` · `lint_roadmap_ci_steps` · `check_roadmap_trackable` · `lint_empty_roadmaps` · `lint_roadmap_later_disposition` · `lint_roadmap_family_cap` · `check_estate_count` · `check_references` · `check_no_roadmap_refs` · `lint_evidence_artifacts` · `check_no_external_sources` · `check_md_language`. `tsc --noEmit` clean. The one source diff outside comments is a single line-number citation in the transport docblock.

## Honest nulls

The comparability digests pin **uncommitted** artefacts — neither the probe nor the observations document is committed, and the observations doc derives from a gitignored projection, so another machine can legitimately produce different digests. They inherit F-A; that is why the heading says *observed*, not *proven*. What is established independently of the corpus is a code property: both arms call the same four functions. `check_md_language` needs paths as separate argv words — shell-joining them makes it scan 0 files and exit non-zero, a gate behaviour worth knowing.
