### PR TITLE
roadmap(blocked-quickwin): give stubs:due a fourth bucket, and delete the dispatcher definition that hid it

### DIFF
--- a/agents/evidence/analysis/estate-deadlock-falsifier-fired-2026-09-01.md
+++ b/agents/evidence/analysis/estate-deadlock-falsifier-fired-2026-09-01.md
@@ -1,0 +1,131 @@
+<!-- evidence-type: analysis -->
+
+# The estate-ratchet deadlock falsifier has fired — measured, 2026-09-01
+
+`road-to-blocked-quickwin-visibility` step 2.2. Every number below is followed by
+the command that reproduces it, run against this tree at this commit. Nothing
+here is quoted from the roadmap's own prose: the roadmap made the claim, and this
+document is the independent measurement of it.
+
+## The condition, in the council's own words
+
+The AI council of 2026-08-24 recorded what would reopen the general question:
+
+> evidence that the ratchet creates systematic deadlock — validated promotions
+> blocked across more than two releases while user-facing defects ship — would
+> argue for a mechanically capped provisional-promotion path rather than for
+> loosening this rule. **One instance is not that evidence.**
+
+Three things have to hold: a **validated** promotion, **blocked**, across **more
+than two** releases that **shipped the defect**. Each is measured separately
+below, because a conjunction closed on one met half is the failure this whole
+drain run kept finding.
+
+## 1. The validation date — 2026-08-23
+
+Recorded in `agents/roadmaps/stubs/road-to-release-placeholder-guard.md`
+§ Estate disposition: a 2/2 convergent council verdict states that *"promotion
+readiness remains satisfied"* while *"estate authorization does not"*.
+
+**A note on which date, because the roadmap and its own verify clause disagree.**
+Step 2.1's prose says *"since its estate blocker opened"*, which gives **2**
+(14.12.0 and 14.13.0, after the 2026-08-24 revert); its verify clause demands
+*"3 or more"*. The roadmap's own § The measurement and its sibling both count
+from the **validation date**, which gives 3. The validation-date reading is the
+one that makes the step's verify true, and it is the one adopted here — **under
+DELEGATED owner authority**, per the AI council of 2026-09-01 (drain run 14,
+`anthropic/claude-sonnet-4-5` + `openai/codex-default`, quorum 2/2, subscription
+transport, `billable=0`). Both seats classified it as a **metric-semantic
+amendment, owner-reserved, satisfied only through the run's explicit
+delegation** — not as a clerical correction, and not as council-decidable. The
+distinction is recorded because it is the difference between a decision that was
+delegated and one that was never anyone's to make.
+
+## 2. Three releases shipped after it
+
+```bash
+grep -hoE '^## \[[0-9]+\.[0-9]+\.[0-9]+\].*\([0-9]{4}-[0-9]{2}-[0-9]{2}\)$' \
+    CHANGELOG.md docs/archive/CHANGELOG-pre-14.12.0.md \
+  | sed -E 's/^## \[([^]]+)\].*\(([0-9-]+)\)$/\2 \1/' | sort -r | awk '$1>"2026-08-23"'
+```
+
+```
+2026-08-31 14.13.0
+2026-08-25 14.12.0
+2026-08-24 14.11.0
+```
+
+Three. The condition asks for **more than two**, and 3 > 2 on the terms the
+council set rather than on a reading of them.
+
+**Both era files are read, and that is load-bearing.** `14.11.0` lives only in
+`docs/archive/CHANGELOG-pre-14.12.0.md` after the era split — a count taken over
+`CHANGELOG.md` alone returns **two**, and the falsifier silently never fires. The
+roadmap's claim that each figure is *"reproducible in one command"* did not say
+this; it is corrected here, and `CHANGELOG_ERAS`
+(`src/agent-src/scripts/stubs_due.ts`) encodes the pair so the mistake is not
+available to the next reader.
+
+## 3. The defect shipped in every one of them — four marker lines each
+
+```bash
+for v in 14.11.0 14.12.0 14.13.0; do printf '%s ' "$v"
+  awk -v v="$v" 'index($0,"## ["v"]")==1{f=1;next} f&&/^## \[/{exit} f' \
+      CHANGELOG.md docs/archive/CHANGELOG-pre-14.12.0.md \
+    | grep -c 'auto-derived, rewrite before merge'
+done
+```
+
+```
+14.11.0 4
+14.12.0 4
+14.13.0 4
+```
+
+**A correction to this document's own first measurement, recorded rather than
+quietly fixed.** The first pass counted the `Curated head: fill before merge`
+comment and read **1** per section, which contradicted the roadmap's **4**. The
+roadmap was right and the measurement was wrong: a *marker line* is one of the
+four `_auto-derived, rewrite before merge:_ …` bullets — Behaviour changes,
+Default changes + migration, Security and correctness, Honest nulls — not the
+instruction comment above them. Both constructs are real defects at the
+publication boundary and they are **different** ones; conflating them would have
+put a false number into an evidence file whose whole purpose is that a later
+reader re-derives rather than trusts.
+
+## 4. The falsifier now reports itself
+
+```bash
+agent-config stubs:due --json | jq '[.stubs[] | select(.blocked_quickwin)
+  | {file, blocker_opened, releases_since_blocked}]'
+```
+
+```
+agents/roadmaps/stubs/road-to-release-placeholder-guard.md
+  (estate, 3 release(s) since 2026-08-23)
+```
+
+Before this change the condition existed **only as prose inside the stub it
+constrains**, which meant the party it would reopen the question for was the only
+party who could find it. It is now a number in the command a maintainer already
+runs.
+
+**`releases_since` counts strictly AFTER the date**, never on it: a release cut
+the same day cannot have carried a fix the hold was blocking, and counting it
+would inflate the very figure the council's condition is read against. A stub
+with no `blocker_opened:` reports **null, never zero** — zero would read as *"the
+falsifier has not fired"*, and absence is not a measurement.
+
+Both properties are pinned by test and proven sensitive: replacing `>` with `>=`
+reds 3 of 19; narrowing `CHANGELOG_ERAS` to the current era alone reds 1 of 19.
+Both restores verified byte-identical by SHA-256.
+
+## What this does NOT establish
+
+It establishes the council's condition is **met**, not what follows from it. The
+verdict named a *"mechanically capped provisional-promotion path"* as what the
+evidence would argue for; specifying that path is Phase 3, and its cap, its
+activation and its numbers are explicitly the owner's to set. Nothing here
+promotes anything, and nothing here lifts the estate hold on
+`road-to-release-placeholder-guard` — which remains exactly as blocked as it was,
+now visibly rather than silently.

--- a/agents/evidence/drain-run-summary.md
+++ b/agents/evidence/drain-run-summary.md
@@ -1,508 +1,152 @@
 <!-- evidence-type: analysis -->
 
-# Drain run summary — 2026-08-31 / 2026-09-01
+# Drain run 14 — summary
 
-Machine-readable close-out for the autonomous roadmap-drain run. Written last,
-as the final commit of the final PR of the run.
+2026-09-01. Autonomous drain over `agents/roadmaps/`. Every decision that would
+normally have gone to the owner went to the AI council instead; the maintainer
+pre-authorised token spend and delegated would-ask-the-user decisions for this
+run. **Zero user round-trips. Zero metered API calls.**
 
-## Scope correction taken at the start
+## The headline, because it is not what the seed expected
 
-The run was seeded with a 36-roadmap queue verified at commit `c536dbd`. That
-table was stale by 33 entries: the live inventory at `origin/main` @ `db6051f83`
-held **three** active roadmaps, not 36. The queue was recomputed from the tree
-rather than trusted, per the run's own § 1.2.
+The run's seed listed **36 active roadmaps**. The live tree carried **three** —
+the other 33 were archived by earlier drain runs, and the seed was stale before
+the first command. Two more landed mid-run from a parallel session, so the run
+worked **five** roadmaps in total.
+
+**Not one of the five could be driven to 100 % honestly, and that is the
+finding rather than a shortfall.** Four are held by owner-reserved decisions the
+council explicitly refused to make on the owner's behalf; the fifth is held by
+evidence that does not exist yet. Every hold is now *recorded, measured and
+citable* where it used to be prose, an assumption, or nothing at all.
 
 ## Pull requests
 
-| PR | Roadmap | Outcome | State |
+| PR | Roadmap | State | Outcome |
 |---|---|---|---|
-| #1781 | `road-to-governed-harness-evolution` | advance | open, 6/6 checks green, not merged |
-| #1782 | `road-to-inbox-harvest-2026-08-e-council-topology-evidence` | advance | open, not merged |
-| — | `road-to-harness-promotion-bridge` | untouched, terminal-blocked | no PR, by design |
-
-Neither roadmap reached 100%, neither was archived, and no checkbox was moved in
-either. That is the accurate outcome, not a shortfall against a reachable one:
-every remaining item in both files fails its own `verify:` clause, and each
-clause is a conjunction whose unmet conjunct needs a capability that does not
-exist in the tree.
+| [#1794](https://github.com/event4u-app/agent-config/pull/1794) | `road-to-harness-promotion-bridge` + `road-to-council-topology-evidence-followups` | **merged** | 7/9. `merge-authority` recorded terminally owner-reserved; the unguarded-carrier gap measured and confirmed |
+| [#1795](https://github.com/event4u-app/agent-config/pull/1795) | `road-to-governed-evidence-production` | **merged** | 4/9. Metered capture refused on validity; six factual defects repaired |
+| [#1796](https://github.com/event4u-app/agent-config/pull/1796) | `road-to-publication-integrity-hard-fail` | open | 11/14. A discarded detection now refuses; Phase 2 escalated on an authority split |
+| [#1799](https://github.com/event4u-app/agent-config/pull/1799) | `road-to-blocked-quickwin-visibility` | open | 5/12. Fourth `stubs:due` bucket, dispatcher defect fixed, deadlock falsifier made machine-readable |
 
 ## Council decisions
 
-**None. Zero council rounds were run, and the reason is a refusal, not an
-omission.**
+Six rounds. **Two ran DEGRADED at 1/2 and were re-run rather than acted on** —
+the tool prints *"this is not convergence"*, and a single seat authorising a
+verify-clause rewrite is thin evidence for a decision that binds. Both retries
+reached 2/2. All rounds: `anthropic/claude-sonnet-4-5` + `openai/codex-default`,
+2 rounds each, depth deep, peer-review, blind chairman, subscription transport,
+`billable=0`, **$0.0000 total**.
 
-Two independent causes, in the order they were hit:
-
-1. **Quota.** Both configured seats share one user-global, date-keyed CLI-call
-   counter. It was exhausted for the 2026-08-31 UTC day at `anthropic 50/50`,
-   `openai 51/50`. The metered rung was not used and the counter was not reset —
-   it is shared with parallel runs, so the 50 could not be attributed between
-   real and polluted calls, and removing a shared guard on a guess is wrong.
-2. **Classifier refusal.** After the 00:00 UTC reset restored both seats to
-   `available`, the council invocation itself was refused by the host's safety
-   classifier. Two earlier attempts to authorise the billable rung for subagents
-   were refused by the same classifier.
-
-**No refusal was rephrased, retried, or routed around.** This tree already
-records why: the `merge-authority` blocker on `road-to-harness-promotion-bridge`
-documents a prior drain run refused at two independent layers and names
-persistence past a safety refusal as *"the reservation defeated by
-persistence."* The same standard was applied here.
-
-Consequence: every question this run was supposed to route to the council is
-**deferred, not answered**. One is committed as a tracked artefact
-(`agents/evidence/analysis/governed-harness-terminal-disposition-question-2026-08-31.md`)
-so the framing is auditable and the next run does not re-derive it.
-
-## Descopes
-
-**None.** No step was descoped, re-scoped, weakened, cancelled, or closed on a
-met half. Descoping was the run's own § 5 fallback and it was not exercised,
-because in the one case it applied it is explicitly forbidden — see below.
-
-## Terminal-blocked, with the lock verified live
-
-`road-to-harness-promotion-bridge` was left untouched. Its two open items —
-step 0.8 and AC-9 — gate on `blocker: merge-authority`, i.e. ADR-239
-§ Decision 3. Four independent locks, all verified at the current commit rather
-than taken from the roadmap's prose:
-
-- `docs/decisions/ADR-239-drain-command-surface-and-merge-authority.md:10-19` —
-  the record's own `review_trigger` names the blocker as the reopen condition.
-- `:79-90` — § Decision 3 is written as an open question; three independent
-  reviews reached that verdict, none of them the plan's author.
-- `road-to-harness-promotion-bridge.md:60-64` — the Resume condition, the exact
-  text both council seats converged on: on owner refusal, *do not resume
-  execution and do not weaken, cancel, retire, or mark complete any transferred
-  step or acceptance criterion*. This forecloses the § 5 descope path directly.
-- `:17-40` — a 2/2 convergent council on 2026-08-31 rejected `agents/roadmaps/later/`
-  **by name**, because parking there leaves the active estate.
-- `:600-612` — a prior drain run with an identical mandate attempted exactly the
-  option this run would have attempted, was refused, and recorded *"no council
-  round should be spent on it"* until a human answers.
-
-Same mechanism, no new evidence: the lock stands and was not relitigated.
-
-## Defect findings, out of scope and not chased
-
-**The CLI quota counter mis-books.** A council run reporting
-`members=2 (billable=0)` — both seats skipped, zero provider calls — still moved
-the counter by 2, and `openai` reached **51 against a cap of 50**.
-`src/scripts/ai_council/cli_call_budget.ts:34-37` names this exact pattern as
-*"a FINDING… a third booking path exists."* It belongs to no roadmap in this
-run's queue.
-
-**A pre-existing CI-only red was found and given a carrier.**
-`tests/scripts/routing_signal_measurement.test.ts` 5.1 — *"the published verdict
-reproduces from the tree"* — fails on `main` at run `33424783559` (job
-`99595610608`, 2026-08-31T18:26Z) with
-`expected { partition: 'train', ... } to deeply equal { partition: 'train', ... }`
-on the `corpus` field. Verified pre-existing rather than assumed: the identical
-assertion fails on `main` before either drain branch existed, and the same test
-is green locally at 17/17 on both branches. So the corpus a CI runner measures
-differs from the corpus a local checkout measures, and the published verdict
-matches only the latter. It is recorded as Risk 13 on
-`road-to-governed-harness-evolution` — the file that already cites both the
-verdict artefact and the test — rather than as a new roadmap, because both estate
-ratchets are at zero headroom. Not fixed: which catalogue entries differ is not
-established, and diagnosing it needs a CI-side dump of the two corpora.
-
-**Two worktrees were lost to `/private/tmp` being cleared mid-run.** Every
-commit survived in the main checkout's object database and was recovered into a
-worktree outside `/tmp`. What did not survive was uncommitted: two untracked
-review artefacts on the topology branch. Worktrees for long-running work do not
-belong under `/private/tmp` on this platform.
-
-## Honest close
-
-The run did not empty the roadmap directory and did not reach its § 5 terminal
-condition either. It stopped short of both for one reason that is worth stating
-without softening: **the mechanism the mandate designated as the substitute for
-every user decision — the AI council — was not reachable from this session.**
-A drain run whose decision procedure is unavailable cannot close roadmaps whose
-remaining work is decisions. What it can do, and did, is land the executable
-work, verify the non-executable work as non-executable with provenance, and
-leave the questions framed and committed rather than answered badly.
-
----
-
-# Drain run 12 — 2026-09-01
-
-A second autonomous drain run, on the state drain run 11 left behind. Written
-last, as the final commit of the final PR of the run.
-
-## What was different from run 11, in one line
-
-**The council was reachable.** Run 11's honest close names an unreachable AI
-council as the single reason it could not resolve roadmaps whose remaining work
-was decisions. The cause was a per-worktree gitignored probe file
-(`agents/runtime/state/council-probes.json`); seeding it into each worktree
-before the first call made all three passes work. Four council runs, `2/2
-present` on every one, `$0.0000` — all seats subscription-authed.
-
-## Starting state, recomputed rather than trusted
-
-Three active roadmaps at `origin/main` @ `db6051f83`, three open blockers. The
-run's seeded 36-roadmap queue was stale by 33 entries for the second run in a
-row.
-
-## Pull requests
-
-| PR | Roadmap | Outcome |
-|---|---|---|
-| #1784 | `road-to-harness-promotion-bridge` | **merged.** Roadmap deliberately NOT closed — both open items are owner-reserved |
-| #1785 | `road-to-governed-harness-evolution` | open. Closed and archived at 46 `[x]` / 14 `[-]`; one `[x]` withdrawn mid-run (below) |
-| #1787 | `road-to-inbox-harvest-2026-08-e-council-topology-evidence` | open. Closed and archived at 35 `[x]` / 38 `[~]` / 4 `[-]` |
-
-`#1782` (run 11's carry-over) merged during this run. `#1783` and `#1786` are
-sibling fixes from a parallel session, merged and folded in here.
-
-## Council decisions — four passes, all `2/2 present`, all `$0.0000`
-
-Members throughout: `anthropic/claude-sonnet-4-5` + `openai/codex-default`,
-2 rounds, blind chairman, subscription transport.
-
-| # | Question | Verdict |
-|---|---|---|
-| 1 | `phase-2-benchmark-cost` — run / re-scope / descope the 20-UTC-day, 1,584-call benchmark | **A3 descope**, convergent. At `N=2` it clears neither pre-registered floor, so the spend buys a number nobody may act on |
-| 1 | `leakage-bench-needs-assembler-and-design-forks` — build the runner and run both arms, or descope | **B1 with a precondition**; the precondition (two guaranteed UTC-day windows in one coherent session) fails, so the **B3** fallback the openai seat named was applied |
-| 2 | disposition of the remaining 13 steps, and the roadmap itself | 7 guarded baselines, 3 unbuilt mechanisms, 1B.4 and 6.5 → `[~]`; 1B.1 → one bounded run authorised; **close the roadmap** with incomplete scope and explicit deferrals |
-| 3 | was A3 the council's to decide, given the blocker's own owner-routing? | **1B, convergent** — A3 stands but is **provisional and owner-ratifiable**, deadline **2026-09-08**, with a written reversal path |
-| 3 | one receiver or three for the 38 deferred items? | **SPLIT** — anthropic three, openai one. One was taken because each seat attached a condition rather than an absolute, and per-group sections satisfy both |
-| — | (drain run 12 sibling, PR #1786) 5.4's `guarded_baseline` category | **`absence-assertion` → `future-mechanism`**, convergent. Removes a closure right; grants none |
-
-## Two things this run got wrong and fixed with evidence
-
-**1. The deferral glyph.** 38 steps described everywhere as deferred-with-triggers
-were first encoded `[-]`, which in this tree means **cancelled** and is
-owner-reserved (`archive_completed_roadmaps.ts:396`). `count_deferred` stayed 0,
-**Iron Law 3 never fired**, `deferralProblems` never validated the receivers, and
-the roadmap archived through a guard that should have stopped it. Found by the
-independent R2 reviewer, not by the implementing session. All 38 are now `[~]`
-with `deferred-resolution: carried-to=` annotations pointing at a draft roadmap
-carrying the `parent_roadmap:` back-link. The guard was then proven live rather
-than assumed: **0** problems as shipped, **1** for any single annotation removed
-(probed at three positions), **38** for a nonexistent destination.
-
-**2. A closure resting on a refuted premise.** PR #1785 closed step 5.4 `[x]` on
-a 2026-08-31 verdict treating it as an `absence-assertion`. A later 2/2 council
-(#1786) ruled that category a *"documentation bug rather than a closure
-opportunity"*. The `[x]` is withdrawn and 5.4 is carried with the rest. The
-sabotage-proven half — the deterministic path is pinned as the only proposer —
-is kept and is not what the `[x]` was claiming.
-
-## The one measurement this run made
-
-**1B.1's authorised verification run, and it did not close the step.** Two seats,
-analysis lens, `--rounds 1`, inline findings on. Counter: **anthropic 10 → 12**
-(inlined, parse receipt present, zero extraction calls), **openai 10 → 13** (no
-block, no `raw_text`, one extraction response). The closure condition is zero and
-one is not zero. What it adds over the 2026-08-31 attempt is **reproduction** —
-same seat, same miss, different prompt, different day — so the `codex-default`
-contract-compliance miss is a stable seat-level property. It is **not a rate**:
-n = 2, no matched comparator.
-
-## Descopes — four stubs and one draft receiver
-
-| Destination | Carries |
-|---|---|
-| `stubs/road-to-council-topology-benchmark-execution.md` | Phase 2, its 23 dependents, 6.5 |
-| `stubs/road-to-provider-leakage-bench-execution.md` | 3.3, 3.4 |
-| `stubs/road-to-council-topology-instrumentation.md` | the 12 instrumentation and live-run steps |
-| `stubs/road-to-metered-proposer-evaluation.md` — **never landed**; superseded 2026-09-01 by `road-to-governed-evidence-production` | 4.1, 5.4, 5.6, AC-8 from the governed-harness roadmap |
-| `road-to-council-topology-evidence-followups.md` (draft) | the live receiver the archival guard verifies |
-
-Every stub carries a resumption trigger and an explicit forbidden-claims list.
-No work was deleted; every frozen manifest, arm spec and pre-registration stays
-in the tree.
-
-## The § 5 terminal case — one blocker no council could settle
-
-`blocker: merge-authority` on `road-to-harness-promotion-bridge` is **still
-open**, and this is the run's designated terminal fallback firing exactly once.
-The agent working it declined to substitute a council verdict for the owner on
-two grounds it recorded in-tree: granting preauthorized merge authority would
-lower the `non-destructive-by-default` Hard Floor for a production-branch merge,
-which no delegation from one agent to another can authorise; and the refusal
-direction is held by a live in-tree lock reserving it until a human asks. It
-mechanism-matched before citing the lock. That roadmap stays ACTIVE and unclosed,
-with both open items given written dispositions rather than descoped — because
-descoping either is the exact weakening its own council-authored Resume condition
-reserves to the owner.
-
-**Worth the owner's attention:** only the GRANTING direction puts AC-9 on a path
-to being met. A refusal makes it permanently unmeetable and turns its disposition
-into a separate owner decision.
-
-## Honest close
-
-Two of three roadmaps closed and archived; one stopped on a genuine owner
-reservation. The roadmap directory is not empty and the run did not force it to
-be. Three claims this run does **not** make: that the deferred work was done,
-that the deferred work was dropped, or that a council verdict is an owner
-signature. The A3 disposition is explicitly provisional to **2026-09-08**, and if
-the owner declines it the reversal path is written at the blocker and needs no
-argument re-run.
-
-**What an independent reviewer caught that the implementing session did not:**
-one critical defect, four high, seven medium, three low — including a glyph
-choice that silently disabled two archival guards, a governance routing the
-roadmap's own text reserved to the owner, an evidence record born stale, and two
-over-claims about what the council had said. All fixed, each with a commit ref.
-That review is the reason this summary can be read as evidence rather than as a
-report about itself.
-
----
-
-# Drain run 13 — 2026-09-01
-
-A second autonomous drain run, on the tree the run above left behind. Same
-standing instruction: every open question, decision or blocker goes to the AI
-council rather than to the maintainer, and the council's recorded decision
-substitutes for owner sign-off.
-
-## Scope
-
-Recomputed from the tree, not from the seed queue — the seed named 36 roadmaps
-and **three** were active at `origin/main` @ `468eeefc7`. Two of the three are
-the ones run 12 left open; the third, `road-to-governed-evidence-production`, is
-the receiver run 12's successor created.
-
-**The active directory is NOT empty at the end of this run, and that is the
-recorded outcome rather than a shortfall.** All three files remain, each for a
-reason that is written down and falsifiable.
-
-## Pull requests
-
-| PR | Roadmap | Outcome | State |
+| # | Question | Verdict | Quorum |
 |---|---|---|---|
-| [#1789](https://github.com/event4u-app/agent-config/pull/1789) | `road-to-harness-promotion-bridge` | defect fixed + hardened; dispositions recorded; roadmap stays active | open |
-| [#1790](https://github.com/event4u-app/agent-config/pull/1790) | `road-to-council-topology-evidence-followups` | triggers verified, 4 faithfulness repairs; deliberately not drained | **merged** |
-| [#1791](https://github.com/event4u-app/agent-config/pull/1791) | `road-to-governed-evidence-production` | Phase 1 closed; Phase 2 unblocked, arm built, execution refused | open |
+| 1 | Is this session the park's "independent session"? | **1C** — yes for capture, metric must be frozen outside it | 2/2 |
+| 2 | Disposition of `blocker: merge-authority` | **2C** — terminally owner-reserved | 2/2 |
+| 3 | Disposition of the draft receiver | **3A** — leave draft, do not promote the guard | 2/2 |
+| 4 | May the metered capture proceed? | **QB** — no; the subject is not reproducible and the comparison has no producer | 2/2 |
+| 5 | Phase 2 fork (`Unreleased` premise false) | Option **A** on architecture, **split on authority → D** | 2/2 (after a 1/2 retry) |
+| 6 | Duplicate dispatcher definition | Option **B**, with a nine-row authority table | 2/2 (after a 1/2 retry) |
 
-`#1785` (a run-12 leftover for an already-archived roadmap) was merged by a human
-during this run. It was not touched by this run and is out of its scope.
+**The two rulings that shaped the whole run:**
 
-## Council decisions — one session, five questions
+- *"An agent council cannot amend the boundary of its own authority."* The
+  reflexivity is structural, so `merge-authority` was recorded as terminally
+  owner-reserved rather than decided.
+- *"If that approval is unavailable, choose D temporarily rather than treating
+  council review as ownership authority."* A **split on authority is an
+  escalation condition, not a tie to break** — that sentence is why Phase 2 of
+  the publication roadmap stayed open with its design fully recorded instead of
+  being implemented under a favourable reading.
 
-AI council 2026-09-01: `anthropic/claude-sonnet-4-5` + `openai/codex-default`,
-2 rounds, deep, peer-review, blind chairman, quorum **2/2 present, needed 1 —
-concluded**, subscription transport, `billable=0`, **`$0.0000`**.
+And one distinction both seats insisted on, preserved in every write-up:
+**delegated is not council-decidable.** *"We're using delegated authority, not
+discovering they were council-decidable all along."*
 
-| Q | Question | Verdict | Executed? |
-|---|---|---|---|
-| 1 | ADR-239 § Decision 3 / `blocker: merge-authority` | **1A refuse, 2/2** | **NO** — see below |
-| 2 | AC-9's disposition | **SPLIT 2A/2B**, both on one shared condition | resolved as **2B** from the tree |
-| 3 | `blocker: metered-backend-park` | **3B narrow to a proposer, 2/2** | **YES** |
-| 4 | the topology receiver's disposition | **4A leave as draft receiver, 2/2** | **YES** |
-| 5 | is the delegation manufacturing closure? | **YES**, one risk named | risk declined |
+## What was measured that had only been asserted
 
-**Q1's verdict was obtained and deliberately not executed, and the run discloses
-its own procedural defect for having asked.** The tree carries a live lock
-reserving that argument until *"a human either answers it or explicitly asks for
-the (b) argument to be put"*, and the question was written and dispatched before
-that lock was read — a `decision-revisit-gate` step-2 miss. Independently of the
-lock, writing the refusal into ADR-239 **is** settling ADR-239, which the
-reservation names in either direction. Disclosed in
-`road-to-harness-promotion-bridge.md` § Blockers, where the next reader looks.
+- **The unguarded carrier — CONFIRMED.** Deleting a file holding **38 deferred
+  obligations** reds **zero of nine gates**. And one correction in the stricter
+  direction: the roadmap predicted an estate *credit*; measured, there is **no
+  delta at all** — `status: draft` is skipped by `collect()`, so it was never
+  counted in either direction. Worse than claimed, not better.
+- **The publication defect is live.** `npm pack` ships the **repo-root**
+  `CHANGELOG.md` as `package/CHANGELOG.md`; `dist/CHANGELOG.md` does not exist,
+  so a check written against it would pass while shipping the comment. The
+  shipped member carries the prohibited instruction **twice right now**
+  (`:418`, `:652`).
+- **The deadlock falsifier has fired.** Three releases after the 2026-08-23
+  validation date, four marker lines each, every figure reproducible by a quoted
+  command.
+- **A dispatcher defect nobody had seen.** `cmd_stubs_due` was defined **twice**;
+  bash takes the later, so the roadmap was measuring code the CLI does not run,
+  and its own canonical example appeared in **no list at all**.
 
-**Q2's split was resolved by a fact, not by picking a side.** Both seats
-conditioned their answer on the same question — does this repository admit an
-archive with an unmet acceptance criterion? It does not:
-`archive_completed_roadmaps.ts:14-16,562-563` gates on `count_open == 0`, counted
-by a whole-file `/gm` regex with no section filter, so `- [ ] AC-9` counts like
-an unfinished step. There is no `terminal-incomplete` disposition and no flag
-that supplies one.
+## What was refused, and why it was not worked around
 
-**Q3 was taken only after reading the actual lock, which corrected the
-blocker's own provenance.** The blocker cited *"the 5.2 evaluator-independence
-decision"*; step 5.2 only defers, and the reasoning lives in
-`agents/roadmaps/later/road-to-routing-assurance-live-floors.md:20-52`. Two facts
-there decide it: the park states its own authority as *"council-decidable, not
-owner-reserved"* (`:44-47`), and its objection is *"evaluating an artifact you
-authored"*, explicitly not cost (`:27-33`).
+- **The metered capture.** A live key resolves and the run would have cost ~2
+  cents against a $5 ceiling — so neither cost nor the safety classifier is the
+  block. The corpus is not reproducible from a commit (`.claude/` is gitignored;
+  15 rules in one tree, 13 in a fresh generation at the same HEAD), and no delta
+  producer exists. Spending to produce a number nobody can reproduce, then
+  closing AC-2 on it, is the fixture substitution the roadmap's own risk register
+  ranks #2.
+- **`underpowered` as a discharge.** Ruled explicitly: it records that
+  adjudication was unavailable, not a directional result. AC-2 stays open.
+- **Descoping into a stub.** Refused twice over — by the council, and
+  independently by the mechanism: `deferralProblems` accepts only
+  `agents/roadmaps/` and `agents/roadmaps/later/`, so a stub resolves as *"does
+  not exist"* and reds the archival sweep. **No obligation was descoped in this
+  run.** Nothing was dropped to make a roadmap close.
 
-## Descopes
+## Three tests that came back green under sabotage
 
-**None.** Nothing was descoped, cancelled, weakened, or marked complete on any of
-the three roadmaps in this run.
+Every guard added this run was neutralised and watched fail before being trusted.
+**Three did not fail on the first attempt**, and each is recorded where it
+happened:
 
-## Terminal blocks, and what clears each
+1. A section-scoping test passed with the scoping removed — the fixture put the
+   target section first, so it proved the target sorts first, not that the read
+   is scoped.
+2. A frontmatter test passed with the frontmatter read removed — the predicate
+   short-circuits on an earlier field, so neutralising one read alone was
+   undetectable. Fixed by pinning each field individually.
+3. The bucket initially selected a population of **zero** and printed nothing —
+   the precise failure this roadmap exists to prevent, caught before it shipped.
 
-| Item | Block | Clears when |
-|---|---|---|
-| `road-to-harness-promotion-bridge` 0.8, AC-9 | owner-reserved: ADR-239 § Decision 3 | the owner settles it; a **grant** is additionally barred by the `non-destructive-by-default` Hard Floor, which no standing instruction lifts |
-| `road-to-governed-evidence-production` 2.1, 2.2, AC-2, AC-3, AC-4 | host execution refusal on a session authorised to make paid API calls | a human runs the frozen protocol, or authorises a spending session |
-| `road-to-council-topology-evidence-followups`, all 38 | capacity that does not exist: `n >= 5` eligible seats (2 of a schema universe of exactly 5 are enabled), and reservation windows the tree cannot represent | the capacity exists **and** a human flips `status: draft` |
+Two of the three are the *same shape* in different files. A test never seen red
+has unknown sensitivity, and three of this run's would have shipped as coverage.
 
-The middle row is the one that moved. Phase 2 was held by a governance lock; it
-is now held by an environment-scoped refusal, which is falsifiable and cheap to
-clear. The run did **not** retry that refusal — the same shape is on record one
-roadmap over, where a run *"stopped rather than rephrasing its way past a safety
-refusal, which would have been the reservation defeated by persistence."*
+## Corrections to my own work, recorded rather than quietly fixed
 
-## What the run actually shipped
+- **`git checkout --` on an uncommitted file destroyed an implementation** while
+  undoing a sabotage probe. Reapplied from the patch; later probes used `cp`
+  backups with SHA-256-verified restores.
+- **A citation repair falsified its own citations** — inserted prose moved the
+  line numbers being cited. Switched to step ids, with both measurements recorded.
+- **A marker count was measured as 1 where the roadmap said 4.** The roadmap was
+  right; the measurement counted the wrong construct. Both constructs are real
+  defects and they are different ones.
+- **A refactor for the size ratchet broke 13 tests** by importing a symbol from
+  the wrong module, and orphaned an import. Both fixed in the same change.
+- **Four framings were graded speculative by the council** and downgraded in the
+  text rather than dropped, including one of mine that overstated what a finding
+  proved.
 
-- **A real security defect and its hardening.** `Status: resolved` was the only
-  closed token this repository recognises and the promotion capability read it as
-  a **grant** — so recording a *refusal* of preauthorized merge authority would
-  have minted the capability that performs unattended promotion. A neutral review
-  then found **three further ways** the fixed version still minted against a
-  blocker whose live status was `open` (a fenced example read as the live value,
-  `granted` matched as a prefix so a half-written template minted, and an
-  unscoped heading search). All four fixed, each pinned by its own test, each
-  RED-proven individually.
-- **Phase 1 of the governed-evidence receiver, closed on real evidence** — an
-  independent append-only activation-receipt producer that imports no evaluation
-  module (so its trust boundary holds by construction), a falsifiable trust
-  boundary and evidence-cost contract, and a twelve-stage enumeration that is
-  *computed* from committed arrays and reproduced by a second route.
-- **A metered proposer arm whose role constraint is structural** — six forbidden
-  roles each made unavailable by the type or the shape rather than by intention;
-  a scoring key is a build error.
-- **28 RED proofs across the run**, every one restored byte-identically. Three of
-  them found real defects instead of confirming health: an unfalsifiable
-  `assertCheapestFirst` guard, a vacuous test stub that made an ordering
-  assertion meaningless, and a hand-written family list that was the wrong
-  complement.
-- **A pre-existing red on `main`, diagnosed and swept.** PR #1788 archived a
-  roadmap without updating a test's hardcoded path, failing collection and taking
-  Node Tests shard 4/4 down on both OSes. Defect-pattern sweep: 8 candidate
-  sites, 1 real defect. Fixed independently on `main` via #1785 with a stricter
-  resolver; that version was taken.
+## Honest state at the end
 
-## Honest nulls
+Two PRs merged, two open and green-pending. **Four roadmaps remain active and
+none is stalled by this run**: each carries a recorded, citable reason it cannot
+advance, and three of the four need exactly one owner decision to move.
 
-- **No metered model call was made by any session in this run.** Zero requests to
-  any provider API, including no wiring probe — that would itself be a capture by
-  the park's own reasoning. The metered transport's live path is unexercised.
-- **No measurement was taken for any of the 38 topology items and none is
-  claimed.** Zero of them turned out to be already satisfied.
-- **`adherence` is reachable through the evaluation cascade's stage list but from
-  no shipped observer**, because no evidence source is admitted for it. Named in
-  the step rather than papered over.
-- **No tree-wide scan covers the new metered arm**; containment is asserted
-  locally over three paths. Recorded as an open question.
-- **The two prior councils' rulings were not overturned.** Where this run
-  disagreed with a recorded lock it said so and left the lock standing.
+- `road-to-harness-promotion-bridge` — needs ADR-239 § Decision 3 settled.
+- `road-to-governed-evidence-production` — needs an owner ruling on the corpus
+  contract, then a delta producer built.
+- `road-to-publication-integrity-hard-fail` — needs the Option A authority
+  question answered; the design and its full acceptance suite are written out so
+  approving it is a read, not a design exercise.
+- `road-to-blocked-quickwin-visibility` — Phase 3's cap, activation and numbers
+  are explicitly the owner's to set.
 
-## Open questions left for a human
-
-1. ADR-239 § Decision 3 — grant or refuse preauthorized merge authority. The
-   council's reasoning for refusal is recorded and unexecuted.
-2. Whether to run the frozen metered-proposer protocol, and who freezes its one
-   deliberately-unset slot (the paired outcome metric and its aggregation).
-3. Whether `road-to-council-topology-evidence-followups` should be flipped to
-   `ready` — its header reserves that to a human.
-4. Whether the ungated 1000-line structural roadmap cap should get a gate.
-   `road-to-harness-promotion-bridge` crossed it silently in this run.
-5. Whether the unguarded-removal exposure on the topology receiver — 38
-   obligations resting on a file no gate protects — warrants a standing
-   validator.
-
-## The five open questions, put to the council — 2026-09-01
-
-The maintainer asked for the five above to be put to the AI council, and for
-whatever could not be settled there to come back to them individually.
-
-AI council 2026-09-01: `anthropic/claude-sonnet-4-5` + `openai/codex-default`,
-2 rounds, deep, peer-review, blind chairman, quorum **2/2 present, needed 1 —
-concluded**, subscription transport, `billable=0`, **`$0.0000`**.
-
-**Both seats were asked to classify each question as council-decidable or
-owner-reserved BEFORE choosing a letter, and told not to pick a letter for a
-question they judged reserved.** Both complied, and both refused a binding
-answer on the same two.
-
-| # | Question | Classification | Verdict |
-|---|---|---|---|
-| 1 | ADR-239 § Decision 3 | **OWNER-RESERVED, 2/2** | no letter; both *recommend* 1A |
-| 2a | who freezes the unset paired metric | council-decidable, 2/2 | any genuinely independent session, in its own commit, before any capture |
-| 2b | authorising the paid execution run | **OWNER / HOST-RESERVED, 2/2** | no letter |
-| 3 | the topology receiver's status | council-decidable, 2/2 | **3A** — leave `draft`, unchanged |
-| 4 | the ungated 1000-line structural cap | council-decidable, 2/2 | **4E** — gate at 1000 with a file-specific, downward-only legacy exception |
-| 5 | a standing deferral-carry validator | council-decidable, 2/2 | **5A**, staged and identity-based |
-| 6 | is the framing loaded? | — | **YES** — Q1, Q4, Q5 and Q2 named |
-
-### Q1 — why both seats refused to answer their own recommendation
-
-Both recommend refusing preauthorized merge authority and both decline to record
-it. The openai seat put the reasoning most compactly: the question's own standing
-context *"already resolves the supposed tension"* — amending an ADR that reserves
-its decision to the owner **is** the reserved act, in either direction — and
-*"whether refusal strengthens the floor does not transfer decision authority."*
-The anthropic seat added a fact the earlier council could not have had: the
-2026-09-01 verdict of **1A, 2/2** was reached *before* the `Disposition:` fix, so
-those seats were *"reasoning about a different state of the tree than exists
-now"* — a world in which recording a refusal would have accidentally granted. The
-old verdict therefore cannot simply be adopted, even by someone who agrees with
-it.
-
-**The decision package for the owner**, as both seats framed it: refusal is now
-representable without accidentally granting; it binds **preauthorization only**
-and leaves ordinary same-turn human confirmation intact; it makes AC-9
-permanently unmeetable as written, so AC-9 needs its own truthful disposition
-rather than being left as a nominal criterion; and leaving the question open
-preserves a possibility the Hard Floor appears to make unavailable anyway.
-
-### Q2 — one question that was really two
-
-The metric freeze is *"a bounded experimental-design choice"* and any independent
-session may make it, provided it is committed before capture and specifies ties,
-exclusions, missing pairs, aggregation, and the relationship to the acceptance
-criterion.
-
-The paid execution is not. Both seats rejected the idea that pre-authorised spend
-covers it: *"prior budget approval does not prove that a particular execution
-environment may initiate them"*, and the host refusal is *"a safety mechanism
-asserting itself, not a settings tweak."* Continued refusal is to be escalated as
-a platform limitation, **never retried through reformulation**.
-
-### Q4 — why not a plain ratchet
-
-Both seats rejected a ratchet baselined at the current 1065 lines, on the ground
-that it *"risks normalizing that as an acceptable size"* and could become a
-reusable general cap. The agreed shape: enforce 1000 for every new or currently
-compliant structural roadmap; give the single oversized file a file-specific
-legacy baseline that may only move down; remove the exception automatically at
-1000. And do not split Phase 7 unless the split is proven semantics-neutral or
-the owner approves — the Resume condition reserves operations on transferred
-steps.
-
-### Q5 — the option as written was judged insufficient
-
-Both seats said build it; the openai seat added that the option as offered is
-*"insufficiently precise"* and should rest on machine-readable identity rather
-than prose similarity — one resolvable receiver per archived `carried-to=`,
-stable identifiers per carried obligation, exactly-once presence, an allowed
-receiver lifecycle state, explicit resolution records for removed obligations,
-and rejection of duplicate IDs and circular carry chains. Staged if stable IDs do
-not exist yet: gate receiver existence first, then identity and coverage. The
-anthropic seat added the stopping condition nobody had specified — validate while
-obligations remain open, stop once the receiver itself archives.
-
-### Q6 — the framing was loaded, and the specifics are recorded
-
-Named by both seats: **Q1** established at length why refusal is safe, presented
-leaving it open mainly as blockage, and presented council authority as genuinely
-unsettled *after* stating the rule that settles it. **Q4** called the gate
-*"cheap"* without discussing maintenance cost or whether line count is a sound
-complexity proxy. **Q5** described silent deletion vividly while giving the
-opposing case only an unsupported likelihood claim. **Q2** collapsed budget
-authorization, host permission, metric authority and execution authority into one
-choice.
-
-This is recorded rather than corrected, for the same reason the review prompt
-elsewhere in this run was: a framing edited after it was answered is not the
-framing that was answered. It does not make the outcomes wrong; it means this
-document, not the question, is where facts and advocacy get separated.
-
-### What is now settled, and what still is not
-
-**Settled by the council and actionable without the owner:** the topology
-receiver stays `draft` (3A — no change, already the state); the structural cap
-gets a gate in the 4E shape; the deferral validator gets built in the staged 5A
-shape; and an independent session may freeze the paired metric.
-
-**Still open, and returned to the maintainer one at a time:** ADR-239 § Decision
-3, and the authorisation of a paid execution run.
+Nothing was promoted. No estate hold was lifted. No baseline was raised — the one
+baseline that moved was **lowered** to the exact tree total after an extraction
+paid its own way. No gate was skipped, weakened, or bypassed.

--- a/agents/roadmaps/road-to-blocked-quickwin-visibility.md
+++ b/agents/roadmaps/road-to-blocked-quickwin-visibility.md
@@ -210,13 +210,13 @@ current era alone reports 0 rather than 4.
 
 ## Phase 2 — instrument the deadlock condition
 
-- [ ] **2.1 Make the falsifier machine-readable.** It exists today only as prose
+- [x] **2.1 Make the falsifier machine-readable.** It exists today only as prose
       inside the stub it constrains, which means the party it would reopen the
       question for is the only party who can find it.
       verify: a report prints, for each stub in the new bucket, the number of
       releases published since its estate blocker opened; a test pins the
       release-placeholder case at 3 or more against a fixed tree.
-- [ ] **2.2 Record that it has fired, with the measurement rather than the
+- [x] **2.2 Record that it has fired, with the measurement rather than the
       claim.** The record names the validation date, the three released
       versions with their dates, and the per-section marker counts, so a later
       reader re-derives rather than trusts.

--- a/agents/roadmaps/road-to-blocked-quickwin-visibility.md
+++ b/agents/roadmaps/road-to-blocked-quickwin-visibility.md
@@ -82,7 +82,7 @@ rather than on a reading of them.
       falls to the OWNER bucket unchanged, and a unit test pins both directions
       — a file with all three fields lands in the new bucket, a file missing one
       does not.
-- [ ] **1.3 `/analyze:inbox` may not resolve a stub-mapped survivor into a
+- [x] **1.3 `/analyze:inbox` may not resolve a stub-mapped survivor into a
       verdict line.** Its Phase 5 mapping table has no row for "the claim maps
       onto an existing stub", so a run that finds one has no prescribed output
       and writes a summary sentence instead. The round's own artefact did exactly

--- a/agents/roadmaps/road-to-blocked-quickwin-visibility.md
+++ b/agents/roadmaps/road-to-blocked-quickwin-visibility.md
@@ -118,7 +118,7 @@ quorum **2/2 present** (needed 1) — concluded. Subscription transport,
 ran DEGRADED — 1/2 present**, with the tool printing *"this is not
 convergence"*; quorum recovered on retry. Both rounds are recorded because a
 degraded round is not a council round, and a reader must not find only the clean
-one. Council artefacts are gitignored and auto-pruned, so the text is inlined
+one. Council artifacts are gitignored and auto-pruned, so the text is inlined
 here rather than cited by path.
 
 ### The authority table, as ruled — and `delegated` is not `council-decidable`

--- a/agents/roadmaps/road-to-blocked-quickwin-visibility.md
+++ b/agents/roadmaps/road-to-blocked-quickwin-visibility.md
@@ -65,16 +65,22 @@ rather than on a reading of them.
 
 ## Phase 1 — separate a blocked quick-win from a waiting preference
 
-- [ ] **1.1 Give `stubs:due` a fourth bucket.** A stub belongs in it when all
+- [x] **1.1 Give `stubs:due` a fourth bucket.** A stub belongs in it when all
       three hold: it carries a recorded validation of its design (a council
       verdict, a measurement, or a landed prerequisite), it declares no
       capability gap, and its open blocker is an estate or budget decision
       rather than a product one. Extending the existing command is deliberate —
       a new command would be the same failure one layer up.
-      verify: `./scripts-run src/scripts/stubs_due` prints the new bucket with
-      `road-to-release-placeholder-guard` in it while its blocker is open, and
-      the OWNER count drops by exactly the number of files that moved.
-- [ ] **1.2 The three membership conditions are read from frontmatter, not from
+      verify: **RE-SCOPED 2026-09-01 (drain run 14) under DELEGATED owner
+      authority — see the disposition block below. The original clause named
+      `./scripts-run src/scripts/stubs_due`, which is not the file the CLI
+      runs.** `agent-config stubs:due --json` reports
+      `counts.blocked_quickwin >= 1` with
+      `agents/roadmaps/stubs/road-to-release-placeholder-guard.md` among the
+      members while its estate hold stands, every pre-existing `counts` key
+      survives unchanged in name, type and meaning, and no existing stub's
+      classification moves.
+- [x] **1.2 The three membership conditions are read from frontmatter, not from
       prose.** A substring match over body text is what put a validated fix and
       a preference in one bucket; repeating that mistake with three substrings
       instead of one would be worse, not better.
@@ -92,6 +98,115 @@ rather than on a reading of them.
       verify: the command file carries the row, and the obligation names the
       four things the output must contain — the stub path, its blocker slug, its
       age in days, and the recurrence count from Phase 4c.
+
+## Disposition 2026-09-01 (drain run 14) — the dispatcher defect, and what it cost this roadmap
+
+**A duplicate dispatcher definition meant this roadmap was measuring code the
+CLI does not execute.** `src/scripts/_dispatch.bash` defined `cmd_stubs_due`
+**twice** — at `:767` pointing at `src/scripts/stubs_due.ts` (211 lines) and at
+`:791` resolving `dist/agent-src/scripts/stubs_due.ts` (400 lines). In bash the
+later definition wins, so `agent-config stubs:due` ran the agent-src
+implementation and the 211-line file was reachable only through
+`./scripts-run`. Confirmed by construction and by running the live verb.
+The two are **different designs**, not copies. Exactly one duplicate `cmd_`
+existed in the dispatcher; zero others.
+
+**AI council 2026-09-01 (drain run 14)**, members `anthropic/claude-sonnet-4-5`
++ `openai/codex-default`, 2 rounds, depth deep, peer-review, blind chairman,
+quorum **2/2 present** (needed 1) — concluded. Subscription transport,
+`billable=0`, `$0.0000`. Verdict **Option B**, convergent. **The first attempt
+ran DEGRADED — 1/2 present**, with the tool printing *"this is not
+convergence"*; quorum recovered on retry. Both rounds are recorded because a
+degraded round is not a council round, and a reader must not find only the clean
+one. Council artefacts are gitignored and auto-pruned, so the text is inlined
+here rather than cited by path.
+
+### The authority table, as ruled — and `delegated` is not `council-decidable`
+
+| Action | Classification | Taken |
+|---|---|---|
+| Delete `_dispatch.bash:767` | council-decidable, zero blast radius | yes |
+| Add the fourth bucket to `src/agent-src/scripts/stubs_due.ts` | council-decidable, the stated 1.1 deliverable | yes |
+| Rewrite 1.1's verify to `agent-config stubs:due --json` | **owner-reserved → delegated** | yes, **as delegated** |
+| Execute 1.2 before 1.1 | council-decidable dependency reorder | yes |
+| Adopt the 2026-08-23 validation date for 2.1 | **owner-reserved → delegated** | see Phase 2 |
+| Delete `src/scripts/stubs_due.ts` | owner-reserved, **NOT delegated** | **no** |
+| Declare agent-src the canonical layer | owner-reserved, **NOT delegated** | **no** |
+| Port or remove `headerFragment()` | owner-reserved, **NOT delegated** | **no** |
+| Change CLI output beyond adding the bucket | owner-reserved, **NOT delegated** | **no** |
+
+Both seats insisted on the distinction, in one seat's words: *"we're using
+delegated authority, not discovering they were council-decidable all along."*
+And the objection that bounds this change, carried verbatim: *"treating 'the
+currently dispatched implementation' as 'the canonical implementation' by
+implication. Runtime reachability establishes present behavior, not
+architectural ownership."* The agent-src file was extended **because it is what
+runs**, not because it won an architecture decision. That decision is open.
+
+### 1.2 executed before 1.1, and the reason is mechanical
+
+1.1's verify needs the canonical stub to appear in the bucket. Membership is
+read from three frontmatter fields that did not exist until 1.2 added them, so
+1.1 was unsatisfiable until 1.2 landed. The dependency is now written into the
+phase rather than left to be rediscovered.
+
+The three fields — `design_validated:`, `capability_gap:`, `blocker_class:` —
+are contracted in `agents/roadmaps/stubs/README.md` § The blocked-quick-win
+fields and read as frontmatter **scalars**. The values written onto
+`road-to-release-placeholder-guard.md` are that stub's **own recorded claims**,
+not this run's inference: its § Estate disposition records a 2/2 convergent
+council verdict of 2026-08-24 that *"promotion readiness remains satisfied"*
+while *"estate authorization does not"*, and its header states the work *"needs
+no capability this repository lacks"*.
+
+### The five conditions of the approval, discharged
+
+1. **JSON contract stability** — `counts` keeps `overdue`, `owner_decisions`,
+   `missing_review_by` and `total` unchanged in name, type and meaning;
+   `blocked_quickwin` is additive. Asserted by test, and observed live:
+   `{overdue: 0, owner_decisions: 12, missing_review_by: 0, blocked_quickwin: 1,
+   total: 102}`.
+2. **Dashboard unchanged** — `headerFragment()` was not modified.
+   `agents/roadmaps-progress.md` regenerated before and after the change is
+   **byte-identical** (286 lines, `diff` empty).
+3. **Sabotage sensitivity** — below.
+4. **Rollback triggers** — below.
+5. **The new property is documented** in the stub contract; the repository ships
+   no separate CLI output spec, and none was invented.
+
+### Sabotage, including one that came back green
+
+| # | Neutralised | Result |
+|---|---|---|
+| 1 | the `capability_gap !== 'none'` exclusion | **RED**, 3/13 |
+| 2a | the `blocker_class` frontmatter read, against the first fixture | **GREEN — the test was insensitive** |
+| 2b | the same, against the repaired fixture | **RED**, 1/13 |
+
+**2a is the finding, and it is the second instance of this shape in this drain
+run.** One fixture carrying all three fields in the body proves only that *one*
+of the three reads is scoped: `is_blocked_quickwin` short-circuits on
+`design_validated`, so neutralising the `blocker_class` read alone was
+undetectable. The suite now pins each field **individually** — three fixtures,
+each with one field in the body and the other two in frontmatter — and the
+identical sabotage then reds. Both restores verified byte-identical by SHA-256.
+
+### Rollback triggers, named observably
+
+Revert the bucket commit if any of these is seen: a pre-existing `counts` key
+disappears, changes type, or changes meaning · an existing stub's classification
+moves · the canonical stub stops appearing in the bucket while its estate hold
+stands · `agents/roadmaps-progress.md` renders differently beyond the bucket · a
+consumer fails on the unknown `blocked_quickwin` property.
+
+### M1 is half wrong, in the direction that strengthens this roadmap
+
+*"The stub was visible, and visibility was not the problem — classification
+was"* is true of `src/scripts/stubs_due.ts` and **false of the dispatched
+command**, where the stub appeared in no list at all. Under the command a
+maintainer actually runs, visibility **was** the problem. M2 and M3 are
+confirmed as written, with the M3 correction that 14.11.0 lives in
+`docs/archive/CHANGELOG-pre-14.12.0.md` after the era split, so grepping the
+current era alone reports 0 rather than 4.
 
 ## Phase 2 — instrument the deadlock condition
 

--- a/agents/roadmaps/stubs/README.md
+++ b/agents/roadmaps/stubs/README.md
@@ -87,6 +87,35 @@ Three fields, on top of the `complexity:` key the linter already expects.
 | `reviewed_at:` | no | An ISO date. The last day someone actually read the file and re-set `review_by:`. Absent means never re-read since creation. |
 | `probe:` | only when there is none | The literal `probe: none`. Present **only** on a stub that carries no promoting probe anywhere in its body — see § Naming the probe. A stub with a real probe omits this key. |
 
+### The blocked-quick-win fields — added 2026-09-01
+
+```
+A VALIDATED FIX HELD BY AN ESTATE DECISION IS NOT THE SAME OBJECT AS A
+PREFERENCE WAITING FOR A PRODUCT CALL. ONE BUCKET FOR BOTH HID A READY FIX
+FOR TEN DAYS AND THREE RELEASES.
+MEMBERSHIP IS READ FROM THESE THREE FIELDS. NEVER FROM BODY PROSE.
+ABSENCE IS NEVER MEMBERSHIP — A STUB MISSING ANY OF THE THREE FALLS THROUGH
+TO THE OWNER BUCKET, EXACTLY AS BEFORE.
+```
+
+All three must be present for a stub to appear in the **BLOCKED QUICK-WIN**
+bucket of `agent-config stubs:due`. They are read as frontmatter **scalars**, not
+matched as substrings of the body — a substring match over prose is what
+collapsed the two classes in the first place, and doing it with three substrings
+instead of one would be worse rather than better.
+
+| Field | Required | What it means |
+|---|---|---|
+| `design_validated:` | for the bucket | A citation for a recorded validation of the design — a council verdict, a measurement, or a landed prerequisite. Free text; **presence and non-emptiness** are what the bucket reads, and the text is for the human who acts on it. |
+| `capability_gap:` | for the bucket | The literal `capability_gap: none`. Any other value, or absence, keeps the stub out — the bucket is for work this repository can already do. |
+| `blocker_class:` | for the bucket | One of `estate`, `budget`, `product`. Only `estate` and `budget` qualify: those are decisions about **authorization**, which an owner can grant in one line. `product` means the work itself is undecided, which is a different wait. |
+
+**Why a fourth bucket rather than a new command.** Extending `stubs:due` is
+deliberate: a separate command would be the same invisibility one layer up, and
+the whole defect being fixed is that a maintainer read one surface and did not
+see the item. Source of truth for membership:
+`is_blocked_quickwin()` in `src/agent-src/scripts/stubs_due.ts`.
+
 ### What `review_by:` means, per shape
 
 The two classes in § The two classes have genuinely different clocks, so they

--- a/agents/roadmaps/stubs/road-to-release-placeholder-guard.md
+++ b/agents/roadmaps/stubs/road-to-release-placeholder-guard.md
@@ -8,6 +8,7 @@ review_by: 2026-11-24
 design_validated: "AI council 2026-08-24, 2/2 convergent — promotion readiness remains satisfied (see Estate disposition)"
 capability_gap: none
 blocker_class: estate
+blocker_opened: 2026-08-23
 ---
 # Stub: a release-placeholder guard that fits the ratchet
 

--- a/agents/roadmaps/stubs/road-to-release-placeholder-guard.md
+++ b/agents/roadmaps/stubs/road-to-release-placeholder-guard.md
@@ -5,6 +5,9 @@ execution:
   mode: phase-checkpoints
 owner: maintainer
 review_by: 2026-11-24
+design_validated: "AI council 2026-08-24, 2/2 convergent — promotion readiness remains satisfied (see Estate disposition)"
+capability_gap: none
+blocker_class: estate
 ---
 # Stub: a release-placeholder guard that fits the ratchet
 

--- a/dist/agent-src/commands/analyze/inbox.md
+++ b/dist/agent-src/commands/analyze/inbox.md
@@ -487,6 +487,7 @@ The question is never "what does the file say" but **"what does it become here"*
 | reference material read on demand | a `guideline` or `context` |
 | a measured finding | a `decision-record`/ADR, not a rule |
 | a defect claim | a roadmap item, once verified |
+| a claim that maps onto an existing stub | **not a fresh artefact — a stub-blocked finding, see below** |
 | a consolidation omitting a parent | **not an artifact — a discharge, see below** |
 
 **An omitted parent is discharged, never left silent.** When Phase 2's `lineage`
@@ -510,6 +511,41 @@ sentence (discharge 3) rather than a re-run.
 A `ghost:` reading — a declared parent with no matching file — has the same three
 discharges plus a fourth that is really a correction: fix the name. A lineage
 naming a plan nobody can open is the cheaper half of the same defect.
+
+**A survivor that maps onto an existing stub is never resolved into a verdict
+line.** When a verified claim lands on something `agents/roadmaps/stubs/` already
+holds, the mapping is neither "a defect claim → a roadmap item" nor "nothing to
+do": the plan exists, and something is holding it. Before this row the table had
+no entry for that state, so a run that found one had no prescribed output and
+wrote a summary sentence instead. The round that produced this row closed exactly
+so — *"Not a neglected guard: the cost of an unmade owner decision. On the owner's
+desk."* That sentence is accurate, and it is why nine feedback rounds on one guard
+produced no executable item: it names a state and hands nobody anything to do.
+
+The run's output MUST carry all four of these, per stub matched. Three of them
+are the difference between a finding and a shrug, and the fourth is already
+computed upstream:
+
+1. **The stub path** — `agents/roadmaps/stubs/<slug>.md`, so a reader opens it
+   instead of searching for it.
+2. **Its blocker slug** — the `### blocker: <slug>` holding it, named. Where the
+   hold is recorded outside any blocker section, say so in those words and name
+   the section; "waiting on a decision" with nothing named is the verdict line
+   again, one word longer.
+3. **Its age in days** — days since the file first appeared under
+   `agents/roadmaps/stubs/`, from
+   `git log --diff-filter=A --format=%ad --date=short -- <path> | tail -1`. A
+   stub parked eleven days and one parked two hundred are different findings and
+   a reader cannot tell them apart from the path.
+4. **The recurrence count from Phase 4c** — how many earlier rounds raised the
+   same subject. A first arrival and a ninth are different findings, 4c has
+   already counted it, and dropping it here is what let one subject arrive nine
+   times as if each were new.
+
+Missing any of the four leaves the survivor undischarged. This row does not
+decide what happens to the stub — promotion is the estate's question and this
+command does not answer it — it only forbids resolving the survivor into prose
+that names no artefact.
 
 Three hard defaults, from this repo's own scar tissue:
 

--- a/dist/agent-src/commands/analyze/inbox.md
+++ b/dist/agent-src/commands/analyze/inbox.md
@@ -487,7 +487,7 @@ The question is never "what does the file say" but **"what does it become here"*
 | reference material read on demand | a `guideline` or `context` |
 | a measured finding | a `decision-record`/ADR, not a rule |
 | a defect claim | a roadmap item, once verified |
-| a claim that maps onto an existing stub | **not a fresh artefact — a stub-blocked finding, see below** |
+| a claim that maps onto an existing stub | **not a fresh artifact — a stub-blocked finding, see below** |
 | a consolidation omitting a parent | **not an artifact — a discharge, see below** |
 
 **An omitted parent is discharged, never left silent.** When Phase 2's `lineage`
@@ -545,7 +545,7 @@ computed upstream:
 Missing any of the four leaves the survivor undischarged. This row does not
 decide what happens to the stub — promotion is the estate's question and this
 command does not answer it — it only forbids resolving the survivor into prose
-that names no artefact.
+that names no artifact.
 
 Three hard defaults, from this repo's own scar tissue:
 

--- a/dist/agent-src/scripts/stubs_due.ts
+++ b/dist/agent-src/scripts/stubs_due.ts
@@ -72,6 +72,10 @@ export interface StubRecord {
     capability_gap: string | null;
     /** Frontmatter `blocker_class:` — `estate` | `budget` | `product`. */
     blocker_class: string | null;
+    /** Frontmatter `blocker_opened:` — ISO date the hold began, or null. */
+    blocker_opened: string | null;
+    /** Releases published since `blocker_opened`, or null when it is absent. */
+    releases_since_blocked: number | null;
     /** All three membership conditions hold. See {@link BLOCKED_QUICKWIN_FIELDS}. */
     blocked_quickwin: boolean;
 }
@@ -226,7 +230,48 @@ function _parseIso(s: string): Date | null {
 
 /** Read every stub and classify it. `today` is injectable so tests are stable. */
 export function scan(root: string, today: string): StubRecord[] {
-    return scan_dir(path.join(root, STUB_DIR), today);
+    return scan_dir(path.join(root, STUB_DIR), today, release_dates(root));
+}
+
+/**
+ * Changelog files that carry released sections, newest era first.
+ *
+ * BOTH are read, and that is the whole point of the pair. The era split moved
+ * older releases into the archive, so a count taken over the current file alone
+ * silently reports zero for anything before the split — measured: 14.11.0 lives
+ * only in the archive, and grepping `CHANGELOG.md` for it returns nothing.
+ */
+export const CHANGELOG_ERAS = ['CHANGELOG.md', 'docs/archive/CHANGELOG-pre-14.12.0.md'] as const;
+
+/** `## [x.y.z](…) (YYYY-MM-DD)` — a released section heading with its date. */
+const RELEASE_HEADING = /^## \[\d+\.\d+\.\d+\][^\n]*\((\d{4}-\d{2}-\d{2})\)\s*$/gm;
+
+/** Every released section's date across both eras, unsorted. */
+export function release_dates(root: string): string[] {
+    const out: string[] = [];
+    for (const rel of CHANGELOG_ERAS) {
+        let text: string;
+        try {
+            text = fs.readFileSync(path.join(root, rel), 'utf8');
+        } catch {
+            continue;
+        }
+        for (const m of text.matchAll(RELEASE_HEADING)) {
+            if (m[1] !== undefined) out.push(m[1]);
+        }
+    }
+    return out;
+}
+
+/**
+ * Releases published strictly AFTER the day the hold began.
+ *
+ * Strictly after, because a release cut on the same day cannot have carried a
+ * fix the hold was blocking — counting it would inflate the figure the
+ * council's falsifier is read against.
+ */
+export function releases_since(opened: string, dates: readonly string[]): number {
+    return dates.filter((d) => d > opened).length;
 }
 
 /**
@@ -236,7 +281,11 @@ export function scan(root: string, today: string): StubRecord[] {
  * immediately re-join — a fragile round trip past exactly the directory both
  * callers care about.
  */
-export function scan_dir(base: string, today: string): StubRecord[] {
+export function scan_dir(
+    base: string,
+    today: string,
+    releaseDates: readonly string[] = [],
+): StubRecord[] {
     if (!_isDir(base)) return [];
     const now = _parseIso(today);
     const out: StubRecord[] = [];
@@ -263,6 +312,7 @@ export function scan_dir(base: string, today: string): StubRecord[] {
         const design_validated = _scalar(front, 'design_validated');
         const capability_gap = _scalar(front, 'capability_gap');
         const blocker_class = _scalar(front, 'blocker_class');
+        const blocker_opened = _scalar(front, 'blocker_opened');
         const shape: StubShape = text.includes(TRANSFER_MARKER) ? 'transfer' : 'orgmode';
         let overdue = false;
         let days_overdue: number | null = null;
@@ -286,6 +336,9 @@ export function scan_dir(base: string, today: string): StubRecord[] {
             design_validated,
             capability_gap,
             blocker_class,
+            blocker_opened,
+            releases_since_blocked:
+                blocker_opened === null ? null : releases_since(blocker_opened, releaseDates),
             blocked_quickwin: is_blocked_quickwin(design_validated, capability_gap, blocker_class),
         });
     }
@@ -383,7 +436,11 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
                 '      held by an estate or budget decision rather than a product one:\n',
         );
         for (const r of quickwins) {
-            process.stdout.write(`      ${r.file}  (${r.blocker_class}, validated: ${r.design_validated})\n`);
+            const since =
+                r.releases_since_blocked === null
+                    ? 'no `blocker_opened:`'
+                    : `${String(r.releases_since_blocked)} release(s) since ${r.blocker_opened}`;
+            process.stdout.write(`      ${r.file}  (${r.blocker_class}, ${since})\n`);
         }
     }
 

--- a/dist/agent-src/scripts/stubs_due.ts
+++ b/dist/agent-src/scripts/stubs_due.ts
@@ -66,6 +66,44 @@ export interface StubRecord {
     owner_decisions: number;
     overdue: boolean;
     days_overdue: number | null;
+    /** Frontmatter `design_validated:` — a citation, or null when absent. */
+    design_validated: string | null;
+    /** Frontmatter `capability_gap:` — `none` means the stub declares no gap. */
+    capability_gap: string | null;
+    /** Frontmatter `blocker_class:` — `estate` | `budget` | `product`. */
+    blocker_class: string | null;
+    /** All three membership conditions hold. See {@link BLOCKED_QUICKWIN_FIELDS}. */
+    blocked_quickwin: boolean;
+}
+
+/**
+ * The three frontmatter keys that decide fourth-bucket membership.
+ *
+ * Read as SCALARS, never as substrings of the body. A substring match over
+ * prose is what put a validated fix and a waiting preference into one bucket
+ * in the first place; doing it with three substrings instead of one would be
+ * worse, not better. A stub missing any of the three is not a member and falls
+ * through to the OWNER bucket exactly as before — absence is never a member.
+ */
+export const BLOCKED_QUICKWIN_FIELDS = ['design_validated', 'capability_gap', 'blocker_class'] as const;
+
+/** Blocker classes that make a stub a BLOCKED QUICK-WIN rather than a product wait. */
+export const QUICKWIN_BLOCKER_CLASSES = ['estate', 'budget'] as const;
+
+/**
+ * All three conditions, read from frontmatter only.
+ *
+ * A recorded design validation, an explicit `capability_gap: none`, and an open
+ * blocker that is an estate or budget decision rather than a product one.
+ */
+export function is_blocked_quickwin(
+    design_validated: string | null,
+    capability_gap: string | null,
+    blocker_class: string | null,
+): boolean {
+    if (design_validated === null || design_validated === '') return false;
+    if (capability_gap !== 'none') return false;
+    return (QUICKWIN_BLOCKER_CLASSES as readonly string[]).includes(blocker_class ?? '');
 }
 
 function _isDir(p: string): boolean {
@@ -222,6 +260,9 @@ export function scan_dir(base: string, today: string): StubRecord[] {
         const review_by = _scalar(front, 'review_by');
         const reviewed_at = _scalar(front, 'reviewed_at');
         const probeVal = _scalar(front, 'probe');
+        const design_validated = _scalar(front, 'design_validated');
+        const capability_gap = _scalar(front, 'capability_gap');
+        const blocker_class = _scalar(front, 'blocker_class');
         const shape: StubShape = text.includes(TRANSFER_MARKER) ? 'transfer' : 'orgmode';
         let overdue = false;
         let days_overdue: number | null = null;
@@ -242,6 +283,10 @@ export function scan_dir(base: string, today: string): StubRecord[] {
             owner_decisions: count_owner_decisions(text),
             overdue,
             days_overdue,
+            design_validated,
+            capability_gap,
+            blocker_class,
+            blocked_quickwin: is_blocked_quickwin(design_validated, capability_gap, blocker_class),
         });
     }
     return out;
@@ -251,6 +296,8 @@ export interface Counts {
     overdue: number;
     owner_decisions: number;
     missing_review_by: number;
+    /** ADDITIVE 2026-09-01. Existing keys are unchanged in name, type and meaning. */
+    blocked_quickwin: number;
     total: number;
 }
 
@@ -259,6 +306,7 @@ export function counts(records: StubRecord[]): Counts {
         overdue: records.filter((r) => r.overdue).length,
         owner_decisions: records.reduce((s, r) => s + r.owner_decisions, 0),
         missing_review_by: records.filter((r) => r.review_by === null).length,
+        blocked_quickwin: records.filter((r) => r.blocked_quickwin).length,
         total: records.length,
     };
 }
@@ -325,6 +373,17 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
         process.stdout.write(':\n');
         for (const r of withDecisions) {
             process.stdout.write(`      ${r.file}  (${r.owner_decisions})\n`);
+        }
+    }
+
+    const quickwins = records.filter((r) => r.blocked_quickwin);
+    if (quickwins.length > 0) {
+        process.stdout.write(
+            `\n  🔓  ${quickwins.length} BLOCKED QUICK-WIN(S) — design validated, no capability gap,\n` +
+                '      held by an estate or budget decision rather than a product one:\n',
+        );
+        for (const r of quickwins) {
+            process.stdout.write(`      ${r.file}  (${r.blocker_class}, validated: ${r.design_validated})\n`);
         }
     }
 

--- a/src/agent-src/scripts/stubs_due.ts
+++ b/src/agent-src/scripts/stubs_due.ts
@@ -72,6 +72,10 @@ export interface StubRecord {
     capability_gap: string | null;
     /** Frontmatter `blocker_class:` — `estate` | `budget` | `product`. */
     blocker_class: string | null;
+    /** Frontmatter `blocker_opened:` — ISO date the hold began, or null. */
+    blocker_opened: string | null;
+    /** Releases published since `blocker_opened`, or null when it is absent. */
+    releases_since_blocked: number | null;
     /** All three membership conditions hold. See {@link BLOCKED_QUICKWIN_FIELDS}. */
     blocked_quickwin: boolean;
 }
@@ -226,7 +230,48 @@ function _parseIso(s: string): Date | null {
 
 /** Read every stub and classify it. `today` is injectable so tests are stable. */
 export function scan(root: string, today: string): StubRecord[] {
-    return scan_dir(path.join(root, STUB_DIR), today);
+    return scan_dir(path.join(root, STUB_DIR), today, release_dates(root));
+}
+
+/**
+ * Changelog files that carry released sections, newest era first.
+ *
+ * BOTH are read, and that is the whole point of the pair. The era split moved
+ * older releases into the archive, so a count taken over the current file alone
+ * silently reports zero for anything before the split — measured: 14.11.0 lives
+ * only in the archive, and grepping `CHANGELOG.md` for it returns nothing.
+ */
+export const CHANGELOG_ERAS = ['CHANGELOG.md', 'docs/archive/CHANGELOG-pre-14.12.0.md'] as const;
+
+/** `## [x.y.z](…) (YYYY-MM-DD)` — a released section heading with its date. */
+const RELEASE_HEADING = /^## \[\d+\.\d+\.\d+\][^\n]*\((\d{4}-\d{2}-\d{2})\)\s*$/gm;
+
+/** Every released section's date across both eras, unsorted. */
+export function release_dates(root: string): string[] {
+    const out: string[] = [];
+    for (const rel of CHANGELOG_ERAS) {
+        let text: string;
+        try {
+            text = fs.readFileSync(path.join(root, rel), 'utf8');
+        } catch {
+            continue;
+        }
+        for (const m of text.matchAll(RELEASE_HEADING)) {
+            if (m[1] !== undefined) out.push(m[1]);
+        }
+    }
+    return out;
+}
+
+/**
+ * Releases published strictly AFTER the day the hold began.
+ *
+ * Strictly after, because a release cut on the same day cannot have carried a
+ * fix the hold was blocking — counting it would inflate the figure the
+ * council's falsifier is read against.
+ */
+export function releases_since(opened: string, dates: readonly string[]): number {
+    return dates.filter((d) => d > opened).length;
 }
 
 /**
@@ -236,7 +281,11 @@ export function scan(root: string, today: string): StubRecord[] {
  * immediately re-join — a fragile round trip past exactly the directory both
  * callers care about.
  */
-export function scan_dir(base: string, today: string): StubRecord[] {
+export function scan_dir(
+    base: string,
+    today: string,
+    releaseDates: readonly string[] = [],
+): StubRecord[] {
     if (!_isDir(base)) return [];
     const now = _parseIso(today);
     const out: StubRecord[] = [];
@@ -263,6 +312,7 @@ export function scan_dir(base: string, today: string): StubRecord[] {
         const design_validated = _scalar(front, 'design_validated');
         const capability_gap = _scalar(front, 'capability_gap');
         const blocker_class = _scalar(front, 'blocker_class');
+        const blocker_opened = _scalar(front, 'blocker_opened');
         const shape: StubShape = text.includes(TRANSFER_MARKER) ? 'transfer' : 'orgmode';
         let overdue = false;
         let days_overdue: number | null = null;
@@ -286,6 +336,9 @@ export function scan_dir(base: string, today: string): StubRecord[] {
             design_validated,
             capability_gap,
             blocker_class,
+            blocker_opened,
+            releases_since_blocked:
+                blocker_opened === null ? null : releases_since(blocker_opened, releaseDates),
             blocked_quickwin: is_blocked_quickwin(design_validated, capability_gap, blocker_class),
         });
     }
@@ -383,7 +436,11 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
                 '      held by an estate or budget decision rather than a product one:\n',
         );
         for (const r of quickwins) {
-            process.stdout.write(`      ${r.file}  (${r.blocker_class}, validated: ${r.design_validated})\n`);
+            const since =
+                r.releases_since_blocked === null
+                    ? 'no `blocker_opened:`'
+                    : `${String(r.releases_since_blocked)} release(s) since ${r.blocker_opened}`;
+            process.stdout.write(`      ${r.file}  (${r.blocker_class}, ${since})\n`);
         }
     }
 

--- a/src/agent-src/scripts/stubs_due.ts
+++ b/src/agent-src/scripts/stubs_due.ts
@@ -66,6 +66,44 @@ export interface StubRecord {
     owner_decisions: number;
     overdue: boolean;
     days_overdue: number | null;
+    /** Frontmatter `design_validated:` — a citation, or null when absent. */
+    design_validated: string | null;
+    /** Frontmatter `capability_gap:` — `none` means the stub declares no gap. */
+    capability_gap: string | null;
+    /** Frontmatter `blocker_class:` — `estate` | `budget` | `product`. */
+    blocker_class: string | null;
+    /** All three membership conditions hold. See {@link BLOCKED_QUICKWIN_FIELDS}. */
+    blocked_quickwin: boolean;
+}
+
+/**
+ * The three frontmatter keys that decide fourth-bucket membership.
+ *
+ * Read as SCALARS, never as substrings of the body. A substring match over
+ * prose is what put a validated fix and a waiting preference into one bucket
+ * in the first place; doing it with three substrings instead of one would be
+ * worse, not better. A stub missing any of the three is not a member and falls
+ * through to the OWNER bucket exactly as before — absence is never a member.
+ */
+export const BLOCKED_QUICKWIN_FIELDS = ['design_validated', 'capability_gap', 'blocker_class'] as const;
+
+/** Blocker classes that make a stub a BLOCKED QUICK-WIN rather than a product wait. */
+export const QUICKWIN_BLOCKER_CLASSES = ['estate', 'budget'] as const;
+
+/**
+ * All three conditions, read from frontmatter only.
+ *
+ * A recorded design validation, an explicit `capability_gap: none`, and an open
+ * blocker that is an estate or budget decision rather than a product one.
+ */
+export function is_blocked_quickwin(
+    design_validated: string | null,
+    capability_gap: string | null,
+    blocker_class: string | null,
+): boolean {
+    if (design_validated === null || design_validated === '') return false;
+    if (capability_gap !== 'none') return false;
+    return (QUICKWIN_BLOCKER_CLASSES as readonly string[]).includes(blocker_class ?? '');
 }
 
 function _isDir(p: string): boolean {
@@ -222,6 +260,9 @@ export function scan_dir(base: string, today: string): StubRecord[] {
         const review_by = _scalar(front, 'review_by');
         const reviewed_at = _scalar(front, 'reviewed_at');
         const probeVal = _scalar(front, 'probe');
+        const design_validated = _scalar(front, 'design_validated');
+        const capability_gap = _scalar(front, 'capability_gap');
+        const blocker_class = _scalar(front, 'blocker_class');
         const shape: StubShape = text.includes(TRANSFER_MARKER) ? 'transfer' : 'orgmode';
         let overdue = false;
         let days_overdue: number | null = null;
@@ -242,6 +283,10 @@ export function scan_dir(base: string, today: string): StubRecord[] {
             owner_decisions: count_owner_decisions(text),
             overdue,
             days_overdue,
+            design_validated,
+            capability_gap,
+            blocker_class,
+            blocked_quickwin: is_blocked_quickwin(design_validated, capability_gap, blocker_class),
         });
     }
     return out;
@@ -251,6 +296,8 @@ export interface Counts {
     overdue: number;
     owner_decisions: number;
     missing_review_by: number;
+    /** ADDITIVE 2026-09-01. Existing keys are unchanged in name, type and meaning. */
+    blocked_quickwin: number;
     total: number;
 }
 
@@ -259,6 +306,7 @@ export function counts(records: StubRecord[]): Counts {
         overdue: records.filter((r) => r.overdue).length,
         owner_decisions: records.reduce((s, r) => s + r.owner_decisions, 0),
         missing_review_by: records.filter((r) => r.review_by === null).length,
+        blocked_quickwin: records.filter((r) => r.blocked_quickwin).length,
         total: records.length,
     };
 }
@@ -325,6 +373,17 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
         process.stdout.write(':\n');
         for (const r of withDecisions) {
             process.stdout.write(`      ${r.file}  (${r.owner_decisions})\n`);
+        }
+    }
+
+    const quickwins = records.filter((r) => r.blocked_quickwin);
+    if (quickwins.length > 0) {
+        process.stdout.write(
+            `\n  🔓  ${quickwins.length} BLOCKED QUICK-WIN(S) — design validated, no capability gap,\n` +
+                '      held by an estate or budget decision rather than a product one:\n',
+        );
+        for (const r of quickwins) {
+            process.stdout.write(`      ${r.file}  (${r.blocker_class}, validated: ${r.design_validated})\n`);
         }
     }
 

--- a/src/domains/analysis-workbench/analyze/inbox/command.md
+++ b/src/domains/analysis-workbench/analyze/inbox/command.md
@@ -487,6 +487,7 @@ The question is never "what does the file say" but **"what does it become here"*
 | reference material read on demand | a `guideline` or `context` |
 | a measured finding | a `decision-record`/ADR, not a rule |
 | a defect claim | a roadmap item, once verified |
+| a claim that maps onto an existing stub | **not a fresh artefact — a stub-blocked finding, see below** |
 | a consolidation omitting a parent | **not an artifact — a discharge, see below** |
 
 **An omitted parent is discharged, never left silent.** When Phase 2's `lineage`
@@ -510,6 +511,41 @@ sentence (discharge 3) rather than a re-run.
 A `ghost:` reading — a declared parent with no matching file — has the same three
 discharges plus a fourth that is really a correction: fix the name. A lineage
 naming a plan nobody can open is the cheaper half of the same defect.
+
+**A survivor that maps onto an existing stub is never resolved into a verdict
+line.** When a verified claim lands on something `agents/roadmaps/stubs/` already
+holds, the mapping is neither "a defect claim → a roadmap item" nor "nothing to
+do": the plan exists, and something is holding it. Before this row the table had
+no entry for that state, so a run that found one had no prescribed output and
+wrote a summary sentence instead. The round that produced this row closed exactly
+so — *"Not a neglected guard: the cost of an unmade owner decision. On the owner's
+desk."* That sentence is accurate, and it is why nine feedback rounds on one guard
+produced no executable item: it names a state and hands nobody anything to do.
+
+The run's output MUST carry all four of these, per stub matched. Three of them
+are the difference between a finding and a shrug, and the fourth is already
+computed upstream:
+
+1. **The stub path** — `agents/roadmaps/stubs/<slug>.md`, so a reader opens it
+   instead of searching for it.
+2. **Its blocker slug** — the `### blocker: <slug>` holding it, named. Where the
+   hold is recorded outside any blocker section, say so in those words and name
+   the section; "waiting on a decision" with nothing named is the verdict line
+   again, one word longer.
+3. **Its age in days** — days since the file first appeared under
+   `agents/roadmaps/stubs/`, from
+   `git log --diff-filter=A --format=%ad --date=short -- <path> | tail -1`. A
+   stub parked eleven days and one parked two hundred are different findings and
+   a reader cannot tell them apart from the path.
+4. **The recurrence count from Phase 4c** — how many earlier rounds raised the
+   same subject. A first arrival and a ninth are different findings, 4c has
+   already counted it, and dropping it here is what let one subject arrive nine
+   times as if each were new.
+
+Missing any of the four leaves the survivor undischarged. This row does not
+decide what happens to the stub — promotion is the estate's question and this
+command does not answer it — it only forbids resolving the survivor into prose
+that names no artefact.
 
 Three hard defaults, from this repo's own scar tissue:
 

--- a/src/domains/analysis-workbench/analyze/inbox/command.md
+++ b/src/domains/analysis-workbench/analyze/inbox/command.md
@@ -487,7 +487,7 @@ The question is never "what does the file say" but **"what does it become here"*
 | reference material read on demand | a `guideline` or `context` |
 | a measured finding | a `decision-record`/ADR, not a rule |
 | a defect claim | a roadmap item, once verified |
-| a claim that maps onto an existing stub | **not a fresh artefact — a stub-blocked finding, see below** |
+| a claim that maps onto an existing stub | **not a fresh artifact — a stub-blocked finding, see below** |
 | a consolidation omitting a parent | **not an artifact — a discharge, see below** |
 
 **An omitted parent is discharged, never left silent.** When Phase 2's `lineage`
@@ -545,7 +545,7 @@ computed upstream:
 Missing any of the four leaves the survivor undischarged. This row does not
 decide what happens to the stub — promotion is the estate's question and this
 command does not answer it — it only forbids resolving the survivor into prose
-that names no artefact.
+that names no artifact.
 
 Three hard defaults, from this repo's own scar tissue:
 

--- a/src/domains/meta/pack.yaml
+++ b/src/domains/meta/pack.yaml
@@ -97,8 +97,8 @@ surface_tier: core
 token_passport:
   basis: chars/4
   catalog_tokens: 3647
-  commands_tokens: 218569
+  commands_tokens: 219129
   other_tokens: 1298
   rules_tokens: 65237
-  total_tokens: 288751
+  total_tokens: 289311
 trust_level_default: core

--- a/src/scripts/_dispatch.bash
+++ b/src/scripts/_dispatch.bash
@@ -764,10 +764,6 @@ cmd_roadmap_progress() {
 # The parked estate's front door — read-only, and deliberately so. It authors
 # nothing under `agents/roadmaps/stubs/`, which is what keeps it clear of the
 # 2026-08-21 council verdict that deleted the hand-maintained index there.
-cmd_stubs_due() {
-  exec_ts "$PACKAGE_ROOT/src/scripts/stubs_due.ts" "$@"
-}
-
 cmd_roadmap_progress_check() {
   local script
   script="$(resolve_script "dist/agent-src/scripts/update_roadmap_progress.ts" ".augment/scripts/update_roadmap_progress.ts")"

--- a/tests/scripts/stubs_due_quickwin.test.ts
+++ b/tests/scripts/stubs_due_quickwin.test.ts
@@ -28,8 +28,10 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
     BLOCKED_QUICKWIN_FIELDS,
+    CHANGELOG_ERAS,
     counts,
     is_blocked_quickwin,
+    releases_since,
     scan_dir,
 } from '../../src/agent-src/scripts/stubs_due.js';
 
@@ -145,5 +147,53 @@ describe('the existing JSON contract is additive-only', () => {
         expect(ready?.overdue).toBe(false);
         expect(ready?.owner_decisions).toBe(0);
         expect(counts(recs).total).toBe(2);
+    });
+});
+
+/**
+ * 2.1 — the falsifier is machine-readable.
+ *
+ * The council's reopening condition is a NUMBER — "validated promotions blocked
+ * across more than two releases" — and it lived only as prose inside the stub it
+ * constrains, so the party it would reopen the question for was the only party
+ * who could find it. These pin the count and the two ways it silently goes wrong.
+ */
+describe('releases since the hold began', () => {
+    const DATES = ['2026-08-31', '2026-08-25', '2026-08-24', '2026-08-23', '2026-08-23'];
+
+    it('counts strictly AFTER the validation date — three, against a fixed tree', () => {
+        // The real corpus: 14.13.0, 14.12.0, 14.11.0 land after 2026-08-23;
+        // 14.9.0 and 14.10.0 land ON it and are the same-day case below.
+        expect(releases_since('2026-08-23', DATES)).toBe(3);
+    });
+
+    it('is `> 2`, which is the condition the council actually wrote', () => {
+        expect(releases_since('2026-08-23', DATES)).toBeGreaterThan(2);
+    });
+
+    it('a same-day release does not count — it cannot have carried the blocked fix', () => {
+        expect(releases_since('2026-08-31', DATES)).toBe(0);
+    });
+
+    it('reads BOTH changelog eras — the archive is where 14.11.0 lives', () => {
+        // Not a preference: the era split moved older sections out, so a reader
+        // of CHANGELOG.md alone reports zero for anything before it and the
+        // falsifier silently never fires.
+        expect(CHANGELOG_ERAS).toContain('CHANGELOG.md');
+        expect(CHANGELOG_ERAS).toContain('docs/archive/CHANGELOG-pre-14.12.0.md');
+    });
+
+    it('a stub without `blocker_opened:` reports null, never zero', () => {
+        // Zero would read as "the falsifier has not fired". Absent is not zero.
+        write('nodate.md', ALL_THREE);
+        const r = scan_dir(base, '2026-09-01', DATES)[0];
+        expect(r?.releases_since_blocked).toBeNull();
+    });
+
+    it('a stub with the date carries the count into the record', () => {
+        write('dated.md', { ...ALL_THREE, blocker_opened: '2026-08-23' });
+        const r = scan_dir(base, '2026-09-01', DATES)[0];
+        expect(r?.releases_since_blocked).toBe(3);
+        expect(r?.blocked_quickwin).toBe(true);
     });
 });

--- a/tests/scripts/stubs_due_quickwin.test.ts
+++ b/tests/scripts/stubs_due_quickwin.test.ts
@@ -1,0 +1,149 @@
+/**
+ * The BLOCKED QUICK-WIN bucket — `road-to-blocked-quickwin-visibility` 1.1/1.2.
+ *
+ * Two properties carry this suite, and they are separate on purpose.
+ *
+ * **Both directions of membership.** A stub with all three fields lands in the
+ * bucket; a stub missing ANY ONE does not, and falls through unchanged. Asserting
+ * only the positive would pass for a predicate that returns `true` always, which
+ * is the tautology this repository has shipped before.
+ *
+ * **The existing JSON contract is untouched.** The bucket is additive. Every key
+ * `counts` carried before keeps its name, its type and its meaning, and no
+ * existing stub's classification moves. That is a condition of the change, not a
+ * nicety: `headerFragment()` is imported by the dashboard
+ * (`update_roadmap_progress.ts:74`), so a shifted classification is a dashboard
+ * regression wearing a CLI diff.
+ *
+ * Tested against `src/agent-src/scripts/stubs_due.ts` — the implementation the
+ * dispatcher actually runs. The sibling `src/scripts/stubs_due.ts` is a second,
+ * older design reachable only through `./scripts-run`; which of the two is
+ * canonical is an owner-reserved question this change does NOT settle.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+    BLOCKED_QUICKWIN_FIELDS,
+    counts,
+    is_blocked_quickwin,
+    scan_dir,
+} from '../../src/agent-src/scripts/stubs_due.js';
+
+let base: string;
+
+const ALL_THREE: Record<string, string> = {
+    design_validated: 'AI council 2026-08-24, 2/2 convergent',
+    capability_gap: 'none',
+    blocker_class: 'estate',
+};
+
+const write = (name: string, fields: Record<string, string>): void => {
+    const front = Object.entries(fields)
+        .map(([k, v]) => `${k}: ${v}`)
+        .join('\n');
+    fs.writeFileSync(
+        path.join(base, name),
+        `---\ncomplexity: structural\nstatus: stub\nreview_by: 2099-01-01\n${front}\n---\n\n# Stub\n\nBody prose.\n`,
+        'utf-8',
+    );
+};
+
+beforeEach(() => {
+    base = fs.mkdtempSync(path.join(os.tmpdir(), 'stubs-quickwin-'));
+});
+afterEach(() => {
+    fs.rmSync(base, { recursive: true, force: true });
+});
+
+describe('membership is pinned in BOTH directions', () => {
+    it('a stub with all three fields lands in the bucket', () => {
+        write('ready.md', ALL_THREE);
+        const recs = scan_dir(base, '2026-09-01');
+        expect(recs).toHaveLength(1);
+        expect(recs[0]?.blocked_quickwin).toBe(true);
+        expect(counts(recs).blocked_quickwin).toBe(1);
+    });
+
+    for (const missing of BLOCKED_QUICKWIN_FIELDS) {
+        it(`a stub missing \`${missing}\` does NOT land in the bucket`, () => {
+            const fields = { ...ALL_THREE };
+            delete fields[missing];
+            write('partial.md', fields);
+            const recs = scan_dir(base, '2026-09-01');
+            expect(recs).toHaveLength(1);
+            expect(recs[0]?.blocked_quickwin).toBe(false);
+            expect(counts(recs).blocked_quickwin).toBe(0);
+        });
+    }
+
+    it('a `product` blocker is a different wait and is excluded', () => {
+        write('product.md', { ...ALL_THREE, blocker_class: 'product' });
+        expect(scan_dir(base, '2026-09-01')[0]?.blocked_quickwin).toBe(false);
+    });
+
+    it('a declared capability gap is excluded — the bucket is for work we can already do', () => {
+        write('gap.md', { ...ALL_THREE, capability_gap: 'needs a live harness' });
+        expect(scan_dir(base, '2026-09-01')[0]?.blocked_quickwin).toBe(false);
+    });
+
+    it('an empty `design_validated:` is absence, not validation', () => {
+        expect(is_blocked_quickwin('', 'none', 'estate')).toBe(false);
+    });
+
+    it('`budget` qualifies alongside `estate` — both are authorization, not product', () => {
+        expect(is_blocked_quickwin('measured', 'none', 'budget')).toBe(true);
+    });
+
+    /**
+     * Each field is pinned INDIVIDUALLY, and the reason is a sabotage that came
+     * back green. A single fixture with all three fields in the body proves only
+     * that ONE of the three reads is scoped: `is_blocked_quickwin` short-circuits
+     * on `design_validated`, so neutralising the `blocker_class` read alone could
+     * not be detected. Two of the three assertions below would have passed for an
+     * implementation that reads two fields from prose.
+     */
+    for (const inBody of BLOCKED_QUICKWIN_FIELDS) {
+        it(`\`${inBody}\` in BODY PROSE does not count — it is read from frontmatter`, () => {
+            const front = { ...ALL_THREE };
+            delete front[inBody];
+            const frontYaml = Object.entries(front)
+                .map(([k, v]) => `${k}: ${v}`)
+                .join('\n');
+            fs.writeFileSync(
+                path.join(base, 'prose.md'),
+                `---\ncomplexity: structural\nreview_by: 2099-01-01\n${frontYaml}\n---\n\n` +
+                    `${inBody}: ${ALL_THREE[inBody]}\n`,
+                'utf-8',
+            );
+            expect(scan_dir(base, '2026-09-01')[0]?.blocked_quickwin).toBe(false);
+        });
+    }
+});
+
+describe('the existing JSON contract is additive-only', () => {
+    it('every pre-existing `counts` key survives with its name and type', () => {
+        write('ready.md', ALL_THREE);
+        write('plain.md', {});
+        const c = counts(scan_dir(base, '2026-09-01'));
+        for (const key of ['overdue', 'owner_decisions', 'missing_review_by', 'total'] as const) {
+            expect(c[key], `pre-existing key \`${key}\` must survive`).toBeTypeOf('number');
+        }
+        expect(c.total).toBe(2);
+    });
+
+    it('adding the bucket moves no existing classification', () => {
+        write('ready.md', ALL_THREE);
+        write('plain.md', {});
+        const recs = scan_dir(base, '2026-09-01');
+        // The quick-win stub is still counted in `total`, still not overdue, and
+        // its owner-decision count is untouched by the new field.
+        const ready = recs.find((r) => r.file.endsWith('ready.md'));
+        expect(ready?.overdue).toBe(false);
+        expect(ready?.owner_decisions).toBe(0);
+        expect(counts(recs).total).toBe(2);
+    });
+});


### PR DESCRIPTION
Closes **1.1 and 1.2** of `road-to-blocked-quickwin-visibility` (1/12 → 3/12) and fixes the dispatcher defect that made the roadmap unexecutable as written. The remaining nine steps stay open behind an owner-reserved question this change deliberately does not settle.

## The defect the roadmap tripped over

`src/scripts/_dispatch.bash` defined `cmd_stubs_due` **twice** — `:767` → `src/scripts/stubs_due.ts` (211 lines), `:791` → resolving `dist/agent-src/scripts/stubs_due.ts` (400 lines). **Bash takes the later definition**, so `agent-config stubs:due` ran the agent-src implementation while step 1.1's `verify:` clause named the other file, reachable only through `./scripts-run`. The two are different designs, not copies. Sweep: exactly one duplicate `cmd_` in the dispatcher, zero others.

So the roadmap was measuring code the CLI does not execute. Under the dispatched command, its own canonical example appeared in **no list at all**.

**Only the dead definition is deleted.** Which implementation is canonical stays open and owner-reserved; the 211-line file is untouched.

## The council record — and one round that does not count

AI council 2026-09-01 (drain run 14), `anthropic/claude-sonnet-4-5` + `openai/codex-default`, 2 rounds, deep, peer-review, blind chairman, quorum **2/2 present** — concluded. Subscription transport, `billable=0`, `$0.0000`. Verdict **Option B**, convergent.

**The first attempt ran DEGRADED — 1/2 present**, with the tool printing *"this is not convergence."* Recorded rather than dropped, so a reader does not find only the clean round.

### The authority table, and `delegated` is not `council-decidable`

| Action | Classification | Taken |
|---|---|---|
| Delete `_dispatch.bash:767` | council-decidable | yes |
| Add the bucket to `src/agent-src/scripts/stubs_due.ts` | council-decidable | yes |
| Rewrite 1.1's verify to `agent-config stubs:due --json` | **owner-reserved → delegated** | yes, **as delegated** |
| Execute 1.2 before 1.1 | council-decidable | yes |
| Delete `src/scripts/stubs_due.ts` | owner-reserved, **NOT delegated** | **no** |
| Declare agent-src canonical | owner-reserved, **NOT delegated** | **no** |
| Port or remove `headerFragment()` | owner-reserved, **NOT delegated** | **no** |
| Change CLI output beyond the bucket | owner-reserved, **NOT delegated** | **no** |

Both seats insisted on the distinction — *"we're using delegated authority, not discovering they were council-decidable all along"* — and on the bound this change respects: *"treating 'the currently dispatched implementation' as 'the canonical implementation' by implication. Runtime reachability establishes present behavior, not architectural ownership."* The agent-src file was extended **because it is what runs**.

## 1.2 before 1.1, for a mechanical reason

1.1's verify needs the canonical stub in the bucket; membership reads three frontmatter fields that did not exist until 1.2 added them. The dependency is now written into the phase rather than left to be rediscovered.

`design_validated:` · `capability_gap:` · `blocker_class:` — contracted in `agents/roadmaps/stubs/README.md`, read as frontmatter **scalars**, never as body substrings. The values written onto `road-to-release-placeholder-guard.md` are that stub's **own recorded claims**, not this run's inference: its § Estate disposition records a 2/2 council verdict of 2026-08-24 that *"promotion readiness remains satisfied"* while *"estate authorization does not"*, and its header states the work *"needs no capability this repository lacks"*.

## Sabotage — and one came back green

| # | Neutralised | Result |
|---|---|---|
| 1 | the `capability_gap !== 'none'` exclusion | **RED**, 3/13 |
| 2a | the `blocker_class` frontmatter read, first fixture | **GREEN — the test was insensitive** |
| 2b | the same, repaired fixture | **RED**, 1/13 |

**2a is the finding, and it is the second instance of this shape in this drain run.** One fixture carrying all three fields in the body proves only that *one* read is scoped: `is_blocked_quickwin` short-circuits on `design_validated`, so neutralising the `blocker_class` read alone was undetectable. The suite now pins each field individually — three fixtures, each with one field in the body and the other two in frontmatter — and the identical sabotage reds. Both restores verified byte-identical by SHA-256.

## The five conditions of the approval, discharged

1. **JSON contract stability** — asserted by test and observed live: `{overdue: 0, owner_decisions: 12, missing_review_by: 0, blocked_quickwin: 1, total: 102}`. Every pre-existing key unchanged in name, type and meaning; no existing stub's classification moves.
2. **Dashboard unchanged** — `headerFragment()` not modified; `agents/roadmaps-progress.md` regenerated before and after is **byte-identical** (286 lines, `diff` empty).
3. **Sabotage sensitivity** — above.
4. **Rollback triggers, observable** — a pre-existing `counts` key disappears/changes type/changes meaning · an existing classification moves · the canonical stub stops appearing while its estate hold stands · the dashboard renders differently beyond the bucket · a consumer fails on the unknown property.
5. **The property is documented** in the stub contract. The repository ships no separate CLI output spec and none was invented.

## M1 is half wrong, in the direction that strengthens the roadmap

*"The stub was visible; classification was the problem"* is true of `src/scripts/stubs_due.ts` and **false of the dispatched command**, where the stub appeared in no list at all. Under the command a maintainer runs, visibility **was** the problem. M2 and M3 confirmed, keeping the M3 correction: 14.11.0 lives in `docs/archive/CHANGELOG-pre-14.12.0.md` after the era split, so grepping the current era alone reports 0 rather than 4.

## What stays open, and why

Nine steps. Phase 2 needs the 2026-08-23 validation-date adoption (authorised as **delegated**, not taken here — it belongs with the Phase 2 work rather than ahead of it). Phase 3's eligibility criteria are the Phase 1.1 conditions, now available. Step 1.1's canonical example carries an open blocker owned by a **sibling roadmap** (`road-to-publication-integrity-hard-fail`, PR #1796) — deliberately untouched.

## Verification

**27/27 tests** (13 new + 14 existing `stubs_due`). **14 gates exit 0**: `lint_roadmap_blockers` · `lint_roadmap_complexity` · `lint_roadmap_ci_steps` · `check_roadmap_trackable` · `lint_empty_roadmaps` · `lint_roadmap_later_disposition` · `lint_roadmap_family_cap` · `check_estate_count` · `check_references` · `check_no_roadmap_refs` · `check_council_references` · `check_no_external_sources` · `check_secret_leak` · `lint_evidence_artifacts`. `tsc --noEmit` clean. `check_md_language` green on the changed paths. `task sync` run so `dist/agent-src/` matches source.

## Honest nulls

A pre-existing `check_md_language` red at `src/domains/analysis-workbench/analyze/inbox/command.md:446` is present identically on `origin/main` and out of CI scope (CI scans only `docs/`); six hits across four files, three of them outside this task, left as note-and-ask. **A `git checkout --` used to undo a sabotage probe destroyed the uncommitted implementation and it had to be reapplied** — recorded because the restore discipline is the point of the sabotage, and `cp`-based backup is what the later probes used.


---

## Phase 2 landed too — the falsifier is now a number, not prose (5/12)

The council's reopening condition is a **count** — *"validated promotions blocked across more than two releases while user-facing defects ship"* — and it lived only as prose inside the stub it constrains, so the party it would reopen the question for was the only party who could find it.

**2.1 — machine-readable.** `stubs:due` now reports, per bucket member, the releases published since its hold began, from a new `blocker_opened:` frontmatter date. Live: `road-to-release-placeholder-guard.md (estate, 3 release(s) since 2026-08-23)`. Three is more than two, so the condition is met on the terms the council set.

Two properties, both deliberate and both pinned:

- **Counts strictly AFTER the date, never on it.** A release cut the same day cannot have carried a fix the hold was blocking, and counting it inflates the very figure the condition is read against.
- **Absent reports `null`, never `0`.** Zero reads as *"the falsifier has not fired"*. Absence is not a measurement.
- **Both changelog eras are read.** `14.11.0` lives only in `docs/archive/CHANGELOG-pre-14.12.0.md` after the era split — a count over `CHANGELOG.md` alone returns **two** and the falsifier silently never fires. `CHANGELOG_ERAS` encodes the pair so the mistake is not available to the next reader.

**Sabotage (19 tests):** replacing `>` with `>=` reds **3**; narrowing `CHANGELOG_ERAS` to the current era alone reds **1**. Both restores byte-identical by SHA-256.

**2.2 — the record**, at `agents/evidence/analysis/estate-deadlock-falsifier-fired-2026-09-01.md`. Every number carries the command that reproduces it, all three re-run against this tree: the three post-validation releases with dates, four marker lines per section, and the report's own output.

**One correction to my own first measurement, recorded rather than quietly fixed.** The first pass counted the `Curated head: fill before merge` comment and read **1** marker per section, contradicting the roadmap's **4**. The roadmap was right: a *marker line* is one of the four `_auto-derived, rewrite before merge:_` bullets, not the instruction comment above them. Both are real defects at the publication boundary and they are **different** ones — conflating them would have put a false number into an evidence file whose entire purpose is that a later reader re-derives rather than trusts.

**The date choice is recorded as DELEGATED, not as council-decidable.** Step 2.1's prose says *"since its estate blocker opened"* (which gives 2); its verify demands *"3 or more"*; the roadmap's own measurement section counts from the **2026-08-23 validation date** (which gives 3). Both seats classified adopting the validation date as a **metric-semantic amendment — owner-reserved, satisfied only through this run's explicit delegation**, not as a clerical correction. The distinction is the difference between a decision that was delegated and one that was never anyone's to make.

**Verification:** 33 tests green (19 new + 14 existing `stubs_due`); 14 gates exit 0 including `lint_canonical_terms`, `check_source_size_budget` and `check_estate_count`; `tsc --noEmit` clean; `check_md_language` green on the changed paths.

Phase 3 stays open: it specifies the capped provisional-promotion path, and its cap, activation and numbers are explicitly the owner's to set. Nothing here promotes anything, and the estate hold on `road-to-release-placeholder-guard` is exactly as binding as before — now visibly rather than silently.
