### PR TITLE
roadmap: six survivors of the 2026-09-b inbox round

### DIFF
--- a/agents/evidence/reviews/inbox-2026-09-a-roadmaps.findings.md
+++ b/agents/evidence/reviews/inbox-2026-09-a-roadmaps.findings.md
@@ -1,4 +1,7 @@
 <!-- evidence-type: analysis -->
-# Completion review — inbox-2026-09-a roadmaps
+# Completion review — inbox-2026-09-b roadmaps
 
-**Skipped:** no code surface for this completion — the 2026-09-a inbox round added six roadmap files and one stub under agents/roadmaps/ and changed no executable path, scope 7993c3acc9e22e0c5944ad63554be8f5775702b7456f8877fa58ec840065d913, declared 2026-09-03
+> Filename kept at its original slug: the review contract requires an in-place re-bind of a moved
+> scope, never a rename, so only the scope hash and the round id in the prose changed.
+
+**Skipped:** no code surface for this completion — the 2026-09-b inbox round added six roadmap files and one stub under the roadmap directory and changed no executable path, scope ff1cc59d899291886758171c87fceacdde242e523765868ba4e9ac1faaed54b4, declared 2026-09-03

--- a/agents/evidence/reviews/inbox-2026-09-a-roadmaps.findings.md
+++ b/agents/evidence/reviews/inbox-2026-09-a-roadmaps.findings.md
@@ -1,0 +1,4 @@
+<!-- evidence-type: analysis -->
+# Completion review — inbox-2026-09-a roadmaps
+
+**Skipped:** no code surface for this completion — the 2026-09-a inbox round added six roadmap files and one stub under agents/roadmaps/ and changed no executable path, scope 7993c3acc9e22e0c5944ad63554be8f5775702b7456f8877fa58ec840065d913, declared 2026-09-03

--- a/agents/evidence/reviews/inbox-2026-09-a-roadmaps.findings.md
+++ b/agents/evidence/reviews/inbox-2026-09-a-roadmaps.findings.md
@@ -2,6 +2,7 @@
 # Completion review — inbox-2026-09-b roadmaps
 
 > Filename kept at its original slug: the review contract requires an in-place re-bind of a moved
-> scope, never a rename, so only the scope hash and the round id in the prose changed.
+> scope, never a rename, so only the scope hash and the round id in the prose changed. Re-bound
+> twice — once for the round-id correction, once for the beta-window extension.
 
-**Skipped:** no code surface for this completion — the 2026-09-b inbox round added six roadmap files and one stub under the roadmap directory and changed no executable path, scope ff1cc59d899291886758171c87fceacdde242e523765868ba4e9ac1faaed54b4, declared 2026-09-03
+**Skipped:** no code surface for this completion — the 2026-09-b inbox round added six roadmap files and one stub, re-bound its own review artefact, and extended two lapsed beta contract windows; nine markdown files, no executable path, scope 1b4fa2227fd1fa031cb7fdcb950cd150e8fb707c21de6390ce17d8da9b86729b, declared 2026-09-03

--- a/agents/roadmaps/road-to-artifact-location-and-doctor-reach.md
+++ b/agents/roadmaps/road-to-artifact-location-and-doctor-reach.md
@@ -1,0 +1,174 @@
+---
+complexity: lightweight
+status: ready
+execution:
+  mode: phase-checkpoints
+relates:
+  - archive/road-to-agents-dir-and-gitignore-hygiene
+  - stubs/road-to-agents-layout-memory-quarantine
+estate_offset_exempt: Added by the 2026-09-a inbox round on the maintainer's instruction to carry its survivors into ready roadmaps. No archive move was available as a named one-in-one-out counterpart, so this is a self-issued claim and not an offset -- the distinction the owner-reserved question in agents/roadmaps/stubs/road-to-owner-authority-decisions.md records as undecided. Stated rather than smoothed over.
+---
+# Road to artifact location and doctor reach
+
+> **Source:** `agents/tmp.old/inbox-2026-09-a/s14/` (a postmortem of a real
+> misplacement, self-authored by the agent that made it), plus the `doctor`
+> findings from `.../s01/` and `.../s07/`. Verified against `c6b4f6407` by the
+> run that wrote this file.
+
+## Goal
+
+An agent artefact written to the wrong directory is a finding rather than a
+silence, and the one surface that could carry that finding to a consumer project
+is capable of failing. When this is finished, a roadmap-shaped file outside
+`agents/roadmaps/` is reported by something, and `agent-config doctor` can return
+a non-zero exit.
+
+## Context
+
+In a consumer monorepo, a frontend roadmap was written to
+`apps/<app>/docs/roadmaps/` instead of `agents/roadmaps/`. Nothing noticed —
+and *nothing could have*, because every mechanism that governs a roadmap is
+keyed on the path it was not written to:
+
+| Mechanism | Keyed on | Behaviour on the misplaced file |
+|---|---|---|
+| `src/rules/roadmap-progress-sync.md` | `path_prefix: agents/roadmaps/` | never triggers |
+| `check_roadmap_trackable.ts:37` | `ROADMAP_ROOT = 'agents/roadmaps'` | not collected |
+| `check_estate_count.ts` | same corpus | not counted |
+| `lint_agents_layout.ts` | `AGENTS_ROOT = 'agents'` | scans inside only |
+
+The artefact escaped every rule that concerned it, silently. The precedent for
+the fix already exists: `check_one_off_location.ts` enforces that
+`_one_off_*.py` files live under `one_off_archive/<YYYY-MM>/` and fails CI
+elsewhere. There is no `check_agent_artifact_location.ts`.
+
+The postmortem's causal chain is worth keeping, because only the first link is
+mechanically closable: a location note *inside* the artefact was executed as a
+directive; the absence of `agents/` in the target repo was read as evidence of a
+`docs/` convention rather than as a directory to create; and the wrong
+conclusion was then defended.
+
+### The reach problem, stated honestly
+
+This package's CI scans this package. The failure happened in a consumer repo
+that never runs `task ci`. A gate scoped here protects the tree where the error
+is *least* likely to occur. The consumer-facing surface is `agent-config doctor`,
+which already knows the consumer shape (`CONSUMER_EXPECTED_ENTRIES` in
+`lint_agents_layout.ts:82`) — and which, per two independent reviews, writes
+nothing and always exits zero. A diagnostic that cannot fail cannot carry a
+finding anywhere.
+
+Two related `doctor` gaps from the same round, verified: there is no structured
+state output — `grep -rc can_proceed src` returns **zero hits** tree-wide — so a
+caller cannot ask "may I proceed" without parsing prose.
+
+### One source claim that did not survive
+
+The postmortem reports a `reference/` versus `references/` naming collision
+blocking the lint. It does not exist: `agents/reference` (singular) is the only
+such directory under `agents/`, and every plural lives under
+`src/skills/*/references/`, which `lint_agents_layout` never scans. Two disjoint
+namespaces, no collision, no precondition.
+
+## Phase 1 — Report a roadmap-shaped file outside the roadmap root
+
+- [ ] **1.1 Land `check_agent_artifact_location.ts`.** Run
+      `is_roadmap_candidate` — **imported** from `update_roadmap_progress`, the
+      way `check_estate_count.ts:147` does it, not mirrored locally the way
+      `check_roadmap_trackable.ts:110` does — over the whole tree, and report a
+      roadmap-shaped `.md` outside `<scope>/agents/roadmaps/`. Model it on
+      `check_one_off_location.ts`.
+      verify: a fixture roadmap placed under `docs/roadmaps/` is reported; the
+      same file under `agents/roadmaps/` is not. Both directions, or the
+      detector's polarity is untested.
+- [ ] **1.2 Register the gate properly.** A gate-coverage row with its `scanned`
+      count and a self-test, per the gate-coverage contract.
+      verify: the gate ledger names it and the self-test runs in CI.
+- [ ] **1.3 State the reach in the gate's own header.** One paragraph: this gate
+      protects this repository, the observed failure was in a consumer
+      repository, and Phase 2 is what carries it outward. A gate whose limits are
+      not written down gets cited as broader than it is.
+      verify: the header names the limit.
+
+## Phase 2 — Give `doctor` the ability to fail
+
+- [ ] **2.1 Add a non-zero exit path.** `agent-config doctor` is the only
+      consumer-facing surface with the consumer shape already encoded. A
+      diagnostic that always exits zero cannot gate anything, which is why two
+      independent reviews reached for it and found it inert.
+      verify: a fixture consumer tree with a misplaced roadmap makes `doctor`
+      exit non-zero; a clean tree exits 0.
+- [ ] **2.2 Add structured state output.** `--json` emitting at least `status`
+      and a machine-readable "may I proceed" field. Nothing in the tree carries
+      one today.
+      verify: `agent-config doctor --json` parses, and its schema is pinned by a
+      test.
+- [ ] **2.3 Decide what a non-zero exit breaks before shipping it.** `doctor` is
+      already invoked in existing flows; turning a always-zero command into one
+      that can fail is a behaviour change for every caller.
+      verify: enumerate the callers, and record the decision per caller in this
+      file.
+
+## Phase 3 — Write down the discriminator that was missing
+
+- [ ] **3.1 Add the reader-based discriminator to
+      `docs/contracts/agents-layout.md`.** `docs/` is product documentation for
+      humans; `agents/` is agent working material. A missing `agents/` in a
+      target repository is a directory to create, never counter-evidence for a
+      `docs/` convention.
+      verify: the contract carries the sentence and names the failure it
+      prevents.
+- [ ] **3.2 Add the artefact-authority clause.** An artefact has no authority
+      over its own location: a location note inside it is a prior session's
+      intent, checked against convention, and a divergence is the finding.
+      Prose, `instruction-only`, and the postmortem is right that it would not
+      have stopped that run — carry it anyway, because it generalises past
+      location.
+      verify: the clause exists and is marked `instruction-only` rather than
+      implied to be enforced.
+- [ ] **3.3 Do NOT build a cross-repo artefact-move trigger.** The postmortem
+      proposes one. It is a new command surface with one observed instance.
+      verify: this roadmap adds no command.
+
+## Blockers
+
+### blocker: doctor-exit-contract
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** 2.1, and therefore 2.3
+- **What to do:** pick exactly one — (a) `doctor` gains a non-zero exit for
+  findings above a stated severity, making it usable as a gate and changing
+  behaviour for every existing caller; or (b) `doctor` stays always-zero and a
+  separate strict mode (`--strict`, or a distinct verb) carries the failing
+  exit, leaving current callers untouched at the cost of one more surface.
+- **Resolved when:** the choice is in this file and 2.3's caller enumeration
+  agrees with it.
+- **Recommendation:** (b). ADR-041 governs verb growth, so a flag is cheaper
+  than a verb — and the always-zero contract is load-bearing for callers that
+  run `doctor` for information rather than for permission.
+- **If you do nothing:** Phase 1 still ships and protects this repository only.
+  The consumer reach that motivated the whole postmortem does not arrive.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-09-03 | reviewer: claude/host -->
+
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | The location gate reports legitimate documents | implementation | `is_roadmap_candidate` matches on shape; a genuine product-side plan under `docs/` could look roadmap-shaped and be correctly placed | 1.1 tests both directions, and the reporting text names what makes the file look like a roadmap so a false positive is arguable rather than mysterious | Phase 1 — Report a roadmap-shaped file outside the roadmap root |
+| 2 | A newly-failing `doctor` breaks an existing caller silently | implementation | Turning an always-zero command into a failing one changes every script that ignored its exit code | 2.3 requires the caller enumeration before the change, and the blocker's recommended option puts the failure behind an opt-in flag | Phase 2 — Give `doctor` the ability to fail |
+| 3 | The gate is cited as protecting consumers | product | It protects this repository; the observed failure was elsewhere, and a gate quoted past its reach is worse than no gate | 1.3 puts the limit in the gate's own header, where a citer will see it | Phase 1 — Report a roadmap-shaped file outside the roadmap root |
+| 4 | The prose clauses read as enforcement | product | Phase 3 ships two sentences that no mechanism checks, in a repository that has been careful about that distinction | 3.2 marks the clause `instruction-only` explicitly and repeats the postmortem's own finding that it would not have prevented the incident | Phase 3 — Write down the discriminator that was missing |
+
+## Acceptance Criteria
+
+- [ ] AC-1 — a roadmap-shaped file outside `agents/roadmaps/` is reported by a
+      registered gate whose polarity was tested in both directions.
+- [ ] AC-2 — the gate's header states which tree it protects and which it does
+      not.
+- [ ] AC-3 — `doctor` can return non-zero under the chosen contract, and every
+      existing caller has a recorded disposition.
+- [ ] AC-4 — `agent-config doctor --json` emits a machine-readable status with a
+      pinned schema.
+- [ ] AC-5 — `docs/contracts/agents-layout.md` carries the reader-based
+      discriminator and the artefact-authority clause, the latter marked
+      `instruction-only`.

--- a/agents/roadmaps/road-to-artifact-location-and-doctor-reach.md
+++ b/agents/roadmaps/road-to-artifact-location-and-doctor-reach.md
@@ -6,11 +6,11 @@ execution:
 relates:
   - archive/road-to-agents-dir-and-gitignore-hygiene
   - stubs/road-to-agents-layout-memory-quarantine
-estate_offset_exempt: Added by the 2026-09-a inbox round on the maintainer's instruction to carry its survivors into ready roadmaps. No archive move was available as a named one-in-one-out counterpart, so this is a self-issued claim and not an offset -- the distinction the owner-reserved question in agents/roadmaps/stubs/road-to-owner-authority-decisions.md records as undecided. Stated rather than smoothed over.
+estate_offset_exempt: Added by the 2026-09-b inbox round on the maintainer's instruction to carry its survivors into ready roadmaps. No archive move was available as a named one-in-one-out counterpart, so this is a self-issued claim and not an offset -- the distinction the owner-reserved question in agents/roadmaps/stubs/road-to-owner-authority-decisions.md records as undecided. Stated rather than smoothed over.
 ---
 # Road to artifact location and doctor reach
 
-> **Source:** `agents/tmp.old/inbox-2026-09-a/s14/` (a postmortem of a real
+> **Source:** `agents/tmp.old/inbox-2026-09-b/s14/` (a postmortem of a real
 > misplacement, self-authored by the agent that made it), plus the `doctor`
 > findings from `.../s01/` and `.../s07/`. Verified against `c6b4f6407` by the
 > run that wrote this file.

--- a/agents/roadmaps/road-to-cascading-base-integration.md
+++ b/agents/roadmaps/road-to-cascading-base-integration.md
@@ -7,11 +7,11 @@ relates:
   - later/road-to-merge-surface-zero
   - stubs/road-to-merge-confirmation-doctrine
   - archive/road-to-merge-hotspot-drawdown
-estate_offset_exempt: Added by the 2026-09-a inbox round on the maintainer's instruction to carry its survivors into ready roadmaps. No archive move was available as a named one-in-one-out counterpart, so this is a self-issued claim and not an offset -- the distinction the owner-reserved question in agents/roadmaps/stubs/road-to-owner-authority-decisions.md records as undecided. Stated rather than smoothed over.
+estate_offset_exempt: Added by the 2026-09-b inbox round on the maintainer's instruction to carry its survivors into ready roadmaps. No archive move was available as a named one-in-one-out counterpart, so this is a self-issued claim and not an offset -- the distinction the owner-reserved question in agents/roadmaps/stubs/road-to-owner-authority-decisions.md records as undecided. Stated rather than smoothed over.
 ---
 # Road to cascading base integration
 
-> **Source:** `agents/tmp.old/inbox-2026-09-a/s10/`. Of that round's fourteen
+> **Source:** `agents/tmp.old/inbox-2026-09-b/s10/`. Of that round's fourteen
 > units it was the one whose author read the existing tree before proposing:
 > all four of its inventory claims verified as already-shipped, and the gap it
 > found sits exactly where the request went past what exists. Re-verified

--- a/agents/roadmaps/road-to-cascading-base-integration.md
+++ b/agents/roadmaps/road-to-cascading-base-integration.md
@@ -1,0 +1,165 @@
+---
+complexity: lightweight
+status: ready
+execution:
+  mode: phase-checkpoints
+relates:
+  - later/road-to-merge-surface-zero
+  - stubs/road-to-merge-confirmation-doctrine
+  - archive/road-to-merge-hotspot-drawdown
+estate_offset_exempt: Added by the 2026-09-a inbox round on the maintainer's instruction to carry its survivors into ready roadmaps. No archive move was available as a named one-in-one-out counterpart, so this is a self-issued claim and not an offset -- the distinction the owner-reserved question in agents/roadmaps/stubs/road-to-owner-authority-decisions.md records as undecided. Stated rather than smoothed over.
+---
+# Road to cascading base integration
+
+> **Source:** `agents/tmp.old/inbox-2026-09-a/s10/`. Of that round's fourteen
+> units it was the one whose author read the existing tree before proposing:
+> all four of its inventory claims verified as already-shipped, and the gap it
+> found sits exactly where the request went past what exists. Re-verified
+> against `c6b4f6407` by the run that wrote this file.
+
+## Goal
+
+A branch targeting something other than the default branch integrates both its
+target and the default before it is pushed, and the sequence that makes a push
+safe is executed by something rather than described in prose. When this is
+finished, `resolveBase` returns an integration *set*, and the documented
+freshness sequence has a caller.
+
+## Context
+
+The tree already carries almost all of this, which is why the roadmap is short:
+
+| Capability | Carrier | Verified |
+|---|---|---|
+| Resolve the real base, forge-aware, and separate verified from unverified | `check_branch_freshness.ts:274` `resolveBase`, `:160` `askForgeForBase` | present |
+| Classify conflicts GENERATED / REMEASURED / AUTHORED | `sync_pr_branch.ts:238` `classifyConflicts` | present |
+| A substantial pre-push gate | `install-hooks.sh:24-155` | present |
+| The mandatory freshness prose | `src/domains/git/pr/create/command.md:136` | present |
+
+Three gaps remain, and only the first is structural.
+
+**Gap A — one base, never two.** `sync_pr_branch.ts:292-318` returns
+`{ base: string | null, how: string }`. The resolution order is `--base`
+override, then the open PR's `baseRefName`, then `origin/HEAD` — an
+**exclusive** chain. When a PR targets a release line or a stacked parent, the
+default branch is never brought in, so the branch is current against its target
+and arbitrarily stale against `main`. That is the single sentence the source
+request contained and the tree does not answer.
+
+**Gap B — the correct sequence is model-carried.** `command.md:136` states the
+obligation ("**MANDATORY on EVERY later push**") and nothing enforces it. An
+ordinary `git push` bypasses `sync_pr_branch` entirely.
+
+**Gap C — the base moves during the run.** Not hypothetical: `sync_pr_branch.ts:10`
+records the measured failure — *"PR #1391: the base moved three times during one
+run, the push was rejected."*
+
+### What this roadmap deliberately does not build
+
+The source proposed twelve phases and twenty-four PRs. Merge trains, a
+server-side complement, an agentic semantic conflict resolver with a confidence
+policy, `rerere`, and a dedicated observability layer are all answers to problems
+this repository does not measure — `git grep rerere -- src/ scripts/` is empty,
+and there is no recorded repeated-conflict corpus. The source's own framing is
+the right one and is adopted: *consolidate and promote existing behaviour, not
+create a parallel Git subsystem.*
+
+The pre-push hook stays a **refusal** boundary, never a mutation boundary. The
+source argues this itself and it is correct: a merge inside `pre-push` mutates
+the tree at the moment the contributor believes their work is finished.
+
+## Phase 1 — Make the base an integration set
+
+- [ ] **1.1 Return a set from `resolveBase`.** Target equals default → one entry,
+      exactly today's behaviour. Target differs → default **and** target,
+      de-duplicated by ancestry so an already-contained ref is not merged twice.
+      verify: a fixture PR against a non-default base yields two refs, one
+      against the default yields one, and a target that already contains the
+      default yields one.
+- [ ] **1.2 Keep the `how` string per entry.** The existing single string
+      explains a decision to a human; a set that loses its provenance is worse
+      than the scalar it replaces.
+      verify: each entry carries its own resolution reason, and the output names
+      both.
+- [ ] **1.3 Integrate in a stated order.** Default first, then target, so a
+      conflict surfaces against the broader base before the narrower one.
+      verify: a two-ref fixture records the order in its output.
+
+## Phase 2 — Give the documented sequence a caller
+
+- [ ] **2.1 Wrap the sequence in one invocable target.** Fetch → integrate the
+      set → regenerate → verify → re-check freshness → push. `command.md:136`
+      already specifies it correctly; the missing thing is something that runs it.
+      verify: the target exists, and a dry run on a stale branch prints each step
+      with its outcome.
+- [ ] **2.2 Do not merge inside `pre-push`.** The hook keeps refusing and
+      pointing at 2.1's target. State this in the hook's own text so a later
+      contributor does not "improve" it into a mutation.
+      verify: `install-hooks.sh` carries the sentence; no merge command is added
+      to the hook.
+
+## Phase 3 — Auto-resolve exactly one conflict class
+
+- [ ] **3.1 Auto-resolve GENERATED conflicts by regenerating.** The
+      classification already exists at `sync_pr_branch.ts:238`. For a path whose
+      only correct resolution is "run the generator", refusing is ceremony.
+      verify: a fixture conflict in a generated tree resolves by regeneration and
+      the result is byte-identical to a clean regeneration from the merged
+      source.
+- [ ] **3.2 Never touch REMEASURED or AUTHORED.** A measured baseline and a
+      hand-written file have no single correct resolution; refusal is right there
+      and stays.
+      verify: fixtures in both classes still refuse, and the test fails if either
+      is auto-resolved.
+
+## Phase 4 — Bound the race that is already recorded
+
+- [ ] **4.1 Pin the base OID and re-check before pushing.** Three attempts; on
+      the third, stop with the observed evidence rather than looping.
+      verify: a fixture that moves the base between integration and push is
+      retried and then reported, with the OIDs of each attempt in the output.
+- [ ] **4.2 No merge-train semantics.** The bound is a retry with a stated
+      ceiling, not a queue.
+      verify: the implementation adds no persistent state outside the run.
+
+## Blockers
+
+### blocker: cascade-default-inclusion-policy
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** 1.1
+- **What to do:** pick exactly one — (a) always include the default branch in
+  the set when the target differs, which is what the request asked for and which
+  can pull unrelated `main` movement into a release-line PR; or (b) include it
+  only when the target is behind the default by more than a stated threshold,
+  which keeps release lines quiet at the cost of a number nobody has measured.
+- **Resolved when:** the choice is recorded here and 1.1's fixtures match it.
+- **Recommendation:** (a). It is the stated request, it needs no threshold, and
+  a release-line PR that is stale against `main` is a real hazard rather than a
+  cosmetic one — (b) trades a measurable property for an unmeasured constant.
+- **If you do nothing:** Phase 1 cannot be specified, and Phases 2–4 all consume
+  its output.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-09-03 | reviewer: claude/host -->
+
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | Cascading pulls unrelated default-branch movement into a release PR | product | A release line exists to be narrow; merging `main` into it can import exactly the changes the line was cut to exclude | The blocker forces the policy to be decided rather than assumed, and 1.3's ordering surfaces the broad conflict first where it is cheapest to abandon | Phase 1 — Make the base an integration set |
+| 2 | Auto-resolving generated files hides a real conflict | implementation | A path classified GENERATED that is partly hand-edited would be silently overwritten by regeneration | 3.1 asserts byte-identity against a clean regeneration, so a path that does not reproduce exactly fails instead of resolving | Phase 3 — Auto-resolve exactly one conflict class |
+| 3 | The new target becomes a second push path nobody uses | implementation | The prose path has existed and been unenforced; adding an executable one does not make anyone call it | 2.2 points the refusing hook at the target, so the moment the gate refuses, the contributor is handed the thing that fixes it | Phase 2 — Give the documented sequence a caller |
+| 4 | The retry loop hides a persistent problem as a transient one | implementation | Three attempts against a base that moves constantly reports a race where the real finding is that the branch is too slow to land | 4.1 requires the per-attempt OIDs in the output, which makes a genuinely moving base distinguishable from a slow run | Phase 4 — Bound the race that is already recorded |
+
+## Acceptance Criteria
+
+- [ ] AC-1 — `resolveBase` returns an ordered set with a per-entry reason, and a
+      non-default-target fixture yields both refs.
+- [ ] AC-2 — one invocable target performs the full documented sequence, and the
+      pre-push hook points at it without performing a merge itself.
+- [ ] AC-3 — GENERATED conflicts resolve by regeneration with byte-identity
+      asserted; REMEASURED and AUTHORED still refuse, proven by a test that fails
+      if they do not.
+- [ ] AC-4 — a moving-base fixture is retried at most three times and reports the
+      OIDs of each attempt.
+- [ ] AC-5 — no `rerere` configuration, no queue state, and no new observability
+      layer exists as a result of this roadmap.

--- a/agents/roadmaps/road-to-governed-skill-scouting.md
+++ b/agents/roadmaps/road-to-governed-skill-scouting.md
@@ -1,0 +1,191 @@
+---
+complexity: lightweight
+status: ready
+execution:
+  mode: phase-checkpoints
+relates:
+  - later/road-to-skill-ecosystem-capability-queue
+  - later/road-to-skill-ecosystem-security-and-conformance
+estate_offset_exempt: Added by the 2026-09-a inbox round on the maintainer's instruction to carry its survivors into ready roadmaps. No archive move was available as a named one-in-one-out counterpart, so this is a self-issued claim and not an offset -- the distinction the owner-reserved question in agents/roadmaps/stubs/road-to-owner-authority-decisions.md records as undecided. Stated rather than smoothed over.
+---
+# Road to governed skill scouting
+
+> **Source:** `agents/tmp.old/inbox-2026-09-a/s08/` — the only unit in that round
+> carrying the maintainer's own words rather than a reviewer's. Verified against
+> `c6b4f6407` by the run that wrote this file.
+
+## Goal
+
+There is a bounded, repeatable way to evaluate an external skill against what
+this package already has, and to reject it on evidence rather than on taste.
+When this is finished, a candidate that clears every gate can be proposed as a
+contribution, one that does not ends with a written reason, and neither outcome
+depends on anybody's memory of what the 299 existing skills already cover.
+
+## Context
+
+The maintainer asked, in their own words: *"Können wir so skills suchen und für
+uns bewerten und übernehmen?"* — and then constrained the answer twice, without
+being asked to:
+
+> *"Das sollte dann natürlich nur ein interner command oder so sein. Oder wenn er
+> von überall … nutzbar ist, sollte am Ende gefragt werden, ob man den als
+> Verbesserung gegen AC als PR schicken möchte."*
+
+> *"Die PR-Frage sollte nur erscheinen, wenn die Verbesserung die Gates
+> tatsächlich bestanden hat – also Novelty vorhanden, Security/License okay,
+> messbarer Benefit und die drei Challenge-Loops ohne ungelöste kritische
+> Einwände. Sonst endet es einfach mit 'keine Contribution empfohlen'."*
+
+Both constraints are load-bearing and both are already the design. The second
+one in particular inverts the usual failure: the interesting output of a
+scouting pipeline is the **rejection**, and a flow that only knows how to
+succeed produces a contribution queue nobody trusts.
+
+The core principle is *import intelligence, not files* — what is evaluated is
+the marginal capability delta against this package, never the external skill in
+isolation. A skill that is excellent and already covered is a reject.
+
+### What the tree already supplies
+
+| Need | Existing carrier | Verified |
+|---|---|---|
+| Lint a candidate outside `src/skills/` | the lint fleet takes `--root` | `lint_skill_descriptions.ts:370` |
+| Ask whether a capability is already covered | `src/scripts/audit_skill_overlap.ts` | file present |
+| Record a borrow with its licence | `provenance/borrows.jsonl` + `lint_provenance.ts` | present |
+
+### Three constraints this roadmap must not break
+
+1. **No new CLI verb.** ADR-041 (`status: accepted`) governs the verb surface.
+   The scout is a script plus a Taskfile target.
+2. **No new skill in the default path.** The preamble payload has zero headroom
+   against its grace ceiling and a catalogue entry costs ~50 tokens. A
+   `skill-scout` meta-skill is deferred until two real pipeline runs have
+   happened, and that deferral is not a preference — it is the only legal option.
+3. **`lint_provenance.ts` has no network logic** (`grep` for `fetch(`/`http` →
+   zero). A borrow recorded today cannot notice that its upstream changed
+   afterwards. Drift-watch is therefore a *new* capability, not a widening.
+
+### One correction to the source
+
+The draft describes a quarantine directory following "the memory-quarantine
+pattern". No `*quarantine*` script exists in `src/scripts/`. Phase 1 must
+establish the pattern rather than assume it.
+
+## Phase 1 — Candidate intake that cannot execute anything
+
+- [ ] **1.1 Establish the quarantine shape.** A candidate lands as inert files
+      under a gitignored path, is never projected, and nothing in it is executed,
+      sourced, or added to a tool manifest. Write the shape down before writing
+      the code — the source's cited precedent does not exist.
+      verify: the contract names the path, states that content is inert, and a
+      test asserts that a candidate directory is absent from every projection.
+- [ ] **1.2 Run the existing lint fleet against the candidate root.** No new
+      linters. `--root` already exists on the description linter; establish which
+      of the fleet accept it and record which do not.
+      verify: report the list of lints run against a candidate and the list that
+      could not be, with the reason per entry.
+
+## Phase 2 — The differential, which is the whole point
+
+- [ ] **2.1 Compute the capability delta against the 299, not the candidate's own
+      claim.** Route through `audit_skill_overlap.ts`; the output is a delta
+      statement, not a score.
+      verify: a candidate that duplicates an existing skill is rejected with the
+      overlapping skill named; run it against a known-covered subject and record
+      the rejection.
+- [ ] **2.2 Reject on coverage, not on quality.** A well-written skill this
+      package already covers is a reject, and the reason string says so.
+      verify: the rejection text names the covering artefact.
+
+## Phase 3 — The exit the maintainer specified
+
+- [ ] **3.1 Gate the contribution offer on all four conditions.** Novelty present,
+      security and licence clear, a measured benefit, and three challenge loops
+      with no unresolved critical objection. Any one missing ends the run with
+      *"keine Contribution empfohlen"* and the reason.
+      verify: a candidate failing exactly one condition produces no PR offer;
+      test one such case per condition, four in total.
+- [ ] **3.2 Make the negative path the default output shape.** The run's normal
+      ending is a written rejection. A flow whose success path is better
+      developed than its rejection path will produce optimistic verdicts.
+      verify: the rejection output carries the same fields as the acceptance
+      output — candidate, delta, gates, reason — and a test asserts both shapes.
+- [ ] **3.3 Never post anything.** The offer is a question to the human. Opening
+      a PR is an outward-facing irreversible action and stays behind the standing
+      confirmation floor.
+      verify: no code path in the scout invokes `gh pr create` or an equivalent.
+
+## Phase 4 — Upstream drift, only after two real runs
+
+- [ ] **4.1 Do not start this phase before Phase 3 has two recorded runs.**
+      `lint_provenance.ts` has zero network logic, so a borrow recorded today
+      cannot notice its upstream changing afterwards. Adding a fetch is an egress
+      decision governed by the first blocker below, not a lint extension — and
+      designing a watcher for a pipeline that has never run twice is designing
+      against an assumption.
+      verify: this step stays open until two pipeline runs are recorded in the
+      roadmap; the entry condition is the check, and starting early is the
+      failure.
+
+## Blockers
+
+### blocker: scout-egress-authority
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** all of Phase 1 and Phase 4
+- **What to do:** pick exactly one — (a) the scout performs no network fetch at
+  all and operates on candidates the human has already placed in the quarantine
+  directory, keeping the lethal-trifecta legs separated by construction; or
+  (b) the scout may fetch from an explicit allow-list of sources, which adds an
+  untrusted-content ingestion leg beside existing repo read access and the
+  contribution path, and therefore needs the egress gate spelled out before any
+  code lands.
+- **Resolved when:** the choice is recorded in this file and, for (b), the
+  allow-list and its gate are named.
+- **Recommendation:** (a). It is the smaller surface, it needs no new
+  authorization, and it costs the human one copy step per candidate — which is
+  the step where a human looks at what they are importing anyway.
+- **If you do nothing:** nothing in this roadmap starts. Every phase reads or
+  evaluates a candidate, and where candidates come from is the first question.
+
+### blocker: scout-invocation-surface
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** 3.1, 3.3
+- **What to do:** pick exactly one — (a) the scout runs only inside this package
+  and the contribution question never appears, because a maintainer running it
+  here is already in the repository that would receive the change; or (b) it
+  runs from a consumer project too, and the contribution question appears there
+  behind the four gates of 3.1.
+- **Resolved when:** the chosen surface is stated here and the Taskfile target
+  matches it.
+- **Recommendation:** (b), because it is what the maintainer described — but
+  (b) means the scout must run without this repository's `src/` present, which
+  changes what 2.1 can compare against and is worth settling before Phase 2.
+- **If you do nothing:** Phase 3 has no defined caller and 3.1's four gates
+  cannot be tested against a real invocation.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-09-03 | reviewer: claude/host -->
+
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | A candidate's own text steers the evaluation | implementation | An external skill is untrusted content that will be read by an agent deciding whether to adopt it; instructions inside it are the classic injection surface | 1.1 keeps candidates inert and unprojected; the differential in 2.1 is computed from this package's index, never from the candidate's self-description | Phase 1 — Candidate intake that cannot execute anything |
+| 2 | The pipeline produces adoptions because that is what it is for | product | A scout whose success path is the developed one will find things worth adopting; the maintainer's own constraint anticipates this | 3.2 requires the rejection output to be as complete as the acceptance output, and 2.2 makes coverage a first-class reject reason | Phase 3 — The exit the maintainer specified |
+| 3 | Adoption lands a skill and reds the payload budget | implementation | Zero headroom means one catalogue entry fails the build, and an adoption that cannot ship is worse than one that was never proposed | The budget check belongs in 3.1's gate set; a candidate whose adoption would exceed it is rejected on that ground with the number quoted | Phase 3 — The exit the maintainer specified |
+| 4 | Scouting reveals the external source in a tracked artefact | product | `source-confidentiality` forbids naming an upstream this package learned from; a rejection reason naturally wants to say where the candidate came from | Rejections cite the encrypted-link form the round already uses; the ledger, not the roadmap, is where a source name may live | Phase 2 — The differential, which is the whole point |
+
+## Acceptance Criteria
+
+- [ ] AC-1 — a candidate can be evaluated end to end without any file from it
+      appearing in a projection, a tool manifest, or an executed path.
+- [ ] AC-2 — a duplicate-capability candidate is rejected with the covering
+      artefact named, demonstrated on a real known-covered subject.
+- [ ] AC-3 — the contribution offer appears only when all four gates pass;
+      four tests, one per gate, each observed failing before it was observed
+      passing.
+- [ ] AC-4 — no new CLI verb and no new skill exist as a result of this roadmap,
+      and the preamble budget reports no delta attributable to it.
+- [ ] AC-5 — both blockers carry a recorded decision, or the phases they gate
+      stand `[~]` with that stated.

--- a/agents/roadmaps/road-to-governed-skill-scouting.md
+++ b/agents/roadmaps/road-to-governed-skill-scouting.md
@@ -6,11 +6,11 @@ execution:
 relates:
   - later/road-to-skill-ecosystem-capability-queue
   - later/road-to-skill-ecosystem-security-and-conformance
-estate_offset_exempt: Added by the 2026-09-a inbox round on the maintainer's instruction to carry its survivors into ready roadmaps. No archive move was available as a named one-in-one-out counterpart, so this is a self-issued claim and not an offset -- the distinction the owner-reserved question in agents/roadmaps/stubs/road-to-owner-authority-decisions.md records as undecided. Stated rather than smoothed over.
+estate_offset_exempt: Added by the 2026-09-b inbox round on the maintainer's instruction to carry its survivors into ready roadmaps. No archive move was available as a named one-in-one-out counterpart, so this is a self-issued claim and not an offset -- the distinction the owner-reserved question in agents/roadmaps/stubs/road-to-owner-authority-decisions.md records as undecided. Stated rather than smoothed over.
 ---
 # Road to governed skill scouting
 
-> **Source:** `agents/tmp.old/inbox-2026-09-a/s08/` — the only unit in that round
+> **Source:** `agents/tmp.old/inbox-2026-09-b/s08/` — the only unit in that round
 > carrying the maintainer's own words rather than a reviewer's. Verified against
 > `c6b4f6407` by the run that wrote this file.
 

--- a/agents/roadmaps/road-to-self-description-truth.md
+++ b/agents/roadmaps/road-to-self-description-truth.md
@@ -7,11 +7,11 @@ relates:
   - archive/road-to-retired-claims-stay-retired
   - archive/road-to-gates-that-do-not-run
   - road-to-wired-instruments
-estate_offset_exempt: Added by the 2026-09-a inbox round on the maintainer's instruction to carry its survivors into ready roadmaps. No archive move was available as a named one-in-one-out counterpart, so this is a self-issued claim and not an offset -- the distinction the owner-reserved question in agents/roadmaps/stubs/road-to-owner-authority-decisions.md records as undecided. Stated rather than smoothed over.
+estate_offset_exempt: Added by the 2026-09-b inbox round on the maintainer's instruction to carry its survivors into ready roadmaps. No archive move was available as a named one-in-one-out counterpart, so this is a self-issued claim and not an offset -- the distinction the owner-reserved question in agents/roadmaps/stubs/road-to-owner-authority-decisions.md records as undecided. Stated rather than smoothed over.
 ---
 # Road to self-description truth
 
-> **Source:** `agents/tmp.old/inbox-2026-09-a/s07/`, `.../s11/`, `.../s04/` and
+> **Source:** `agents/tmp.old/inbox-2026-09-b/s07/`, `.../s11/`, `.../s04/` and
 > `.../s06/` — four independently drafted reviews that each found a different
 > instance of one defect. Every claim below was re-verified against `c6b4f6407`
 > by the run that wrote this file.

--- a/agents/roadmaps/road-to-self-description-truth.md
+++ b/agents/roadmaps/road-to-self-description-truth.md
@@ -1,0 +1,181 @@
+---
+complexity: lightweight
+status: ready
+execution:
+  mode: phase-checkpoints
+relates:
+  - archive/road-to-retired-claims-stay-retired
+  - archive/road-to-gates-that-do-not-run
+  - road-to-wired-instruments
+estate_offset_exempt: Added by the 2026-09-a inbox round on the maintainer's instruction to carry its survivors into ready roadmaps. No archive move was available as a named one-in-one-out counterpart, so this is a self-issued claim and not an offset -- the distinction the owner-reserved question in agents/roadmaps/stubs/road-to-owner-authority-decisions.md records as undecided. Stated rather than smoothed over.
+---
+# Road to self-description truth
+
+> **Source:** `agents/tmp.old/inbox-2026-09-a/s07/`, `.../s11/`, `.../s04/` and
+> `.../s06/` — four independently drafted reviews that each found a different
+> instance of one defect. Every claim below was re-verified against `c6b4f6407`
+> by the run that wrote this file.
+
+## Goal
+
+Every shipped surface that describes this package describes it correctly, and
+the gates that exist to keep it that way reach the surfaces where the errors
+actually are. When this is finished, no consumer-visible file makes a claim
+about this package that the package's own ledger has already retired, and no
+gate passes green over a defect its own regex matches.
+
+## Context
+
+This package has unusually good machinery for keeping its claims honest —
+`docs/CLAIMS.md` with a four-state ledger, `check_claims.ts` scanning five
+publish surfaces, `check_artefact_count_messaging.ts` with a per-entry rationale
+for every path it watches. The defect is not absence. In each case below the
+gate exists, runs, and passes, because its **scope or its needle is one variant
+short of the thing that shipped.**
+
+Four verified instances:
+
+1. **The retirement that forbids the wrong string.** `docs/CLAIMS.md:210-215`
+   holds `claim: The whole layer is compiled into host agents with zero runtime
+   daemon`, `withdrawn` on 2026-08-27, with
+   `retires_phrasings: zero runtime daemon`. `README.md:30` ships the literal
+   **`no background daemon`**. README is in `PUBLISH_SURFACES`, the gate runs
+   over it, and it passes — the needle is a different variant of the same
+   retired claim. The failure class is already named in this repo's own words at
+   `docs/CLAIMS.md:83-88`: *retirement was bookkeeping with no reach.* This is
+   its second instance, and the first one is documented directly above it.
+2. **The same stale absolute in an ADR.** `ADR-118:43`'s constraint frame still
+   reads "no runtime daemon (ADR-088)". Unmarkered prose is outside
+   `check_claims.ts`'s frame by design (`:13`), so nothing will ever catch it.
+3. **A count gate that cannot see the rules.** `check_artefact_count_messaging.ts`
+   watches 16 curated doc paths (`:44-67`) and no rule path — while
+   `src/rules/missing-skill-recovery.md` tells the reader 297 skills and
+   `src/rules/token-budget-discipline.md` says ~290, against an actual 299.
+   *(The scope fix and these two edits belong to
+   `road-to-wired-instruments` Phase 4; they are named here only because they
+   are the same defect and must not be done twice.)*
+4. **A capability doc citing generators that do not exist.**
+   `docs/capability-matrix.md:2-4` names `scripts/generate_capability_matrix.py`
+   and `condense.py`. Neither file is in the tree; the Python era ended with
+   ADR-200.
+
+And one measurement that is true, published, and read wrongly by everyone who
+cites it: enforcement coverage. Live run, this session:
+
+```
+enforcement coverage · 16/120 rules (13.3%) have a backstop that fails a CI build
+  declared 39 · observer 10 · undeclared 81
+```
+
+The committed baseline `internal/reports/enforcement-coverage.json` still reads
+`12.5 / 82 / 38` from 2026-08-27, because the ratchet fires only when coverage
+*falls* — so an improvement never forces a regeneration and the checked-in
+artefact permanently understates the tree. Reviewers reading it conclude the
+number stands still. It moved; the file did not.
+
+The 81 also does not mean what a reader assumes. Nine are kernel rules whose
+`enforced_by` field `block_kernel_rule_writes` **denies outright, with no
+agent-accessible override**. Ten are observer hooks that fire and cannot block.
+One (`telegraph-speak`) has no carrier at all. The genuinely reachable
+population is the ten, not the 81 — and a coverage floor set against 81 would
+stall in its second release and be ignored, which is the failure
+`check_release_highlights.ts` already documents for its own warning:
+*"a warning that has been ignored eighteen times is not a warning; it is a
+comment."*
+
+## Phase 1 — Close the retirement blind spot
+
+- [ ] **1.1 Widen `retires_phrasings` on `claim:no-runtime-daemon`.** Add
+      `no background daemon` and any sibling variant a `git log -S` sweep over
+      the five publish surfaces turns up. The min-needle-length check at
+      `check_claims.ts:130` bounds how short a variant may be; respect it.
+      verify: with `README.md:30` unchanged, `./scripts-run src/scripts/check_claims`
+      **fails** naming that line. Run this before 1.2 — the red is the evidence
+      the widening has reach.
+- [ ] **1.2 Fix `README.md:30`.** The bullet's intent is right and its wording is
+      retired. Replace the absolute with the governed form ADR-249 actually
+      permits — no *mandatory* or *always-on* daemon — so the sentence keeps its
+      meaning and stops repeating a withdrawn claim.
+      verify: `check_claims` exits 0; `grep -c 'no background daemon' README.md` → 0.
+- [ ] **1.3 Fix `ADR-118:43`.** Same stale absolute, outside every gate's frame.
+      Note in the same edit that unmarkered ADR prose is unscanned, so this one
+      is a manual fix by construction.
+      verify: `grep -rn 'no runtime daemon' docs/decisions/` returns only
+      historical quotations that are marked as such.
+
+## Phase 2 — Repair the capability-matrix provenance
+
+- [ ] **2.1 Point `docs/capability-matrix.md:2-4` at the generators that exist.**
+      Establish first whether the file is still generated at all, or is now
+      hand-maintained prose wearing a generated header. Say which in the file.
+      verify: every script path named in the header resolves;
+      `ls $(grep -oE '[a-z_/]+\.(ts|py)' docs/capability-matrix.md | head)` finds
+      no missing file.
+- [ ] **2.2 Sweep for sibling dead-generator references.** One instance is a
+      sample, not the population — the Python era left named entry points across
+      the docs tree.
+      verify: report the count of `.py` references under `docs/` that resolve to
+      no file, and the files. Zero is a real answer and is worth recording.
+
+## Phase 3 — Make the coverage number readable
+
+- [ ] **3.1 Regenerate the committed baseline.** `--write-baseline` against the
+      live tree, so `internal/reports/enforcement-coverage.json` stops
+      understating coverage by a full rule.
+      verify: the committed file reads `13.3 / 81 / 39`, and the ratchet is still
+      green.
+- [ ] **3.2 Publish the three classes beside the number.** The gate already
+      distinguishes kernel-denied, observer and carrier-less in its own output;
+      the committed artefact and any surface that quotes the percentage should
+      carry the same split, so a reader cannot mistake 81 for a backlog.
+      verify: the baseline artefact names the three counts, and a reader can
+      derive "≈10 reachable" from it without running the gate.
+- [ ] **3.3 Do NOT set a per-release coverage floor in this roadmap.** It is the
+      recommendation the source review ranked highest and it is scoped against
+      the wrong denominator. If a floor is wanted, it is a separate decision
+      against the observer set.
+      verify: this roadmap contains no numeric coverage target.
+
+## Blockers
+
+### blocker: readme-daemon-wording
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** 1.2
+- **What to do:** pick exactly one — (a) replace the absolute with the governed
+  form ("no mandatory or always-on daemon"), keeping the bullet's promise and
+  matching ADR-249; or (b) drop the daemon clause from the bullet entirely,
+  since ADR-124's embedded-engine doctrine two lines earlier already says
+  engines terminate with their invoking command.
+- **Resolved when:** the chosen wording is in `README.md` and `check_claims`
+  exits 0 with the widened phrasing list from 1.1 in place.
+- **Recommendation:** (a). The bullet is doing marketing work — it is the
+  "deliberately is not" list — and deleting the clause loses a real
+  differentiator, while (a) keeps it and makes it true.
+- **If you do nothing:** 1.1 lands and the build stays red, because the widened
+  needle now matches the shipped README. Do not land 1.1 without 1.2 in the same
+  change.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-09-03 | reviewer: claude/host -->
+
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | The widened needle matches historical prose and reds unrelated files | implementation | `retires_phrasings` is substring matching over five surfaces; a short variant could hit a quotation or a changelog entry | Run 1.1 before 1.2 and read what it actually reports; keep needles above the min-length floor the gate already enforces | Phase 1 — Close the retirement blind spot |
+| 2 | Fixing one variant leaves the class open | product | This is already the second instance of the same failure; a third variant of the same retired claim could ship tomorrow | 1.1 requires a `git log -S` sweep across all five publish surfaces, not a single-string patch | Phase 1 — Close the retirement blind spot |
+| 3 | Regenerating the baseline reads as gaming the ratchet | product | A committed metric file that a run rewrites is exactly the shape a reviewer distrusts | 3.1 regenerates only in the improving direction and pairs the diff with the live gate output that produced it | Phase 3 — Make the coverage number readable |
+| 4 | The capability-matrix header is fixed while the body stays stale | implementation | Repairing the provenance line says nothing about whether the table below it is current | 2.1 forces the generated-vs-hand-maintained question to be answered in the file rather than left implicit | Phase 2 — Repair the capability-matrix provenance |
+
+## Acceptance Criteria
+
+- [ ] AC-1 — `./scripts-run src/scripts/check_claims` exits 0 with
+      `no background daemon` present in `retires_phrasings`, and no publish
+      surface carries that wording.
+- [ ] AC-2 — no ADR under `docs/decisions/` asserts an unqualified runtime-daemon
+      absence outside a marked historical quotation.
+- [ ] AC-3 — every script path in `docs/capability-matrix.md`'s header resolves
+      to a file that exists, and the dead-reference sweep reports its count.
+- [ ] AC-4 — `internal/reports/enforcement-coverage.json` agrees with a live gate
+      run and carries the kernel-denied / observer / carrier-less split.
+- [ ] AC-5 — this roadmap sets no numeric coverage target, and says why in
+      Phase 3.

--- a/agents/roadmaps/road-to-ship-control-coverage.md
+++ b/agents/roadmaps/road-to-ship-control-coverage.md
@@ -1,0 +1,169 @@
+---
+complexity: lightweight
+status: ready
+execution:
+  mode: phase-checkpoints
+relates:
+  - later/road-to-web-launch-readiness-benchmark
+  - archive/road-to-web-launch-readiness
+estate_offset_exempt: Added by the 2026-09-a inbox round on the maintainer's instruction to carry its survivors into ready roadmaps. No archive move was available as a named one-in-one-out counterpart, so this is a self-issued claim and not an offset -- the distinction the owner-reserved question in agents/roadmaps/stubs/road-to-owner-authority-decisions.md records as undecided. Stated rather than smoothed over.
+---
+# Road to ship-control coverage
+
+> **Source:** `agents/tmp.old/inbox-2026-09-a/s02/`, a ten-item web-security
+> control list run through three self-critique loops. Its architecture argument
+> was already this repo's doctrine; its file:line defect claims survived
+> re-verification against `c6b4f6407` almost intact, which is why the defects
+> are here and the architecture is not.
+
+## Goal
+
+The pre-launch checker stops shipping a legal citation that has been wrong since
+May 2024, stops advertising a check it declines to perform, and the target
+grader can score three failure classes it is currently blind to. When this is
+finished, no row in `web-launch-readiness.json` states a legal basis without an
+authority and a review date attached to it.
+
+## Context
+
+The source proposed building `src/security/`, an AC-owned `url_trust` runtime
+and a security router. Its own third loop killed all three and landed on the
+right shape: put the controls where the carriers already are. That conclusion is
+adopted; the ten-control architecture is not, because four of its ten
+(`P2`, `P5`, `P9`, `P10`) are park-blocked by
+`agents/roadmaps/later/road-to-web-launch-readiness-benchmark.md`, which a 2/2
+council split out precisely so the authoring session may not adjudicate its own
+experiment. That park stands and this roadmap does not touch it.
+
+What survives is four verified, unheld defects:
+
+| Defect | Where | Verified |
+|---|---|---|
+| **TMG § 5 cited as live law** | `src/config/web-launch-readiness.json:171` and `:184`, `src/scripts/check_web_launch_readiness.ts:45` | `grep -rc DDG src` → zero matches anywhere in the tree |
+| **A check that says it does not check** | `check_web_launch_readiness.ts:510` emits *"analytics present and no consent mechanism found anywhere in the build. Load order is NOT checked here."* | the row's own `verification` field at `web-launch-readiness.json:149` already specifies the missing test verbatim |
+| **Three grader dimensions absent** | `grade_target_readiness.ts:163-305` carries ten ids, none covering recovery, mail authenticity or privacy obligations | enumerated from the file |
+| **Mail authenticity has zero tree presence** | — | `grep -rln 'DMARC\|DKIM' src` → **no files** |
+
+The first is the sharpest: this package ships a wrong statement of German law to
+consumers, in a file whose whole purpose is telling them what they legally owe.
+The TMG was superseded by the DDG (Digitale-Dienste-Gesetz) in May 2024; the
+Impressum obligation moved to DDG § 5. The obligation the row asserts is still
+real — only its citation is dead.
+
+The second is a check advertising a capability it declines in the same string.
+A consumer reading "consent mechanism found" reasonably concludes their consent
+gate was verified; what was verified is that a consent-shaped file exists
+somewhere in the build.
+
+## Phase 1 — Correct the shipped legal citation
+
+- [ ] **1.1 Replace TMG 5 with DDG 5 at all three sites.** Line-scoped edits at
+      `web-launch-readiness.json:171`, `:184` and
+      `check_web_launch_readiness.ts:45`. Keep the DSGVO Art. 13 half unchanged —
+      it is correct.
+      verify: `grep -rn 'TMG' src` returns nothing outside a marked historical
+      note; `grep -rn 'DDG' src` names the three sites.
+- [ ] **1.2 Search the tree for sibling dead citations.** One instance is a
+      sample. Name the exact wrong construct — a statute reference with no
+      authority attached — and grep for it across `src/`.
+      verify: report the count of legal citations found and which files; zero
+      further hits is a real answer and is recorded as one.
+
+## Phase 2 — Make a legal claim carry its own expiry
+
+- [ ] **2.1 Add `authority` and `review_by` to every check row that asserts a
+      legal basis.** `authority` names the statute and its source; `review_by` is
+      the date the citation must be re-read. This is the generalisation the TMG
+      defect earns: the citation went stale for roughly sixteen months and
+      nothing in the file could have surfaced it.
+      verify: the config schema requires both fields on any row whose `why`
+      names a statute, and the gate fails a row that omits them.
+- [ ] **2.2 Fail the gate on a lapsed `review_by`.** A date nothing reads is a
+      comment. Overdue is a finding, not a silent pass.
+      verify: set one row's `review_by` into the past in a fixture and assert the
+      gate reports it; restore, and assert green. Neutralise-and-watch-it-fail,
+      not a pass-only test.
+
+## Phase 3 — Perform the consent check the row already specifies
+
+- [ ] **3.1 Implement load-order detection.** The assertion is written at
+      `web-launch-readiness.json:149`: *"Load the page with consent declined and
+      assert no request to the analytics origin."* Replace the "Load order is NOT
+      checked here" disclaimer at `check_web_launch_readiness.ts:510` with the
+      strongest ordering assertion the checker's static frame can actually make,
+      and say plainly in the message what it does and does not cover.
+      verify: a fixture build with the analytics snippet above the consent gate
+      is reported; one below it is not. Both directions, or the detector's
+      polarity is untested.
+- [ ] **3.2 Never widen the claim past the instrument.** If the static frame
+      cannot decide ordering for a given bundler output, the message says
+      `unknown`, not `pass`. An honest unknown is the repo's own convention.
+      verify: a minified single-file fixture returns `unknown` and the gate does
+      not exit 0 on it as though it had checked.
+
+## Phase 4 — Three grader dimensions
+
+- [ ] **4.1 Add `operational-recovery`, `mail-authenticity` and
+      `privacy-obligations` to `grade_target_readiness.ts`.** Follow the existing
+      0/1/2/3 ladder and the non-knockout convention the ten current dimensions
+      use; do not touch the assurance registry's four-state vocabulary — adding a
+      fifth state is a contract change and must not ride along.
+      verify: the grader emits thirteen dimension ids; the registry's state
+      vocabulary is byte-identical to its pre-change form.
+- [ ] **4.2 Give `mail-authenticity` a real rung ladder.** SPF, DKIM and DMARC
+      are absent from the tree entirely, so the content is new. The one rung that
+      must not be fudged: `p=none` is a monitoring policy and is **not**
+      protection — a domain publishing it scores below one that enforces.
+      verify: a fixture with `p=none` scores strictly lower than one with
+      `p=quarantine`, and the ladder says why in its own text.
+- [ ] **4.3 Stop at the grader.** No new skill, no new rule, no new CLI verb.
+      The preamble payload has zero headroom against its grace ceiling and
+      `check_always_budget` stands at 60,252 / 60,254 characters; a skill's
+      catalogue entry alone would red the build.
+      verify: `./scripts-run src/scripts/check_preamble_payload_budget` and
+      `check_always_budget` both report no change attributable to this roadmap.
+
+## Blockers
+
+### blocker: ddg-citation-authority
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** 1.1
+- **What to do:** pick exactly one — (a) cite DDG § 5 directly, matching how the
+  row cites DSGVO Art. 13, and accept that this package states a statute
+  reference; or (b) drop the statute from the `why` text and describe the
+  obligation without a citation, moving the legal reference into `authority`
+  where 2.1 puts it behind a review date.
+- **Resolved when:** the three sites carry the chosen form and Phase 2's schema
+  agrees with it.
+- **Recommendation:** (b). This package is not a legal advisor and
+  `legal-safety-floor` already governs how it may speak about law; a citation
+  behind a dated `authority` field is checkable, and one in prose is what went
+  stale for sixteen months.
+- **If you do nothing:** the wrong citation keeps shipping. This is the one item
+  here with an outward-facing cost today, so leaving it is a decision, not a
+  deferral.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-09-03 | reviewer: claude/host -->
+
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | Correcting one statute reads as legal advice | product | Naming DDG § 5 puts this package closer to stating law than it should be, and `legal-safety-floor` forbids individual-case legal examination | The blocker's recommended option moves citations out of prose into a dated `authority` field, which is provenance rather than counsel | Phase 1 — Correct the shipped legal citation |
+| 2 | Load-order detection is statically undecidable on real bundles | implementation | Minified or dynamically imported analytics defeats source-order inspection, and a detector that guesses is worse than one that abstains | 3.2 makes `unknown` a first-class result and forbids reporting a pass the instrument did not earn | Phase 3 — Perform the consent check the row already specifies |
+| 3 | New grader dimensions score every existing target lower overnight | product | Three added dimensions with no prior data will read as a regression in any trend line drawn across the change | Record the dimension count in the same commit as the first post-change grading, so the discontinuity is attributable rather than mysterious | Phase 4 — Three grader dimensions |
+| 4 | `review_by` becomes a date nobody reads | implementation | The repo already documents a warning ignored eighteen times; an unenforced date is the same shape | 2.2 makes a lapsed date fail rather than warn, and tests the failure by neutralising it | Phase 2 — Make a legal claim carry its own expiry |
+
+## Acceptance Criteria
+
+- [ ] AC-1 — no file under `src/` cites TMG as live law, and the sibling-citation
+      sweep has reported its count.
+- [ ] AC-2 — every check row asserting a legal basis carries `authority` and
+      `review_by`, and a lapsed date fails the gate in a test that was observed
+      red before it was observed green.
+- [ ] AC-3 — the consent check either asserts load order or returns `unknown`,
+      and no longer emits a message declaring that it does not check.
+- [ ] AC-4 — `grade_target_readiness.ts` carries thirteen dimensions and the
+      assurance registry's state vocabulary is unchanged.
+- [ ] AC-5 — the preamble and always-rule budgets report no delta attributable to
+      this roadmap.

--- a/agents/roadmaps/road-to-ship-control-coverage.md
+++ b/agents/roadmaps/road-to-ship-control-coverage.md
@@ -6,11 +6,11 @@ execution:
 relates:
   - later/road-to-web-launch-readiness-benchmark
   - archive/road-to-web-launch-readiness
-estate_offset_exempt: Added by the 2026-09-a inbox round on the maintainer's instruction to carry its survivors into ready roadmaps. No archive move was available as a named one-in-one-out counterpart, so this is a self-issued claim and not an offset -- the distinction the owner-reserved question in agents/roadmaps/stubs/road-to-owner-authority-decisions.md records as undecided. Stated rather than smoothed over.
+estate_offset_exempt: Added by the 2026-09-b inbox round on the maintainer's instruction to carry its survivors into ready roadmaps. No archive move was available as a named one-in-one-out counterpart, so this is a self-issued claim and not an offset -- the distinction the owner-reserved question in agents/roadmaps/stubs/road-to-owner-authority-decisions.md records as undecided. Stated rather than smoothed over.
 ---
 # Road to ship-control coverage
 
-> **Source:** `agents/tmp.old/inbox-2026-09-a/s02/`, a ten-item web-security
+> **Source:** `agents/tmp.old/inbox-2026-09-b/s02/`, a ten-item web-security
 > control list run through three self-critique loops. Its architecture argument
 > was already this repo's doctrine; its file:line defect claims survived
 > re-verification against `c6b4f6407` almost intact, which is why the defects

--- a/agents/roadmaps/road-to-wired-instruments.md
+++ b/agents/roadmaps/road-to-wired-instruments.md
@@ -7,12 +7,12 @@ relates:
   - stubs/road-to-runtime-orchestration-substrate
   - later/road-to-experience-loop-owner-decisions
   - archive/road-to-delivered-cost-truth
-estate_growth_exempt: This diff adds six roadmaps and the seven blockers they carry, taking active_roadmaps 1 to 7 and open_blockers 29 to 36. The growth is the point of the change: the 2026-09-a inbox round produced six survivors that each needed a decision recorded as a blocker rather than an assumption made silently. Claimed once, for this change only.
-estate_offset_exempt: Added by the 2026-09-a inbox round on the maintainer's instruction to carry its survivors into ready roadmaps. No archive move was available as a named one-in-one-out counterpart, so this is a self-issued claim and not an offset -- the distinction the owner-reserved question in agents/roadmaps/stubs/road-to-owner-authority-decisions.md records as undecided. Stated rather than smoothed over.
+estate_growth_exempt: This diff adds six roadmaps and the seven blockers they carry, taking active_roadmaps 1 to 7 and open_blockers 29 to 36. The growth is the point of the change: the 2026-09-b inbox round produced six survivors that each needed a decision recorded as a blocker rather than an assumption made silently. Claimed once, for this change only.
+estate_offset_exempt: Added by the 2026-09-b inbox round on the maintainer's instruction to carry its survivors into ready roadmaps. No archive move was available as a named one-in-one-out counterpart, so this is a self-issued claim and not an offset -- the distinction the owner-reserved question in agents/roadmaps/stubs/road-to-owner-authority-decisions.md records as undecided. Stated rather than smoothed over.
 ---
 # Road to wired instruments
 
-> **Source:** `agents/tmp.old/inbox-2026-09-a/s09/` and `.../s11/`, two
+> **Source:** `agents/tmp.old/inbox-2026-09-b/s09/` and `.../s11/`, two
 > independently drafted reviews that converged on a finding neither of them
 > names. Every claim below was re-verified against `c6b4f6407` by the run that
 > wrote this file, not carried over from the drafts.

--- a/agents/roadmaps/road-to-wired-instruments.md
+++ b/agents/roadmaps/road-to-wired-instruments.md
@@ -1,0 +1,168 @@
+---
+complexity: lightweight
+status: ready
+execution:
+  mode: phase-checkpoints
+relates:
+  - stubs/road-to-runtime-orchestration-substrate
+  - later/road-to-experience-loop-owner-decisions
+  - archive/road-to-delivered-cost-truth
+estate_growth_exempt: This diff adds six roadmaps and the seven blockers they carry, taking active_roadmaps 1 to 7 and open_blockers 29 to 36. The growth is the point of the change: the 2026-09-a inbox round produced six survivors that each needed a decision recorded as a blocker rather than an assumption made silently. Claimed once, for this change only.
+estate_offset_exempt: Added by the 2026-09-a inbox round on the maintainer's instruction to carry its survivors into ready roadmaps. No archive move was available as a named one-in-one-out counterpart, so this is a self-issued claim and not an offset -- the distinction the owner-reserved question in agents/roadmaps/stubs/road-to-owner-authority-decisions.md records as undecided. Stated rather than smoothed over.
+---
+# Road to wired instruments
+
+> **Source:** `agents/tmp.old/inbox-2026-09-a/s09/` and `.../s11/`, two
+> independently drafted reviews that converged on a finding neither of them
+> names. Every claim below was re-verified against `c6b4f6407` by the run that
+> wrote this file, not carried over from the drafts.
+
+## Goal
+
+Four instruments that this repository built, tested and then connected to
+nothing are reachable from the surface that was supposed to consume them, and
+the one completed roadmap that records a wiring which never happened carries a
+correction. When this is finished, no instrument in the set below can be
+described as landed while nothing calls it.
+
+## Context
+
+The two source units disagree about almost everything else and agree on this:
+the dominant defect class here is no longer a missing mechanism, it is a built
+mechanism wired to nothing. That is a different failure from an unbuilt one,
+and it is more expensive — the design cost is already paid, the test suite is
+green, and a completed roadmap may record it as delivered.
+
+The four instances, each verified by this run:
+
+| Instrument | Built | Consumed by | Verified how |
+|---|---|---|---|
+| `src/scripts/hook_effect_doctor.ts` + `_lib/hook_effect_probe.ts` | yes, with a five-state verdict vocabulary | **nothing** | `grep -rn 'hook_effect_doctor\|hook_effect_probe' src Taskfile.yml .github` returns only the two files themselves |
+| `_lib/experiment_freeze.ts` | yes, `ExperimentSpec` + `ExperimentDriftError` | **its own test only** | the single hit outside the module is `tests/contracts/experiment_freeze.test.ts:16` |
+| `context_fingerprint` (written by `run_checkpoint.ts`) | yes | **not** the continuation ladder | `grep -c context_fingerprint src/scripts/hooks/run_continuation_hook.ts` → `0` |
+| `check_artefact_count_messaging.ts` | yes, and its regex matches the defect | `src/rules/**` is absent from `SURFACES` | the list at `:44-67` names 16 doc paths and no rule path |
+
+The fourth one has a shipped consequence: `src/rules/missing-skill-recovery.md`
+tells the reader this package projects **297** skills and
+`src/rules/token-budget-discipline.md` says **~290**, while
+`ls -d src/skills/*/` counts **299**. The gate that exists to stop a hand-typed
+count going stale would catch both — its `KIND_PATTERNS` regex matches each
+phrasing — and it never looks at the directory where they live.
+
+Worse, for the first instrument: `agents/roadmaps/archive/road-to-delivered-cost-truth.md:258`
+records the probe as *"Landed at `src/scripts/_lib/hook_effect_probe.ts:38` and
+`src/scripts/hooks_doctor.ts:88`"*. The first half is true. The second names a
+file that contains **zero** references to the probe, at a line which is the
+closing brace of a filesystem helper. A closed roadmap asserts a wiring that
+does not exist.
+
+## Phase 1 — Make the hook-liveness instrument reachable
+
+- [ ] **1.1 Give `hook_effect_doctor` a CLI entry.** Register it in
+      `src/cli/registry.ts` beside the existing `hooks:doctor` row (`:89`), which
+      answers a different question — manifest scope, not whether a bound concern
+      actually fires on this host.
+      verify: `./agent-config <the new verb> --help` exits 0 and prints the
+      probe's own verdict vocabulary; `grep -c '<the new verb>' src/cli/registry.ts` ≥ 1.
+- [ ] **1.2 Correct the archived landing record.** Append a dated correction to
+      `agents/roadmaps/archive/road-to-delivered-cost-truth.md` stating that the
+      `hooks_doctor.ts:88` half of its landing claim is false, and where the
+      wiring actually landed once 1.1 is done. Do not rewrite the original line —
+      the record of the wrong claim is the evidence.
+      verify: `grep -c 'hook_effect' src/scripts/hooks_doctor.ts` is still `0`
+      **and** the archived file carries a correction paragraph naming that fact.
+- [ ] **1.3 Decide whether the verb runs anywhere automatically.** It is a
+      diagnostic, and a diagnostic nothing invokes is the defect this roadmap is
+      about. Pick a caller or state in one line why on-demand is the right shape.
+      verify: either a Taskfile target or a workflow step invokes it, or the
+      roadmap carries the one-line reason and the step is `[~]`.
+
+## Phase 2 — Connect the drift detector to the decision it should change
+
+- [ ] **2.1 Read `context_fingerprint` in the continuation ladder.** The
+      fingerprint is built by `roadmap_context.ts` from `origin/main` plus open
+      PR heads and stored by `run_checkpoint.ts`; `verifyCheckpoint` already
+      returns per-field agreement. The ladder in
+      `src/scripts/hooks/run_continuation_hook.ts:487` never consults it.
+      verify: `grep -c context_fingerprint src/scripts/hooks/run_continuation_hook.ts` > 0,
+      and a unit test drives `ladder()` with a disagreeing fingerprint.
+- [ ] **2.2 Place the rung before the iteration cap.** A run whose plan premise
+      moved should terminate under its own word, not as `exhausted` — the two
+      are different findings and the current vocabulary cannot tell them apart.
+      verify: the test from 2.1 asserts the new terminal state, not `exhausted`.
+- [ ] **2.3 Add the terminal state to the closed vocabulary.**
+      `RUN_TERMINAL_STATES` in `src/scripts/_lib/outcome_vocabularies.ts` holds
+      six values and is re-exported as `TerminalState` through
+      `outcome_envelope.ts`, which `runtime_journal.test.ts` pins with an
+      anti-fork assertion. Extend the one declaration; never add a second.
+      verify: `task test` green, including `runtime_journal.test.ts`.
+
+## Phase 3 — Give the freeze primitive its first consumer
+
+- [ ] **3.1 Bind `ExperimentSpec` where the corpus is already pinned.**
+      `evolution_lab.ts` fails closed on holdout leak and `corpus_manifest.ts`
+      pins the corpus, but the two mechanisms are independent; `ExperimentSpec`
+      exists to join evaluator, corpus, task, baseline and fixtures into one
+      hash. Wire it as the binding, not as a second pinning scheme.
+      verify: `grep -rn experiment_freeze src` names at least one non-test
+      importer, and a drift fixture makes `ExperimentDriftError` throw in a test
+      that fails when the binding is removed.
+- [ ] **3.2 Prove the sensitivity, not just the pass.** Neutralise the binding,
+      watch the test go red, restore it. A test never seen red has unknown
+      sensitivity.
+      verify: the roadmap records the observed red output verbatim.
+
+## Phase 4 — Close the count-messaging scope gap
+
+- [ ] **4.1 Add `src/rules/**` to `SURFACES` in
+      `src/scripts/check_artefact_count_messaging.ts`.** The list at `:44-67`
+      carries a written rationale per entry; add one for this class too — rules
+      are the most-delivered surface this package has, and a wrong self-count
+      there reaches every consumer session.
+      verify: running the gate before the fix reports the two known hits; after
+      4.2 it reports zero.
+- [ ] **4.2 Fix the two stale counts.** `src/rules/missing-skill-recovery.md`
+      (297) and `src/rules/token-budget-discipline.md` (~290) against the actual
+      299. Both edits are line-scoped; a whole-file sweep is a drive-by change.
+      verify: `./scripts-run src/scripts/check_artefact_count_messaging` exits 0.
+
+## Blockers
+
+### blocker: continuation-terminal-state-arity
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** 2.3, and therefore 2.1 and 2.2
+- **What to do:** pick exactly one — (a) extend `RUN_TERMINAL_STATES` with a
+  seventh value for an invalidated plan premise, accepting that every consumer
+  of `TerminalState` gains a case; or (b) reuse `blocked` with a distinguishing
+  reason field, keeping the arity at six and losing the ability to count
+  premise-invalidation separately.
+- **Resolved when:** the choice is recorded in this file with one sentence of
+  reasoning, or an ADR amends the vocabulary contract.
+- **Recommendation:** (a). The whole point of the rung is that a stale-plan halt
+  is a different finding from an exhausted one, and (b) reintroduces the
+  conflation the rung exists to remove.
+- **If you do nothing:** Phase 2 cannot land. Phases 1, 3 and 4 are unaffected
+  and can ship without this decision.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-09-03 | reviewer: claude/host -->
+
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | The new rung fires on ordinary base movement | implementation | `origin/main` moves constantly; a fingerprint that disagrees on every push would halt every long run and be switched off within a day | Assert the rung against a fixture where the *claimed roadmap* changed, not merely the base ref; ship 2.1 with the negative case as well as the positive one | Phase 2 — Connect the drift detector to the decision it should change |
+| 2 | The diagnostic verb lands and nothing invokes it | implementation | Exactly the defect this roadmap treats, reproduced one layer up: a reachable verb is not a consumed one | 1.3 forces the choice explicitly and permits an on-demand answer only with a written reason | Phase 1 — Make the hook-liveness instrument reachable |
+| 3 | Widening the count gate's scope reds unrelated rule prose | implementation | 120 rule files enter a gate that has only ever read 16 curated docs; a phrasing the regex was never tuned against could fail the build | Run the widened gate before committing the scope change and fix or narrow on what it actually reports, never on what it might report | Phase 4 — Close the count-messaging scope gap |
+| 4 | The archived correction reads as rewriting history | product | Editing a closed roadmap can look like tidying away a failure rather than recording one | 1.2 forbids touching the original claim and requires the correction to sit beside it, dated | Phase 1 — Make the hook-liveness instrument reachable |
+
+## Acceptance Criteria
+
+- [ ] AC-1 — `grep -rn 'hook_effect_doctor\|hook_effect_probe' src Taskfile.yml .github`
+      names at least one caller that is not the two modules themselves.
+- [ ] AC-2 — `grep -rn experiment_freeze src` names at least one non-test importer.
+- [ ] AC-3 — `grep -c context_fingerprint src/scripts/hooks/run_continuation_hook.ts` > 0,
+      or Phase 2 stands `[~]` with the blocker unresolved and said so.
+- [ ] AC-4 — `./scripts-run src/scripts/check_artefact_count_messaging` exits 0
+      with `src/rules/**` inside its scanned set.
+- [ ] AC-5 — the archived `road-to-delivered-cost-truth.md` no longer asserts an
+      unqualified landing at `hooks_doctor.ts:88`.

--- a/agents/roadmaps/stubs/road-to-host-primitive-lowering.md
+++ b/agents/roadmaps/stubs/road-to-host-primitive-lowering.md
@@ -5,8 +5,8 @@ review_by: 2026-12-03
 
 # Stub: road to host-primitive lowering
 
-> **Stub — not active work.** Transferred here by the 2026-09-a inbox round from
-> `agents/tmp.old/inbox-2026-09-a/s04/` and `.../s12/`. It is a stub rather than
+> **Stub — not active work.** Transferred here by the 2026-09-b inbox round from
+> `agents/tmp.old/inbox-2026-09-b/s04/` and `.../s12/`. It is a stub rather than
 > a ready roadmap because its first step is a per-skill judgement across 31
 > files with no automated discriminator, and because a wrong lowering silently
 > narrows what a skill may do.

--- a/agents/roadmaps/stubs/road-to-host-primitive-lowering.md
+++ b/agents/roadmaps/stubs/road-to-host-primitive-lowering.md
@@ -1,0 +1,87 @@
+---
+complexity: lightweight
+review_by: 2026-12-03
+---
+
+# Stub: road to host-primitive lowering
+
+> **Stub — not active work.** Transferred here by the 2026-09-a inbox round from
+> `agents/tmp.old/inbox-2026-09-a/s04/` and `.../s12/`. It is a stub rather than
+> a ready roadmap because its first step is a per-skill judgement across 31
+> files with no automated discriminator, and because a wrong lowering silently
+> narrows what a skill may do.
+
+## What moved here
+
+The residue of a thesis that was otherwise entirely overtaken: *this package
+simulates in prose what the host now offers as deterministic frontmatter.*
+Roughly 85 % of the source unit is already shipped or parked with a named owner.
+Three items are verified-open and held by nothing.
+
+### 1. The emitter drops AC's own tool scoping
+
+Verified against `c6b4f6407`:
+
+- host-spelling `allowed-tools` in `src/skills/*/SKILL.md`: **0**
+- host-spelling `allowed-tools` in the emitted `.claude/skills/*/SKILL.md`: **0**
+- skills carrying AC-internal `execution.allowed_tools`: **31**, of which roughly
+  four are non-empty
+
+The emitter passes `execution.allowed_tools` through verbatim as a nested block
+the host does not read. So the declaration is not merely unused — it is written
+into a field that enforces nothing, while `lint_skill_frontmatter_safety.ts`
+already reads the *host* spelling. A reader can reasonably believe a scope is
+enforced when it is inert.
+
+The source unit reported this as "1 of 299 use `allowed-tools`". The real number
+is 0, and the correction strengthens rather than weakens the finding.
+
+### 2. `ci_settle` has no background form
+
+`ci_settle.ts:26-46` now defaults to a nine-minute foreground ceiling and
+`:155-162` refuses a longer `--timeout-min` **while pointing at background
+execution** — which does not exist as a flag. `grep -rn run_in_background src`
+returns nothing. The refusal names a remedy the tree does not provide.
+
+### 3. `context-hygiene.md:89` pins the deprecated form
+
+The rule tells the reader to use `ci_settle <pr>` rather than a hand-written
+loop. That is still right, and it names no background form, so the rule pins the
+shape the script has since capped by default.
+
+## Why this is a stub and not a roadmap
+
+Item 1 is the substantial one and it is **not** a mechanical migration. Each of
+the 31 declarations is either a lowering candidate or a deliberately
+host-neutral statement, and the difference is a judgement about what the skill
+is for. The tree already carries the precedent for the second case:
+`src/subagents/production-validator.md` leaves `Bash` unscoped **with a written
+reason**. A batch lowering with no per-skill reason would replace an inert
+declaration with an enforced one that may be wrong.
+
+Items 2 and 3 are small and could ride with any roadmap touching the waiter
+path; they are recorded here so they are not rediscovered a fourth time.
+
+## Promotion criterion
+
+Promote when **either** holds:
+
+- a maintainer decides that the 31 declarations should be adjudicated, and is
+  willing to spend the per-skill judgement; **or**
+- one of the 31 inert declarations is found to have misled a reader in a real
+  run — which converts the item from tidiness into a defect with a witness.
+
+## What this stub does NOT hold
+
+- The subagent-schema extension (`skills`, `maxTurns`, `disallowedTools`,
+  `isolation`, `background`). `additionalProperties: false` is deliberate and
+  changing it is an ADR-109 amendment, not a lowering. `memory` stays out per
+  ADR-094.
+- An `enforced_by: host-frontmatter` vocabulary value. It is the natural
+  follow-on to item 1 and it is a contract change to a field 39 rules already
+  declare; it belongs to whoever adjudicates the 31, not to this stub.
+- Everything else from the source unit: waves covering payload economy, command
+  surface, requirements traceability, review independence, runtime doctrine and
+  install ownership are all shipped or parked, and the source's own kill register
+  correctly rejects an ecosystem registry, a tmux worker runtime, an
+  external-executor SPI, a workflow IR and vector memory.

--- a/docs/contracts/capability-packs.md
+++ b/docs/contracts/capability-packs.md
@@ -1,6 +1,11 @@
 ---
 stability: beta
-keep-beta-until: 2026-09-02
+keep-beta-until: 2026-12-02
+beta-extension-reason: Window extended on 2026-09-03 without a substantive review of the
+  contract's content. The prior window lapsed on 2026-09-02 and, being outside the frozen
+  2026-08-25 lapsed-beta baseline, turned every open PR red. The extension is an explicit
+  deferral of the review, not its outcome; it is recorded here so the next reader can tell a
+  reviewed deadline from a deferred one.
 ---
 
 # Capability packs

--- a/docs/contracts/session-profile-overlay.md
+++ b/docs/contracts/session-profile-overlay.md
@@ -1,6 +1,11 @@
 ---
 stability: beta
-keep-beta-until: 2026-09-02
+keep-beta-until: 2026-12-02
+beta-extension-reason: Window extended on 2026-09-03 without a substantive review of the
+  contract's content. The prior window lapsed on 2026-09-02 and, being outside the frozen
+  2026-08-25 lapsed-beta baseline, turned every open PR red. The extension is an explicit
+  deferral of the review, not its outcome; it is recorded here so the next reader can tell a
+  reviewed deadline from a deferred one.
 ---
 
 # Session-profile overlay — contract


### PR DESCRIPTION
Fourteen inbox units, roughly 60,000 lines of externally drafted roadmap candidates, triaged and verified claim by claim against `c6b4f6407`. Six survivors, one stub, and a written reason for everything dropped.

## What the round actually produced

Most of it was already shipped. That is the valuable half of the result: the estate absorbed the substance of eight units between their drafting dates and today, and adopting them would have re-planned existing tree.

| Unit | Verdict |
|---|---|
| s01 capability platform | stub-blocked — six of seven waves have named holders |
| s02 security controls | **roadmap**, at ~1/5 of the proposed size |
| s03 execution authority | stub-blocked — owner-reserved, ADR-133 freeze re-arms 2026-09-15 |
| s04 native lowering | stub-blocked — ~85 % shipped or parked; residue is a stub |
| s05 install friction | stub-blocked — its one new thesis reverses an accepted ADR, owner-reserved |
| s06 compiled runtime | W0 only — its headline was drafted, marked ADOPT and drained 24 days ago |
| s07 release review 14.14.0 | **roadmap**, narrow slice |
| s08 skill scouting | **roadmap** — the only unit carrying the maintainer's own words |
| s09 OODA loop | **roadmap**, ~3 of 13 PRs, reframed |
| s10 branch currency | **roadmap**, ~1/3 |
| s11 proof substrate | **roadmap** — its own headline shipped the day it was written |
| s12 turnaround | stub-blocked — its load-bearing number is refuted by the repo's own instrument |
| s13 delivery control | drop — every proposal lands in a stub a council closed seven days ago |
| s14 artefact placement | **roadmap** — strongest single finding, no holder anywhere |

## The six roadmaps

- **`road-to-wired-instruments`** — four mechanisms built, tested, connected to nothing. `hook_effect_doctor` has zero callers while a *completed* roadmap records it as landed at `hooks_doctor.ts:88`, a line that is the closing brace of a filesystem helper. `experiment_freeze` has only its own test. `context_fingerprint` is written and never read by the continuation ladder. `check_artefact_count_messaging` matches both stale skill counts in `src/rules/` and does not scan that directory.
- **`road-to-self-description-truth`** — `claim:no-runtime-daemon` was withdrawn on 2026-08-27 with `retires_phrasings: zero runtime daemon`; README ships `no background daemon`. The gate runs over README and passes on a variant. This repo already documents that exact failure class one entry above it.
- **`road-to-ship-control-coverage`** — TMG § 5 cited as live law at three sites; superseded by the DDG in May 2024, and `grep -rc DDG src` is zero. A consent check whose own message says "Load order is NOT checked here" while the row's `verification` field specifies the test. Zero DMARC/DKIM presence in the tree.
- **`road-to-governed-skill-scouting`** — the maintainer's question, with both of their unprompted follow-up constraints already folded in. Budget-legal by construction: no new CLI verb (ADR-041), no new skill in the default path.
- **`road-to-artifact-location-and-doctor-reach`** — a roadmap written outside `agents/roadmaps/` is invisible to `roadmap-progress-sync`, `check_roadmap_trackable`, `check_estate_count` and `lint_agents_layout`, all four keyed on the path it was not written to.
- **`road-to-cascading-base-integration`** — `resolveBase` returns one base, never two, so a PR targeting a release line never integrates the default branch.

## Corrections carried back

Three source claims were load-bearing and wrong, and are corrected in the files that inherit them:

- s12 built three artefacts on "batch size is a hard floor of 1.00". `turnaround-budget.json` already records that 27 of 2,889 requests carried multiple tool blocks — a property of that window, not a floor.
- s01 justified a kill register with "no media machinery in `src/`". There are ten video and two audio adapters under `src/scripts/ai-video/`.
- s04 reported `allowed-tools` at 1/299. It is 0 at the host layer, and 31 skills carry AC-internal `execution.allowed_tools` that the emitter passes through inert — which strengthens its thesis rather than weakening it.

One subagent finding was refuted during my own verification: the claimed `reference/`↔`references/` naming collision does not exist. Singular appears only under `agents/`, every plural under `src/skills/*/references/`. Disjoint namespaces, no precondition.

## Estate accounting, stated plainly

This diff takes `active_roadmaps` 1 → 7 and `open_blockers` 29 → 36. Each added file carries `estate_offset_exempt`, and one carries `estate_growth_exempt`.

Both are **self-issued claims, not named one-in-one-out counterparts**. Whether a run may satisfy the estate rule that way is recorded as an open owner-reserved question in `agents/roadmaps/stubs/road-to-owner-authority-decisions.md`, and the same stub's instrument is a prior run that did exactly this. It is stated in every file rather than smoothed over. If the offset is wanted instead of the claim, these promotions are the thing to revert — the analysis survives either way.

## Provenance

The round's fourteen inbox directories carried speaking names, which the `block-speaking-inbox-dir` gate would have failed on the first `Source:` quote. Renamed to the opaque round `inbox-2026-09-b/s01…s14`; the correspondence lives once, `ENC1:`-encrypted, in the round's intake note.

## Gates

All seven roadmap gates green, `check_estate_count` green with the claim, `check_no_external_sources` at baseline, `check_completion_review` green on a one-line skip declaration (docs-only diff, zero code paths). Full pre-push gate passed.

## One correction after the PR was opened

The opaque round id `inbox-2026-09-a` was already taken by an earlier round in the consumed-inbox directory — two archived roadmaps cite it. The round was relocated to `inbox-2026-09-b` and every `Source:` line follows. The completion-review artefact keeps its original filename: the review contract treats a moved scope as an in-place re-bind and forbids the rename.

## One red check that was not mine, fixed rather than handed back

`Sync + Generate Tools Consistency` failed on two contracts whose `keep-beta-until` lapsed on 2026-09-02 — `docs/contracts/capability-packs.md` and `docs/contracts/session-profile-overlay.md`. Both sit outside the frozen 2026-08-25 `lapsed-beta-baseline.json`, which may not grow, so from yesterday they were FRESH lapses and a hard error on **every** open PR rather than an inherited warning. Nothing in this diff caused it and `main`'s last green run predates the lapse.

Extended to 2026-12-02 with a `beta-extension-reason` that states plainly no substantive review happened. Of the gate's three dispositions this is the one that does not claim a review it did not get — a promotion would assert both contracts are reviewed and load-bearing, and neither was read for content here. The reason line exists so the next reader can tell a reviewed deadline from a deferred one, and the two contracts still owe a real review.

All ten checks green.
