### PR TITLE
fix(deps): clear the three runtime advisories failing the audit gate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4443,9 +4443,9 @@
             }
         },
         "node_modules/fast-uri": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-            "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+            "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
             "funding": [
                 {
                     "type": "github",
@@ -4558,9 +4558,9 @@
             }
         },
         "node_modules/fastify/node_modules/fast-json-stringify/node_modules/fast-uri": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.2.tgz",
-            "integrity": "sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==",
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.4.tgz",
+            "integrity": "sha512-dODXrIxlS9JSdgAnhIUKOosKV1oMtU2VtVw87QRaHzyl5jxO290Ii5tEZfCfzfWNHi3jKWwBSdQj0qIyshdZdQ==",
             "funding": [
                 {
                     "type": "github",
@@ -5012,9 +5012,9 @@
             }
         },
         "node_modules/hono": {
-            "version": "4.12.32",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
-            "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+            "version": "4.13.5",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.5.tgz",
+            "integrity": "sha512-O6+/eCYRkzzzy0rPWwKLiGBR1nFuUPZynnwjxN1MBA62NNqbT0wQEzQyK2gSO5yDIDB336sXQleAhOHrzlYyKw==",
             "license": "MIT",
             "engines": {
                 "node": ">=16.9.0"
@@ -6559,12 +6559,13 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.15.2",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-            "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+            "version": "6.16.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+            "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "side-channel": "^1.1.0"
+                "es-define-property": "^1.0.1",
+                "side-channel": "^1.1.1"
             },
             "engines": {
                 "node": ">=0.6"
@@ -6967,14 +6968,14 @@
             }
         },
         "node_modules/side-channel": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+            "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
-                "object-inspect": "^1.13.3",
-                "side-channel-list": "^1.0.0",
+                "object-inspect": "^1.13.4",
+                "side-channel-list": "^1.0.1",
                 "side-channel-map": "^1.0.1",
                 "side-channel-weakmap": "^1.0.2"
             },


### PR DESCRIPTION
## What this is

The `Static Checks (ESLint · typecheck · prepack)` job fails on `main` and on
every branch cut from it, on `npm audit`. This clears it.

## The finding

`npm audit --omit=dev --audit-level=high` — the exact invocation at
`.github/workflows/tests.yml:447` and
`.github/workflows/release-validation.yml:408` — reports:

```
3 vulnerabilities (2 moderate, 1 high)
```

Not one of the roadmap PRs currently open touches the lockfile, so each of them
inherited a red that was never theirs. Fixing it in any one of them would have
buried a dependency bump inside an unrelated change, which is why it is here on
its own.

## The bump

Lockfile only. No direct dependency touched. No semver-major.

| Package | From | To | Severity |
|---|---|---|---|
| `fast-uri` | 3.1.5 | 3.1.7 | **high** |
| `fast-uri` | 4.1.2 | 4.1.4 | **high** |
| `hono` | 4.12.32 | 4.13.5 | moderate ×4 |
| `qs` | 6.15.2 | 6.16.0 | moderate ×2 |

The `hono` set includes GHSA-f23p-vx2j-j53r — `memo()` retaining SSR output
across requests, i.e. cross-user data disclosure — which is the one worth naming
rather than counting.

Every advisory carried `fixAvailable: true`, so none required a major.

## What is deliberately NOT in here

The same tree carries dev-only advisories in `vitest`, `vite`, `vite-node`,
`@vitest/mocker` and `esbuild`. All of them need **semver-major** bumps
(`vitest@4`, `vite@8`), and the CI gate scopes them out with `--omit=dev`. They
are left alone rather than swept in: a toolchain major belongs in its own change
with its own test evidence, and bundling it here would make a one-line security
fix unreviewable.

## Verification

After `rm -rf node_modules && npm ci` against the new lockfile:

- `npm audit --omit=dev --audit-level=high` → **found 0 vulnerabilities**
- `tsc -p tsconfig.json --noEmit` → clean
- `vitest tests/scripts/check_gate_coverage.test.ts` → 53/53

Diff is 19 insertions, 18 deletions, all in `package-lock.json`.
