### PR TITLE
docs(evidence): record drain run 18

### DIFF
--- a/agents/evidence/drain-run-summary.md
+++ b/agents/evidence/drain-run-summary.md
@@ -1,6 +1,200 @@
-<!-- evidence-type: v1 | type: current-binding | declared: 2026-09-02 -->
+<!-- evidence-type: v1 | type: current-binding | declared: 2026-09-03 -->
 
-# Autonomous roadmap drain — run 17, 2026-09-02
+# Autonomous roadmap drain — run 18, 2026-09-03
+
+Autonomous roadmap drain under a written owner instruction: drive every active
+roadmap to completion, route every open decision to the AI council rather than
+to the owner, close gates only legitimately, one PR per roadmap, no user
+round-trips.
+
+Base commit `2b3d2b347`. Seven active roadmaps; **all seven carry a PR**, plus
+one shared-defect PR the run had to open to make any of them green.
+
+## The queue, recomputed
+
+The instruction carried a seed table of 36 roadmaps. **It was stale in full** —
+none of its 36 names exists in `agents/roadmaps/` today, and the live set is
+seven files, every one at 0/N. The instruction's own step 1.2 says to recompute
+rather than trust the seed; that is what happened, and it is recorded because a
+reader comparing the two would otherwise assume 29 roadmaps were dropped.
+
+All seven were below the 10 % line, so the ordering rule was ascending
+complexity then ascending step count.
+
+## Pull requests
+
+| PR | Roadmap | State |
+|---|---|---|
+| [#1815](https://github.com/event4u-app/agent-config/pull/1815) | `road-to-governed-skill-scouting` | complete, archived |
+| [#1816](https://github.com/event4u-app/agent-config/pull/1816) | `road-to-ship-control-coverage` | complete, archived |
+| [#1817](https://github.com/event4u-app/agent-config/pull/1817) | `road-to-self-description-truth` | complete, archived |
+| [#1818](https://github.com/event4u-app/agent-config/pull/1818) | `road-to-wired-instruments` | complete, archived |
+| [#1819](https://github.com/event4u-app/agent-config/pull/1819) | `road-to-artifact-location-and-doctor-reach` | complete, archived |
+| [#1820](https://github.com/event4u-app/agent-config/pull/1820) | `road-to-council-topology-evidence-followups` | **parked, deliberately** — see § Terminal |
+| [#1821](https://github.com/event4u-app/agent-config/pull/1821) | `road-to-cascading-base-integration` | complete, archived |
+| [#1822](https://github.com/event4u-app/agent-config/pull/1822) | — | shared defect: `npm audit`, see § The shared red |
+
+## Council decisions
+
+All under the standing delegation, all on **2026-09-03**, members
+`anthropic/claude-sonnet-4-5` and `openai/codex-default`, blind chairman,
+subscription transport (`billable=0`, `$0.0000`). Council artefacts are
+gitignored and auto-pruned, so each decision is inlined in the roadmap and the
+PR that consumed it, per `no-roadmap-references`.
+
+### Round 1 — the seven blockers, three rounds
+
+| Blocker | Verdict | Roadmap's own recommendation | Agreed? |
+|---|---|---|---|
+| `doctor-exit-contract` | **(b)** `--strict` carries the failing exit | (b) | yes |
+| `cascade-default-inclusion-policy` | **split** — see below | (a) | — |
+| `scout-egress-authority` | **(a)** no network fetch | (a) | yes |
+| `scout-invocation-surface` | **(a)** in-repo only | (b) | **no — overruled** |
+| `readme-daemon-wording` | **(a)** governed wording | (a) | yes |
+| `ddg-citation-authority` | **(b)** structured `authority` | (b) | yes |
+| `continuation-terminal-state-arity` | **(a)** a seventh state | (a) | yes |
+
+Six unanimous. One reversal worth naming: on `scout-invocation-surface` both
+seats independently rejected the roadmap's own recommendation, calling consumer
+invocation a different trust domain rather than another entry point — three new
+contracts, not one. The evidence that would reopen it is recorded with the
+decision.
+
+Several verdicts carried conditions that were adopted as part of the decision
+rather than treated as advice: quarantine must still enforce provenance and
+inertness because "a human copied it" is not a content-trust guarantee; the
+strict mode needs a configurable severity threshold and a kill switch that is
+not a code rollback; the seventh terminal state ships only with a consumer
+inventory, schema versioning, unknown-value tolerance and a downgrade mapping;
+the legal citation must migrate atomically, sibling citation included.
+
+### Round 2 — specifying the split
+
+`cascade-default-inclusion-policy` split (a)/(b) — **but not on substance.**
+Both seats independently named the *same* third option as correct and picked
+opposite fallbacks only because the framing demanded a fallback. A focused
+follow-up round specified it, and the two seats converged on a near-identical
+design: an explicit per-target branch-convergence policy read exclusively from
+the resolved PR target SHA, exact target names, fail-on-missing-entry, one
+stable result type with closed reason codes, and a kill switch surfaced as
+bypassed rather than passed. That specification is what #1821 builds.
+
+### Round 3 — the source-size residual
+
+`doctor --strict` needed 16 lines of wiring in a file 2,100 lines past the
+size-budget threshold, against a ratchet that permits zero growth. The council
+**split**: one seat for raising the baseline with a payback obligation, one for
+descoping the feature.
+
+**Neither was taken, and the reason is evidence rather than preference.** A
+parallel branch demonstrated the same day that paying the ratchet down is
+achievable in this codebase. So the implementation was extracted into two new
+under-cap modules, the delta went `+137 → −21`, and the baseline was **lowered**
+18,230 → 18,209. The gate's own test comment prescribes exactly this: a commit
+that splits a god-file lowers the excess and must carry the lowered baseline.
+
+A split resolved by measurement is not a split that needed a third opinion.
+
+### Not re-run — the topology carrier
+
+`road-to-council-topology-evidence-followups` already carried a recorded council
+verdict on this exact question, mechanism and instruction shape, reached under a
+**materially identical** owner instruction on 2026-09-01. Re-asking after an
+unwelcome verdict is verdict shopping, so the council was not consulted again
+and the recorded boundary was honoured.
+
+## Descopes and carries
+
+| What | Where it went | Why |
+|---|---|---|
+| `road-to-governed-skill-scouting` Phase 4 — upstream drift-watch | `later/road-to-skill-ecosystem-capability-queue`, with a `parent_roadmap` back-link | Not deferred for capacity. Drift-watch requires a network fetch, and the egress decision that unblocked the rest of the roadmap forbids one. The decision closed the phase. |
+| `road-to-self-description-truth` step 2.2's finding | new `road-to-python-era-doc-references` | The step asked for a count and got **1,089 dead `.py` references**, 946 of them across 233 live doc files. Three orders of magnitude past the instance that prompted it, and past a lightweight roadmap's scope. |
+| `road-to-council-topology-evidence-followups` — all 38 obligations | nowhere; left in place | See § Terminal. |
+
+## Terminal — the one roadmap not drained
+
+`road-to-council-topology-evidence-followups` is a carrier holding 38 items
+deferred out of an archived parent. Its resumption triggers are facts about the
+world, and they were **measured live rather than assumed**:
+
+| Trigger | Requires | Measured | Verdict |
+|---|---|---|---|
+| Phase 2 seats | `n >= 5` independent eligible seats | `council:status` → **2 enabled of 5** | unmet by three seats |
+| Phase 2 capacity | a verified 20-consecutive-UTC-day reservation | none exists | unmet |
+| Phase 3 windows | two consecutive UTC-day windows at 30 calls/provider against a 50/day cap | no reservation | unmet |
+
+This is the instruction's own terminal case, and its *"legitimate gate closure
+only"* clause is what decides it: no execution, council decision, re-scope or
+descope can conjure three council seats or a capacity reservation. **Zero of the
+38 obligations were executed and none is claimed complete.**
+
+What #1820 does carry is a factual repair. Three header claims had gone false —
+the file said `status: draft` (it reads `carrier`), said "nothing guards this
+file", and said deleting it "would red nothing". A guard landed on 2026-09-02
+and, measured by moving the file out of the tree, deletion now produces
+**38 broken deferral carries and exit 1**. Two links pointed at a stub the
+guard's own change consumed. A carrier whose subject is "a mechanism keyed on
+something that moved" is the worst place to leave a stale claim standing.
+
+## The shared red
+
+Every roadmap PR failed `Static Checks` on `npm audit --omit=dev
+--audit-level=high`: 3 advisories (`fast-uri` high, `hono` and `qs` moderate,
+including a cross-user SSR disclosure). Red on `main` and on every branch cut
+from it; no roadmap diff touches the lockfile.
+
+#1822 fixes it alone — patch/minor only, no semver-major, 0 vulnerabilities
+after a clean `npm ci`. It is separate on purpose: burying a dependency bump
+inside an unrelated roadmap PR makes both unreviewable. **Merge #1822 first**
+and the audit red clears from the rest.
+
+The dev-only advisories in the same tree (`vitest`, `vite`, `esbuild`) all need
+semver-majors and the gate scopes them out with `--omit=dev`. Deliberately not
+swept in.
+
+## Findings worth keeping
+
+- **`lint_roadmap_complexity` is red on clean `main`** for every lightweight
+  roadmap: `relates:` rows use the old slug-only form and rule 18 requires
+  `slug:` + `relation:`. Each PR fixed **only its own** rows. Rows for roadmaps
+  a run had not executed were left alone deliberately — inventing a relation
+  value for a roadmap nobody read is a fabricated frontmatter field.
+- **A `--root` flag is not a capability.** Four lints accept `--root`; run
+  against a real quarantined candidate, exactly **one** reaches it. Two take it
+  to mean the *repository* root; one scans a sub-path a text-only candidate does
+  not have. A fleet list built by grepping for the flag would have been wrong in
+  three places and would have reported three lints as having scanned nothing.
+- **`is_roadmap_candidate` is a name filter, not a detector.** Over an arbitrary
+  tree it accepts nearly every `.md`. The location gate pairs it with a
+  three-signal content shape; a looser predicate turns 6 of 14 cases red.
+- **`doctor` was never "always exits zero".** It already returned 1 on manifest
+  drift, and `--ci` already folded check failures in. The real gap was a failing
+  exit outside the `--ci` JSON contract.
+- **`main()` in `cmd_doctor.ts` has two exit paths and only one is obvious.** A
+  strict check wired into the drift branch alone exits 0 on any repository
+  without an install manifest — including this one.
+- **`context_fingerprint` was written by nothing**, not merely unread, so
+  consuming it would have reproduced the defect class its own roadmap was
+  fixing. The producer had to come first.
+- **A test guard fired on its own documentation** — the no-egress source guard
+  matched the tokens its header named. The header was reworded rather than the
+  guard loosened.
+
+## Honest nulls
+
+- The `git log -S` sweep for daemon-variant phrasings across five publish
+  surfaces returned **zero** beyond the two already known.
+- The sibling-citation sweep found **35 citation sites**, of which 3 were the
+  known defect and 32 were live law — **no further dead citations**.
+- **Zero anchor drift** across every roadmap: every cited `file:line` resolved
+  at `2b3d2b347`.
+- No cross-repo artefact-move trigger was built. One observed instance does not
+  justify a new command surface, and the roadmap asked for exactly that
+  restraint.
+
+---
+
+# Prior run — autonomous roadmap drain, run 17, 2026-09-02
 
 The only report the maintainer asked to read. Every claim below was produced by a
 command in this run, not carried from a prior session. **Zero metered calls to


### PR DESCRIPTION
## What this is

The one report the owner instruction asks to read, for the autonomous roadmap
drain of 2026-09-03.

**Appended, not overwritten.** `agents/evidence/drain-run-summary.md` already
held two prior runs; the run-17 heading is demoted to the prior-run form the
file's own convention uses, and the `evidence-type` marker's `declared:` date
moves to this run's.

**Numbered 18, not 16.** Two prior runs in that file both carry `2026-09-02`, so
the next ordinal was already taken. Recorded in the commit because a report that
silently renumbers its predecessor is worse than one with a gap.

## What the run did

Seven active roadmaps, every one at 0/N. **All seven carry a PR**, plus one for a
shared pre-existing defect that was blocking all of them.

| PR | Roadmap |
|---|---|
| #1815 | `road-to-governed-skill-scouting` — complete, archived |
| #1816 | `road-to-ship-control-coverage` — complete, archived |
| #1817 | `road-to-self-description-truth` — complete, archived |
| #1818 | `road-to-wired-instruments` — complete, archived |
| #1819 | `road-to-artifact-location-and-doctor-reach` — complete, archived |
| #1820 | `road-to-council-topology-evidence-followups` — **parked** (merged) |
| #1821 | `road-to-cascading-base-integration` — complete, archived |
| #1822 | shared defect: three `npm audit` advisories |

## Three things worth the reader's time

**The seed queue was stale in full.** The instruction listed 36 roadmaps at a
named commit and said to recompute. None of those 36 names exists in
`agents/roadmaps/` today; the live set was seven. The recomputation is recorded
so a reader comparing the two does not conclude 29 roadmaps were dropped.

**A council verdict overruled its own roadmap.** On `scout-invocation-surface`
both seats independently rejected the roadmap's recorded recommendation, calling
consumer invocation a different trust domain rather than another entry point —
three new contracts, not one. The evidence that would reopen it is recorded with
the decision.

**One council split was resolved by measurement, not by asking again.** The
source-size residual split (raise the baseline / descope the feature). Neither
was taken: a parallel branch demonstrated the same day that paying the ratchet
down is achievable here, so the code was extracted into two under-cap modules,
the delta went `+137 → −21`, and the baseline was **lowered**. The gate's own
test comment prescribes exactly that.

## The one roadmap not drained, and why that is the correct outcome

`road-to-council-topology-evidence-followups` holds 38 deferred obligations
whose resumption triggers are facts about the world. Measured live, not assumed:
`n >= 5` eligible council seats required, **2 enabled of 5** present; a verified
20-consecutive-UTC-day capacity reservation required, none exists; two
consecutive UTC-day provider windows required, none reserved.

No execution, council decision, re-scope or descope can conjure council seats.
That is the instruction's own terminal case, and its *"legitimate gate closure
only"* clause is what decides it. **Zero of the 38 were executed and none is
claimed complete.**

## Merge ordering

**#1822 first.** Every remaining red on the roadmap PRs is the same
`npm audit --omit=dev --audit-level=high` failure — red on `main` and on every
branch cut from it, and untouched by any roadmap diff. #1822 clears it alone.

## Contents

The record carries: all eight PRs, all three council rounds with their verdicts
and the conditions attached to them, every descope and where it went, the
terminal roadmap with its measured triggers, seven findings worth keeping, and
four honest nulls stated as nulls rather than omitted.
