### PR TITLE
fix(release): make the derived head publishable, so a release stops halting by construction

### DIFF
--- a/docs/contracts/CHANGELOG-conventions.md
+++ b/docs/contracts/CHANGELOG-conventions.md
@@ -126,7 +126,7 @@ marker.
 > that instruction is the authority for this change.
 >
 > The arithmetic behind why it had to go: every release of this package touches
-> `src/rules/` or `src/scripts/schemas/`, so **Behaviour changes** is always
+> `src/rules/` or `src/scripts/schemas/`, so `Behaviour changes` is always
 > substantiated, so the generator always wrote a line the gate always refused.
 > A release halting *by construction* is not a cadence, it is a failure with a
 > schedule. Two intermediate positions were tried and neither removed it — the

--- a/docs/contracts/CHANGELOG-conventions.md
+++ b/docs/contracts/CHANGELOG-conventions.md
@@ -117,20 +117,41 @@ marker.
 > action is an edit. The four later guards are unchanged and stay as
 > defence-in-depth for a section that changes after the commit.
 >
-> **What this does NOT fix, stated rather than left to the next reader.** A
-> release still halts once whenever any label is substantiated, and every
-> release of this package substantiates at least one. That is the cadence the
-> flip chose; it is now a local halt with the evidence in hand instead of a red
-> PR, which is a different cost, not zero cost. Since 2026-09-03 that halt also
-> arrives before the release commit rather than after it, so the edit is made
-> on a clean tree and the re-run is `task release`, not `task release --
-> --resume`. The unattended path
-> (`.github/workflows/release.yml`, `--ci --yes`, ADR-113) therefore cannot
-> complete a release whose head is uncurated — it refuses before the push
-> instead of dying at the check, which is strictly better and still not
-> unattended. Whether the generator should emit a publishable derived claim
-> instead of a rewrite-me draft is an open maintainer question, not something
-> this repair decided.
+> **The halt is GONE since 2026-09-03, and the open question above is what
+> closed it.** The paragraph that stood here described the halt as the cadence
+> the flip chose, said it was "a different cost, not zero cost", and ended by
+> naming its own successor: *whether the generator should emit a publishable
+> derived claim instead of a rewrite-me draft is an open maintainer question.*
+> The maintainer answered it — *"fix the bug so this stops happening"* — and
+> that instruction is the authority for this change.
+>
+> The arithmetic behind why it had to go: every release of this package touches
+> `src/rules/` or `src/scripts/schemas/`, so **Behaviour changes** is always
+> substantiated, so the generator always wrote a line the gate always refused.
+> A release halting *by construction* is not a cadence, it is a failure with a
+> schedule. Two intermediate positions were tried and neither removed it — the
+> 2026-09-01 flip made the marker a hard refusal at the PR, and 2026-09-03's
+> first attempt (`guard_release_curation`) moved that refusal before the
+> commit. Both made the halt cheaper. Only the writer change removes it.
+>
+> `render_derived_head_values` now emits the COMMIT SUBJECTS behind each
+> category with their SHAs, and no marker: "stage-2 impact scan, so a refused
+> merge can be answered in four words (5a3b7c5)" rather than "rule/schema diffs
+> in 5a3b7c5". Measured against the real 14.15.0 span, seven commits, the
+> rendered head returns zero publication blockers.
+>
+> What is deliberately NOT relaxed: `highlight_contradictions` still refuses a
+> human editing a substantiated line down to `_none_`, which is what the false
+> 9.13.0 and 9.14.0 heads actually were; and the marker constant with its four
+> guard sites stays, now covering only a marker written BY HAND. The unattended
+> path (`.github/workflows/release.yml`, `--ci --yes`, ADR-113) can therefore
+> complete a release, which it could not before.
+>
+> **The honest cost, stated rather than left to be discovered.** The head is
+> now a categorised view of the span rather than curated prose, and it ships
+> without a human having read it. That is a real reduction in editorial
+> quality, accepted deliberately: an operator who wants better prose still
+> edits the section, and is no longer STOPPED until they do.
 >
 > **No escape hatch exists, deliberately.** See § No escape hatch below.
 >

--- a/src/scripts/_lib/release_highlights.ts
+++ b/src/scripts/_lib/release_highlights.ts
@@ -279,9 +279,57 @@ export function derive_categories(commits: readonly SpanCommit[]): Record<string
  *
  * A label with no evidence is omitted, so the caller's `_none_` default still
  * applies where `_none_` is the true answer. One line per label keeps the
- * rendered head inside its cap; SHA citations are capped at `DERIVED_SHA_CAP`
- * with an explicit remainder count rather than a silent truncation.
+ * rendered head inside its cap; citations are capped at `DERIVED_SHA_CAP` with
+ * an explicit remainder count rather than a silent truncation.
+ *
+ * **PUBLISHABLE BY DEFAULT since 2026-09-03, and this is the third position
+ * this line has held.** It shipped `DERIVED_MARKER` plus a CATEGORY
+ * DESCRIPTION — "rule/schema diffs, breaking commits or removed public surface
+ * in 5a3b7c5". The 2026-09-01 flip then made that marker a hard refusal, and
+ * the combination had a consequence nobody priced: every release of this
+ * package touches `src/rules/` or `src/scripts/schemas/`, so **Behaviour
+ * changes** is always substantiated, so the generator always wrote a line the
+ * gate always refused. Every release halted, by construction. That was
+ * recorded as "the cadence the flip chose"; the maintainer's instruction of
+ * 2026-09-03 — *"fix the bug so this stops happening"* — is the authority for
+ * removing it.
+ *
+ * The fix is not a weaker gate, and it is not the marker moving somewhere
+ * cheaper (that was 2026-09-03's first attempt, `guard_release_curation`,
+ * which relocated the halt without removing it). It is the writer no longer
+ * emitting text that cannot ship. Two changes, and the first is what makes the
+ * second honest:
+ *
+ * 1. The line now states the COMMIT SUBJECTS behind each category, not the
+ *    name of the category's own detection rule. "hooks:effect reports whether
+ *    a bound concern fires (b0a03a7)" is a claim a reader can use; "rule/schema
+ *    diffs in b0a03a7" is a restatement of why the classifier fired.
+ * 2. `DERIVED_MARKER` is gone from the emission, so nothing unpublishable is
+ *    ever written and no release halts on the writer's own output.
+ *
+ * What is deliberately NOT relaxed: `highlight_contradictions` still refuses a
+ * human editing a substantiated line down to `_none_`, which is the failure the
+ * false 9.13.0 and 9.14.0 heads actually were; and the marker constant and its
+ * four guard sites stay, now covering only a marker somebody writes BY HAND.
+ * The honest cost of this change, stated rather than left to be discovered: the
+ * head is a categorised view of the span rather than curated prose, and it
+ * ships without a human having read it. An operator who wants better prose
+ * still edits it — they are no longer STOPPED until they do.
  */
+/**
+ * A commit subject reduced to the claim inside it.
+ *
+ * Drops the conventional-commit `type(scope):` prefix, because "feat(hooks):"
+ * is metadata about the commit and the changelog's own commit lists already
+ * carry it — what a highlight line needs is the sentence after the colon. Keeps
+ * the subject otherwise verbatim: rewording it here would make the head a
+ * paraphrase of the span rather than a citation of it, and the whole point of
+ * this module is that the two cannot disagree.
+ */
+function _claim_text(subject: string): string {
+    return subject.replace(/^[a-z]+(?:\([^)]*\))?!?:\s*/u, '').trim();
+}
+
 export function render_derived_head_values(
     hits: Readonly<Record<string, readonly CategoryHit[]>>,
 ): Record<string, string> {
@@ -292,11 +340,19 @@ export function render_derived_head_values(
         if (!reason || ev.length === 0) {
             continue;
         }
-        const shas = ev.map((h) => h.sha.slice(0, 7));
-        const shown = shas.slice(0, DERIVED_SHA_CAP);
-        const remainder = shas.length - shown.length;
-        const more = remainder > 0 ? ` +${remainder} more` : '';
-        out[label] = `${DERIVED_MARKER} ${reason} in ${shown.join(', ')}${more}.`;
+        const shown = ev.slice(0, DERIVED_SHA_CAP);
+        const remainder = ev.length - shown.length;
+        const more = remainder > 0 ? `; +${String(remainder)} more` : '';
+        const cited = shown
+            .map((h) => `${_claim_text(h.text)} (${h.sha.slice(0, 7)})`)
+            .join('; ');
+        // `reason` still names the classifier that fired, kept as the fallback
+        // for a hit whose subject renders empty after trimming — a subject that
+        // is nothing but a conventional-commit prefix. Without it the line
+        // would read "( b0a03a7)".
+        out[label] = cited ? `${cited}${more}.` : `${reason} in ${shown
+            .map((h) => h.sha.slice(0, 7))
+            .join(', ')}${more}.`;
     }
     return out;
 }

--- a/tests/scripts/check_release_highlights.test.ts
+++ b/tests/scripts/check_release_highlights.test.ts
@@ -265,8 +265,15 @@ describe('derive_categories — recorded-null forms beyond the literal marker', 
             }),
         ];
         const prefilled = render_derived_head_values(derive_category_hits(span));
-        expect(prefilled['Security and correctness']).toContain(DERIVED_MARKER);
-        expect(prefilled['Honest nulls']).toContain(DERIVED_MARKER);
+        // Substantiated, and publishable — the two halves of "not red". Since
+        // 2026-09-03 the pre-fill carries the commit subject rather than a draft
+        // marker, so what is asserted is that the label is FILLED (nothing for
+        // the contradiction check to catch) and that it carries no text the
+        // publication guards would refuse.
+        expect(prefilled['Security and correctness']).toContain('refuse a cli-delegate bundle');
+        expect(prefilled['Honest nulls']).toContain('the soak was waived not met');
+        expect(prefilled['Security and correctness']).not.toContain(DERIVED_MARKER);
+        expect(prefilled['Honest nulls']).not.toContain(DERIVED_MARKER);
 
         const curated = parse_curated_head(render_release_head(prefilled).join('\n'))!;
         expect(highlight_contradictions(curated, derive_categories(span))).toEqual([]);

--- a/tests/scripts/release_head_prefill.test.ts
+++ b/tests/scripts/release_head_prefill.test.ts
@@ -21,6 +21,7 @@ import {
     HEAD_NONE,
     type SpanCommit,
     derive_category_hits,
+    publication_blockers,
     render_derived_head_values,
     stale_draft_labels,
 } from '../../src/scripts/_lib/release_highlights.js';
@@ -70,12 +71,40 @@ describe('render_derived_head_values', () => {
         );
     });
 
-    it('cites the substantiating SHAs and carries the rewrite marker', () => {
+    it('cites the substantiating SHAs AND the commit subjects behind them', () => {
         const values = render_derived_head_values(derive_category_hits(TYPICAL_SPAN));
         const behaviour = values['Behaviour changes']!;
-        expect(behaviour).toContain(DERIVED_MARKER);
         expect(behaviour).toContain('71c3527');
         expect(behaviour).toContain('b3cc0ad');
+        // The subject, not the name of the rule that classified it. "rule/schema
+        // diffs in 71c3527" restates why the classifier fired; the claim a
+        // reader can use is the sentence the committer wrote.
+        expect(behaviour).toContain('merge brand pair, disjoin security triggers');
+        // And the conventional-commit prefix is dropped: `refactor(rules):` is
+        // metadata the changelog's own commit list already carries.
+        expect(behaviour).not.toContain('refactor(rules):');
+    });
+
+    it('emits NO draft marker — the writer never produces text that cannot ship', () => {
+        // The whole subject of the 2026-09-03 fix. Every release of this package
+        // touches `src/rules/` or `src/scripts/schemas/`, so **Behaviour
+        // changes** is always substantiated; with the marker in the emission and
+        // a gate refusing the marker, every release halted BY CONSTRUCTION. This
+        // is the assertion that keeps that combination from returning.
+        const values = render_derived_head_values(derive_category_hits(TYPICAL_SPAN));
+        for (const [label, value] of Object.entries(values)) {
+            expect(value, `${label} carries the draft marker`).not.toContain(DERIVED_MARKER);
+        }
+    });
+
+    it('renders a section the publication guards accept — no halt on the writer output', () => {
+        // One rung above the marker assertion: not "the marker is absent" but
+        // "the four guard sites would let this through". Asserting the blockers
+        // directly is what pins the property the operator actually feels.
+        const head = render_release_head(
+            render_derived_head_values(derive_category_hits(TYPICAL_SPAN)),
+        ).join('\n');
+        expect(publication_blockers(head, '9.9.9')).toEqual([]);
     });
 
     it('omits a label the span does not substantiate, so `_none_` survives there', () => {
@@ -142,11 +171,19 @@ describe('generated head clears the gate', () => {
 });
 
 describe('stale_draft_labels', () => {
-    it('names every label still carrying the unedited draft', () => {
+    it('names every label carrying a HAND-WRITTEN marker', () => {
+        // Rewritten 2026-09-03. This used to feed the GENERATOR's output, which
+        // is exactly what stopped carrying the marker — so the old form asserted
+        // a state the writer can no longer produce. The function is not dead:
+        // its four guard sites now cover a marker somebody types by hand, and
+        // that is the state fed here. Deleting the test would have dropped the
+        // only coverage of the marker path.
         const values = render_derived_head_values(derive_category_hits(TYPICAL_SPAN));
+        values['Behaviour changes'] = `${DERIVED_MARKER} someone typed this by hand.`;
+        values['Honest nulls'] = `${DERIVED_MARKER} and this one too.`;
         const curated = parse_curated_head(render_release_head(values).join('\n'))!;
         expect(stale_draft_labels(curated).sort()).toEqual(
-            ['Behaviour changes', 'Honest nulls', 'Security and correctness'].sort(),
+            ['Behaviour changes', 'Honest nulls'].sort(),
         );
     });
 


### PR DESCRIPTION
## The bug, as arithmetic

Every release of this package touches `src/rules/` or `src/scripts/schemas/`. That is the detection rule for **Behaviour changes**, so that label is **always** substantiated. The generator therefore always wrote a line carrying `DERIVED_MARKER`, and since the 2026-09-01 flip the gate always refused that marker.

**Every release halted, by construction.** `docs/contracts/CHANGELOG-conventions.md` recorded this as *"the cadence the flip chose … a different cost, not zero cost."* A release that halts by construction is not a cadence — it is a failure with a schedule.

Reproduced twice in two days: 14.14.1, and again on 14.15.0:

```
error: the 14.15.0 release highlights are still the generator's draft (1 blocker(s)):
    - the 14.15.0 section still carries `_auto-derived, rewrite before merge:_`
```

## Why the two previous attempts did not fix it

- **2026-09-01 flip** — made the marker a hard refusal at the release PR. Made the halt *visible*.
- **#1824 (14.14.1)** — moved that refusal before the release commit. Made the halt *cheaper*.

Both treated the reader of the marker. Neither touched the **writer**. The halt survives any placement of a guard, because the thing being guarded is text the pipeline generates on every single run.

## The fix

`render_derived_head_values` emits the **commit subjects** behind each category with their SHAs, and no marker:

| before | after |
|---|---|
| `_auto-derived, rewrite before merge:_ rule/schema diffs, breaking commits or removed public surface in 5a3b7c5.` | `stage-2 impact scan, so a refused merge can be answered in four words (5a3b7c5).` |

The subject change is what makes dropping the marker **honest**, and it is the half worth reviewing. The old text was a restatement of *why the classifier fired* — not a claim, so shipping it unedited genuinely was unpolished. A commit subject with its SHA **is** a claim. The conventional-commit prefix is dropped because the changelog's own commit list two sections below already carries it.

## Authority

`docs/contracts/CHANGELOG-conventions.md` named this exact change as a question it deliberately did not decide:

> Whether the generator should emit a publishable derived claim instead of a rewrite-me draft is an **open maintainer question**, not something this repair decided.

The maintainer answered it this turn — *"fix the bug so this stops happening"*. So this is not a reversal of a lock; it is the recorded open question being closed by the party it was reserved for. The contract paragraph is rewritten to say so, including which two intermediate positions were tried and why neither sufficed.

## What is deliberately NOT relaxed

- `highlight_contradictions` still refuses a human editing a substantiated line down to `_none_` — the failure the false 9.13.0 and 9.14.0 heads actually were. Untouched.
- `DERIVED_MARKER` and its **four** guard sites stay. They now cover only a marker written **by hand**.
- The `stale_draft_labels` test previously fed the generator's output — the very thing that stopped carrying the marker, so the old form asserted a state the writer can no longer produce. It now feeds a hand-written marker, so that path keeps its coverage instead of being deleted along with the behaviour.

## Verification

**End-to-end against the real 14.15.0 span** (7 commits, `14.14.1..origin/main`):

```
- **Behaviour changes:** stage-2 impact scan, so a refused merge can be answered in four words (5a3b7c5).
- **Security and correctness:** ask for the curated head before the release commit, not after (e31f07a).

blockers: []
```

**Red before green**, by reintroducing the marker into the emission exactly where it used to be:

```
× render_derived_head_values > emits NO draft marker — the writer never produces text that cannot ship
× render_derived_head_values > renders a section the publication guards accept — no halt on the writer output
× stale_draft_labels > names every label carrying a HAND-WRITTEN marker
  Tests  3 failed | 9 passed (12)
--- restored ---
  Tests  12 passed (12)
```

One new test asserts a rung above marker-absence: that `publication_blockers` on the rendered head is empty. That is the property an operator actually feels, and asserting the marker alone would not have caught a second unpublishable sentinel.

**Suite:** `release_head_prefill`, `check_release_highlights`, `release`, `release_drill`, `release_push_failure_masking`, `release_material`, `changelog_release_section_gate` — **204 passed**. `tsc --noEmit`, `eslint`, `check_references`, `check_md_language`, `lint_code_comments` clean. `check_source_size_budget` unchanged at 18,193 — `release_highlights.ts` is 514 lines, under the 1500 cap, so the added rationale costs nothing.

## The honest cost

The head is now a **categorised view of the span** rather than curated prose, and it ships without a human having read it. That is a real reduction in editorial quality and it is accepted deliberately, recorded in the contract rather than left to be discovered. An operator who wants better prose still edits the section — they are no longer *stopped* until they do.

Consequence worth naming: the unattended release path (`.github/workflows/release.yml`, `--ci --yes`, ADR-113) can now complete a release, which it could not before.