### PR TITLE
release: 14.15.0

### DIFF
--- a/.augment-plugin/marketplace.json
+++ b/.augment-plugin/marketplace.json
@@ -1,20 +1,20 @@
 {
   "name": "event4u-agent-config",
   "description": "Governed agent system — skills, rules, commands, and guidelines for AI-assisted development.",
-  "version": "14.14.1",
+  "version": "14.15.0",
   "owner": {
     "name": "event4u",
     "email": "dev@event4u.app"
   },
   "metadata": {
     "description": "A policy-driven execution system that enforces quality, consistency, and developer-like behavior for AI agents.",
-    "version": "14.14.1"
+    "version": "14.15.0"
   },
   "plugins": [
     {
       "name": "agent-config",
       "description": "Full governed agent system — rules, skills, commands, guidelines, and runtime tooling.",
-      "version": "14.14.1",
+      "version": "14.15.0",
       "source": ".",
       "category": "governance",
       "tags": [

--- a/.augment-plugin/plugin.json
+++ b/.augment-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-config",
   "description": "A governed skill framework for AI agents — runtime execution, tooling, observability, feedback, and lifecycle management with policy-driven quality enforcement.",
-  "version": "14.14.1",
+  "version": "14.15.0",
   "author": {
     "name": "event4u",
     "email": "dev@event4u.app"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "Bootstrap shim for the event4u agent-config suite. This plugin ships ONLY the dispatcher hooks plus one install-pointer skill — ALL content (skills, rules, commands) is installed via `npx -y @event4u/agent-config init`, which writes the file projection AND registers the same hooks in ~/.claude/settings.json. DEPRECATED as a content channel; kept so the marketplace listing stays discoverable and existing installs keep working hooks.",
-    "version": "14.14.1",
+    "version": "14.15.0",
     "keywords": [
       "agent-config",
       "skills",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -434,6 +434,36 @@ Entry-shape contract: [`docs/contracts/CHANGELOG-conventions.md`](docs/contracts
 > that forces a new era split (`# Era: 14.15.x`, etc.) — see
 > [`docs/contracts/CHANGELOG-conventions.md § Era splits`](docs/contracts/CHANGELOG-conventions.md).
 
+## [14.15.0](https://github.com/event4u-app/agent-config/compare/14.14.1...14.15.0) (2026-09-03)
+
+### Release highlights
+
+- **Behaviour changes:** stage-2 impact scan, so a refused merge can be answered in four words (5a3b7c5).
+- **Default changes + migration:** _none_
+- **Security and correctness:** make the derived head publishable, so a release stops halting by construction (e6f6744); ask for the curated head before the release commit, not after (e31f07a).
+- **Honest nulls:** _none_
+- **Known limitations:** _none_
+
+### Features
+
+* **authz:** stage-2 impact scan, so a refused merge can be answered in four words ([5a3b7c5](https://github.com/event4u-app/agent-config/commit/5a3b7c5064b2e92523781530cbfe6ef09bd26f35))
+* **authz:** classify the 17 destructive operations the guard could not see ([a1327b2](https://github.com/event4u-app/agent-config/commit/a1327b2767751d4ce6e680af1b8f9732faf97b88))
+* **authz:** target-bound merge grants that outlive the clock ([c286570](https://github.com/event4u-app/agent-config/commit/c286570d1e9a421a51571bb27e3a2945a54e8f8c))
+
+### Bug Fixes
+
+* **docs:** cite the head label as code, not bold — the ratchet counts bold ([3f78ead](https://github.com/event4u-app/agent-config/commit/3f78ead4fd9023ed189ccd15aac2659397072ca8))
+* **release:** make the derived head publishable, so a release stops halting by construction ([e6f6744](https://github.com/event4u-app/agent-config/commit/e6f67444c0c11873f6231fd007b70b404f9e883a))
+* **ci:** drop code-comment-discipline from the rule-enforcement baseline ([731924a](https://github.com/event4u-app/agent-config/commit/731924ae778191bafefb3bbcfcb92c2acf76b558))
+* **release:** ask for the curated head before the release commit, not after ([e31f07a](https://github.com/event4u-app/agent-config/commit/e31f07ab8bb4b25e048f1b4c78ffa32b27fd59f5))
+
+### Documentation
+
+* **adr:** ADR-252 evidence section, and the census it moves ([19e99a4](https://github.com/event4u-app/agent-config/commit/19e99a4febfc6e9f8d092ecafc8c8e23c8f1699e))
+* **adr:** ADR-252 supersedes ADR-251 — specificity replaces recency, for merge only ([ef930e0](https://github.com/event4u-app/agent-config/commit/ef930e01d450a4b78730f545a4f04eab1812eccb))
+
+Tests: 20922 (+146 since 14.14.1)
+
 ## [14.14.1](https://github.com/event4u-app/agent-config/compare/14.14.0...14.14.1) (2026-09-03)
 
 ### Release highlights

--- a/dist/agent-src/templates/agents/agent-project-settings.example.yml
+++ b/dist/agent-src/templates/agents/agent-project-settings.example.yml
@@ -39,7 +39,7 @@ schema_version: 1
 # CI guard: a release bump of `package.json` must update this value
 # in lockstep — see scripts/check_template_pin_drift.ts (road-to-
 # portable-runtime-and-update-check P3.3).
-agent_config_version: "14.14.1"
+agent_config_version: "14.15.0"
 
 # --- Project identity ---
 project:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@event4u/agent-config",
-    "version": "14.14.1",
+    "version": "14.15.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@event4u/agent-config",
-            "version": "14.14.1",
+            "version": "14.15.0",
             "license": "MIT",
             "dependencies": {
                 "@fastify/static": "^10.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@event4u/agent-config",
     "mcpName": "io.github.event4u-app/agent-config",
-    "version": "14.14.1",
+    "version": "14.15.0",
     "description": "Governed skills, rules and commands for AI coding tools (Claude Code, Cursor, Windsurf, Copilot) — every claim machine-checked, including the counts in these badges.",
     "license": "MIT",
     "private": false,

--- a/src/agent-src/templates/agents/agent-project-settings.example.yml
+++ b/src/agent-src/templates/agents/agent-project-settings.example.yml
@@ -39,7 +39,7 @@ schema_version: 1
 # CI guard: a release bump of `package.json` must update this value
 # in lockstep — see scripts/check_template_pin_drift.ts (road-to-
 # portable-runtime-and-update-check P3.3).
-agent_config_version: "14.14.1"
+agent_config_version: "14.15.0"
 
 # --- Project identity ---
 project:


### PR DESCRIPTION
Release 14.15.0.

<!-- release-pr-only:start -->
<!-- Curated head: fill before merge, keep it under 10 lines, and leave `_none_` where it is genuinely the answer. The generated log below is unchanged. -->
<!-- release-pr-only:end -->

### Release highlights

- **Behaviour changes:** stage-2 impact scan, so a refused merge can be answered in four words (5a3b7c5).
- **Default changes + migration:** _none_
- **Security and correctness:** make the derived head publishable, so a release stops halting by construction (e6f6744); ask for the curated head before the release commit, not after (e31f07a).
- **Honest nulls:** _none_
- **Known limitations:** _none_

### Features

* **authz:** stage-2 impact scan, so a refused merge can be answered in four words ([5a3b7c5](https://github.com/event4u-app/agent-config/commit/5a3b7c5064b2e92523781530cbfe6ef09bd26f35))
* **authz:** classify the 17 destructive operations the guard could not see ([a1327b2](https://github.com/event4u-app/agent-config/commit/a1327b2767751d4ce6e680af1b8f9732faf97b88))
* **authz:** target-bound merge grants that outlive the clock ([c286570](https://github.com/event4u-app/agent-config/commit/c286570d1e9a421a51571bb27e3a2945a54e8f8c))

### Bug Fixes

* **docs:** cite the head label as code, not bold — the ratchet counts bold ([3f78ead](https://github.com/event4u-app/agent-config/commit/3f78ead4fd9023ed189ccd15aac2659397072ca8))
* **release:** make the derived head publishable, so a release stops halting by construction ([e6f6744](https://github.com/event4u-app/agent-config/commit/e6f67444c0c11873f6231fd007b70b404f9e883a))
* **ci:** drop code-comment-discipline from the rule-enforcement baseline ([731924a](https://github.com/event4u-app/agent-config/commit/731924ae778191bafefb3bbcfcb92c2acf76b558))
* **release:** ask for the curated head before the release commit, not after ([e31f07a](https://github.com/event4u-app/agent-config/commit/e31f07ab8bb4b25e048f1b4c78ffa32b27fd59f5))

### Documentation

* **adr:** ADR-252 evidence section, and the census it moves ([19e99a4](https://github.com/event4u-app/agent-config/commit/19e99a4febfc6e9f8d092ecafc8c8e23c8f1699e))
* **adr:** ADR-252 supersedes ADR-251 — specificity replaces recency, for merge only ([ef930e0](https://github.com/event4u-app/agent-config/commit/ef930e01d450a4b78730f545a4f04eab1812eccb))

Tests: 20922 (+146 since 14.14.1)

Created by `src/scripts/release.ts`.