### PR TITLE
roadmap: correct four measured claims on the council-topology carrier

### DIFF
--- a/agents/roadmaps/road-to-council-topology-evidence-followups.md
+++ b/agents/roadmaps/road-to-council-topology-evidence-followups.md
@@ -50,11 +50,20 @@ parent_roadmap: road-to-inbox-harvest-2026-08-e-council-topology-evidence
 > archived, so that check can never run against this pair again. The standing
 > validator is what closed the gap, not a change to the one-shot one.
 >
-> Two claims are NOT re-verified here and are left as they stand: whether
-> deletion still scores as an estate **credit**
-> (`src/scripts/check_estate_count.ts:490-534`), and the reference-gate reach.
-> Deletion is a hard failure now regardless of how the estate would score it, so
-> the credit question no longer decides anything.
+> Two claims were NOT re-verified when this was written. **One of them is now
+> measured, 2026-09-03, and it moved in the stricter direction:** deleting this
+> file scores as a **shrink of one**, not as a credit and not as nothing.
+> `check_estate_count` reports `active_roadmaps 4 (floor 4, +0)` with the file
+> present and `3 (floor 4, -1)` with it moved aside — probed by moving the file
+> out and back with a byte-identical restore. The mechanism is
+> `countActiveCarriers` (`src/scripts/check_estate_count.ts:460`), added into
+> `active_roadmaps` at `:527` precisely so that flipping a status is
+> count-neutral and a roadmap cannot be laundered out of the count by adding one
+> word. A carrier's removal still earns no offset (`classifyDiff`), so the
+> deletion is visible and unrewarded. The reference-gate reach is still not
+> re-verified. Deletion is a hard failure now regardless of the score, so this
+> changes no disposition — it removes the one thing the earlier text called worse
+> than a credit, which was invisibility.
 >
 > Full derivation, including the 43 inbound-reference census:
 > [`agents/evidence/analysis/topology-followups-disposition-evidence-2026-09-01.md`](../evidence/analysis/topology-followups-disposition-evidence-2026-09-01.md)
@@ -259,6 +268,20 @@ transitions fails closed today, which both seats asked for as a deliberately
 immobile first version. `agents/roadmaps/stubs/road-to-carrier-transition-vocabulary.md`
 records it.
 
+## Where the governing Blockers and Acceptance Criteria live
+
+This file carries **no `## Blockers` section and no `## Acceptance Criteria`
+section**, and that is deliberate rather than an omission — it is a receiver,
+not a schedulable roadmap. Both surfaces belong to the archived parent
+`road-to-inbox-harvest-2026-08-e-council-topology-evidence`: nine blocker
+entries, all `Status: resolved` (which is why that roadmap could archive at
+all), and 29 numbered acceptance criteria. Each of the 38 obligations below is
+measured against those, not against anything in this file.
+
+Stated here because the absence is otherwise indistinguishable from an artefact
+that forgot to write them, and a reader concluding the obligations carry no
+acceptance criteria would conclude the opposite of the truth.
+
 ## What this file may NOT be read as claiming
 
 That any deferred mechanism was verified against a real population; that
@@ -333,6 +356,23 @@ have been a visible delta — a number moving, something a reader or a ratchet
 could notice. There is none. The deletion is not merely unpunished; it is
 **invisible**. The header's wording is left in place above and corrected here
 rather than rewritten, so the claim and its refutation stay side by side.
+
+**Re-measured 2026-09-03 — the invisibility is closed, and this paragraph is
+appended rather than rewritten for the same reason the paragraph above was.**
+`check_estate_count` now reports `active_roadmaps 4 (floor 4 at origin/main, +0)`
+with this file present and `3 (floor 4, -1)` with it moved aside. Probed by
+moving the file out, running the gate, and moving it back to a byte-identical
+copy; the working tree was clean before and after.
+
+The mechanism is `countActiveCarriers` (`src/scripts/check_estate_count.ts:460`),
+whose result is added into `active_roadmaps` at `:527`. Its own docblock states
+the defect it closes, and it is this one: *"flipping one file to `carrier` moved
+`active_roadmaps 3 → 2` and the gate printed 'estate within its ratchet'
+… any roadmap can be laundered out of the count by adding one word."* So the
+`status: draft`-then-`carrier` invisibility this section measured on 2026-09-01
+was a real hole and is now plugged from the other side. Deleting this file is a
+**visible** shrink of one — and still earns no offset, because `classifyDiff`
+grants none for a carrier's removal, which is the half that has not changed.
 
 ### Why the gap was not closed in this run
 

--- a/agents/roadmaps/stubs/road-to-council-topology-instrumentation.md
+++ b/agents/roadmaps/stubs/road-to-council-topology-instrumentation.md
@@ -57,7 +57,7 @@ The guard is falsifiable today; the thing it guards does not exist.
 | 11.1 | `tests/scripts/ai_council/routing_training_row.test.ts` | 3 of 13 RED |
 | 12.1 | `tests/scripts/ai_council/council_topology_surface.test.ts` | 3 of 11 RED |
 | 12.2 | `tests/scripts/ai_council/explain_route.test.ts` | 6 of 15 RED |
-| 12.3 | `tests/scripts/ai_council/force_topology_prohibitions.test.ts` | 4 of 11 RED, byte-identical restore |
+| 12.3 | `tests/scripts/ai_council/force_topology_prohibitions.test.ts` | 3 of 13 and 1 of 13 RED across two sabotages, byte-identical restore (sha256-pinned) |
 
 **Resumption trigger, per step:** when the population it guards — topology
 selection, a force-topology control, a stage-output producer, prompt storage on
@@ -73,10 +73,22 @@ test exists and detects the planted violation.
 ## Group 2 — three steps whose mechanism is unbuilt
 
 - **5.4** *Final synthesis retains unresolved disagreement, the strongest
-  minority evidence, and what evidence would resolve it.* No synthesis template
-  asks for any of the three: `DEFAULT_SYNTHESIS`
-  (`src/scripts/ai_council/prompts.ts:284`) and its three siblings are all
-  silent. The openai seat refined the framing and it is worth keeping: the
+  minority evidence, and what evidence would resolve it.* **Corrected
+  2026-09-03: the templates are not silent, and the remaining gap is one element
+  of the three, not all three.** Measured over
+  `src/scripts/ai_council/prompts.ts`: element 1, unresolved disagreement, is
+  asked for by all four templates — `### Clashes` in `DEFAULT_SYNTHESIS`
+  (`:291`, "State both sides with a one-line reviewer-label citation per side"),
+  `### Conflicts` in `PR_SYNTHESIS` (`:320`), `### Outliers` in
+  `ANALYSIS_SYNTHESIS` (`:356`), and the mandated convergence / divergence
+  synthesis in `CREATIVE_SYNTHESIS` (`:380`). Element 2, retaining the strongest
+  minority evidence, is asked for by one — `### Outliers`, "Keep them — they are
+  signal for a future deeper analysis pass" (`:356-358`). Element 3, what
+  evidence would resolve the disagreement, appears in **none**: a grep for that
+  clause across the file returns zero, and `### Kill criteria` (`:305`, `:332`,
+  `:366`, `:384`) falsifies the *recommendation*, not the disagreement. So 5.4's
+  remaining scope is ONE element in four templates. The openai seat refined the
+  framing and it is worth keeping: the
   population here is **not** empty — dissent exists today. What is absent is an
   explicit synthesis contract and a qualifying validation run. Both seats
   refused to license building it as prose-only: *"merely adding prose to four
@@ -88,8 +100,11 @@ test exists and detects the planted violation.
 - **10.2** *Attribute each useful correction to the first stage where it
   appeared.* The vocabulary exists with **no producer**: `StageOutput {stage,
   produced, calls}` (`src/scripts/ai_council/replay_route.ts:49-54`) is carried
-  on `CouncilRouteRecord` (`:74`), and the module's only importer anywhere is
-  its own test.
+  on `CouncilRouteRecord` (`:74`), and its only importers anywhere are two test
+  files — `tests/scripts/ai_council/replay_route.test.ts` and
+  `tests/scripts/ai_council/probe_path_above_council.test.ts`. **Zero production
+  importers**, which is the load-bearing half; the count was corrected 2026-09-03
+  from "its own test" alone.
   **Resume when** production code emits stage records and a real correction
   crosses observable stages. **Do not claim** per-correction attribution or
   operational use of `CouncilRouteRecord`.


### PR DESCRIPTION
**This roadmap is not closed, and closing it is not available to an autonomous run.** It is a deferral carrier holding 38 open obligations; all 38 checkboxes are byte-identical in this branch. What this PR ships is four factual corrections to claims that no longer reproduce, each re-measured in this run rather than carried over from a report.

## Why it cannot close, and why no council was convened

`agents/roadmaps/road-to-council-topology-evidence-followups.md` carries `status: carrier` and a recorded boundary from a 2-round, 2/2-quorum council verdict on this exact question, under this exact instruction shape:

> preserve all 38 obligations in place · preserve the three measurable resumption triggers · do not archive, cancel, promote or transfer the carrier · do not claim its work is complete

The file additionally states that re-asking after an unwelcome verdict is verdict shopping rather than rigour. Under the decision-revisit gate this is a mechanism match with no new counter-evidence, so the lock applies and the disposition it already recorded — leave the status untouched, correct in place — is the one executed here.

The two facts that would have to move first, both re-measured today:

- **Phase 2's trigger needs `n >= 5` independent eligible seats.** `agent-config council:status` reports `2 enabled of 5` (anthropic, openai), both currently `available`. Unmet by three seats. *(An earlier recon pass in this same session read one seat as `unavailable`; that was a transient transport failure — `os_error: ENOBUFS` on a live run — and it is deliberately **not** written into the roadmap. The roadmap's existing "2 enabled of 5" is correct and current.)*
- **Phase 2's benchmark needs 1,584–1,804 provider calls across 20 consecutive UTC days** at 46–50 calls per provider per day against a 50/provider/day cap — i.e. both seats monopolised for twenty days, while those same two seats *are* this repository's decision mechanism. Nine of the 38 items cannot be closed without paid provider calls.

Zero of the 38 criteria are met. Mechanism-exists is not criterion-met, and the roadmap's own § What this file may NOT be read as claiming governs.

## The four corrections

### 1. The carrier's self-correction section is stale in the stricter direction

On 2026-09-01 that section measured that deleting this file "scores as nothing at all" — `active_roadmaps 2 (floor 2, +0)` with the file present *and* deleted — and called the invisibility worse than a credit would have been.

Re-measured 2026-09-03:

```
with the file present:     active_roadmaps 4  (floor 4 at origin/main, +0)
with the file moved aside: active_roadmaps 3  (floor 4 at origin/main, -1)
```

Probed by moving the file out, running `task check-estate-count`, and moving it back to a byte-identical copy; `git status` was clean before and after. The mechanism is `countActiveCarriers` (`src/scripts/check_estate_count.ts:460`), whose result is added into `active_roadmaps` at `:527`, and whose own docblock names the defect it closes: *"flipping one file to `carrier` moved `active_roadmaps 3 → 2` and the gate printed 'estate within its ratchet' … any roadmap can be laundered out of the count by adding one word."*

So the hole that section measured is plugged from the other side. Removal is now a **visible** shrink of one, and still earns no offset — `classifyDiff` grants none for a carrier's removal, which is the half that has not changed.

**Appended, not rewritten.** That is the convention the section itself established for its own predecessor: the claim and its refutation stay side by side.

### 2. The header's deferred estate-credit question is now answerable

`:52-57` left two claims un-re-verified. One is now measured (above); the reference-gate reach is still open, and the text says so.

### 3. The receiver carries no Blockers and no Acceptance Criteria, and nothing said so

Neither section exists in this file — deliberately, since it is a receiver rather than a schedulable roadmap. Both live on the archived parent, counted in this run: **9** blocker entries, **all 9** `Status: resolved` (which is why that roadmap could archive at all), and **29** numbered acceptance criteria.

A reader finding neither section would conclude the 38 obligations have no acceptance criteria, which is the opposite of the truth. A pointer section now states where they live.

### 4. Three wrong numbers in the instrumentation stub

| Item | Recorded | Measured today |
|---|---|---|
| 12.3 red-proof | "4 of 11 RED, byte-identical restore" | the suite has **13** tests; the parent's own record is two 2026-09-01 sabotages reddening **3 of 13** and **1 of 13**, `13/13` green after sha256-pinned byte-identical restores |
| 5.4 synthesis contract | "No synthesis template asks for any of the three … all silent" | element 1 (unresolved disagreement) is asked for by **all four** templates — `### Clashes` (`prompts.ts:291`), `### Conflicts` (`:320`), `### Outliers` (`:356`), the mandated convergence/divergence synthesis (`:380`); element 2 (retain strongest minority evidence) by **one** (`:356-358`, "Keep them"); element 3 (what evidence would resolve it) by **none** — grep returns zero, and `### Kill criteria` falsifies the *recommendation*, not the disagreement |
| 10.2 importers | "the module's only importer anywhere is its own test" | **two** test importers (`replay_route.test.ts`, `probe_path_above_council.test.ts`); **zero production importers**, which is the load-bearing half and is unchanged |

Correction 3 on 5.4 is the one that changes future work rather than just the record: it narrows that step from "add three elements to four templates" to one.

## Gates

```
lint_roadmap_blockers            ✅  0 violations
check_roadmap_trackable          ✅  0 violations
lint_carrier_integrity           ✅  665 scanned, 1 live carrier justified
lint_roadmap_complexity          ✅  5 roadmaps complexity-clean
check_no_roadmap_refs            ✅  no roadmap-file references in stable artifacts
check_estate_count               ✅  within its ratchet (+0 on every axis)
```

## Honest notes

- **No checkbox changed.** `git diff` matches zero lines beginning `+- [` or `-- [`. The 38 obligations are preserved exactly as the boundary requires.
- **Nothing here claims progress on the 38.** These are corrections to the record about them.
- **`agent-config` emits a tsx-fallback warning** on this machine (`package-local tsx not found`). Pre-existing, unrelated to this diff, and it does not affect the `council:status` reading quoted above.
- The three resumption triggers are unchanged and unmonitored — the roadmap names that gap itself, and the only one of the three a machine can currently read is the seat count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
