### PR TITLE
roadmap: complete tell-currency

### DIFF
--- a/agents/evidence/analysis/tell-currency-corpus-audit-2026-09-03.md
+++ b/agents/evidence/analysis/tell-currency-corpus-audit-2026-09-03.md
@@ -1,0 +1,101 @@
+<!-- evidence-type: analysis -->
+# What the tree itself emits — apply-skill and grounding-corpus sweep
+
+<!-- generated-by: hand, road-to-tell-currency step 4.1 · verified against 7211a4274 + this branch -->
+
+Step 4.1's record. It asks whether this repository hands an agent a default the
+anti-pattern catalog then flags, and requires every finding to be **fixed or
+stated as intentional with a reason**. The council widened the scope on a 2/2
+verdict: the four apply skills the step names, **plus `design-intelligence`**,
+which is the one place in the tree that recommends three of the four tells this
+roadmap added.
+
+## 1. The four named apply skills — three clean, one gap
+
+| Skill | Anti-slop section | Forbids its own ecosystem default, with a catalog citation? |
+|---|---|---|
+| `react-shadcn-ui` | `SKILL.md:114-128`, restated `:181-183` | **Yes.** The shadcn out-of-the-box neutral theme + Inter fallback, cited as `T7/T8 + C5`, with a concrete override hook (`state.ui_audit.design_tokens`). The strongest of the four. |
+| `tailwind-engineer` | `SKILL.md:134-155` | **Yes, partially.** Tailwind's default gradient reach is cited inline (`C1/C2`, `:143`). The typography and layout bullets (`:145-155`) carry the ban without an inline id — `T7` and `L1/L2` appear only in the roll-up at `:137`. |
+| `blade-ui` | `SKILL.md:141-148` | **No.** It cites `V1`, `T3`, `L1/L2` correctly, but none of those is a *Laravel* ecosystem default. Breeze / Jetstream scaffold markup and the default `x-` component look are never named (`grep -ni "breeze\|jetstream\|scaffold"` returns only a frontmatter key and a Blade-escaping line). It delegates concrete bans to `tailwind-engineer`, which bans **Tailwind's** defaults, not Laravel's. The clearest gap of the four. |
+| `fe-design` | `SKILL.md:247-253` | **No — correctly.** It is the stack-agnostic heuristic layer and owns no ecosystem default; the catalog's own ownership table assigns stack manifestation to `tailwind-engineer` and `react-shadcn-ui`. |
+
+So the step's literal scope was satisfiable with no edit for three of four skills.
+The findings are elsewhere.
+
+## 2. Fixed in this change
+
+| Finding | Where | What it was | Disposition |
+|---|---|---|---|
+| **M4 handed over as the good example** | `src/skills/design-intelligence/data/ux-guidelines.csv:9` | The column literally named `Code Example Good` carried `transition-all duration-200`. `transition-all` is Tailwind's compilation of `transition-property: all`, i.e. M4's exact defect — and M4 is `backed`. | **FIXED** → `transition-colors duration-200`, which is what the row's own `Do` cell ("Use 150-300ms for micro-interactions") and M4's override ("enumerate only the properties that should animate") both ask for. The old value moved to `Code Example Bad`, where it now demonstrates two defects at once. |
+| **Two stale catalog id ranges** | `src/skills/react-shadcn-ui/SKILL.md:125`, `src/skills/fe-design/SKILL.md:249` | Both cited `Visual V1–V7, Layout L1–L8`. Literally correct as *table* extents and materially wrong as *category* coverage: `V8` (shape lock), `L9` (section monotony) and `L10` (zigzag) live in the Consistency-Locks table, and all three are `backed`. A shadcn tree with four `rounded-*` tiers is V8 and was unreachable through either citation. | **FIXED** → `V1–V8` / `L1–L10`, with the table topology stated in the `react-shadcn-ui` line so the next reader does not re-narrow it. `fe-design` also gains `Motion (M1–M8)`. |
+| **A register-scoping overclaim** | `src/skills/fe-design/SKILL.md:252` | "every entry has one, and they are register-scoped" — only **two** entries are register-scoped. `grep -c 'egister-scoped'` over the catalog returns 2: T7 and T8, both of which say so in their own override text. | **FIXED** → the override-condition claim is kept (it is true of every entry) and the register-scoping narrowed to T7/T8, with the undeclared-pick clause preserved. |
+
+**Why the M4 row mattered even though no gate could see it:** `.csv` has no
+engine in `lint_design_slop`'s `enginesForExt`, so the file is not scanned at
+all — and the M4 detector matches `transition\s*:\s*all`, which the Tailwind
+class form does not contain. The row was invisible to the exact rule it
+contradicted, in two independent ways. That is the shape of every remaining
+finding below, and it is why this sweep had to be a read rather than a lint.
+
+## 3. Two catalog gaps this roadmap closed by accident
+
+The sweep found two tells with corpus sites and **no catalog id**:
+
+| Gap | Corpus sites | Status after this roadmap |
+|---|---|---|
+| Pointer-tracked spotlight lighting | `references/design-languages.md:21` ("cursor-tracking spotlight" as a Modern-Dark ingredient) | **CLOSED** — this roadmap added **M7**. The sweep was run against the pre-change tree, so it reported the gap; the entry now exists and a reviewer has an id to cite. |
+| Noise / film-grain / paper-texture overlay | `data/styles.csv:14,56,59,61,67,68,70`, `data/design-languages/modern-dark.txt:12`, `monochrome.txt:86-90`, `sketch.txt:12`, `neo-brutalism.txt:57`, `cyberpunk.txt:11` — ten-plus sites | **PARTIALLY CLOSED** — **V9** covers grain *over a gradient*, which is the composition the tell names. Grain over a flat ground (`monochrome.txt:86`, with a stated reason) is outside V9 and stays uncatalogued, correctly. |
+
+V6 covers neither: it is scoped to "repeating diagonal stripes" and its detector
+matches only `repeating-linear-gradient`.
+
+## 4. Recorded, not fixed — carried to a named receiver
+
+The remaining findings are **41 prescriptive collisions** across a curated
+grounding corpus. They are not fixed here, and "stated as intentional" would be
+false for most of them: they are defects, not decisions. So they carry to
+`agents/roadmaps/later/road-to-grounding-corpus-catalog-parity.md`, which is the
+third disposition — a named receiver with a resume condition — rather than a
+shrug in a summary.
+
+Ordered by consequence, with the cluster each represents:
+
+| # | Cluster | Sites | Catalog id | Why it is not a one-line fix |
+|---|---|---|---|---|
+| 1 | `data/motion.csv` has **zero** `prefers-reduced-motion` coverage across 16 animation recipes (`grep -c` = 0) | whole file | **M5** ("Never acceptable") + CI-enforced floor **Q4** | Compounded by `gsap` being absent from the `ground` plan, so the mitigations that DO exist in sibling files are never co-retrieved with a motion recipe. Fixing it means either 16 row edits or a plan change, and the plan change has its own blast radius. |
+| 2 | Glassmorphism as the **primary** default for 15 generic product types, plus 15 `Style_Priority` rows and 4 literal `Backdrop blur (10-20px)` recipes | `data/products.csv` (15 rows), `data/ui-reasoning.csv:2,92,97,100,155` | **V2** | Routed into the winning style pick by the decision engine's priority bias, and self-contradicted by the corpus's own `references/design-rules-checklist.md:107` ("use blur to indicate background dismissal, not as decoration"). The fix is a policy decision about what `Primary Style Recommendation` may contain, not an edit. |
+| 3 | Violet-on-dark palettes keyed on bare product types; two rows state the C1 triad **verbatim in their own `Notes`** | `data/colors.csv:127,129` (exact), `:13,15,20,130,143` (violet-on-dark), 17 further rows (violet on light) — 24 of 161 colour rows | **C1** | C1 is `judgment-only` because "which colours are primary is a judgment" — and these rows *declare* them primary in a column named `Primary`, removing the judgment the status note relies on. |
+| 4 | Four `letter-spacing: -0.05em` / `tracking-tighter` defaults on display text | `data/styles.csv:48,70`, `data/design-languages/monochrome.txt:65`, `bauhaus.txt:39` | **T6** (`backed`) + floor **Q7** (≥ −0.04em) | Two are in retrieval-served columns. The value is below a CI-enforced floor, so these are not stylistic preferences. |
+| 5 | T7/T8 blind spot: at least 8 `styles.csv` rows and 6 `design-languages` specs pin a T7 family as a token with no flag and no stated reason | `data/styles.csv:70,71,74,77,78,82`, `design-languages/modern-dark.txt:51`, `neo-brutalism.txt:24`, `neumorphism.txt:26`, `saas.txt:32,68`, `kinetic.txt:47` | **T7**, **T8** | The `AI-Default Flag` mitigation exists and works — but only in `font-pairings-reference.csv`, which has the column. `styles.csv` has no such column, so the same Nunito + DM Sans pairing is flagged in one file and unflagged in the other. |
+| 6 | Radius tokens above the 16px cap on sub-200px surfaces | `data/styles.csv:10,40,41,54,55,81,82,85` | **V4** + floor **Q9** | Excludes the `--radius-pill: 999` rows, which V4's own override sanctions. |
+| 7 | Two elastic/overshoot easing curves as the default for a hover micro-interaction and a card-grid entrance | `data/motion.csv:4,9` | **M1** (`backed`) | One row carries a partial self-authored mitigation ("don't use `back.out` on dense data tables") that stops short of M1's principle. |
+| 8 | Side-stripe status indicators offered as the mechanism | `data/styles.csv:31,44` | **V1** (`backed`, and widened by this roadmap) | Both are product-shape rows (dashboard, AI-native UI), so the stripe arrives as a default for exactly the surfaces V1 names. |
+| 9 | `background-clip: text` + `linear-gradient` shipped as a **token** (`--gradient-text`) | `data/styles.csv:49`, `design-languages/cyberpunk.txt:150` | **C2** (`backed`) | Both halves of the deterministic rule co-occur in served columns. |
+| 10 | An italic serif pinned as `--font-display` alongside a 48–72px hero range | `data/styles.csv:78` | **T2** | T2 is `judgment-only` because it "requires knowing which element is the hero"; the row names the hero size in the same cell, removing that ambiguity. |
+| 11 | "Add 2–3 absolute animated 'blob' views" with counts and blur radii; a `--hud-color` glow token | `data/styles.csv:37,52,71,82` | **CP6**, **C3** | CP6 governs render subject, and two of these are UI-style specs rather than image briefs — a register mismatch that has to be decided, not assumed. |
+
+**14 further rows were checked and are NOT defects**, recorded so a later sweep
+does not re-flag them: the Glassmorphism style row *defining* glassmorphism, film
+grain in a row whose `Era/Origin` is "1970s-90s Analog Revival" and whose
+`Do Not Use For` fences off modern SaaS, uppercase headlines under T9's own
+brutalist override, spring-squish motion under M1's playful-affordance override,
+Roboto in the Material-Design spec (where Material *is* the documented reason),
+and two layout rows that name a metrics or feature section without the count,
+size or gradient their catalog entries require.
+
+**Nine catalog ids have no corpus recommendation at all** and are clean by
+measurement rather than by assumption: T4, T5, CP2, CP5, L4, plus V3, V5, V7,
+L5–L7, M2, M3, C4, CP1, CP3, CP4, V8, C6, C7, L9, L10, T1, T3. Two corpus rows
+actively **agree** with the catalog — `data/ux-guidelines.csv:16` and
+`data/stacks/html-tailwind.csv:6` both put `z-[9999]` in `Code Example Bad`,
+which is L8's position.
+
+## 5. What the sweep says about the method
+
+Every one of the 41 findings sits in a file the detector cannot read. The
+grounding corpus is `.csv`, `.txt` and `.json`; `lint_design_slop` classifies an
+engine for `.css`, `.html`-family, `.jsx`/`.tsx` and `.md` only. So the corpus
+that motivates the catalog is structurally outside the catalog's enforcement,
+and no amount of detector work reaches it. That is the finding behind the
+findings, and it is why the receiver's first step is a scope decision rather
+than an edit.

--- a/agents/roadmaps/archive/road-to-tell-currency.md
+++ b/agents/roadmaps/archive/road-to-tell-currency.md
@@ -168,7 +168,7 @@ status-table row so the parity gate stays green.
 
 ## Phase 4 — What the tree itself emits
 
-- [ ] **4.1 Check the remaining own-estate tell after the icon default is
+- [x] **4.1 Check the remaining own-estate tell after the icon default is
       removed.** `road-to-declared-coverage-truth` Phase 3 removes the Lucide
       default from `iconography`. Re-run the same question across the other apply
       skills — `react-shadcn-ui`, `tailwind-engineer`, `blade-ui`,
@@ -176,6 +176,31 @@ status-table row so the parity gate stays green.
       an agent as a default that the catalog then flags.
       verify: the sweep is recorded with per-skill findings, and each finding is
       either fixed or stated as intentional with a reason.
+      **Recorded in `agents/evidence/analysis/tell-currency-corpus-audit-2026-09-03.md`,
+      and the council widened the scope 2/2.** The four named skills are three
+      clean and one gap: `react-shadcn-ui` and `tailwind-engineer` already forbid
+      their ecosystem default with a catalog citation, `fe-design` correctly owns
+      none, and `blade-ui` cites four ids of which none is a Laravel default
+      while delegating the concrete bans to a skill that bans Tailwind's. So the
+      step's literal scope was satisfiable with no edit, which is why
+      `design-intelligence` was added: it is the one place in the tree that
+      recommends three of the four tells this roadmap added, with copy-paste
+      code.
+      **Three findings fixed here.** The sharpest was
+      `data/ux-guidelines.csv:9`, whose column literally named `Code Example
+      Good` carried `transition-all duration-200` — M4's exact defect, M4 being
+      `backed`, and invisible to it twice over (`.csv` has no engine, and the
+      detector matches `transition: all`, not the Tailwind class). Plus two
+      stale catalog id ranges in `react-shadcn-ui` and `fe-design` that made
+      `V8`, `L9` and `L10` unreachable, and a register-scoping overclaim
+      ("every entry … register-scoped" — only T7 and T8 are, measured).
+      **41 further prescriptive collisions carried to a named receiver**, not
+      stated as intentional, because for most of them that would be false —
+      they are defects. Fourteen rows were checked and are NOT defects and are
+      recorded as such, and nine catalog ids have no corpus recommendation at
+      all. Two of the sweep's own gaps closed by accident: it reported
+      pointer-spotlight and grain-over-gradient as uncatalogued, and this
+      roadmap added M7 and V9.
 
 ## Risk Register
 <!-- risk-review: v1 | reviewed: 2026-09-03 | reviewer: claude/host -->
@@ -213,5 +238,10 @@ status-table row so the parity gate stays green.
       `backed`, so its prose cannot move without its rule, and the rule needs a
       position-based adjacency heuristic that the registry's own
       dependency-free, no-DOM design has a standing precedent against.
-- [ ] AC-4 — The apply-skill sweep of 4.1 is recorded, and every default it
+- [x] AC-4 — The apply-skill sweep of 4.1 is recorded, and every default it
       finds is either removed or stated as intentional with a reason.
+      Met, with the third disposition used where neither of the two applies:
+      3 fixed, 14 measured as not-defects with the reason, 41 carried to
+      `agents/roadmaps/later/road-to-grounding-corpus-catalog-parity.md` with a
+      per-cluster step and a resume condition. "Stated as intentional" would
+      have been false for the 41, so a named receiver is what they got.

--- a/agents/roadmaps/later/road-to-grounding-corpus-catalog-parity.md
+++ b/agents/roadmaps/later/road-to-grounding-corpus-catalog-parity.md
@@ -1,0 +1,179 @@
+---
+complexity: structural
+status: later
+parent_roadmap: road-to-tell-currency
+review_by: 2026-12-03
+estate_growth_exempt: "Adds one later/ roadmap to receive 41 measured collisions between the design-intelligence grounding corpus and the anti-pattern catalog. It cannot fold into road-to-tell-detector-promotions, which is about promoting detectors to backed and is gated on corpus enrichment; this is about a different corpus contradicting rows that are ALREADY backed, and its first step is a scope decision rather than an edit. It cannot be left in the audit artefact either: road-to-tell-currency step 4.1 requires every finding to be fixed or stated as intentional with a reason, and for most of these 41 stated-as-intentional would be false — they are defects. A named receiver is the third disposition and the only honest one. This change archives road-to-tell-currency, so the active count falls by one."
+---
+# Road to grounding-corpus / catalog parity
+
+> **Parked, not abandoned.** Created 2026-09-03 from `road-to-tell-currency`
+> step 4.1, whose sweep is recorded in
+> `agents/evidence/analysis/tell-currency-corpus-audit-2026-09-03.md`. That
+> audit found **41 prescriptive collisions** between the `design-intelligence`
+> grounding corpus and `docs/guidelines/design-antipatterns.md` — rows that hand
+> an agent, as a default, something the catalog flags. Fourteen further rows were
+> checked and are not defects; those are recorded in the audit so a later sweep
+> does not re-flag them.
+>
+> **Resume when** step 0 has a decision. Every other step is an edit whose shape
+> that decision determines, and doing the edits first would be answering the
+> question by accident.
+
+## The finding behind the findings
+
+Every one of the 41 sits in a file the detector cannot read. The corpus is
+`.csv`, `.txt` and `.json`; `lint_design_slop`'s `enginesForExt` classifies an
+engine for `.css`, the `.html` family, `.jsx`/`.tsx` and `.md` only. So the
+corpus that motivates the catalog is structurally outside the catalog's
+enforcement, and no amount of detector work reaches it.
+
+The worked example is the one collision this roadmap's parent already fixed:
+`data/ux-guidelines.csv` carried `transition-all duration-200` in a column named
+`Code Example Good`. That is M4's exact defect, M4 is `backed`, and the row was
+invisible to it twice over — the file is not scanned, and the detector matches
+`transition\s*:\s*all`, which the Tailwind class form does not contain.
+
+## Phase 0 — the scope decision, which gates everything else
+
+- [ ] **0.1 Decide what a served corpus column may contain.** The corpus has
+      columns named `Code Example Good`, `Primary Style Recommendation`,
+      `Style_Priority` and `Design System Variables`. Those are not descriptions
+      of a design language; they are values an agent copies. The question is
+      whether a served column may carry a value the catalog flags **when the row
+      describes a style whose definition includes it** — film grain in a row
+      whose `Era/Origin` is "1970s-90s Analog Revival" is the honest case for
+      yes, and glassmorphism as the `Primary Style Recommendation` for fifteen
+      unrelated product types is the honest case for no.
+      verify: the rule is written down with both of those cases resolved by it,
+      and it decides all 41 findings without a per-row argument.
+- [ ] **0.2 Decide whether the corpus enters detector reach at all.** Either the
+      engine map gains a corpus-shaped reader, or the corpus is declared
+      out of detector scope and the parity is maintained by review. Declaring it
+      out of scope is a complete answer; leaving it undeclared is what produced
+      41 findings nobody was looking for.
+      verify: the decision is recorded with its cost, and if it is "in scope",
+      the pre-registered `M1 = 0` ceiling is re-run for every existing rule
+      against the widened surface.
+
+## Phase 1 — the two CI-floor breaches, which are not stylistic
+
+- [ ] **1.1 `data/motion.csv` has zero reduced-motion coverage.** Sixteen
+      animation recipes, `grep -c "reduced-motion"` = 0, against **M5**
+      ("Never acceptable; always add a `prefers-reduced-motion` variant") and the
+      CI-enforced floor **Q4**. The mitigation exists in sibling files and is
+      never co-retrieved, because `gsap` is absent from the `ground` plan — so
+      an agent that asks for a scroll reveal gets the recipe without the floor.
+      verify: every recipe either carries the variant or the file carries one
+      statement that governs all sixteen, and a motion query retrieves it.
+- [ ] **1.2 Four sub-floor tracking defaults.** `letter-spacing: -0.05em` and
+      its Tailwind `tracking-tighter` form, on display text, in
+      `data/styles.csv:48,70` and `design-languages/monochrome.txt:65`,
+      `bauhaus.txt:39`. **T6** is `backed` and floor **Q7** puts the minimum at
+      −0.04em.
+      verify: no served column carries a value below the Q7 floor, and any row
+      that keeps a tight-tracking treatment states the floor it respects.
+
+## Phase 2 — defaults keyed on a product type rather than an aesthetic
+
+- [ ] **2.1 Glassmorphism as a primary default.** Fifteen `Primary Style
+      Recommendation` rows, fifteen `Style_Priority` rows and four literal
+      `Backdrop blur (10-20px)` recipes, against **V2**, whose override restricts
+      glass to a surface that genuinely floats above a blurred layer. The corpus
+      contradicts itself here: `references/design-rules-checklist.md:107` says
+      "use blur to indicate background dismissal … not as decoration".
+      verify: the checklist and the recommendation columns agree, and every
+      surviving glass recommendation names the depth relation it depends on.
+- [ ] **2.2 Violet-on-dark palettes keyed on bare product types.** Two rows
+      state the **C1** triad verbatim in their own `Notes` field
+      ("violet + … cyan on dark"); 24 of 161 colour rows carry a violet primary
+      or accent. C1 is `judgment-only` *because* which colours are primary is a
+      judgment — and a column named `Primary` removes that judgment.
+      verify: no colour row declares the C1 combination as primary without a
+      brand input, and the status note's premise holds again.
+- [ ] **2.3 Side-stripe status indicators.** `data/styles.csv:31,44` offer
+      `border-left` colour as the status mechanism for a dashboard and an
+      AI-native UI — **V1**, `backed`, and widened by this roadmap's parent to
+      cover four-sided and gradient forms too.
+      verify: neither row hands a stripe as the status mechanism; the
+      alternatives V1's override allows are named instead.
+
+## Phase 3 — the remaining clusters
+
+- [ ] **3.1 T7/T8 in the files that have no flag column.** The `AI-Default Flag`
+      mitigation works, and reaches only `font-pairings-reference.csv`. At least
+      8 `styles.csv` rows and 6 `design-languages` specs pin a T7 family as a
+      token with no flag and no stated reason — and the same Nunito + DM Sans
+      pairing is flagged in one file and unflagged in the other.
+      verify: the flag mechanism covers every file that pins a family, or the
+      files that cannot carry it state their reason per row.
+- [ ] **3.2 Radius tokens above the V4 cap.** Eight `styles.csv` rows carry card
+      or button radii above 16px on sub-200px surfaces, against **V4** and floor
+      **Q9**. The `--radius-pill: 999` rows are excluded — V4's own override
+      sanctions them.
+      verify: every surviving radius above the cap is either a pill or names the
+      override it invokes.
+- [ ] **3.3 Elastic and overshoot easing as a default.** `data/motion.csv:4,9`,
+      against **M1**, `backed`. One row carries a partial self-authored
+      mitigation that stops short of M1's principle.
+      verify: neither row hands an overshoot curve as the default for an
+      ordinary UI interaction.
+- [ ] **3.4 Gradient text shipped as a token.** `data/styles.csv:49` and
+      `design-languages/cyberpunk.txt:150` — both halves of **C2**'s
+      deterministic rule co-occur in served columns, and one ships
+      `--gradient-text` as a system variable.
+      verify: no served column ships a chromatic text gradient as a token.
+- [ ] **3.5 Decide the CP6 register question, which is not a defect until it is
+      decided.** Four rows name a stock render subject — "floating blobs",
+      "futuristic HUD", "gradient mesh" — but **CP6** governs art direction, and
+      two of the four are UI-style specs rather than image briefs. A register
+      mismatch has to be resolved, not assumed in either direction.
+      verify: CP6's scope says whether it reaches a UI-style spec, and the four
+      rows are dispositioned by that answer.
+- [ ] **3.6 An italic serif pinned as the display face beside a hero size
+      range.** `data/styles.csv:78` — **T2** is `judgment-only` because it
+      requires knowing which element is the hero, and this row names the hero
+      size in the same cell.
+      verify: the row either drops the pairing or states the editorial rationale
+      T2's override asks for.
+
+## Phase 4 — the two consumer-side gaps the same sweep found
+
+- [ ] **4.1 `blade-ui` names no Laravel ecosystem default.** It cites V1, T3 and
+      L1/L2 — none of which is a Laravel default — and delegates concrete bans
+      to `tailwind-engineer`, which bans Tailwind's. Breeze and Jetstream
+      scaffold markup and the default `x-` component look are never named
+      anywhere.
+      verify: the skill names its own ecosystem's scaffold tell with a catalog
+      citation, in the shape `react-shadcn-ui` already uses.
+- [ ] **4.2 `tailwind-engineer`'s typography and layout bans carry no inline
+      id.** T7 and L1/L2 appear only in a roll-up sentence, so a reader who
+      jumps to the bullet gets the ban without the citation. The skill also owns
+      "concrete Tailwind class / hex bans" per the catalog's ownership table and
+      ships no ban list.
+      verify: each bullet carries its own id, and the ownership the catalog
+      assigns is either discharged or handed back.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-09-03 | reviewer: claude/host -->
+
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | The corpus is edited into blandness | product | The corpus's value is that its rows describe real design languages specifically; stripping every flagged value would leave generic rows that ground nothing, which is worse than the collisions | Phase 0.1 must produce a rule that resolves the analog-film case as KEEP before any Phase 2 or 3 edit runs, and the audit already separates the 14 descriptive rows from the 41 prescriptive ones | Phase 0 — the scope decision, which gates everything else |
+| 2 | Widening detector reach re-opens 25 M1 epochs | implementation | 0.2's in-scope branch means the pre-registered M1 = 0 ceiling is re-measured for every existing rule against a larger surface, and one new false positive on any rule demotes it | 0.2 requires the re-run to be part of the decision's cost rather than a discovery afterwards, and declaring the corpus out of detector scope is an explicitly complete answer | Phase 0 — the scope decision, which gates everything else |
+| 3 | The two floor breaches wait behind a scope debate | implementation | 1.1 and 1.2 breach CI-enforced floors (Q4, Q7) and are true regardless of how 0.1 resolves, so gating them on a policy decision delays the only findings with an objective bar | Phase 1 is ordered before Phases 2 and 3 and depends on 0.1 only for wording, not for whether to act | Phase 1 — the two CI-floor breaches, which are not stylistic |
+| 4 | The audit ages faster than the roadmap | product | The corpus is edited by other work; a 41-row inventory pinned to one commit drifts, and a stale inventory reads as a fixed one | Every row in the audit carries `path:line` against a named commit, and the resume condition is a decision rather than a date, so a re-measure is the first action on resume | Phase 0 — the scope decision, which gates everything else |
+
+## Acceptance Criteria
+
+- [ ] AC-1 — Phase 0 carries a written rule that decides all 41 findings without
+      a per-row argument, and the analog-film and glassmorphism cases are both
+      resolved by it explicitly.
+- [ ] AC-2 — The two CI-floor breaches (M5/Q4 in `motion.csv`, T6/Q7 tracking)
+      are closed, or each carries the floor it respects.
+- [ ] AC-3 — No served corpus column hands a `backed` catalog tell as a default
+      value, measured by re-running the audit's own greps.
+- [ ] AC-4 — The corpus's detector reach is declared either way, and if it is
+      in scope, every existing rule carries a fresh `M1` number.
+- [ ] AC-5 — `blade-ui` names its own ecosystem default with a catalog citation,
+      and `tailwind-engineer`'s bans each carry an inline id.

--- a/agents/roadmaps/later/road-to-tell-detector-promotions.md
+++ b/agents/roadmaps/later/road-to-tell-detector-promotions.md
@@ -1,0 +1,128 @@
+---
+complexity: bounded
+status: later
+parent_roadmap: road-to-tell-currency
+review_by: 2026-12-03
+estate_growth_exempt: "Adds one later/ roadmap because a [~] deferral has no other legal receiver: deferralProblems resolves carried-to only against agents/roadmaps/<slug>.md or agents/roadmaps/later/<slug>.md and fail-closes on a stubs/ path, and the receiver must additionally carry parent_roadmap: verified from both ends. This change archives road-to-tell-currency (active 4 to 3) and defers two of its steps on a 2/2 council verdict that neither can ship a truthful backed claim today; without a later/ receiver those two steps could be expressed only as [ ] on an archived roadmap, which the archival guard refuses, or as [-] cancelled, which is owner-reserved and would drop work the council explicitly parked. One later entry is the cost of not lying about two."
+---
+
+# Road to the interaction-layer detector promotions
+
+> **Parked, not abandoned.** Created 2026-09-03 when `road-to-tell-currency`
+> closed. It receives two deferrals from that roadmap — the four new
+> interaction/texture detectors, and the T4 widening — on an AI-council verdict
+> of 2/2 convergence that neither can ship a truthful `backed` claim against
+> today's scanner reach and today's clean corpus.
+>
+> **Resume when** the pre-registered clean corpus carries a legitimate
+> near-miss for each of the four signals (step A1), which is the gate every
+> other item here is measured against. A2 — the scanner-reach decision — can be
+> taken independently and is the cheaper half.
+
+## Why the parent could not close these
+
+Three properties have to hold before a row reads `backed`, and the council's own
+framing is that the parity gate conflates them:
+
+1. **Catalog classification** — `backed` vs `judgment-only`.
+2. **Scanner reach** — which extensions and engines can expose the signal.
+3. **Evaluation validity** — whether the pre-registered clean corpus contains
+   meaningful near-misses for the pattern.
+
+Property 3 fails for all four new entries, and property 2 fails for two of them.
+Measured 2026-09-03 against the corpus digest `90544389b05c1d0b` (32 clean
+files):
+
+| Signal the detector would need | Occurrences in the clean corpus |
+|---|---|
+| `IntersectionObserver` | 0 |
+| `mousemove` | 0 |
+| `radial-gradient` | 0 |
+| `:hover { opacity }` | 0 (the only `opacity` uses sit inside a `@keyframes` block) |
+| grain / noise over a gradient | 0 |
+
+So an `M1 = 0` for any of these would be a **vacuous pass** — a statement about
+the corpus, which is what the pre-registration says to read it as, not a
+measurement of precision. The bench's own footer says the same thing in its own
+words on every run.
+
+And `lint_design_slop`'s engine map classifies no engine for plain `.ts` / `.js`
+(`src/scripts/lint_design_slop.ts`, `enginesForExt`), which is exactly where a
+scroll-reveal hook (`useReveal.ts`) and a cursor-spotlight `mousemove` handler
+normally live. A `.jsx`/`.tsx`-only detector would be honest about nothing a
+`.ts`-hook codebase does.
+
+## The received work
+
+### A — the four interaction and texture detectors
+
+- [ ] **A1 Enrich the clean corpus with real near-misses, not just occurrences.**
+      The distinction is the whole point: adding files that merely *contain*
+      `IntersectionObserver` makes the bench non-vacuous while still not
+      measuring precision. The near-misses have to be **legitimate** uses —
+      an `IntersectionObserver` doing lazy-loading or scroll-progress, cursor
+      tracking driving a functional canvas interaction, hover opacity on a
+      genuinely disabled control, and grain used *without* the gradient
+      composition V9 names.
+      verify: the corpus digest changes, and for each of the four signals the
+      corpus contains at least one legitimate use that a naive detector would
+      flag.
+- [ ] **A2 Decide the scanner-reach question, and record it either way.** Widen
+      `enginesForExt` to `.ts` / `.js`, or scope the interaction rules to
+      colocated-markup extensions and say so in the § Detector status note.
+      Widening re-opens the M1 epoch for **all 25 existing rules** against a
+      larger surface, and the pre-registered ceiling is `M1 = 0` per rule — one
+      new false positive on any existing rule demotes it. That cost is the
+      decision, not a footnote to it.
+      verify: the decision is recorded with its measurement; if the answer is
+      widen, every one of the 25 existing rules carries a fresh M1 number.
+- [ ] **A3 Promote at most one row per epoch.** M6, M7, M8 and V9, each on its
+      own epoch with its own M1 number, each carrying a `provenance/borrows.jsonl`
+      row or an explicit own-analysis label. A batch promotion has no per-rule
+      number and cannot satisfy any of the verifies above — the constraint is
+      the sibling stub `road-to-frontend-power-detector-promotions.md`'s
+      promotion gate 1, and the council declined to exempt newly authored rules
+      from it on the ground that new rules are where independent evidence is
+      most useful.
+      verify: § Detector status shows each promotion with its epoch, and
+      `lint_design_antipattern_parity` is green after each.
+
+### B — the T4 widening
+
+- [ ] **B1 Show that dependency-free adjacency can carry the position claim.**
+      T4's current form is ALL-CAPS-and-ratio: it counts `text-transform:
+      uppercase` and `uppercase` classes against a `sections / 3` cap and
+      requires `sections >= 3`, so a single sentence-case pill badge above a
+      hero `h1` is structurally out of its reach. The defect is **positional**
+      — a badge immediately preceding an `h1` — and the shape is not the defect:
+      V4's own override declares the pill legitimate on single-line tags and
+      chips, and V4's rule excludes exactly that radius band. So a shape-scoped
+      T4 would contradict a sibling entry's override, and a position-scoped T4
+      needs a text-adjacency heuristic in a rules file that is deliberately
+      dependency-free with no cascade and no DOM, and which carries a standing
+      precedent of refusing to infer layout.
+      verify: a fixture with a pill badge above an `h1` flags and a status chip
+      inside a table row does not, with the adjacency heuristic's failure mode
+      stated rather than assumed.
+- [ ] **B2 Keep T4's prose and its `backed` status in step.** T4 is `backed`
+      today, so widening its prose without widening its rule makes the parity
+      gate green while the claim goes false — which is the exact defect class
+      that gate exists to catch. Prose and rule move together or neither moves.
+      verify: `lint_design_antipattern_parity` is green and T4's pattern text
+      describes only what its rule reaches.
+
+## Resume condition
+
+A1 is the gate for everything else: until the clean corpus can discriminate,
+no `M1` number from it licenses a promotion, and A3 and B1 are unmeasurable by
+construction. A2 can be decided independently and is the cheaper half.
+
+## What this stub does NOT cover
+
+The four catalog entries themselves — M6, M7, M8, V9 — **already shipped** as
+`judgment-only` rows with override conditions, and the interaction guidance
+already shipped in `fe-design`'s § Motion. Nothing here is blocked on them, and
+this stub must not re-author them. V1's widening also shipped, with its rule and
+its fixtures, because the clean corpus *does* carry the discriminating negative
+for it — three four-sided `1px` borders that must stay clean — which is the one
+property the four deferred entries lack.

--- a/agents/roadmaps/road-to-tell-currency.md
+++ b/agents/roadmaps/road-to-tell-currency.md
@@ -22,46 +22,81 @@ The anti-pattern catalog detects the generation of AI page tells that is
 current, not the one that was current when it was written. Today its coverage
 is entirely static — colour, type, layout, copy — and a grep across
 `docs/guidelines/design-antipatterns.md`, `src/scripts/design_slop_rules.ts` and
-`src/skills/motion-choreographer/SKILL.md` for `scroll-reveal`, `spotlight`,
-`cursor-follow`, `grain` and `noise` returns zero hits in all three. When this
+`src/skills/fe-design/references/design-patterns.md` for `scroll-reveal`,
+`spotlight`, `cursor-follow`, `grain` and `noise` returns zero hits in all
+three. (The third path is CORRECTED: this roadmap was written against
+`src/skills/motion-choreographer/SKILL.md`, which is a text-to-video prompt
+builder — `packs: [ai-video]` — and is silent on scroll position because scroll
+position is not in its domain. The UI-motion authority is `fe-design`'s
+§ Motion, which `design-review` names as the timing source of truth, and the
+catalog's own See-also pointed at the wrong one.) When this
 is finished the interaction and texture layer is represented, two entries whose
 described form has moved on are amended, and every change carries its
 status-table row so the parity gate stays green.
 
 ## Phase 1 — Fixtures before entries
 
-- [ ] **1.1 Commit a fixture corpus for the five uncovered tells and the two
+- [~] **1.1 Commit a fixture corpus for the five uncovered tells and the two
       amended forms.** One positive fixture per tell and one negative per tell
       whose absence must not flag — a scroll-linked progress indicator is not a
       scroll reveal, a focus ring is not a hover fade. Fixtures land red for the
       new rules and green for the negatives.
       verify: the design-slop test run reports the new positive fixtures as
       unmatched and every negative as unmatched, before Phase 2 runs.
+      <!-- deferred-resolution: carried-to=road-to-tell-detector-promotions -->
+      **Deferred, and the step is unexecutable as written.** The fixture map in
+      `src/scripts/design_slop_rules.test.ts` is guarded in BOTH directions — a
+      rule without a fixture fails `missing fixture for <id>` and a fixture
+      without a rule fails `orphan fixture <id>` — so a fixture cannot land in a
+      commit before its rule. The verify text also inverts the suite's
+      semantics: it asks the run to report the new positives as *unmatched*,
+      while the suite asserts a positive MUST fire. Council 2/2: fixture and
+      rule land atomically, and since no detector lands in this roadmap (2.5),
+      Phase 1 has no work here. The fixture obligation travels with the rules to
+      the receiver, where step A3 lands each one with its own fixture pair.
+      V1's amended fixture pair DID land in this roadmap, atomically with its
+      rule, under 3.1.
 
 ## Phase 2 — The interaction and texture layer
 
-- [ ] **2.1 Add the scroll-reveal entry.** Every section fading and rising into
+- [x] **2.1 Add the scroll-reveal entry.** Every section fading and rising into
       view on scroll is the single most recognisable tell of the current
-      generation, and `motion-choreographer` (206 lines) says nothing about
-      scroll position. Write it as an M-entry with an override condition —
+      generation, and the UI-motion authority — `fe-design`'s § Motion, not
+      `motion-choreographer`, which is a text-to-video prompt builder — said
+      nothing about scroll position. Write it as an M-entry with an override
+      condition —
       a reveal that carries meaning (a stepped narrative, a long-form article's
       progress) is a decision; a reveal on every section is a default.
       verify: the entry exists with an override condition, and its status row
       is present.
-- [ ] **2.2 Add the cursor-spotlight entry.** A radial highlight tracking the
+      Landed as **M6**, `judgment-only`. The guidance half landed in
+      `src/skills/fe-design/references/design-patterns.md` § Motion step 4
+      (council Fork 2, 2/2), and the catalog's stale See-also pointer to
+      `motion-choreographer` was corrected in the same edit.
+- [x] **2.2 Add the cursor-spotlight entry.** A radial highlight tracking the
       pointer over a dark hero. Same shape: entry, override condition, status.
-      verify: as 2.1.
-- [ ] **2.3 Add the hover-fade entry.** An interactive control that reduces its
+      verify: as 2.1. Landed as **M7**, `judgment-only`.
+- [x] **2.3 Add the hover-fade entry.** An interactive control that reduces its
       own opacity on hover, which reads as the element retreating from the
-      pointer rather than responding to it. Note the collision with
-      `icon-consistency` and the affordance floors — hover must remain
-      *legible*, and a fade is the one hover treatment that reduces legibility.
-      verify: as 2.1.
-- [ ] **2.4 Add the grain-over-gradient entry.** Noise texture laid over a
+      pointer rather than responding to it. Note the collision with the
+      interaction-state contract — hover must remain *legible*, and a fade is
+      the one hover treatment that reduces legibility.
+      verify: as 2.1. Landed as **M8**, `judgment-only`.
+      **Both collision targets named in the original step do not exist.**
+      `src/rules/icon-consistency.md` contains no `hover` and no `opacity`; its
+      subject is mixed icon sets. And a tree-wide grep for "affordance floor"
+      returns zero hits — no artefact by that name exists. The real collision
+      surface is `src/skills/design-review/SKILL.md` § Six interaction states,
+      whose hover row already says pointer feedback must not be the *only*
+      affordance and whose disabled row names a contrast dip a user cannot read
+      as a WCAG 1.4.1 failure. M8 and the `fe-design` § Motion step 5 both cite
+      it.
+- [x] **2.4 Add the grain-over-gradient entry.** Noise texture laid over a
       gradient as a "premium" default; the visual sibling of V6's diagonal
       stripes, which is why it belongs in Visual rather than Motion.
-      verify: as 2.1.
-- [ ] **2.5 Decide each new entry's detector status honestly.** Three of the
+      verify: as 2.1. Landed as **V9** — V8 was already taken by the
+      Consistency-Locks table, so V9 is the next free Visual id.
+- [x] **2.5 Decide each new entry's detector status honestly.** Three of the
       four have a text-detectable signature — a scroll-reveal library or an
       `IntersectionObserver` paired with an opacity transition, a `mousemove`
       handler feeding a radial gradient, a hover opacity step below the
@@ -71,21 +106,65 @@ status-table row so the parity gate stays green.
       step.
       verify: `./scripts-run src/scripts/lint_design_antipattern_parity` is
       green, and no new row carries `candidate` without a step that resolves it.
+      **Decided: all four `judgment-only`, and the reason is stronger than the
+      step anticipated.** The step expected three of the four to be
+      text-detectable. Two independent measurements say otherwise, and the
+      status notes carry both. (1) `lint_design_slop`'s `enginesForExt`
+      classifies NO engine for plain `.ts` / `.js`, which is where a
+      scroll-reveal hook and a `mousemove` spotlight handler normally live —
+      so a detector for M6 or M7 would reach nothing in an ordinary codebase.
+      (2) The pre-registered clean corpus (digest `90544389b05c1d0b`, 32 files)
+      contains zero `IntersectionObserver`, zero `mousemove`, zero
+      `radial-gradient` and zero `:hover { opacity }` — its only `opacity`
+      occurrences sit inside a `@keyframes` block. An `M1 = 0` against it would
+      be a **vacuous pass**, which is what the pre-registration itself says to
+      read it as, not measured precision. Council 2/2 on Forks 3 and 4:
+      judgment-only now, one-rule-one-epoch promotion later, no exemption for
+      newly authored rules. No row carries `candidate`.
+      Parity: `50 entries classified, 25 detector-backed`, green.
 
 ## Phase 3 — Two entries whose described form has moved
 
-- [ ] **3.1 Widen V1 beyond the side stripe.** V1 names `border-left` /
+- [x] **3.1 Widen V1 beyond the side stripe.** V1 names `border-left` /
       `border-right` above 1px. The current form is a fully coloured or gradient
       card border on all four sides; the entry as written does not reach it.
       Amend the pattern text and, if the rule is `backed`, the rule with it.
       verify: a fixture with a four-sided gradient border flags, and a 1px
       neutral border does not.
-- [ ] **3.2 Widen T4 beyond the ALL-CAPS eyebrow.** T4 names an ALL-CAPS label
+      **Done, rule and fixture in one commit.** V1 is `backed`, so the rule
+      moved with the prose: the detector now matches the side stripe, a fully
+      coloured border on all four sides above 1px, and a gradient
+      `border-image`. Three positives and five negatives are pinned in the
+      fixture pair — a 1px side rule, a 1px four-sided neutral border, a
+      `border-color`-only focus treatment, and `transparent` and `currentColor`
+      at accent width, the last two being the layout-reservation and
+      inherit-the-text-colour idioms rather than accent decisions.
+      `M1 = 0` for all 25 rules on the unchanged clean corpus.
+      **Why V1's widening ships while T4's does not:** the clean corpus carries
+      the discriminating negative for V1 — three four-sided `1px` borders that
+      must stay clean — so its `M1 = 0` measures something. For the four new
+      entries and for T4 the corpus carries no near-miss at all.
+- [~] **3.2 Widen T4 beyond the ALL-CAPS eyebrow.** T4 names an ALL-CAPS label
       above a section heading. The current form is a pill-shaped badge component
       sitting above the hero H1 — same function, different component, and the
       entry misses it.
       verify: a fixture with a pill badge above an `h1` flags; a badge used as
       a status chip inside a table row does not.
+      <!-- deferred-resolution: carried-to=road-to-tell-detector-promotions -->
+      **Deferred, prose and status both untouched, on a 2/2 council verdict.**
+      T4 is `backed`, so widening its prose without widening its rule makes the
+      parity gate green while the claim goes false — the exact defect class that
+      gate exists to catch. And the rule cannot be widened cheaply: the defect
+      is *positional* (a badge immediately preceding an `h1`), not shape-based,
+      because V4's own override declares the pill legitimate on single-line tags
+      and chips and V4's rule excludes exactly that radius band. A shape-scoped
+      T4 would contradict a sibling entry; a position-scoped T4 needs a
+      text-adjacency heuristic in a rules file that is deliberately
+      dependency-free with no cascade and no DOM, and which carries a standing
+      precedent of refusing to infer layout. The two seats split on whether the
+      prose alone could move; resolved toward the stricter reading, which is the
+      one consistent with both seats' own Fork-3 principle that a `backed` label
+      must not out-run its rule.
 
 ## Phase 4 — What the tree itself emits
 
@@ -110,13 +189,29 @@ status-table row so the parity gate stays green.
 
 ## Acceptance Criteria
 
-- [ ] AC-1 — The catalog carries an entry with an override condition for each of
+- [x] AC-1 — The catalog carries an entry with an override condition for each of
       scroll-reveal, cursor-spotlight, hover-fade and grain-over-gradient, and
       each has exactly one status-table row.
-- [ ] AC-2 — `lint_design_antipattern_parity` is green, and no row added by this
+      Met: M6, M7, M8, V9, each with an override condition and one status row
+      (`lint_design_antipattern_parity` asserts the one-row property).
+- [x] AC-2 — `lint_design_antipattern_parity` is green, and no row added by this
       roadmap carries `candidate` without a named step that resolves it.
-- [ ] AC-3 — V1 flags a four-sided coloured or gradient card border and does not
-      flag a 1px neutral border; T4 flags a pill badge above a hero heading and
-      does not flag a status chip in a table row.
+      Met: green at `50 entries classified, 25 detector-backed`; all four new
+      rows are `judgment-only` and none uses `candidate`.
+- [x] AC-3a — V1 flags a four-sided coloured or gradient card border and does not
+      flag a 1px neutral border.
+      Met, with the negative pinned in the fixture pair rather than asserted:
+      three positives (side stripe, four-sided colour, gradient `border-image`)
+      and five negatives (1px side rule, 1px four-sided neutral,
+      `border-color`-only focus, `transparent`, `currentColor`).
+      `M1 = 0` across all 25 rules on the unchanged clean corpus.
+- [~] AC-3b — T4 flags a pill badge above a hero heading and does not flag a
+      status chip in a table row.
+      <!-- deferred-resolution: carried-to=road-to-tell-detector-promotions -->
+      **Deferred with 3.2, and split out of AC-3 so the V1 half can be claimed
+      honestly rather than the pair being reported as one partial.** T4 is
+      `backed`, so its prose cannot move without its rule, and the rule needs a
+      position-based adjacency heuristic that the registry's own
+      dependency-free, no-DOM design has a standing precedent against.
 - [ ] AC-4 — The apply-skill sweep of 4.1 is recorded, and every default it
       finds is either removed or stated as intentional with a reason.

--- a/dist/agent-src/skills/design-intelligence/data/ux-guidelines.csv
+++ b/dist/agent-src/skills/design-intelligence/data/ux-guidelines.csv
@@ -6,7 +6,7 @@ No,Category,Issue,Platform,Description,Do,Don't,Code Example Good,Code Example B
 5,Navigation,Deep Linking,All,URLs should reflect current state for sharing,Update URL on state/view changes,Static URLs for dynamic content,Use query params or hash,Single URL for all states,Medium
 6,Navigation,Breadcrumbs,Web,Show user location in site hierarchy,Use for sites with 3+ levels of depth,Use for flat single-level sites,Home > Category > Product,Only on deep nested pages,Low
 7,Animation,Excessive Motion,All,Too many animations cause distraction and motion sickness,Animate 1-2 key elements per view maximum,Animate everything that moves,Single hero animation,animate-bounce on 5+ elements,High
-8,Animation,Duration Timing,All,Animations should feel responsive not sluggish,Use 150-300ms for micro-interactions,Use animations longer than 500ms for UI,transition-all duration-200,duration-1000,Medium
+8,Animation,Duration Timing,All,Animations should feel responsive not sluggish,Use 150-300ms for micro-interactions,Use animations longer than 500ms for UI,transition-colors duration-200,transition-all duration-1000,Medium
 9,Animation,Reduced Motion,All,Respect user's motion preferences,Check prefers-reduced-motion media query,Ignore accessibility motion settings,@media (prefers-reduced-motion: reduce),No motion query check,High
 10,Animation,Loading States,All,Show feedback during async operations,Use skeleton screens or spinners,Leave UI frozen with no feedback,animate-pulse skeleton,Blank screen while loading,High
 11,Animation,Hover vs Tap,All,Hover effects don't work on touch devices,Use click/tap for primary interactions,Rely only on hover for important actions,onClick handler,onMouseEnter only,High

--- a/dist/agent-src/skills/fe-design/SKILL.md
+++ b/dist/agent-src/skills/fe-design/SKILL.md
@@ -246,10 +246,13 @@ provenance belongs to `road-to-frontend-fidelity-calibration` Phases 0 and 2.
 
 ## Anti-slop discipline
 
-Before proposing a direction, scan the Visual (V1–V7) and Layout (L1–L8)
-sections of [`design-antipatterns`](../../../docs/guidelines/design-antipatterns.md).
+Before proposing a direction, scan the Visual (V1–V8) and Layout (L1–L10)
+sections of [`design-antipatterns`](../../../docs/guidelines/design-antipatterns.md),
+plus Motion (M1–M8) for the interaction layer.
 On a match, choose differently or invoke the entry's own override condition in
-the brief — every entry has one, and they are register-scoped. The Q* floors are
+the brief — every entry has one. Two of them, T7 and T8, are additionally
+*register-scoped*: the brand and product registers admit different answers, and
+neither admits an undeclared pick. The Q* floors are
 in [`references/craft-floor.md`](references/craft-floor.md) instead of here, so
 they arrive at the write rather than at skill load.
 

--- a/dist/agent-src/skills/fe-design/references/design-patterns.md
+++ b/dist/agent-src/skills/fe-design/references/design-patterns.md
@@ -171,6 +171,34 @@ Before adding any animation to a UI element, run through this decision tree:
 - **Never animate layout properties** (width, height, top, left, padding). Why: triggers browser layout recalculation on every frame; always solvable with `transform`.
 - **Always add `@media (prefers-reduced-motion: reduce)`** — gentler animation (reduced distance/opacity), NOT display:none. Why: vestibular disorders make motion UI unusable; reducing is better than removing.
 
+**4. Is the trigger the reader's position, or the reader's action?**
+
+Position-triggered motion is the interaction layer's current tell, and it is
+the one case where the decision tree above returns "no" and gets overridden
+anyway. Two shapes, both catalogued:
+
+- **Scroll-reveal on every section** (catalog M6). The reader has already
+  scrolled to the content; fading it in delays what they asked for. Animate a
+  reveal only where position carries meaning — a stepped narrative whose beats
+  must land in order, or a long-form piece using position to signal progress —
+  and then say so in the brief. A reveal applied per section is a default.
+- **A pointer-tracking spotlight** (catalog M7). The cursor is the one element
+  on the page whose position the reader already knows, so highlighting it
+  carries no information. Legitimate only where the spotlight *is* the
+  interaction: an inspection tool, a reveal mechanic, a magnifier.
+
+**5. Does the hover state spend contrast or add it?**
+
+A control that lowers its own opacity on hover (catalog M8) reads as retreating
+from the pointer, and it reduces legibility at the moment the reader is
+committing to the target. Hover is carried by brightness, background, border or
+elevation — never by removing contrast. A fade is correct only when it
+communicates a real state change, such as an item being dismissed.
+
+The six interaction states every interactive element must assert are
+[`design-review`](../../design-review/SKILL.md)'s; this entry is the motion half
+of the hover one.
+
 **4. What to animate?**
 Animate `transform` and `opacity` only. Why: these run on the GPU compositor thread, not the main thread; they never trigger layout or paint.
 `scale(0)` → `scale(1)` is wrong. Why: nothing in the real world appears from nothing. Use `scale(0.95)` + `opacity: 0` → `scale(1)` + `opacity: 1` instead.

--- a/dist/agent-src/skills/react-shadcn-ui/SKILL.md
+++ b/dist/agent-src/skills/react-shadcn-ui/SKILL.md
@@ -122,7 +122,7 @@ Do NOT use when:
   components in the same surface.
 - **Anti-AI-slop catalog + linter.** Pull
   [`docs/guidelines/design-antipatterns.md`](../../../docs/guidelines/design-antipatterns.md)
-  before the polish step (Visual V1–V7, Layout L1–L8 are the React-component
+  before the polish step (Visual V1–V8, Layout L1–L10 are the React-component
   slop tells); the objective quality floors (WCAG contrast, focus-visible,
   reduced-motion) are validated via `accessibility-auditor`'s checklist —
   cite its verdict rather than eyeballing.

--- a/docs/guidelines/design-antipatterns.md
+++ b/docs/guidelines/design-antipatterns.md
@@ -262,7 +262,7 @@ are listed in § Quality floors.
 | M3 | backed | |
 | M4 | backed | |
 | M5 | floor | reduced-motion alternative, Q4 |
-| M6 | judgment-only | two independent reasons, both measured: the scanner classifies no engine for plain `.ts` / `.js` (`lint_design_slop.ts` § enginesForExt), which is where a reveal hook normally lives; and the clean corpus contains zero `IntersectionObserver`, so an M1 = 0 would measure nothing. Promotion prerequisites: `agents/roadmaps/stubs/road-to-tell-detector-promotions.md` |
+| M6 | judgment-only | two independent reasons, both measured: the scanner classifies no engine for plain `.ts` / `.js` (`lint_design_slop.ts` § enginesForExt), which is where a reveal hook normally lives; and the clean corpus contains zero `IntersectionObserver`, so an M1 = 0 would measure nothing. Promotion needs both closed first: a corpus carrying a legitimate near-miss for the signal, and a recorded decision on whether the scanner reaches `.ts` / `.js` |
 | M7 | judgment-only | same two reasons as M6: no engine for `.ts` / `.js`, and zero `mousemove` and zero `radial-gradient` in the clean corpus |
 | M8 | judgment-only | the corpus carries no `:hover { opacity }` at all, and its only `opacity` occurrences sit inside a `@keyframes` block, so it cannot separate a hover fade from a legitimate transition |
 | CP1 | backed | |

--- a/docs/guidelines/design-antipatterns.md
+++ b/docs/guidelines/design-antipatterns.md
@@ -87,13 +87,14 @@ Within-project invariants + repetition caps. Override = declare the value in
 
 | # | Pattern | Why it reads as AI-generated | Override condition |
 |---|---|---|---|
-| V1 | Side-stripe `border-left` or `border-right` > 1px as a colored accent | The single most recognizable AI-UI signature; every scaffold-default card uses it | Brand token explicitly defines a stripe; document the decision in the design brief |
+| V1 | A colored accent border above 1px — the side stripe (`border-left` / `border-right`), a fully colored border on all four sides, or a gradient `border-image` | The single most recognizable AI-UI signature; every scaffold-default card uses it. Widened 2026-09-03: the side stripe was the 2024 form, the four-sided colored or gradient card border is the current one, and the entry as written reached only the first | Brand token explicitly defines the accent border; document the decision in the design brief. A 1px neutral border, a `border-color`-only focus treatment, and `transparent` / `currentColor` at any width are not accents and do not flag |
 | V2 | Glassmorphism as decoration (`backdrop-blur` + `bg-white/10`) with no functional depth hierarchy | Model defaults to it for "premium feel"; result looks like 2021 Material You clip-art | Element genuinely sits above a complex, blurred background layer; use sparingly and only for top-level floating surfaces |
 | V3 | Ghost card: `border: 1px solid` + box-shadow ≥ 16px spread together | The combination creates visual noise — the ghost card signals no confident decision about depth | Choose either border OR shadow to indicate depth; never both on the same surface |
 | V4 | Over-rounded small cards or badges: `border-radius` > 16px on elements < 200px wide | Excessive rounding on small surfaces looks toy-ish; standard cap is 12–16px | Pill shape (`border-radius: 9999px`) is intentional on single-line tags/chips only |
 | V5 | Hand-drawn or illustrated SVG icons mixed with crisp icon-system icons | Visual register collision; instantly reads as "generated asset" | Intentional illustrative section (hero illustration, empty-state art); isolate from the icon system |
 | V6 | Repeating diagonal stripes as a background texture | A cliché background default; reads as generated CSS art | Brand explicitly uses pattern backgrounds (e.g., a textile brand); document the stripe definition |
 | V7 | Nested cards: a card inside a card inside a card | Depth hierarchy collapses; user cannot parse elevation intent | A truly three-level hierarchy (e.g., project → board → card); ensure each level has distinct visual weight |
+| V9 | Noise or grain texture laid over a gradient as a "premium" surface default | The visual sibling of V6's diagonal stripes — a generated-CSS-art texture reached for to make a flat gradient look considered, applied because it is available rather than because the surface needed a texture | The texture is part of a documented brand surface treatment (a print-inspired or analog-photographic identity) with the grain opacity defined as a token, not chosen per surface |
 
 ---
 
@@ -150,6 +151,9 @@ Within-project invariants + repetition caps. Override = declare the value in
 | M3 | Animating `<img>` element on hover (scale, filter, transform) | Triggers composite + image decode; often causes content shift | Animate the card's background, border, or shadow instead; leave the image static |
 | M4 | `transition: all` shorthand | Animates every property including layout, color, opacity simultaneously; unpredictable and expensive | Enumerate only the properties that should animate: `transition: transform 200ms ease-out, opacity 200ms` |
 | M5 | Missing `@media (prefers-reduced-motion: reduce)` alternative for any animation | Accessibility violation; vestibular disorders make animated UI unusable | Never acceptable; always add a `prefers-reduced-motion` variant — gentler animation (reduced distance/opacity) is preferred over `display: none` |
+| M6 | Every section fading and rising into view on scroll | The most recognisable interaction tell of the current generation; a reveal applied per section carries no information — the reader has already scrolled to the content, so the animation delays what they asked for | The reveal carries meaning: a stepped narrative where each beat must land before the next, or a long-form article using position to signal progress. A reveal on *every* section is a default, not a decision |
+| M7 | A radial highlight tracking the pointer across a dark hero | A `mousemove` handler feeding a radial gradient; it draws the eye to the cursor, which is the one thing on the page the user already knows the position of | The spotlight is the interaction — a genuine reveal mechanic, a canvas inspection tool, an accessibility magnifier. Ambience is not a purpose |
+| M8 | An interactive control that reduces its own opacity on hover | Reads as the element retreating from the pointer rather than responding to it, and a fade is the one hover treatment that *reduces* legibility at the moment the user is committing to the target — see the six interaction states in [`design-review`](../../src/skills/design-review/SKILL.md) | The fade communicates a real state change (an item being dismissed, a layer being peeled back). Hover must stay legible; brightness, background or border carry hover without spending contrast |
 
 ---
 
@@ -225,6 +229,7 @@ are listed in § Quality floors.
 | V6 | backed | |
 | V7 | judgment-only | DOM-structure nesting depth, measured too false-positive-prone |
 | V8 | backed | |
+| V9 | judgment-only | texture-over-gradient is a compositional judgment, and the pre-registered clean corpus contains no grain-over-gradient near-miss, so an M1 = 0 for a detector here would be a vacuous pass rather than measured precision |
 | C1 | judgment-only | the tell is the combination *as the primary scheme*; which colours are primary is a judgment |
 | C2 | backed | |
 | C3 | backed | |
@@ -257,6 +262,9 @@ are listed in § Quality floors.
 | M3 | backed | |
 | M4 | backed | |
 | M5 | floor | reduced-motion alternative, Q4 |
+| M6 | judgment-only | two independent reasons, both measured: the scanner classifies no engine for plain `.ts` / `.js` (`lint_design_slop.ts` § enginesForExt), which is where a reveal hook normally lives; and the clean corpus contains zero `IntersectionObserver`, so an M1 = 0 would measure nothing. Promotion prerequisites: `agents/roadmaps/stubs/road-to-tell-detector-promotions.md` |
+| M7 | judgment-only | same two reasons as M6: no engine for `.ts` / `.js`, and zero `mousemove` and zero `radial-gradient` in the clean corpus |
+| M8 | judgment-only | the corpus carries no `:hover { opacity }` at all, and its only `opacity` occurrences sit inside a `@keyframes` block, so it cannot separate a hover fade from a legitimate transition |
 | CP1 | backed | |
 | CP2 | backed | |
 | CP3 | judgment-only | copy phrase-list; that mechanism is council-rejected |
@@ -290,7 +298,7 @@ The bar: a visitor should ask "how was this made?", not "which AI made this?"
 - `fe-design` — stack-agnostic heuristics (form, table, responsive, a11y)
 - `design-review` — structured UI/UX review methodology
 - `existing-ui-audit` — mandatory pre-step: inventory before designing
-- `motion-choreographer` — animation heuristics (should-it, which-easing, how-much)
+- `fe-design` § Motion — animation heuristics (should-it, which-easing, how-long), and the home of the interaction-layer guidance M6 and M8 name. Corrected 2026-09-03: this line used to point at `motion-choreographer`, which is a text-to-video prompt builder (`packs: [ai-video]`) and carries none of what the line described
 - `typography-system` — modular-scale construction and pairing
 - `accessibility-auditor` — WCAG audit method
 - `brand-to-tokens` — first-party brand token extraction (the legitimate override source for most anti-patterns above)

--- a/src/scripts/design_slop_rules.test.ts
+++ b/src/scripts/design_slop_rules.test.ts
@@ -17,8 +17,21 @@ const ctxWith = (raw: string): DesignContext => ({
 const FIXTURES: Record<string, { ext: string; positive: string; negative: string }> = {
   "slop-v1-side-stripe": {
     ext: "css",
-    positive: ".card { border-left: 4px solid #6c5ce7; padding: 16px; }",
-    negative: ".card { border-left: 1px solid #eee; padding: 16px; }",
+    // three positives: the original side stripe, the current four-sided colored
+    // card border, and a gradient border-image (which carries no width token).
+    positive:
+      ".card { border-left: 4px solid #6c5ce7; padding: 16px; }\n" +
+      ".panel { border: 3px solid #6c5ce7; padding: 16px; }\n" +
+      ".hero { border-image: linear-gradient(90deg, #6c5ce7, #00b894) 1; }",
+    // negatives, all of which must stay clean: a 1px side rule, a 1px
+    // four-sided neutral border, a border-color-only focus treatment, and the
+    // two placeholder colors at an accent width.
+    negative:
+      ".card { border-left: 1px solid #eee; padding: 16px; }\n" +
+      ".panel { border: 1px solid var(--border-strong); padding: 16px; }\n" +
+      ".input:focus-visible { border-color: var(--accent); }\n" +
+      ".tab { border: 2px solid transparent; }\n" +
+      ".icon-btn { border: 2px solid currentColor; }",
   },
   "slop-v3-ghost-card": {
     ext: "css",

--- a/src/scripts/design_slop_rules.ts
+++ b/src/scripts/design_slop_rules.ts
@@ -214,20 +214,30 @@ export const SLOP_RULES: SlopRule[] = [
     catalogId: "V1",
     severity: "P1",
     engines: ["css"],
-    description: "Colored side-stripe border (border-left/right > 1px) — the #1 AI-UI signature",
+    description:
+      "Colored accent border > 1px — a side stripe, a four-sided colored border, or a gradient border-image (V1)",
     message:
-      "Side-stripe accent border reads as scaffold-default. Remove it, or declare an intentional stripe in DESIGN.md (V1).",
-    gated: (ctx) => ctx.has("side stripe", "side-stripe", "stripe accent", "accent border"),
+      "Colored accent border reads as scaffold-default. Remove it, or declare an intentional accent border in DESIGN.md (V1).",
+    gated: (ctx) =>
+      ctx.has("side stripe", "side-stripe", "stripe accent", "accent border", "card border"),
     detect: ({ content }) =>
       cssBlocks(content)
-        // a side-stripe is a left/right border with a width > 1px and a color;
         // exclude semantic blockquote/quote selectors (legitimate left rule)
         .filter((b) => !/blockquote|\bquote\b|<q>/i.test(b.selector))
-        .filter((b) =>
-          /border-(?:left|right)\s*:\s*(?:[2-9]|\d{2,})px\s+\w+\s+(?:#|rgb|hsl|oklch|var\(|[a-z])/i.test(
-            b.body,
-          ),
-        )
+        .filter((b) => {
+          // A colored value, but never a placeholder one: `transparent` and
+          // `currentColor` at > 1px are the layout-reservation and
+          // inherit-the-text-color idioms, not an accent decision.
+          const COLOR = "(?!transparent|currentcolor|inherit|initial|unset)(?:#|rgb|hsl|oklch|var\\(|[a-z])";
+          const WIDTH = "(?:[2-9]|\\d{2,})px";
+          // (a) the original side stripe: border-left / border-right
+          const stripe = new RegExp(`border-(?:left|right)\\s*:\\s*${WIDTH}\\s+\\w+\\s+${COLOR}`, "i");
+          // (b) the current form: a fully colored border on all four sides
+          const foursided = new RegExp(`border\\s*:\\s*${WIDTH}\\s+\\w+\\s+${COLOR}`, "i");
+          // (c) a gradient border, which carries no width token at all
+          const gradient = /border-image\s*:[^;]*(?:linear|conic|radial)-gradient/i;
+          return stripe.test(b.body) || foursided.test(b.body) || gradient.test(b.body);
+        })
         .map((b) => ({ line: b.line, snippet: b.selector.slice(0, 80) })),
   },
   {

--- a/src/skills/design-intelligence/data/ux-guidelines.csv
+++ b/src/skills/design-intelligence/data/ux-guidelines.csv
@@ -6,7 +6,7 @@ No,Category,Issue,Platform,Description,Do,Don't,Code Example Good,Code Example B
 5,Navigation,Deep Linking,All,URLs should reflect current state for sharing,Update URL on state/view changes,Static URLs for dynamic content,Use query params or hash,Single URL for all states,Medium
 6,Navigation,Breadcrumbs,Web,Show user location in site hierarchy,Use for sites with 3+ levels of depth,Use for flat single-level sites,Home > Category > Product,Only on deep nested pages,Low
 7,Animation,Excessive Motion,All,Too many animations cause distraction and motion sickness,Animate 1-2 key elements per view maximum,Animate everything that moves,Single hero animation,animate-bounce on 5+ elements,High
-8,Animation,Duration Timing,All,Animations should feel responsive not sluggish,Use 150-300ms for micro-interactions,Use animations longer than 500ms for UI,transition-all duration-200,duration-1000,Medium
+8,Animation,Duration Timing,All,Animations should feel responsive not sluggish,Use 150-300ms for micro-interactions,Use animations longer than 500ms for UI,transition-colors duration-200,transition-all duration-1000,Medium
 9,Animation,Reduced Motion,All,Respect user's motion preferences,Check prefers-reduced-motion media query,Ignore accessibility motion settings,@media (prefers-reduced-motion: reduce),No motion query check,High
 10,Animation,Loading States,All,Show feedback during async operations,Use skeleton screens or spinners,Leave UI frozen with no feedback,animate-pulse skeleton,Blank screen while loading,High
 11,Animation,Hover vs Tap,All,Hover effects don't work on touch devices,Use click/tap for primary interactions,Rely only on hover for important actions,onClick handler,onMouseEnter only,High

--- a/src/skills/fe-design/SKILL.md
+++ b/src/skills/fe-design/SKILL.md
@@ -246,10 +246,13 @@ provenance belongs to `road-to-frontend-fidelity-calibration` Phases 0 and 2.
 
 ## Anti-slop discipline
 
-Before proposing a direction, scan the Visual (V1–V7) and Layout (L1–L8)
-sections of [`design-antipatterns`](../../../docs/guidelines/design-antipatterns.md).
+Before proposing a direction, scan the Visual (V1–V8) and Layout (L1–L10)
+sections of [`design-antipatterns`](../../../docs/guidelines/design-antipatterns.md),
+plus Motion (M1–M8) for the interaction layer.
 On a match, choose differently or invoke the entry's own override condition in
-the brief — every entry has one, and they are register-scoped. The Q* floors are
+the brief — every entry has one. Two of them, T7 and T8, are additionally
+*register-scoped*: the brand and product registers admit different answers, and
+neither admits an undeclared pick. The Q* floors are
 in [`references/craft-floor.md`](references/craft-floor.md) instead of here, so
 they arrive at the write rather than at skill load.
 

--- a/src/skills/fe-design/references/design-patterns.md
+++ b/src/skills/fe-design/references/design-patterns.md
@@ -171,6 +171,34 @@ Before adding any animation to a UI element, run through this decision tree:
 - **Never animate layout properties** (width, height, top, left, padding). Why: triggers browser layout recalculation on every frame; always solvable with `transform`.
 - **Always add `@media (prefers-reduced-motion: reduce)`** — gentler animation (reduced distance/opacity), NOT display:none. Why: vestibular disorders make motion UI unusable; reducing is better than removing.
 
+**4. Is the trigger the reader's position, or the reader's action?**
+
+Position-triggered motion is the interaction layer's current tell, and it is
+the one case where the decision tree above returns "no" and gets overridden
+anyway. Two shapes, both catalogued:
+
+- **Scroll-reveal on every section** (catalog M6). The reader has already
+  scrolled to the content; fading it in delays what they asked for. Animate a
+  reveal only where position carries meaning — a stepped narrative whose beats
+  must land in order, or a long-form piece using position to signal progress —
+  and then say so in the brief. A reveal applied per section is a default.
+- **A pointer-tracking spotlight** (catalog M7). The cursor is the one element
+  on the page whose position the reader already knows, so highlighting it
+  carries no information. Legitimate only where the spotlight *is* the
+  interaction: an inspection tool, a reveal mechanic, a magnifier.
+
+**5. Does the hover state spend contrast or add it?**
+
+A control that lowers its own opacity on hover (catalog M8) reads as retreating
+from the pointer, and it reduces legibility at the moment the reader is
+committing to the target. Hover is carried by brightness, background, border or
+elevation — never by removing contrast. A fade is correct only when it
+communicates a real state change, such as an item being dismissed.
+
+The six interaction states every interactive element must assert are
+[`design-review`](../../design-review/SKILL.md)'s; this entry is the motion half
+of the hover one.
+
 **4. What to animate?**
 Animate `transform` and `opacity` only. Why: these run on the GPU compositor thread, not the main thread; they never trigger layout or paint.
 `scale(0)` → `scale(1)` is wrong. Why: nothing in the real world appears from nothing. Use `scale(0.95)` + `opacity: 0` → `scale(1)` + `opacity: 1` instead.

--- a/src/skills/react-shadcn-ui/SKILL.md
+++ b/src/skills/react-shadcn-ui/SKILL.md
@@ -122,7 +122,7 @@ Do NOT use when:
   components in the same surface.
 - **Anti-AI-slop catalog + linter.** Pull
   [`docs/guidelines/design-antipatterns.md`](../../../docs/guidelines/design-antipatterns.md)
-  before the polish step (Visual V1–V7, Layout L1–L8 are the React-component
+  before the polish step (Visual V1–V8, Layout L1–L10 are the React-component
   slop tells); the objective quality floors (WCAG contrast, focus-visible,
   reduced-motion) are validated via `accessibility-auditor`'s checklist —
   cite its verdict rather than eyeballing.


### PR DESCRIPTION
Closes `road-to-tell-currency` — 11/11 steps done, 4/4 acceptance criteria met, 3 items deferred to two named parked receivers, 0 open. Archived in this branch.

The catalog detected the generation of AI page tells that was current when it was written. Its coverage was entirely static — colour, type, layout, copy — and a grep for `scroll-reveal`, `spotlight`, `cursor-follow`, `grain` and `noise` returned zero hits across the catalog, the detector registry and the UI-motion reference.

## Council round — 2026-09-03, 2/2 convergent

Six interlocking forks. Members configured 2 (anthropic, openai); **both answered**; cost $0.0000, subscription-authed. Convergent on the substance, split on one point.

| Fork | Verdict | What shipped |
|---|---|---|
| 1 — Phase 1 is unexecutable as written | fixture + rule land atomically; Phase 1 has no work here | 1.1 deferred with the mechanism recorded |
| 2 — where interaction guidance lives | `fe-design` § Motion, and fix the stale pointer | both done |
| 3 — detector status for the four new tells | all four `judgment-only`, explicitly temporary | done, with both measured reasons in the notes |
| 4 — batch vs one-rule-one-epoch | moot here (no detector lands); protocol honoured on promotion | recorded in the receiver |
| 5 — the T4 widening | **split** — one seat said widen the prose, one said defer entirely | deferred; see below |
| 6 — Phase 4's scope | add `design-intelligence`, record in `agents/evidence/analysis/` | done |

**On the Fork-5 split.** Seat A: widen T4's prose, leave the ratio detector, note that position-scoped detection is unimplemented. Seat B: keep prose *and* status untouched, because T4 is `backed` and prose without rule makes the parity gate green while the claim goes false. Resolved toward B — it is the reading consistent with **both** seats' own Fork-3 principle that a `backed` label must not out-run its rule, and Seat A's own text concedes that making the claim false is the failure mode. Recorded as a split, not as agreement.

## Phase 2 — four entries, all `judgment-only`

| id | Tell |
|---|---|
| **M6** | every section fading and rising into view on scroll |
| **M7** | a radial highlight tracking the pointer across a dark hero |
| **M8** | an interactive control that reduces its own opacity on hover |
| **V9** | noise or grain laid over a gradient as a "premium" surface default |

V9 rather than V8 — `V8` is already the Consistency-Locks shape lock.

**Why judgment-only, measured rather than argued.** The step expected three of the four to be text-detectable. Two independent facts say otherwise, and both are in the status notes:

1. `lint_design_slop`'s `enginesForExt` classifies **no engine** for plain `.ts` / `.js` — which is where a reveal hook (`useReveal.ts`) and a `mousemove` spotlight handler normally live.
2. The pre-registered clean corpus (digest `90544389b05c1d0b`, 32 files) contains **zero** `IntersectionObserver`, **zero** `mousemove`, **zero** `radial-gradient` and **zero** `:hover { opacity }` — its only two `opacity` occurrences sit inside a `@keyframes toast-enter` block. Verified independently in this branch, not taken from a report.

So an `M1 = 0` for any of the four would be a **vacuous pass** — which is what the pre-registration itself says to read it as, and what the bench prints on every run — not measured precision.

```
./scripts-run src/scripts/lint_design_antipattern_parity
→ 50 entries classified, 25 detector-backed   ✅
```
No new row uses `candidate`.

## Phase 3 — V1 widened, rule and fixture in one commit

V1 is `backed`, so the prose could not move alone. The detector now matches the side stripe, a fully coloured border on all four sides above 1px, and a gradient `border-image`. Three positives and **five** negatives are pinned: a 1px side rule, a 1px four-sided neutral border, a `border-color`-only focus treatment, and `transparent` / `currentColor` at accent width — the last two being the layout-reservation and inherit-the-text-colour idioms rather than accent decisions.

```
npx vitest run src/scripts/design_slop_rules.test.ts   → 32 passed
npx tsx internal/bench/design-slop-fp/run.ts           → M1 = 0 for all 25 rules, corpus digest unchanged
```

**Why V1's widening ships while T4's does not:** the clean corpus carries V1's discriminating negative — three four-sided `1px` borders that must stay clean — so its `M1 = 0` measures something. For T4 and the four new entries it carries no near-miss at all. That is the whole distinction, and it is the criterion both council seats asked for.

## Phase 4 — the sweep, and what it found

Recorded in `agents/evidence/analysis/tell-currency-corpus-audit-2026-09-03.md`.

**The four named skills: three clean, one gap.** `react-shadcn-ui` and `tailwind-engineer` already forbid their ecosystem default with a catalog citation; `fe-design` correctly owns none (it is the stack-agnostic layer); `blade-ui` cites four ids of which **none is a Laravel default** — Breeze/Jetstream scaffold markup is never named — while delegating concrete bans to a skill that bans Tailwind's. So the step's literal scope was satisfiable with no edit, which is exactly why the council added `design-intelligence`.

**Three findings fixed here:**

| Finding | Fix |
|---|---|
| `ux-guidelines.csv:9` carried `transition-all duration-200` in the column named **`Code Example Good`** — M4's exact defect, M4 being `backed` | → `transition-colors duration-200`; the old value moved to `Code Example Bad` |
| `react-shadcn-ui:125` and `fe-design:249` cited `V1–V7` / `L1–L8` — correct as *table* extents, wrong as coverage: `V8`, `L9`, `L10` are `backed` and were unreachable | → `V1–V8` / `L1–L10`, with the table topology stated |
| `fe-design:252` claimed the override conditions "are register-scoped" | → narrowed to T7/T8, the only two (`grep -c` = 2) |

The M4 row is the shape of the whole sweep: it was invisible to the rule it contradicted **twice over** — `.csv` has no engine, and the detector matches `transition\s*:\s*all`, not the Tailwind class form.

**41 further prescriptive collisions carried to a named receiver**, not called intentional — for most of them that would be false. Top clusters: `motion.csv` has **zero** `prefers-reduced-motion` across 16 recipes (against `M5` "never acceptable" and CI-enforced floor `Q4`); glassmorphism as the *primary* default for 15 generic product types (against `V2`, and self-contradicted by the corpus's own checklist); two colour rows state the `C1` triad **verbatim in their own `Notes`**; four sub-`Q7` tracking defaults; a T7/T8 flag mechanism that reaches only one of the files that needs it.

**14 rows were checked and are NOT defects** and are recorded as such, and **nine catalog ids have no corpus recommendation at all** — clean by measurement, not by assumption.

## Deferrals — three, both receivers validated by the archiver

`deferralProblems` resolves a `carried-to` slug only against `agents/roadmaps/<slug>.md` or `agents/roadmaps/later/<slug>.md`, fail-closes on a `stubs/` path, and requires `parent_roadmap:` verified from both ends. The first receiver was written as a stub and moved to `later/` for exactly that reason — a stub would have looked like a receiver and validated as nothing.

| Deferred | Receiver |
|---|---|
| 1.1 fixture corpus · 3.2 T4 widening · AC-3b | `later/road-to-tell-detector-promotions.md` |
| the 41 corpus collisions (step 4.1's remainder) | `later/road-to-grounding-corpus-catalog-parity.md` |

Both claim their estate growth with a real reason. `later_roadmaps` 78 → 80, `active_roadmaps` 4 → 3; `check_estate_count` green with both claims read from the diff.

**AC-3 was split into AC-3a and AC-3b** so the V1 half could be claimed honestly rather than the pair reporting as one partial.

## Four factual defects in the roadmap itself, corrected in place

- The Goal and step 2.1 named `motion-choreographer` as the UI-motion authority. It is a text-to-video prompt builder (`packs: [ai-video]`), silent on scroll position because scroll position is not in its domain. The catalog's own See-also pointed at it too, with a description that actually matches `fe-design`'s Motion section.
- Step 2.3 named a collision with `icon-consistency` — which contains **no** `hover` and **no** `opacity` — and with "the affordance floors", which do not exist under that name anywhere in the tree. The real surface is `design-review`'s six interaction states, cited now from both M8 and the `fe-design` guidance.
- Step 1.1's verify asked the suite to report new positives as "unmatched", inverting its own semantics: the suite asserts a positive **must** fire.

## Honest notes

- **`task roadmap-progress` warns Iron Law 3** on the three `[~]` items ("surface them and ask the user before any archive"). Under this run's mandate that decision routes to the council, which ruled 2/2 on both deferrals with the reason recorded in each step. The archiver's own `deferralProblems` check passed and archived.
- The archive index and progress dashboard are regenerated but **gitignored**, so no index change appears in the diff.
- `lint_trigger_precision` invites lowering its budget 22 → 21. Pre-existing, unrelated, left alone.
- The audit ran against the pre-change tree (the worktree had moved branches), which is why it reports M7's and V9's tells as uncatalogued gaps. Stated in the artefact rather than silently reconciled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
