### PR TITLE
docs(roadmaps): drain nine inbox rounds into nine verified roadmaps

### DIFF
--- a/agents/roadmaps/later/road-to-deferred-rule-retriever.md
+++ b/agents/roadmaps/later/road-to-deferred-rule-retriever.md
@@ -5,6 +5,8 @@ complexity: lightweight
 
 # Road to deferred-rule retriever — command-invoked Class-A variant of the rejected MCP retrieval server
 
+> **Arrivals:** 4 (at least) — latest `inbox-2026-09-k` (2026-09-05); earlier: agents/roadmaps/archive/road-to-skill-delivery-over-mcp.md, agents/roadmaps/archive/road-to-activation-evidence-or-refusal.md, agents/roadmaps/archive/road-to-routing-assurance.md.
+
 > **Blocked until BOTH hold:** (1) the first native engine's Phase-5 benchmark
 > verdict is published (ADR-124 sequencing rule — one native engine at a
 > time; queue position 1 behind the code-graph engine per the sequencing plan

--- a/agents/roadmaps/later/road-to-experience-lifecycle-operational-proof.md
+++ b/agents/roadmaps/later/road-to-experience-lifecycle-operational-proof.md
@@ -17,6 +17,8 @@ estate_offset_exempt: >-
 
 # Road to operational proof of the experience-card lifecycle
 
+> **Arrivals:** 3 (at least) — latest `inbox-2026-09-p` (2026-09-05); earlier: agents/roadmaps/archive/road-to-experience-loop-broadening.md, two untracked prior rounds.
+
 > **Parked in `later/` — blocked on an external trigger, not on effort.** Carries **AC-9 verbatim** out of
 > `road-to-experience-loop-broadening`, which closed 2026-08-30 as
 > *implementation complete; operational validation deferred*. AI council

--- a/agents/roadmaps/later/road-to-gateway-harvest.md
+++ b/agents/roadmaps/later/road-to-gateway-harvest.md
@@ -5,6 +5,8 @@ status: later
 
 # Road to gateway harvest — what the runtime layer could carry, parked behind the freeze (Source B)
 
+> **Arrivals:** 2 — latest `inbox-2026-09-n` (2026-09-05); earlier: the untracked round of 2026-08-03 that created this roadmap.
+
 > **FREEZE LIFTED 2026-08-05.** The ADR-211 harvest freeze that parked this
 > roadmap was anchored on external adoption; that anchoring is struck by
 > [`ADR-216`](../../../docs/decisions/ADR-216-restraint-reanchored-to-capacity.md)

--- a/agents/roadmaps/later/road-to-mcp-full-power.md
+++ b/agents/roadmaps/later/road-to-mcp-full-power.md
@@ -5,6 +5,8 @@ status: later
 
 # Roadmap: MCP Full Power — Glama leverage, coverage expansion, execution bridge
 
+> **Arrivals:** 4 (at least) — latest `inbox-2026-09-k` (2026-09-05); earlier: agents/roadmaps/archive/road-to-skill-delivery-over-mcp.md, agents/roadmaps/archive/road-to-activation-evidence-or-refusal.md, agents/roadmaps/archive/road-to-routing-assurance.md.
+
 > Expose the full agent-config capability surface (including the TS background scripts / CLI subcommands) through MCP in safety tiers, and make the Glama + registry listings first-class distribution channels.
 
 > Blocked until the next council-approved MCP tool batch exists — the only open work (Phase 5 Step 3 codegen bridge + AC2) generates tools from an approved cut list, and the 2026-07-07 verdict left zero approved-but-unimplemented entries. Trigger: a new council round approves >= 1 additional tool (or a named consumer asks for a long-tail command via MCP).

--- a/agents/roadmaps/later/road-to-policy-evaluation-core.md
+++ b/agents/roadmaps/later/road-to-policy-evaluation-core.md
@@ -5,6 +5,8 @@ complexity: lightweight
 
 # Road to policy-evaluation core — deterministic Class-A slice of the rejected resident enforcement plane
 
+> **Arrivals:** 3 (at least) — latest `inbox-2026-09-i` (2026-09-05); earlier: two untracked prior rounds on the same subject, recorded in that round's recurrence table.
+
 > **Blocked until BOTH hold:** (1) the first native engine's Phase-5 benchmark
 > verdict is published (ADR-124 sequencing rule; queue position 2 per the
 > sequencing plan in `road-to-native-code-intelligence.md`), AND (2) a named

--- a/agents/roadmaps/later/road-to-routing-assurance-live-floors.md
+++ b/agents/roadmaps/later/road-to-routing-assurance-live-floors.md
@@ -10,6 +10,8 @@ estate_offset_exempt: "Not a new plan. This is the live-harness SUFFIX of road-t
 ---
 # Road to routing assurance — the live-harness floors
 
+> **Arrivals:** 2 (at least) — latest `inbox-2026-09-l` (2026-09-05); earlier: agents/roadmaps/archive/road-to-routing-assurance.md.
+
 > **Parent:** `road-to-routing-assurance`, closed at its Phase 2 cut line on
 > 2026-08-25. That roadmap's own text declares the stop: *"Stopping after Phase
 > 2 is a VALID end state: D1 and D2 are then repaired on the gated surface.

--- a/agents/roadmaps/later/road-to-tell-detector-promotions.md
+++ b/agents/roadmaps/later/road-to-tell-detector-promotions.md
@@ -8,6 +8,8 @@ estate_growth_exempt: "Adds one later/ roadmap because a [~] deferral has no oth
 
 # Road to the interaction-layer detector promotions
 
+> **Arrivals:** 3 (at least) — latest `inbox-2026-09-l` (2026-09-05); earlier: agents/roadmaps/archive/road-to-design-craft-antislop.md, agents/roadmaps/stubs/road-to-frontend-power-detector-promotions.md.
+
 > **Parked, not abandoned.** Created 2026-09-03 when `road-to-tell-currency`
 > closed. It receives two deferrals from that roadmap — the four new
 > interaction/texture detectors, and the T4 widening — on an AI-council verdict

--- a/agents/roadmaps/road-to-admissible-council-seats.md
+++ b/agents/roadmaps/road-to-admissible-council-seats.md
@@ -1,0 +1,123 @@
+---
+complexity: structural
+status: ready
+execution:
+  mode: phase-checkpoints
+estate_growth_exempt: "Phase 1 repairs a live defect — the api transport is dead for three of five configured providers and the only runtime carrier discards every council verdict — which the tree carries today independently of any free-intelligence story, and no existing roadmap owns either."
+estate_offset_exempt: "It offsets nothing: it is the only roadmap this inbox round produces, and the four drafts it consolidates were never in the estate."
+---
+# Road to admissible council seats
+
+> **Source:** `agents/tmp.old/inbox-2026-09-n/` — verified against the tree at 93d63073e on 2026-09-05.
+
+## Goal
+
+The council can today reach exactly two seats, both subscription CLIs from the two vendors whose joint panel this package already measured at zero finding-coverage lift; the API transport throws a package-not-installed error for the other three providers; and the one runtime carrier that resolves a council verdict discards it. This roadmap makes the council's own transports work, gives the resolver a vocabulary for refusing a route on policy rather than only on absence, and files one pre-registered claim for the one role a non-paid seat can hold without contradicting recorded evidence — scoring, never deciding. Success is checkable: every configured provider produces a `CouncilResponse` under `mode: api` in test; a seat can be refused with a named policy reason that `council:status` prints; a project diff cannot reach a seat whose ceiling is public artefacts; and a jury-agreement claim exists in `docs/CLAIMS.md` with its honest-null path written before any run. Work this roadmap does **not** contain, because the inbox round's verification showed it already exists or is already settled: the discovery, admissibility, health, quota, identity, blind-review, disagreement-signal, argument-exhaustion, secret-scan and finding-disposition modules four drafts proposed building are all present in `src/scripts/ai_council/` and `src/scripts/_lib/`; the separate money and entitlement budgets one draft called for are `budget_guard.ts` and `cli_call_budget.ts`; and a re-measurement of cross-vendor *reviewer* lift is excluded because the tree's own re-open condition for that null requires a judge-survivable corpus that does not exist here.
+
+## Phase 1 — Repair the transports the council already claims
+
+- [ ] **1.1 Give `_OpenAICompatibleClient` and `GeminiClient` a live transport.** Both constructors reach an unconditional `throw new Error('… package not installed. pip install …')` after the api-key check (`src/scripts/ai_council/clients.ts:854`, `:929`), so `mode: api` is dead for gemini, xai and perplexity. `OpenAIClient` already carries the pattern to copy — a `_curlJsonPost` shim installed as the `chat.completions.create` callable (`clients.ts:745-760`).
+      verify: a unit test constructs each of `GeminiClient`, `XAIClient` and `PerplexityClient` with an `api_key` and an injected transport double, calls `ask()`, and receives a `CouncilResponse`; the test fails on the current tree with the `pip install` error.
+- [ ] **1.2 Settle the Gemini CLI headless contract in the template, either way.** The seat ships `enabled: false` (`agents/templates/.ai-council.yml.example:394-395`) and the client comment records the contract as unverified because the run reached `IneligibleTierError` first (`clients.ts:2108-2121`). Either a dated probe result or an explicit honest null belongs in the template; an undated `enabled: false` teaches nothing.
+      verify: the template's `gemini:` block carries either a dated probe outcome or a one-line honest null naming what could not be established, and `./scripts-run src/scripts/council_cli status` reports the seat with that reason rather than silently.
+- [ ] **1.3 Make the runtime carrier carry rung-3 and rung-4 verdicts.** `src/scripts/hooks/delegation_nudge_hook.ts:440-441` returns `null` for every verdict that is not `subagent`, and its own comment names "rung-3/4 team/council" among what it discards — so a resolved council verdict produces no output on the only runtime carrier, recorded independently at `agents/evidence/analysis/council-intelligence-baseline.md:103-111`. The output is a pointer line naming `council_cli` / `ask_transport`, never an automatic spawn.
+      verify: a fixture in which `classifyLadder` returns a rung-4 verdict makes `buildNudgeLine` emit a non-null line naming the council entry point; the same fixture returns `null` on the current tree.
+
+## Phase 2 — Make a refusal sayable before making a seat admissible
+
+- [ ] **2.1 Extend `AbsentReason` with the policy exclusions it cannot express.** The union is exactly four values — `no_binary | no_auth | timeout | quota` (`src/scripts/ai_council/transport_resolver.ts:65`) — all of which mean "the route is not reachable". A route that is reachable and must not be used has no name, so the resolver cannot fail closed on terms, privacy, unproven cost, or a served model that is not the requested one. Add the exclusion reasons and make the unknown case resolve to absent, never to available.
+      verify: a unit test asserts each new reason round-trips through the resolver and appears in `council_cli status` output; a seat configured with an unproven-cost route resolves absent with that reason rather than available.
+- [ ] **2.2 Add one binary content ceiling per seat.** Redaction today is a secrets floor and says so (`src/skills/ai-council/references/cost-and-redaction.md`); nothing above it can express "this project's diff may not go to that seat". One attribute — `public-artifact` or `project-content` — carries the decision. Repo-owned artefacts (skill descriptions, trigger corpus, rule text, bench fixtures) are `public-artifact`; everything a consumer supplies defaults to `project-content`.
+      verify: a fixture sending consumer diff content to a `public-artifact` seat resolves absent with a content-ceiling reason and the run stays green; the same fixture sends a trigger-corpus fixture to the same seat and it is admitted.
+- [ ] **2.3 Record the seat-role boundary as an ADR.** A route this package did not pay for may propose findings and may score them; it may never carry a verdict, chair, or act as evaluator. This narrows a recorded park — `agents/roadmaps/later/road-to-governed-evidence-production.md:269-301`, whose `metered-backend-park` was narrowed on 2026-09-01 to a metered proposer only — onto a second axis, so it is a decision record rather than a rule edit.
+      verify: the ADR exists with `status`, `reopen_policy` and its basis set, `docs/decisions/INDEX` regenerates clean, and `src/rules/evaluator-independence.md` cites it by number.
+
+## Phase 3 — One pre-registered claim, on public artefacts only
+
+- [ ] **3.1 File one claim before any measurement runs.** `free-jury-judge-agreement`: on this package's own public evaluation corpus, a family-diverse panel scoring against known ground-truth dispositions reaches Cohen's κ ≥ 0.60, reusing the kappa machinery in `check_quality_regression.ts`. One claim, not two — the proposer-lift question is held behind `metered-backend-park` and is not filed here. The honest-null path is written into the claim: below the bar, the jury stays evaluation-only and no gate consumes it, permanently.
+      verify: `docs/CLAIMS.md` carries the claim with `status: unbacked` and a pre-registration date, and the pre-registration commit precedes any commit that records a measurement.
+- [ ] **3.2 Build the aggregator beside `consensus.ts`, not inside it.** At least two model families are required or the panel is absent; the aggregate is a trimmed mean or median, never a vote count — `docs/CLAIMS.md:522-531` records that a same-posture second vendor's catches were a strict subset of the first's, so counting agreeing voices measures redundancy. Position order swaps per judge, reusing `src/scripts/ai_council/judge_position_bias.ts`.
+      verify: a unit test — a single-family panel returns absent with the family reason; a three-judge panel containing one corrupted score returns the trimmed value and not the arithmetic mean; the position-swap path is exercised and asserted.
+- [ ] **3.3 Run it shadow-only, changing no behaviour.** A ledger records which seat would have been used and what it would have scored, on repo-owned public artefacts only, while every production surface keeps its current output.
+      verify: at least fourteen days of ledger lines exist and a diff over the same window shows no production surface consuming a jury score.
+
+## Phase 4 — A route beyond the two seats that exist
+
+Every step in this phase is held by `blocker: gateway-seat-admission` below. None may be worked before an owner lifts it.
+
+- [ ] **4.1 Add `base_url` to the config layer and a generic OpenAI-compatible route.** `_VALID_PROVIDERS` is closed at five names and `config.ts` contains no `base_url` at all (`src/scripts/ai_council/config.ts:88-94`; `grep -c base_url` returns 0), while the client class already has the field (`clients.ts:913`) — the gap is config, not transport. A route whose zero-cost property is not proven classifies `per-token`, so it stays inside the existing USD gate rather than escaping it. **corrected-from-reproduction:** this is `agents/roadmaps/later/road-to-gateway-harvest.md` M1, which is unprioritised and not blocked — its ADR-211 freeze was struck by ADR-216 on 2026-08-05, and neither ADR-088 nor ADR-249 governs it.
+      verify: a config test — a member declaring `base_url` with no hard-stop evidence resolves to billing class `per-token`, and `council_cli status` names the route and its class.
+- [ ] **4.2 Fold the three provider tables into one.** `PROVIDER_CLI_META`, `PROVIDER_ENV_KEY` and `PROVIDER_KEY_FILE` are three parallel maps over the same key set (`src/scripts/_lib/environment_detector.ts:135-159`), so every provider addition is three edits and any one of them can be forgotten silently.
+      verify: a test asserts that adding a provider requires exactly one edit — it constructs a provider absent from the table and asserts `knownProviders()`, the env-key lookup and the key-file lookup all fail together rather than partially.
+- [ ] **4.3 Close the overlapping parked work this phase implements.** `later/road-to-gateway-harvest.md` M1 and `later/road-to-evidence-calibrated-model-orchestration.md:256` (the loopback-only local member class) describe capabilities 4.1 delivers; leaving both open means the same capability is planned twice.
+      verify: both files carry a supersession note naming the step that implements them, and `lint_carrier_integrity` stays green.
+
+## Blockers
+
+### blocker: gateway-seat-admission
+
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** Phase 4 — A route beyond the two seats that exist
+- **Recommendation:** none; this is the owner's call — the capability is already argued and parked as `agents/roadmaps/later/road-to-gateway-harvest.md` M1, and only the owner can spend the slot that unparks it.
+- **If you do nothing:** Phase 4 stays unopened — 4.1–4.3 remain unauthored, and the two overlapping parked roadmaps (`later/road-to-gateway-harvest.md` M1, `later/road-to-evidence-calibrated-model-orchestration.md`) stay open and undisturbed.
+- **What to do:**
+  1. Read `agents/roadmaps/later/road-to-gateway-harvest.md` M1 and decide whether to spend the slot it names on a route this package does not own.
+  2. Record the decision (a line in that file, or a `docs/decisions/` entry) naming the date and, if authorized, the slot spent; if declined, record the refusal with the same specificity.
+- **Resolved when:** a dated decision — authorizing or declining the gateway seat — is recorded in `later/road-to-gateway-harvest.md` or `docs/decisions/`, and this entry's `Status:` is flipped to `resolved` in the same edit.
+
+Phase 4 adds a council seat pointing at a route this package does not own. That capability is already argued and parked as `agents/roadmaps/later/road-to-gateway-harvest.md` M1, whose file states the one remaining condition in its own words: "the maintainer spends a slot on it." Admitting the seat here without that decision would relitigate a parked disposition from a different roadmap. It is owner-reserved rather than council-decidable because it widens what this package may transmit and to whom.
+
+### blocker: free-seat-measurement-spend
+
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** Phase 3 — One pre-registered claim, on public artefacts only
+- **Recommendation:** none; this is the owner's call — spend against the two reachable metered/subscription seats is Hard-Floor reserved and is never inferred from an open roadmap step.
+- **If you do nothing:** Phase 3's measurement never runs; the pre-registered `free-jury-judge-agreement` claim stays filed with `status: unbacked` and is never resolved to a pass, a fail, or an honest null.
+- **What to do:**
+  1. Confirm the spend Phase 3's measurement would consume — which of the two reachable seats, and roughly how many calls across the ≥14-day shadow-only window in 3.3.
+  2. Record the authorization (a line at this blocker, or a `docs/decisions/` entry) naming the date and the spend ceiling agreed, then flip `Status:` to `resolved`.
+- **Resolved when:** a dated spend authorization (or a dated refusal) for Phase 3's measurement is recorded, and `Status:` is flipped in the same edit.
+
+Phase 3's measurement calls the council, and the council's two reachable seats are metered or subscription-consuming. Spend is owner-reserved by the Hard Floor and is never inferred from a roadmap step being open.
+
+### blocker: free-seat-estate-slot
+
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** nothing in this roadmap — it gates whether this roadmap keeps its own trunk or folds into a sibling file, a bookkeeping decision outside these phases.
+- **Recommendation:** none; this is the owner's call — the estate-budget decision needs the estate gate run on the actual adopting change, not a prediction made here.
+- **If you do nothing:** the roadmap stays adopted as its own file (`active_roadmaps` 1 → 2), which is not itself a problem, but the standalone-vs-fold-in choice against `road-to-council-topology-evidence-followups.md` stays undecided and is re-litigated at the next estate review.
+- **What to do:**
+  1. Run the estate gate on the actual adopting commit to get the measured growth figure, rather than the prediction stated here.
+  2. Decide standalone trunk vs. fold-in and record the decision (a note in this file, or in `road-to-council-topology-evidence-followups.md`), then flip `Status:` to `resolved`.
+- **Resolved when:** the standalone-vs-fold-in decision is recorded with the measured growth figure from the estate gate, and `Status:` is flipped in the same edit.
+
+The active estate holds one roadmap at HEAD. Adopting this one moves `active_roadmaps` 1 → 2; whether it earns its own trunk or folds into `road-to-council-topology-evidence-followups.md` is an estate-budget decision, and the growth figure must be measured with the estate gate on the adopting change rather than predicted here.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-09-05 | reviewer: claude/host -->
+
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | A working api transport lets a seat spend where none could before | implementation | Three providers currently fail closed by accident — the constructor throws. Repairing that removes an unintended cost barrier for anyone who has a key configured | The USD gate in `budget_guard.ts` and the per-provider daily cap in `cli_call_budget.ts` both predate this change and both apply; 1.1 adds no new provider and changes no cap | Phase 1 — Repair the transports the council already claims |
+| 2 | The carrier fix turns a silent path into an automatic one | implementation | Making the nudge hook emit on rung-3/4 could be read as authorising an automatic council spawn | 1.3's output is a pointer line only; the verify fixture asserts a line, never a spawn, and the spend floor is unchanged | Phase 1 — Repair the transports the council already claims |
+| 3 | A new refusal vocabulary defaults open instead of closed | implementation | Adding reasons without changing the default leaves the unknown case resolving to available, which is the failure the phase exists to prevent | 2.1's verify asserts the unproven case resolves absent, not available | Phase 2 — Make a refusal sayable before making a seat admissible |
+| 4 | The jury claim is written so it cannot fail | product | A pre-registered claim whose bar is set after seeing data is not evidence, and this package has recorded that failure shape before | 3.1 requires the pre-registration commit to precede the measurement commit, and the honest-null path is written into the claim text | Phase 3 — One pre-registered claim, on public artefacts only |
+| 5 | Scoring quietly becomes deciding | product | A jury score that a gate begins consuming turns an evaluation aid into a verdict carrier, contradicting the role boundary 2.3 records | 3.3 is shadow-only with a no-behaviour-change verify, and 2.3's ADR states the boundary before any consumer exists | Phase 3 — One pre-registered claim, on public artefacts only |
+| 6 | A public-artifact ceiling leaks project content through a helper | implementation | The ceiling is only as good as the paths that respect it; a caller that bypasses the resolver sends content the attribute forbids | 2.2's verify exercises the refusal from the resolver, and the existing secret-scan floor stays underneath it rather than being replaced | Phase 2 — Make a refusal sayable before making a seat admissible |
+| 7 | Phase 4 duplicates a capability another roadmap owns | implementation | Two parked roadmaps already describe a `base_url` seat and a loopback member class; building here without closing them plans the same work twice | 4.3 supersedes both in the same change, and the phase is held by an owner blocker until the ownership question is settled | Phase 4 — A route beyond the two seats that exist |
+
+## Acceptance Criteria
+
+- [ ] AC-1 — Every provider in `_VALID_PROVIDERS` produces a `CouncilResponse` under `mode: api` in test; no constructor path reaches a package-not-installed error.
+- [ ] AC-2 — The shipped council template states, for the seat it disables, either a dated probe outcome or a named honest null.
+- [ ] AC-3 — A resolved rung-3 or rung-4 verdict produces output on the runtime carrier; none is discarded silently.
+- [ ] AC-4 — A route can be refused for a policy reason, that reason is machine-readable, and `council:status` prints it.
+- [ ] AC-5 — Project content cannot reach a seat whose content ceiling is public artefacts, and the refusal is a green path, not an error.
+- [ ] AC-6 — A decision record states that a route this package did not pay for may propose and may score but may never decide, and `evaluator-independence` cites it.
+- [ ] AC-7 — One jury-agreement claim stands in `docs/CLAIMS.md` with a pre-registration date preceding every measurement commit and an honest-null path written into it.
+- [ ] AC-8 — The aggregator refuses a single-family panel and returns a trimmed statistic rather than a vote count.
+- [ ] AC-9 — No production surface consumes a jury score while the shadow ledger is accumulating.
+- [ ] AC-10 — No capability in this roadmap is also open in a parked roadmap; each overlap is superseded in the change that implements it.

--- a/agents/roadmaps/road-to-asked-not-parked.md
+++ b/agents/roadmaps/road-to-asked-not-parked.md
@@ -1,0 +1,122 @@
+---
+complexity: structural
+status: ready
+execution:
+  mode: phase-checkpoints
+estate_growth_exempt: "Charges +1 active roadmap against a top-level estate of one. Warranted because the four non-kernel surfaces it repairs (blocked-step parking, HANDOFF resume, feature-plan question packs, host ask capability) are each verified-open at 93d63073e, are held by no existing roadmap, and are the exact surfaces the owner named as a hurdle; the kernel half is deliberately excluded and parked as a blocker rather than smuggled in as a step."
+estate_offset_exempt: "Offsets nothing. It arrives from an inbox round and retires no roadmap: the two adjacent artefacts it touches are a stub and a later/ file, both of which stay parked on their own owner-gated resume conditions and neither of which this roadmap closes."
+---
+# Road to asked, not parked
+
+> **Source:** `agents/tmp.old/inbox-2026-09-j/` — verified against the tree at `93d63073e` on 2026-09-05.
+
+## Goal
+
+Today a decision this package needs from its user can end up in three places that are not the user: an inline `blocked-by:` marker in a roadmap file, an `## Open questions` section in a handoff file that no rule obliges the next session to read aloud, and a `{count}` printed instead of a question. This roadmap moves every one of those onto the channel the user is actually watching, one question at a time, and makes the host's own question capability a recorded fact rather than an assumption — so that a later change can route to a native picker without guessing what the host supports. It changes the *channel and the order* of asks; it never changes *whether* an ask happens, and it adds no ask that `no-cheap-questions` would not already permit. Two pieces of work are prevented rather than done: the `pre_tool_use` hook slot the source draft believed unbound is in fact bound on `claude` with fifteen concerns and a per-concern tool filter (`src/scripts/hook_manifest.yaml:1187`), so the guard in Phase 5 is one entry and one script rather than new plumbing; and the source draft's `structured_ask` object cannot be added as written, because every field of `HostCapabilityManifest` is a strict boolean that `asBool` coerces (`src/scripts/_lib/host_capability.ts:83-85`) — Phase 2 carries the corrected shape. The whole kernel half — rewriting `user-interaction.md` or `ask-when-uncertain.md`, and changing the decision sheet's `A/B/C` answer shape — is excluded by construction and parked as blockers, because a locked kernel rule is owner-reserved and a sixteen-day-old stub already holds that exact delta. Someone else can tell whether this happened by running the Phase 1 census twice: once now, once after Phase 4, and finding the `file-parked` and `count-only` classes at zero with the `blocked-by:` markers that remain each carrying a recorded reason for not asking.
+
+## Phase 1 — Measure the ask surface before changing it
+
+- [ ] **1.1 Extend `src/scripts/probe_unblocked_ask.ts` with a `form` dimension** that partitions hand-back ask turns into `text` and `native`, where `native` means the turn carries a tool call whose name matches the host's structured-ask tool. The probe already partitions ask turns and already excludes numbered-block turns (`:20-45`); this adds one axis to an existing instrument rather than a second instrument, which is the constraint its own header sets.
+      verify: `./scripts-run src/scripts/probe_unblocked_ask --help` names the new dimension, and a run over the existing transcript corpus prints a `form:` breakdown whose `text + native` sum equals the pre-change ask-turn total.
+- [ ] **1.2 Add one census script beside the four existing `*_census.ts`** that classifies every ask block in `src/domains/**/command.md`, `src/skills/**`, and `src/agent-src/contexts/**` into `single`, `batch`, `count-only`, `file-parked`. The script publishes its own classification definition in its module header before it publishes any number, and it writes a frozen baseline artefact under `agents/evidence/analysis/` pinned to the commit it ran at. `corrected-from-reproduction`: the source draft's figure of 157 batch-shaped commands does not reproduce — the natural grep returns 129 — so no count is carried forward from the draft and the census defines its own unit.
+      verify: the script runs to exit 0, its output artefact exists with a commit pin, and re-running it at the same commit produces a byte-identical artefact.
+- [ ] **1.3 Record the four baseline numbers and the native-ask rate in the census artefact** as the only figures any later phase may cite.
+      verify: `grep -c 'single\|batch\|count-only\|file-parked' <artefact>` returns all four classes present, and no phase below cites a number absent from that file.
+
+## Phase 2 — Make the host's ask capability a recorded fact
+
+- [ ] **2.1 Add a structured-ask capability to `src/scripts/_lib/host_capability.ts` in a shape the normalizer can actually carry.** `corrected-from-reproduction`: the source draft proposed a nested object; the interface at `:43-71` is `schema_version` plus six strict booleans and `asBool` at `:83-85` coerces every non-`true` value to `false`, so a nested object would normalize silently to nothing. Add `structured_ask: boolean` to the interface and `SAFE_DEFAULT` (false, so an unknown host degrades to text and never fires a call into a host that has no such tool), and put the per-host shape — tool name, question and option ceilings, free-text availability — in a separate typed record that `normalizeHostManifest` reads explicitly.
+      verify: `task typecheck` passes; a unit test asserts `resolveHostCapabilities('<unknown-host>').structured_ask === false`; a second asserts that passing a non-boolean for the field yields `false` rather than a truthy object.
+- [ ] **2.2 Do not write any registry row from documentation.** The manifest's observation protocol requires a real session with a transcript. Ship Phase 2 with zero `structured_ask: true` rows and a header comment naming the protocol as the only path to the first row.
+      verify: `grep -c 'structured_ask: true' src/scripts/_lib/host_capability.ts` returns 0 at merge, and the header comment names the observation protocol.
+- [ ] **2.3 Print the field with its provenance in `routing:doctor`,** so a session can tell a `false` that means "observed absent" from a `false` that means "nobody answered".
+      verify: `agent-config routing:doctor` output contains the field with one of `registry` / `live-probe` / `default` beside it.
+- [ ] **2.4 Add a Codex row to `docs/enforcement-by-host.md`.** The installer detects Codex (`src/install/toolDetection.ts:46`) and the host matrix at `:18-26` lists seven hosts, none of them Codex — so a reader concludes Codex is unsupported when it is merely unlisted.
+      verify: `grep -c -i codex docs/enforcement-by-host.md` is greater than 0, and the new row states runtime hook enforcement honestly rather than by analogy to Claude.
+
+## Phase 3 — Ask before park
+
+- [ ] **3.1 Put an ask step in front of the `blocked-by:` marker for the user-decision class.** `src/agent-src/contexts/execution/terminal-states.md:19` defines `blocked` to include "a decision only the user can make", and `src/agent-src/contexts/execution/roadmap-process-loop.md:323,327` writes and reads the inline marker with no ask in between. Change the loop so a step blocked on a user decision is put to the user first on an interactive host; only a decline, a timeout, or a non-interactive context writes the marker.
+      verify: the marker grammar accepts an `asked:` field; a fixture run in a non-interactive context writes `asked: no` with a reason, and a fixture run on an interactive host records the question having been put before any marker is written.
+- [ ] **3.2 A timeout or a non-interactive context is never consent.** Where the ask cannot be completed, the run ends in `approval-required` — a state `terminal-states.md` already defines — with the question and its conservative default in plain text. Never adopt the default silently.
+      verify: a fixture with a simulated timeout ends in `approval-required` and its output contains the unanswered question verbatim; no fixture path adopts a default without an answer.
+- [ ] **3.3 Oblige a resuming session to put `HANDOFF.md` `## Open questions` to the user, one at a time, before it works.** The section at `src/domains/meta/agent-handoff/command.md:171-173` carries a must-not-drop obligation, and the linter at `:181-185` only checks the section is non-blank — so a `?`-terminated question satisfies every gate while never reaching the user. Answers move into `## Decisions`.
+      verify: the resume path in the command file states the obligation; a fixture handoff carrying two questions produces two separate asks before the first work step, and both answers appear under `## Decisions`.
+- [ ] **3.4 Stop `## Open Questions` in `src/agent-src/templates/features.md:91` from reading as a parking lot** by stating in the template that entries there are questions still owed to the user, not a permanent section.
+      verify: the template line states the obligation, and the sentence names the ask channel rather than the file.
+
+## Phase 4 — Stop asking in packs
+
+- [ ] **4.1 Split `/feature:plan` Rounds 1, 2 and 4 into one decision per ask.** `src/domains/engineering-base/feature/plan/command.md:195` instructs "Ask 1–2 questions at a time" and Round 1 at `:197-203` then asks three; Round 4 at `:225-232` lists N open questions and closes with one collective question, which is the shape the owner named as the hurdle.
+      verify: the census from 1.2 re-run over `feature/plan/command.md` reports `batch: 0` for that file.
+- [ ] **4.2 Turn `OPEN QUESTIONS: {count}` into a summary that follows the asking, never a substitute for it** — `src/domains/engineering-base/feature/refactor/command.md:78` and `src/domains/engineering-base/feature/plan/command.md:311`.
+      verify: the census reports `count-only: 0` across `src/domains`, and each surviving count line is preceded in its own command file by the instruction to ask first.
+- [ ] **4.3 Re-run the Phase 1 census and record the delta against the frozen baseline.**
+      verify: the second census artefact shows `count-only` and `file-parked` at 0 and `batch` strictly below the baseline; the two artefacts are diffable and both carry commit pins.
+
+## Phase 5 — One question per call, where the host honours a deny
+
+- [ ] **5.1 Add a `pre_tool_use` concern that denies a structured-ask tool call carrying more than one question.** `corrected-from-reproduction`: this is one entry in `src/scripts/hook_manifest.yaml` under the `claude` platform's existing `pre_tool_use` list (`:1187`, fifteen concerns) plus one script under `src/scripts/hooks/`, using the per-concern `tools:` filter that seven concerns already use (`block-no-verify` at `:167-172` is the shape). The source draft believed the slot unbound and scoped this as new plumbing; it is not. Deny with a stated reason rather than silently truncating to the first question — a truncation hides the questions that were dropped.
+      verify: a hook fixture with a two-question payload returns the block exit code with a reason string; a one-question payload passes; `./scripts-run src/scripts/lint_hook_manifest` stays green.
+- [ ] **5.2 State the enforcement reach honestly in the concern's own header and in `docs/enforcement-by-host.md`:** bound on the platforms the manifest lists, honoured as a deny only where the host honours one. Do not claim a guard on a host that ignores the dispatcher's verdict.
+      verify: `agent-config hooks:status` output and the concern header agree on which platforms bind the slot, and neither claims a deny on a platform that discards dispatcher output.
+
+## Blockers
+
+### blocker: kernel-ask-form-authority
+
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** nothing in this roadmap — it names kernel-rule work excluded by construction and already parked as `agents/roadmaps/stubs/road-to-batch-elicitation-kernel-delta.md`.
+- **Recommendation:** none; this is the owner's call — moving ask-form authority out of `user-interaction.md` / `ask-when-uncertain.md` is a kernel edit, and the parked stub already names this exact authority question.
+- **If you do nothing:** the kernel rules keep prescribing a text numbered-options block as the only ask form; the contract decision sheet's option `B` answer shape (`"1=x, 2=y"`) stays in tension with `user-interaction.md:53`; and the stub, open since 2026-08-20, stays open.
+- **What to do:**
+  1. Read `agents/roadmaps/stubs/road-to-batch-elicitation-kernel-delta.md` and rule on the ask-form-authority delta it names — authorize, decline, or defer with a reason.
+  2. If authorized, route the edit through the kernel-edit path (`src/agent-src/contexts/authority/kernel-rule-edits.md`: own PR, soak window); if declined, record the refusal in the stub and here, and resolve the contract-decision-sheet option-`B` contradiction by editing the sheet's shape instead of the kernel rule.
+- **Resolved when:** a dated ruling (authorization or refusal) is recorded in `agents/roadmaps/stubs/road-to-batch-elicitation-kernel-delta.md`, and this entry's `Status:` is flipped to `resolved` in the same edit.
+
+`src/rules/user-interaction.md` and `src/rules/ask-when-uncertain.md` are two of the nine locked kernel rules. Both prescribe the ask **form** as a text numbered-options block: `user-interaction.md:21,24-31,35-38` builds both Iron Laws around numbered options and a recommended number, and `ask-when-uncertain.md:39` reads "Numbered options (per user-interaction). Short." Moving the form authority out of those rules — into a contract, into a host capability, or anywhere else — is a kernel edit. `block-kernel-rule-writes` denies it at tool-call time, and the kernel-edit guarantee requires its own PR and a soak window that no autonomous run may shorten or self-authorize.
+
+A closely-related delta is already parked on the owner: `agents/roadmaps/stubs/road-to-batch-elicitation-kernel-delta.md`, transferred 2026-08-20, whose criterion is "the user authorizes or declines the `ask-when-uncertain` delta". This blocker is the same authority question one step wider, and it is recorded here rather than acted on so that no phase above quietly re-opens it.
+
+Two further items sit behind this blocker and must not ship without it:
+
+- The contract decision sheet's option `B` (`src/agent-src/contexts/execution/contract-decision-sheet.md:52`) asks for the answer shape `"1=x, 2=y"`, which `src/rules/user-interaction.md:53` names as a self-check violation. The contradiction is real and confined to option `B`; option `A` is defended by the sheet's own one-keystroke argument at `:57-61`. Resolving it means touching either the sheet's shape or the kernel rule's clause.
+- The source drafts propose five new Iron Laws. Adding an Iron Law to a kernel rule is the same class of edit, and one of the five duplicates obligations `no-cheap-questions` already carries.
+
+### blocker: first-structured-ask-observation
+
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** nothing in this roadmap — Phase 2 already ships zero `true` rows on purpose (2.2); this names the future per-host ask-rewrite capability that stays unavailable until the observation happens.
+- **Recommendation:** none; this is the owner's call — running a live session per host to observe the structured-ask capability is a decision about spending session time, not something derivable from documentation.
+- **If you do nothing:** the `structured_ask` field keeps resolving to its safe default (`false`) on every host, the projection stays byte-identical everywhere, and no per-host ask-block rewrite ever becomes possible.
+- **What to do:**
+  1. Run one real session per target host and observe whether it exposes a structured-ask tool, per the manifest's observation protocol in `src/scripts/_lib/host_capability.ts`.
+  2. Record the observed result as the first `structured_ask: true` (or confirmed-`false`) row with its provenance, then flip `Status:` to `resolved`.
+- **Resolved when:** at least one host carries an observed (not assumed) `structured_ask` row with provenance recorded, and `Status:` is flipped in the same edit.
+
+Phase 2 ships the capability field with no `true` row, because the host-capability manifest's observation protocol requires a capability to be established in a real session with a transcript rather than copied from documentation. Writing the first row, and therefore enabling any per-host rewrite of an ask block, needs one observed session per host. Until that observation exists, the projection stays byte-identical everywhere and the capability resolves to its safe default.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-09-05 | reviewer: claude/host -->
+
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | Asking before parking raises the ask count | product | Phase 3 converts a silently-parked decision into a question the user must answer, which is the opposite of the standing direction to ask less. If it lands as extra interruptions the user experiences a regression, not a fix. | The conversion is channel-only: every question Phase 3 puts to the user is one the tree already decided was owed. The `no-cheap-questions` Pre-Send Self-Check runs first and drops any ask it would have dropped before. Phase 4 removes packs in the same roadmap, so the number of ask *turns* is measured by 1.1 in both directions. | Phase 3 — Ask before park |
+| 2 | The census defines its unit badly and the delta means nothing | implementation | A classification that counts `1.`-lines instead of decision blocks produces a number that moves without the surface moving — the exact failure that made the source draft's figure irreproducible. | 1.2 requires the definition to be published in the module header before any count, and 4.3 compares two artefacts produced by the same script at two pins rather than a number quoted in prose. | Phase 1 — Measure the ask surface before changing it |
+| 3 | The capability field is added and never observed | implementation | A `structured_ask` field that permanently resolves to its safe default is dead weight that reads like a capability. | 2.2 ships zero true rows deliberately and names the protocol; the `first-structured-ask-observation` blocker records the condition explicitly rather than leaving the field to rot silently. | Phase 2 — Make the host's ask capability a recorded fact |
+| 4 | The one-question guard denies a legitimate call and stalls a run | implementation | A deny on a slot that already carries fifteen concerns is on the critical path of every tool call; a false positive blocks work rather than shaping it. | 5.1 requires a passing one-question fixture alongside the failing two-question one, and the concern uses the existing per-concern `tools:` filter so it never sees a call it does not target. | Phase 5 — One question per call, where the host honours a deny |
+| 5 | Phase 4 edits drift into the kernel's form prescription | implementation | De-batching a command's rounds is one edit away from restating the ask form, which is kernel-owned and blocked. | Phase 4 changes only how many decisions a block carries, never how a block is rendered; the `kernel-ask-form-authority` blocker names the boundary and the census classes measure count, not form. | Phase 4 — Stop asking in packs |
+
+## Acceptance Criteria
+
+- [ ] AC-1 — The census artefact exists at a named path with a commit pin, its classification definition is stated in the script header, and re-running it at that pin is byte-identical.
+- [ ] AC-2 — `probe_unblocked_ask` reports a `form` breakdown whose classes sum to its own ask-turn total.
+- [ ] AC-3 — `HostCapabilityManifest` carries a structured-ask field that resolves to its safe default for an unknown host and for a non-boolean input, with zero `true` rows in the registry.
+- [ ] AC-4 — `docs/enforcement-by-host.md` contains a Codex row.
+- [ ] AC-5 — No `blocked-by:` marker of the user-decision class can be written without an `asked:` field recording whether the question was put and, if not, why.
+- [ ] AC-6 — A resume from a handoff carrying open questions puts each one to the user separately before the first work step, and the answers are recorded under `## Decisions`.
+- [ ] AC-7 — The post-change census reports `count-only: 0` and `file-parked: 0` across `src/domains` and `src/agent-src/contexts`, with `batch` strictly below the frozen baseline.
+- [ ] AC-8 — A two-question structured-ask payload is denied with a stated reason on a platform that honours a deny, and a one-question payload passes; `lint_hook_manifest` is green.
+- [ ] AC-9 — No file under `src/rules/` is modified by this roadmap, and both blockers stand open with a named owner.

--- a/agents/roadmaps/road-to-authorization-that-reaches-further.md
+++ b/agents/roadmaps/road-to-authorization-that-reaches-further.md
@@ -1,0 +1,135 @@
+---
+complexity: structural
+status: ready
+execution:
+  mode: phase-checkpoints
+estate_growth_exempt: "The one verified new capability in the round — the dispatcher never emits the host's permissionDecision field although the host contract records it as offered — has no receiver anywhere in the estate, and the four owner-reserved questions it exposes have sat unrecorded in two stubs for fourteen days."
+estate_offset_exempt: "It offsets nothing: it closes no existing roadmap, and the two stubs it names stay open because only the owner can close them."
+---
+# Road to authorization that reaches further
+
+> **Source:** `agents/tmp.old/inbox-2026-09-m/` — verified against the tree at `5c539505d` on 2026-09-05.
+
+## Goal
+
+Reduce the confirmations a normal coding task costs, without moving any recorded floor, by making the authorization the user already gave reach the operations it plainly covers — and by putting the questions that genuinely require the owner in front of the owner instead of leaving them in a stub. Verification against the tree removed most of the round's proposed work before it was planned, and a decision that landed while this file was being written removed most of the rest. ADR-254 (accepted 2026-09-04, owner-directed, superseding ADR-252) deletes the `block-unauthorized-git` concern and its three `pre_tool_use` bindings: **nothing in this package enforces git authorization any more**, the enforcing half of the reader is gone, and `src/scripts/hooks/block_unauthorized_git.ts` survives only as the non-gating parser `src/scripts/hooks/git_command_classifier.ts` for `block_no_verify` and `conformance_scan`. What survives is the `git-authorization` ledger concern, advisory exactly as it always was (`src/scripts/hook_manifest.yaml:485-489`) — it records what a turn's own words authorized and blocks nothing — plus `conformance_scan`'s after-the-fact count of irreversible operations that ran unauthorized (`src/scripts/conformance_scan.ts:807`). The Hard Floor is unchanged as a rule and is now **model-held** for git operations. So the plan below builds on the advisory record and the measurement, never on a gate. The one capability that ADR-254 does not touch is still absent: the dispatcher constructs only an `additionalContext` envelope (`src/scripts/hooks/host_semantics.ts:114-119`) even though the host contract records `permissionDecision` as offered and not emitted (`docs/contracts/hook-architecture-v1.md:496-512`). This roadmap is done when a category-A tool call reaches the host carrying an explicit allow, the package stops teaching the `cd X && …` shape that provokes a host prompt, the ledger records the consequence operations the owner named so the conformance count can see them, the friction is measured rather than asserted, and the five owner-reserved questions carry a dated ruling or a recorded refusal to rule.
+
+## Phase 1 — Stop provoking prompts nobody in this package asked for
+
+- [ ] **1.1 Emit `permissionDecision: allow` for category-A tool calls.** The dispatcher builds exactly one envelope shape at `src/scripts/hooks/host_semantics.ts:114-119` and never the permission field, although the host contract records the field as offered and explicitly names our own plumbing as the thing that does not emit it at `docs/contracts/hook-architecture-v1.md:496-512`. Category A is reads, navigation, build, test and lint inside the working tree with no consequence operation attached; nothing in this package gates those today — and after ADR-254 nothing in this package gates any git operation either — so an explicit allow removes a host prompt without removing a gate. Ship the composition policy with it — one `ask` or `deny` from any concern beats every `allow` — because the undecided composition question at `docs/contracts/hook-architecture-v1.md:518-521` is what stalled this path before.
+      verify: `grep -rn "permissionDecision" src/scripts/hooks/ | wc -l` is greater than zero (it is `0` today), and the composition precedence has a test that goes red when an `allow` is allowed to outrank a `deny`.
+- [ ] **1.2 Replace the `cd X && …` shape in the skill canon with a directory-flag form.** `grep -rn "git -C\|pushd\|subshell" src/rules/` returns zero, so nothing in the rule layer tells an agent to prefer `git -C <path>`, `npm --prefix <path>` or `composer -d <path>`, while `src/skills/using-git-worktrees/SKILL.md:138` teaches the compound form directly. Rewrite that line and re-scope the global worktree root at `src/skills/using-git-worktrees/SKILL.md:108`, which places a working directory outside the repository. `corrected-from-reproduction`
+      verify: `grep -n "cd \.worktrees" src/skills/using-git-worktrees/SKILL.md` returns nothing, and `grep -rn "git -C" src/rules/` returns at least one line.
+- [ ] **1.3 Report the host permission settings that produce the prompts, and write none of them.** A doctor check reads the consumer's own settings and reports read-deny rules, a missing worktree root in the host's additional-directories list, and the active default permission mode, with a copyable snippet. It never writes them: `src/templates/consumer-settings/claude-settings.json` carries `enabledPlugins` and `hooks` and zero `permissions` keys, and that stays true.
+      verify: `grep -c permissions src/templates/consumer-settings/claude-settings.json` returns 0, and the doctor output names each of the three settings on a project where they are absent.
+
+## Phase 2 — Widen what the advisory ledger records
+
+Both steps change what is **recorded and counted**, never what is refused. ADR-254 removed the enforcing reader; the ledger concern it left standing is advisory by manifest (`src/scripts/hook_manifest.yaml:485-489`), and the only consumer that acts on the vocabulary is the after-the-fact conformance count at `src/scripts/conformance_scan.ts:807`. Nothing here re-adds a gate, and nothing here may be read as a step toward one.
+
+- [ ] **2.1 Extend the operation vocabulary from git operations to consequence operations.** `src/scripts/git_authorization_hook.ts:240-267` enumerates exactly 26 git operations, and `src/scripts/hooks/git_command_classifier.ts:86` carries the irreversible subset the conformance scan counts against. The boundaries the owner named — production deploy, production data destruction, production infrastructure change, external send, money movement, force-push to a shared trunk, destructive work outside the task — have no vocabulary at all, so an authorization the user gave in plain words is invisible to the record and the corresponding operation is invisible to the count. Add them following the existing phrase table at `src/scripts/git_authorization_hook.ts:277`, keeping the negation handling at `src/scripts/git_authorization_hook.ts:996` and the fenced-paste exclusion at `src/scripts/git_authorization_hook.ts:517`. Recording an authorization is not granting one, and after ADR-254 there is no grantor left: the record feeds measurement only.
+      verify: a prompt naming a production deletion in German and in English records the operation, a prompt asking what such a deletion does records nothing, a fenced paste containing the phrase records nothing, and `./scripts-run src/scripts/conformance_scan` still exits without an error on the extended vocabulary.
+- [ ] **2.2 Record the object a consequence authorization names, and count mismatches.** An authorization for one table, one environment or one recipient class is not an authorization for another, and today the record cannot express the difference for anything but pull-request numbers. Add the object as a recorded field on the consequence operations from 2.1, mandatory for data destruction, external send and money movement, and teach the conformance check at `src/scripts/conformance_scan.ts:807` to count an operation whose object the turn's record does not name. This is measurement in the shape ADR-254 preserved — the scan reports after the fact and refuses nothing.
+      verify: a turn authorizing one table and executing against a different table produces one conformance violation and zero refusals, and the mismatch is a test that goes red when the object field is dropped.
+
+## Phase 3 — Measure the friction instead of asserting it
+
+- [ ] **3.1 Record the unauthorized-operation baseline ADR-254's review trigger is written against.** The ADR reopens when "the conformance scan's unauthorized-operation count rises over a measured baseline rather than staying flat", and no such baseline exists — the check counts violations per run (`src/scripts/conformance_scan.ts:807,963`) but nothing pins a reference value. Record one over a stated window, with the window size and the session count next to the figure, and re-record it after 2.1 lands so the vocabulary change is visibly separated from a behaviour change.
+      verify: `./scripts-run src/scripts/conformance_scan` reports a `git-authorization` count, and the recorded baseline names its window, its session count and the tree SHA it was measured at.
+- [ ] **3.2 Build an autonomy-friction corpus of the cases the round names.** The corpus holds the payload classes the owner named — directory change, directory change compounded with a status read, a test runner invoked from a subdirectory, a workspace package manager, a consequence operation with the authorizing phrase present, and the same operation with it absent — each with the expected number of confirmations rather than the number of gates that fire.
+      verify: the corpus runs and reports a per-case confirmation count; a case whose expectation is zero and whose observation is one fails.
+- [ ] **3.3 Report the residual interruptions over a window wide enough to mean something.** `src/scripts/interruption_report.ts:1-22` already measures asks, hand-backs and halts per run and already flags a short window; its buffer held five sessions when it was written. Persist enough runs that the window request is met, and pre-register the expected drop as a falsifiable claim with an honest null permitted.
+      verify: `./scripts-run src/scripts/interruption_report` reports a session count meeting its window request without the short-window flag, and the pre-registered claim is recorded before any phase-1 change is measured against it.
+
+## Blockers
+
+### blocker: git-enforcement-reinstatement
+
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** nothing in this roadmap — Phases 1–3 record and measure and refuse nothing; this entry records the two ledger items this file could no longer schedule, because both exist only to be read by a gate that ADR-254 deleted.
+- **Recommendation:** none; this is the owner's call — ADR-254 carries `reopen_policy: owner` and `protected_dimensions: security_floor`, and its own `review_trigger` states: "Explicitly NOT a trigger: a wish to re-add the gate in its old shape. The shape is what failed; a replacement must classify intent into typed transitions rather than test a prompt against a regex."
+- **If you do nothing:** grants keep being minted and stored (`src/scripts/git_authorization_hook.ts:587,739`) and nothing reads them — `consumeGrantTarget` at `src/scripts/git_authorization_hook.ts:1180` has no caller outside its own tests since the enforcing half was deleted — so the object-bound grant shape ADR-252 accepted stays recorded and inert, and git authorization stays model-held under `src/rules/non-destructive-by-default.md`.
+- **What to do:**
+  1. Decide whether a git-authorization gate returns at all, and if it does, whether it takes the typed-transition shape ADR-254's `review_trigger` requires rather than the deleted Boolean-over-prose shape. Two items wait on that ruling and on nothing else: making object binding a **matching** condition rather than a recorded field, and letting object-bound grants cover operations beyond pull-request merge (`src/scripts/git_authorization_hook.ts:590` still states that only `pr-merge` mints grants).
+  2. Record the ruling (authorization or refusal) in `docs/decisions/` as a record that supersedes or amends ADR-254, and update `agents/roadmaps/stubs/road-to-owner-authority-decisions.md` to point at it.
+- **Resolved when:** a dated ruling (or a recorded refusal to rule) is filed in `docs/decisions/`, the stub is updated to point at it, and `Status:` is flipped to `resolved` in the same edit.
+
+ADR-254 is accepted, owner-directed, one day old, and reserves its own reopening to the owner. Its consequences section states the cost plainly: the failure the removed gate was built after is unguarded again, and if it recurs nothing stops it. This roadmap does not argue that away and does not plan around it. It records here, once, that two items the round proposed — mandatory object **matching** and grant generalisation beyond pull-request merge — have no non-gating purpose, so scheduling them would be re-adding mechanical enforcement under another name.
+
+### blocker: autonomy-default-semantics
+
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** nothing in this roadmap — Phases 1–3 are floor-preserving and do not touch `personal.autonomy`; this entry records the round's proposed default-semantics change for a dated ruling rather than dropping it silently.
+- **Recommendation:** none; this is the owner's call — `personal.autonomy` is a consumer-facing default projected to every host, and inverting or changing it changes behaviour for every consumer on their next update.
+- **If you do nothing:** `personal.autonomy` keeps shipping `auto`, resolving as `off` until opt-in; the round's proposed inversion stays unrecorded and unresolved.
+- **What to do:**
+  1. Decide whether the shipped default or its `auto`-resolves-to-`off` semantics (`src/config/agent-settings.template.yml:342`, `src/rules/autonomous-execution.md:30`) should change.
+  2. Record the ruling (authorization or refusal) in `docs/decisions/` and update `agents/roadmaps/stubs/road-to-owner-authority-decisions.md` to point at it, per AC-7.
+- **Resolved when:** a dated ruling (or a recorded refusal to rule) is filed in `docs/decisions/`, the stub is updated to point at it, and `Status:` is flipped to `resolved` in the same edit.
+
+`personal.autonomy` ships as `auto` (`src/config/agent-settings.template.yml:342`) and `auto` resolves to the same behaviour as `off` until the user opts in (`src/rules/autonomous-execution.md:30`). Inverting that meaning, or changing the shipped default, changes behaviour for every consumer of this package on their next update, in a rule that is projected to every host. That is a consumer-facing default, which no agent may flip.
+
+### blocker: hard-floor-scope-reduction
+
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** nothing in this roadmap — Phases 1–3 leave `non-destructive-by-default.md` untouched by construction; this entry records the round's proposed floor-narrowing for a dated ruling.
+- **Recommendation:** none; this is the owner's call — narrowing the Hard Floor (removing the push or commit row, or accepting a run-scoped grant in place of the this-turn confirmation) lowers a recorded safety floor in a kernel rule, which `src/rules/decision-revisit-gate.md:140` reserves to the owner. ADR-254 raises the stakes rather than lowering them: since the gate was removed, this rule is the only carrier left for git operations.
+- **If you do nothing:** the push and commit rows stay inside the Hard Floor exactly as recorded, and every push/commit keeps requiring this-turn confirmation regardless of a standing instruction or roadmap authorization.
+- **What to do:**
+  1. Decide whether to narrow the Hard Floor's push/commit rows (`src/rules/non-destructive-by-default.md:33`) or accept a run-scoped grant in place of the this-turn requirement.
+  2. Record the ruling in `docs/decisions/` and update `agents/roadmaps/stubs/road-to-owner-authority-decisions.md` to point at it, per AC-7.
+- **Resolved when:** a dated ruling (or a recorded refusal) is filed in `docs/decisions/`, the stub is updated, and `Status:` is flipped to `resolved` in the same edit.
+
+`src/rules/non-destructive-by-default.md:33` places any push in the same Hard Floor as production migrations, and the rule's opening requires confirmation on the turn itself, explicitly refusing a standing instruction or a roadmap authorization as a substitute. Removing the push row, removing the commit row, or accepting a run-scoped grant in place of the this-turn requirement each lower a recorded floor in a kernel rule. `src/rules/decision-revisit-gate.md:140` reserves exactly that to the owner, and `src/scripts/hooks/block_kernel_rule_writes.ts:5-16` denies the write at tool-call time.
+
+### blocker: kernel-rule-and-governance-self-amendment
+
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** nothing in this roadmap — the four self-amendment deletions it names are excluded by construction from Phases 1–3; the fourteen-day-old stub `road-to-owner-authority-decisions.md` already holds this exact question unruled.
+- **Recommendation:** none; this is the owner's call — governance self-amendment (deleting `block_kernel_rule_writes.ts`, the soak guarantee, `scope-control.md`'s task-scope reset and git section, or the owner-reserved set in `decision-revisit-gate.md`) is the one class of change with no council-decidable counterpart.
+- **If you do nothing:** the four named deletions stay unmade, `block_kernel_rule_writes.ts` keeps denying kernel writes at tool-call time, and the fourteen-day-old stub stays open with no ruling recorded.
+- **What to do:**
+  1. Rule individually on each of the four named deletions — the task-scope reset and git section in `src/rules/scope-control.md:24-36,54`, `src/scripts/hooks/block_kernel_rule_writes.ts`, the soak guarantee in `src/agent-src/contexts/authority/kernel-rule-edits.md:11-16`, and the owner-reserved set in `src/rules/decision-revisit-gate.md:130-141` — accept, reject, or defer with a stated reason.
+  2. Record the ruling in `docs/decisions/` and update `agents/roadmaps/stubs/road-to-owner-authority-decisions.md` to point at it, closing both records in the same edit.
+- **Resolved when:** a dated ruling (or recorded refusal) covering all four named deletions is filed in `docs/decisions/`, the stub is updated, and `Status:` is flipped to `resolved` in the same edit.
+
+Four requests in this round amend the machinery that decides who may amend the machinery: deleting the task-scope reset and the git section from `src/rules/scope-control.md:24-36,54`, deleting `src/scripts/hooks/block_kernel_rule_writes.ts`, deleting the soak guarantee at `src/agent-src/contexts/authority/kernel-rule-edits.md:11-16`, and removing the owner-reserved set at `src/rules/decision-revisit-gate.md:130-141`. Governance self-amendment is the one row in that table with no council-decidable counterpart. The same question has been open in `agents/roadmaps/stubs/road-to-owner-authority-decisions.md` since 2026-08-22 with no ruling recorded, and its recorded state is authority-unavailable rather than refusal — so a ruling here closes a fourteen-day-old record as well as this blocker.
+
+### blocker: tool-safety-floor-lowering
+
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** nothing in this roadmap — Phases 1–3 leave `tool-safety.md` and `lint_skill_frontmatter_safety.ts`'s severity thresholds untouched; this entry records the round's proposed floor change for a dated ruling.
+- **Recommendation:** none; this is the owner's call — rebuilding the deny-by-default rule as consequence-aware and demoting the wildcard-grant finding both lower a recorded security floor, and "capability is not risk" is a real argument the agent may not settle unilaterally.
+- **If you do nothing:** `src/rules/tool-safety.md` stays deny-by-default with "deny under doubt", and `lint_skill_frontmatter_safety.ts` keeps treating a wildcard tool grant and a permission bypass as high severity.
+- **What to do:**
+  1. Decide whether to accept the consequence-aware rebuild of `src/rules/tool-safety.md` and the severity demotion in `src/scripts/lint_skill_frontmatter_safety.ts`, or keep the current floor.
+  2. Record the ruling in `docs/decisions/` and update `agents/roadmaps/stubs/road-to-owner-authority-decisions.md` to point at it, per AC-7.
+- **Resolved when:** a dated ruling (or recorded refusal) is filed in `docs/decisions/`, the stub is updated, and `Status:` is flipped to `resolved` in the same edit.
+
+`src/rules/tool-safety.md:27,31` is deny-by-default and instructs denial under doubt; `src/scripts/lint_skill_frontmatter_safety.ts:16-18` treats a wildcard tool grant and a permission bypass as high severity. Rebuilding the rule as consequence-aware and demoting the wildcard finding both lower a recorded security floor. The distinction the round draws — that capability is not risk — is a real argument and not one an agent may settle on its own.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-09-05 | reviewer: claude/host -->
+
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | Category-A allow widens further than intended | implementation | An `allow` emitted for a call that carries a consequence operation would hand the host a pass on exactly the operations the Hard Floor still covers, and since ADR-254 that rule is the only carrier left for git. | Allow only inside the working tree with no consequence operation matched, and ship the composition policy in the same step so any `ask` or `deny` outranks it. | Phase 1 — Stop provoking prompts nobody in this package asked for |
+| 2 | Permission field unverified against the running host | implementation | The field is recorded as offered against one probed build; the tree's own contract says every other host is unprobed and warns against reading a fact about this plumbing as a fact about the host. | Probe the running binary before the emission path is enabled, and keep the existing envelope as the fallback when the probe fails. | Phase 1 — Stop provoking prompts nobody in this package asked for |
+| 3 | Wider vocabulary is mistaken for a wider gate | implementation | Extending the phrase table to production and external operations touches the same file the deleted gate read, so a later reader could take the record as an authorization surface and wire a refusal to it. | Keep the existing negation, question-versus-order and fenced-paste handling; state in the step, the code comment and the test names that the consumer is `conformance_scan` and that nothing refuses; leave the reinstatement question in its blocker. | Phase 2 — Widen what the advisory ledger records |
+| 4 | Measured drop is attributed to the wrong cause | implementation | Most confirmations in the round's own account originate outside this package, so a drop after phase 1 could be a host change rather than an effect of this work; the same applies to a change in the unauthorized-operation count after the vocabulary extension. | Pre-register the claim before measuring, record the host build and tree SHA alongside each window, re-record the baseline either side of 2.1, and permit an honest null. | Phase 3 — Measure the friction instead of asserting it |
+| 5 | Blockers stay open and the phases ship a partial answer | product | Every phase here is deliberately floor-preserving, so shipping all of them leaves the posture the owner objected to unchanged; the visible work could read as the answer. | State in the Goal and in each blocker that the posture question is the blockers' content, and keep the five blockers open until a dated ruling exists. | Phase 1 — Stop provoking prompts nobody in this package asked for |
+
+## Acceptance Criteria
+
+- [ ] AC-1 — A category-A tool call reaches the host carrying an explicit allow, and a concern's `ask` or `deny` outranks that allow.
+- [ ] AC-2 — No file under `src/rules/`, `src/skills/` or the consumer settings template teaches the `cd <path> && …` shape, and the rule layer names a directory-flag alternative.
+- [ ] AC-3 — The advisory ledger records the seven consequence operations with the named object recorded for data destruction, external send and money movement, and records nothing from a question, a negation or a fenced paste.
+- [ ] AC-4 — No step in this file adds, restores or wires a refusal on any git operation, and `grep -c 'block-unauthorized-git\|block_unauthorized_git' src/scripts/hook_manifest.yaml` stays at 0 — no concern definition, no `pre_tool_use` binding.
+- [ ] AC-5 — A friction corpus reports a per-case confirmation count, the conformance unauthorized-operation baseline is recorded with its window and tree SHA, and the interruption report meets its window request without the short-window flag.
+- [ ] AC-6 — Every kernel rule, hook and lint threshold named in the five blockers is byte-identical to its state at `5c539505d`, or carries a dated owner ruling authorising the change.
+- [ ] AC-7 — Each of the five blockers carries either a dated owner ruling or a recorded statement that the owner has not ruled, and `agents/roadmaps/stubs/road-to-owner-authority-decisions.md` is updated to point at whichever landed.

--- a/agents/roadmaps/road-to-bounded-reference-harvest-loop.md
+++ b/agents/roadmaps/road-to-bounded-reference-harvest-loop.md
@@ -1,0 +1,126 @@
+---
+complexity: structural
+status: ready
+execution:
+  mode: phase-checkpoints
+estate_growth_exempt: "Unblocks a 16-day-old parked stub (road-to-first-reference-analysis-run) and a pre-registered claim with a 180-day expiry window; the work exists to close two open estate entries, not to add a third."
+estate_offset_exempt: "Offsets nothing on landing by design — the stub it closes is disposed in its final phase, so the disposal cannot be banked in the same change that opens the work."
+---
+# Road to the bounded reference-harvest loop
+
+> **Source:** `agents/tmp.old/inbox-2026-09-h/` — verified against the tree at `93d63073e` on 2026-09-05.
+
+## Goal
+
+Make one command the only place in this package that analyses an external repository, give it a bounded refinement loop with three differently-scoped review lenses, stop it from writing source identity into tracked files, and put a thin harvester in front of it that walks the roadmap estate's encrypted reference tokens and feeds unique repositories through it one at a time without producing one roadmap per repository. Done when: the analysis command carries a machine-readable `limits:` contract whose lines the body restates, a single deterministic discovery script reports the estate census and writes nothing outside the gitignored local area, an interrupted batch resumes without re-running a completed repository, and one real analysis has run end to end under the command's own contract with its outcome written honestly into the pre-registered claim row.
+
+Four things the drafts proposed are **not** in this roadmap because the tree already has them, and each one prevented a phase: the analysis command itself already exists with anchor-table-first ordering, a `--deep` clone tier, an interop probe, verdict convergence and ledger rows (`src/domains/analysis-workbench/analyze/reference-repo/command.md`, 361 lines) — so this is an extension, not a build; the encrypted-link primitive with project → global → environment key resolution already exists (`src/scripts/_lib/link_crypto.ts:216`); the gitignored local landing zone already exists (`.gitignore:290`); and the measurement of whether this loop is worth its cost is already pre-registered with a falsification bar fixed before the data (`docs/CLAIMS.md:487`), so no second evaluation is built. Two further draft proposals were dropped on verification rather than deferred: a "generic bounded-analysis-loop primitive" whose stated premise is refuted by the only existing consumer (`src/domains/meta/optimize/deep/command.md:11-16` ships `mode_default: plan` together with `max_iterations: 3`), and a reuse of a "canonical roadmap-estate reader" that does not exist in `src/scripts/_lib/`.
+
+## Phase 1 — One analysis engine, one name
+
+- [ ] **1.1 Rename `analyze/reference-repo/` to `analyze/repo/`** and set `name: analyze-repo`, `sub: repo`, `replaces: [analyze-reference-repo, analyze:reference-repo]`. `visibility: internal` and `workspaces: [agent-config-maintainer]` are already correct and stay. `replaces:` is the house alias mechanism, so no deprecation window and no second living implementation.
+      verify: `./scripts-run src/scripts/skill_linter` reports 0 FAIL; `task sync` produces `dist/agent-src/commands/analyze/repo.md` and no `reference-repo.md`.
+- [ ] **1.2 Update every inbound reference in the same change** — 18 files under `src/` and `docs/` name the old command, 17 of them outside `docs/archive/`; `src/rules/external-reference-deep-dive.md` calls it "the canonical flow" and must name the new one. `src/config/gate-violation-baselines.json` stays unchanged; its mention is a historical note, not a pointer. `corrected-from-reproduction` — the drafts asserted 16 files.
+      verify: `grep -rln 'analyze-reference-repo\|analyze:reference-repo' src docs` returns only the `replaces:` line, the changelog, `docs/archive/`, and the baseline note.
+- [ ] **1.3 Add the named chain exception to the cluster head.** `src/domains/analysis-workbench/analyze/command.md:116` forbids chaining sub-commands; the harvester is the single exception and gets one sentence saying so: it invokes `repo` once per repository, each in its own subagent, sequentially, never in the orchestrator's own turn and never as a fan-out.
+      verify: the line at `:116` still forbids chaining generally and names exactly one exception; `routes_to` in the head's frontmatter lists `analyze-repo` and `analyze-roadmap-repos`.
+
+## Phase 2 — A bounded loop with three different questions
+
+- [ ] **2.1 Add the `limits:` block** to `analyze:repo`: `mode_default: plan`, `max_iterations: 3`, `hard_ceiling: 5`, `no_gain_stop: 2`, `target_metric: required`, and restate every one of those lines in the command body — the schema requires the body to carry what the frontmatter pins. The command has no loop contract today; its only convergence is inside the verdict table. `corrected-from-reproduction` — the loop contract goes on this command directly; no generic primitive is extracted first, because the schema already permits plan-mode loops and would give the primitive exactly one other consumer.
+      verify: the command-schema test passes; `grep -c 'max_iterations\|hard_ceiling\|no_gain_stop' ` over the command body returns a hit for each limit line.
+- [ ] **2.2 Pin the upstream revision before any reasoning.** The seed pass resolves the reference's head revision once; all three loops read that same revision; only `--refresh` re-resolves. Loop *n* cannot read deeper than the seed pass without a local clone, so `--deep` becomes the default whenever the loop runs, and the per-loop read ceiling is logged when it is hit.
+      verify: a run's iteration record shows one resolved revision repeated on every pass, and one read-ceiling line per loop that hit it.
+- [ ] **2.3 Give the three loops three different jobs.** Loop 1 Coverage — what was missed, what was wrongly marked absent, which rows have a weak anchor. Loop 2 Adversary — was the form copied instead of the principle, is this only different rather than better, does this package already solve it elsewhere, what does it cost in tokens, surface and maintenance. Loop 3 Convergence — resolve contradictions, fold duplicates, cut the speculative, bind every remaining line to evidence on both sides. Each loop takes the previous analysis **and** the previous roadmap as input and appends its own delta row (added / removed / flipped / folded, with a reason per line) to the existing `## Iteration record`.
+      verify: a run with three loops writes three delta blocks, each naming its lens; a loop whose delta block is empty of added, removed, flipped and folded entries is recorded as a zero-delta loop, not omitted.
+- [ ] **2.4 Make the target metric a decision-quality measure**, not an output-volume one: the count of ADOPT/ADAPT rows carrying a concrete `file:line` on both the reference side and this package's side. Halt on spin after two consecutive zero-delta loops; a contested verdict table stops the run with a maintainer question. A zero delta in one lens never cancels the remaining lenses — it is a signal about that lens, not about the next one.
+      verify: a fixture run in which loop 1 produces zero delta still executes loop 2; a fixture run with two consecutive zero-delta loops stops before the next one and says why.
+- [ ] **2.5 Drop the mandatory scope menu.** `src/domains/analysis-workbench/analyze/reference-repo/command.md:46-58` opens with a four-option prompt ending in "Wait for the user's choice", which in a batch is a prompt per repository. A bare repository argument means full scope; `--focus` means focused; the only remaining question is an unresolvable repository identity. The write-acts (roadmap landing, ledger rows) keep their confirmations.
+      verify: a fixture invocation with an explicit repository argument asks nothing before its first fetch.
+
+## Phase 3 — The output stops naming its source
+
+- [ ] **3.1 Derive an opaque id** from the canonical repository identity and the pinned revision, and keep the plaintext-to-opaque mapping only in the local manifest under the gitignored area.
+      verify: the opaque id is stable across two runs at the same revision and differs across revisions.
+- [ ] **3.2 Move every pass and loop artefact to `agents/.harvest-local/repo/<opaque-id>/`** and stop writing `agents/evidence/analysis/compare-*.md`. That directory is already gitignored (`.gitignore:290`) and already exists; only `compare-*.md` is covered under the evidence directory (`.gitignore:285`), so any other tracked name there would be unprotected.
+      verify: `git status --porcelain` after a full run shows nothing new except the tracked roadmap the run deliberately landed.
+- [ ] **3.3 Name the tracked roadmap after the defect, never after the source.** Today the command offers `agents/roadmaps/adopt-<owner>-<repo>.md` (§ 7 option 1) with the plaintext URL in the document header — a tracked filename carrying the source identity. The landed roadmap is named for the capability gap and carries a provenance block with an encrypted token instead.
+      verify: `./scripts-run src/scripts/check_no_external_sources` passes; the landed filename contains neither the owner nor the repository name.
+- [ ] **3.4 Never pass plaintext to the subagent.** The orchestrator hands the subagent the opaque id; the subagent reads the URL from the local manifest itself. The cost of this is one indirection and it is taken on precaution — whether a transcript or audit log would actually retain the argument is host-dependent and was not verifiable from the tree.
+      verify: the harvester's body contains no step that passes a resolved URL as an argument; the manifest read is the only resolution point.
+
+## Phase 4 — Deterministic discovery and a thin harvester
+
+- [ ] **4.1 Write one discovery script**, not a module family — discover, decrypt, classify, canonicalize, deduplicate, write the manifest, in the house form of `src/scripts/sweep_source_surfaces.ts`: refuse without a key rather than skipping silently, and never decrypt to stdout except at a terminal. Reuse `src/scripts/_lib/link_crypto.ts` rather than reimplementing the token format, and reuse its token regex from `sweep_source_surfaces.ts:587`. `corrected-from-reproduction` — the script enumerates the five roadmap directories itself; no shared estate-reader library exists to depend on.
+      verify: a dry run reports 149 token occurrences, 117 unique tokens across 63 files, with 57 files in the archive directory, 6 in the later directory and 0 at the active level — the census re-derived by hand at this tree.
+- [ ] **4.2 Classify after decryption, never from the surrounding prose.** The tokens are a mixed pool — repositories, articles, threads, packages, a paper, a video — and the descriptors around them are inconsistent enough that a proximity count is not reproducible. Classification reads the resolved URL: a repository host or a `.git` suffix is a repository; anything else is recorded as not-a-repository and never analysed. `corrected-from-reproduction` — the drafts' descriptor census did not reproduce.
+      verify: unit tests cover extraction (a prose placeholder is not matched), canonicalization (four spellings of one repository collapse to one identity), and classification (a documentation URL is not a repository).
+- [ ] **4.3 Deduplicate on identity plus pinned revision, never on the token.** Encryption is randomised, so two tokens for one repository do not compare equal; and one repository at two historical pins is two pieces of evidence, not one. Each unique entry fans in the roadmap files that cited it.
+      verify: a fixture with two distinct tokens for one repository yields one manifest entry with two citing files; a fixture with two revisions of one repository yields two entries.
+- [ ] **4.4 Write a resumable manifest** under the gitignored area, one line per identity, with an explicit status vocabulary covering pending, running, done, skipped-as-not-a-repository, skipped-as-duplicate, skipped-as-fresh, blocked-on-missing-key, blocked-as-unresolvable, and failed. Freshness is keyed on identity, upstream revision, contract version, loop count and focus — **not** on this package's own revision, which would change with every commit and make every entry permanently stale.
+      verify: interrupt a run after the second repository and resume; repositories one and two do not run again, and the run says which entries it skipped and why.
+- [ ] **4.5 Add the harvester command** at `analyze/roadmap-repos/`, `type: orchestrator`, `visibility: internal`, with no analysis steps in its body at all: call the script, read the manifest, dispatch one subagent per repository, then run the ownership pass. Default batch limit is small; every external fetch is spent deliberately.
+      verify: the command body contains no analysis instruction; every analysis reference points at `analyze-repo`.
+
+## Phase 5 — One gap, one roadmap, and one real run
+
+- [ ] **5.1 Gate every new roadmap behind an ownership check.** Before a run lands anything, it consults `src/scripts/roadmap_context.ts` and the run's own candidate registry and picks one disposition per repository: no action, already planned, extend an existing roadmap, create a follow-up, create new, or contested. Three repositories showing the same gap strengthen the evidence on one owning roadmap; they do not create three.
+      verify: a fixture with two repositories surfacing the same gap produces one roadmap with two registered sources, and `./scripts-run src/scripts/check_estate_count` stays green.
+- [ ] **5.2 Run one real analysis end to end under the command's own contract** against a small reference, before any batch work, so the pre-registered claim's window is not spent on scaffolding. The claim at `docs/CLAIMS.md:487` requires each of the next two runs to produce at least one interop-probe finding at `file:line` precision **and** at least one bound-claim routing, compared against a shadow run of the pre-upgrade command text.
+      verify: the run's artefacts exist under the gitignored area and the iteration record shows the contract's passes; nothing about the outcome is asserted before the run.
+- [ ] **5.3 Write the outcome honestly into the claim row** — backed or honest null, with the null consequence the claim already specifies, and no goalpost moved after the data. Then dispose of `agents/roadmaps/stubs/road-to-first-reference-analysis-run.md`, whose two stated trust boundaries (an outbound third-party fetch and raw named evidence) are exactly what Phases 3 and 4 resolve.
+      verify: the claim row carries a `last_verified` date and a status that matches what the runs produced; the stub is archived and the archive index regenerated.
+
+## Blockers
+
+### blocker: wave-consolidate-estate-slot
+
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** Phase 5 — One gap, one roadmap, and one real run
+- **Recommendation:** none; this is the owner's call — it turns on how much of the estate's growth allowance a recurring, automated process may consume, which is a policy decision, not a technical one.
+- **If you do nothing:** every run keeps writing its consolidated result to the gitignored local area only, so no batch is visible in the roadmap dashboard, and the estate-ratchet allowance question stays open indefinitely.
+- **What to do:**
+  1. Decide whether a per-run consolidate roadmap may take an active top-level estate slot, or whether consolidated results stay local-only, or land in the parked directory instead.
+  2. Record the decision (e.g. a short note in `docs/decisions/` or an update to this blocker) and, if a slot is granted, adjust the T2/T4 boundary conditions in `src/scripts/check_estate_count.ts` to account for the recurring addition.
+- **Resolved when:** the owner states either that a per-run consolidate may take an active top-level slot, or that consolidated results stay local-only or land in the parked directory.
+
+One draft lineage proposes a per-run consolidate roadmap landing at the active top level so a batch is visible in the dashboard; the other proposes no wave roadmap at all, because a batch having run is not by itself a reason to create an estate entry. The disagreement is not resolvable from tree evidence: it is a question about how much of the estate's growth allowance a recurring, automated process may consume.
+
+The boundary is the estate ratchet (`src/scripts/check_estate_count.ts`, T2 and T4). The active floor is currently 1, and an addition that cannot be offset raises the allowance by one — permanently, per run, if a recurring process is permitted to take one each time. Raising one's own growth allowance is not a decision an agent may take, so this stays with the owner rather than being resolved by recommendation.
+
+Blocks: the landing-zone half of Phase 5 step 5.1 — the fold gate itself is unaffected, but where a run's consolidated result lands is undecided. Until the decision lands, a run writes its consolidated result to the gitignored local area only.
+
+Resolved when: the owner states either that a per-run consolidate may take an active top-level slot, or that consolidated results stay local-only or land in the parked directory.
+
+## Open questions
+
+Carried deliberately as questions rather than as steps, because each refines a mechanism that does not exist yet and would otherwise be built before it has anything to refine:
+
+- Whether resume state needs a per-pass state machine (seed done, loop 1 done, loop 2 done, finalizing) rather than the status vocabulary in step 4.4. Revisit after the first interrupted batch shows where it actually resumes badly.
+- Whether freshness should become capability-sensitive, so that an unrelated documentation commit in this package does not invalidate historical analyses. Step 4.4 already excludes this package's revision from the key, which is the cheap version of the same fix; the expensive version waits for evidence that it is needed.
+- Whether the not-a-repository tokens (articles, threads, a paper, a video) should be routed to inbox analysis rather than only recorded in the manifest.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-09-05 | reviewer: claude/host -->
+
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | Source identity leaks into a tracked surface | implementation | Filenames, document headers, subagent arguments and error snapshots are all surfaces; the command leaks through two of them today (`command.md` § 6 slug rule and § 7 draft path) | Phase 3 in full — opaque id, gitignored artefacts, defect-derived filename, no plaintext argument; verified by `check_no_external_sources` and a `git status` check after a run | Phase 3 — The output stops naming its source |
+| 2 | The loop becomes three rewordings | product | Four passes over one reference produce prose churn instead of new findings, and the cost is paid in external fetches | Three named lenses with different questions, a decision-quality target metric, and a delta block per loop that records zero as zero | Phase 2 — A bounded loop with three different questions |
+| 3 | The claim window expires unmeasured | product | The pre-registered measurement has a fixed window from its merge, and expiry counts as the bar not cleared, reverting three mechanisms | Step 5.2 runs before any batch work, so scaffolding does not consume the window | Phase 5 — One gap, one roadmap, and one real run |
+| 4 | Batch output floods the estate | product | Over a hundred unique tokens, each capable of proposing a roadmap, against an active floor of 1 | Ownership fold gate and candidate registry in step 5.1; a small default batch limit in step 4.5; landing zone undecided and local-only until the blocker resolves | Phase 5 — One gap, one roadmap, and one real run |
+| 5 | The rename breaks inbound references | implementation | 18 files name the old command, one of them a rule calling it the canonical flow | Step 1.2 in the same change, with a grep as its verification | Phase 1 — One analysis engine, one name |
+| 6 | Context exhaustion during a batch | implementation | Over a hundred identities at four passes each cannot share one session | One subagent per repository, sequential, no fan-out; the manifest is the only shared state | Phase 4 — Deterministic discovery and a thin harvester |
+| 7 | The discovery script silently under-reports | implementation | A missing key, a prose placeholder matched as a token, or a repository host not in the pattern set all produce a quietly short census | Refuse-without-key rather than skip; unit tests for extraction, canonicalization and classification; the dry-run census is checked against the hand-derived figures in step 4.1 | Phase 4 — Deterministic discovery and a thin harvester |
+
+## Acceptance Criteria
+
+- [ ] AC-1 — A single command directory holds the repository-analysis engine; the old name resolves through `replaces:`; no second implementation and no alias command exist.
+- [ ] AC-2 — That command's frontmatter carries a `limits:` block and its body restates every limit line.
+- [ ] AC-3 — A run with three loops leaves three delta records, each naming a different lens, and a zero-delta loop is recorded rather than skipped.
+- [ ] AC-4 — After a full run, the only new tracked file is the roadmap the run deliberately landed; the source-name check passes and no landed filename contains the reference's owner or repository name.
+- [ ] AC-5 — The discovery script's dry run reproduces the estate census by hand-checkable counts and writes nothing outside the gitignored local area.
+- [ ] AC-6 — An interrupted batch resumed with the resume flag runs no repository twice, and fresh entries are skipped unless refresh is requested.
+- [ ] AC-7 — Two repositories surfacing one capability gap leave one roadmap carrying two registered sources.
+- [ ] AC-8 — The pre-registered claim row carries a verification date and an outcome that matches what the runs produced, and the parked stub is disposed.

--- a/agents/roadmaps/road-to-host-enforcement-truth.md
+++ b/agents/roadmaps/road-to-host-enforcement-truth.md
@@ -1,0 +1,102 @@
+---
+complexity: structural
+status: ready
+execution:
+  mode: phase-checkpoints
+estate_growth_exempt: "Third round on the same subject; the two earlier rounds produced prose corrections that this roadmap replaces with one table and one expiry field, so it exists to stop the recurrence rather than to add a surface."
+estate_offset_exempt: "Offsets nothing — the estate holds one roadmap and zero ready at HEAD, so no swap candidate is displaced."
+---
+# Road to host enforcement truth
+
+> **Source:** `agents/tmp.old/inbox-2026-09-i/` — verified against the tree at 5c539505d on 2026-09-05.
+
+## Goal
+
+Every statement this package makes about which host can enforce a hook decision is either backed by a row in one table, or is absent. Today six surfaces assert that one host "has no hook surface" and four assert a CLI limitation, none of those assertions carries an expiry, five hand-written binding constants disagree with the one generated bridge, and the `hooks:status` a consumer runs points them at a file deleted with the Python retirement. When this is done a reader can ask "can host H enforce decision D?" and get an answer from `host_lowering.yaml` with the date it was established and the date it expires, and no prose anywhere contradicts it. Prevented work, already shipped and therefore absent from the phases below: the in-process concern dispatcher, the `hooks:doctor/effect/status/replay/install` verb set, `check_enforcement_coverage --json`, the injection budget and emission-shaping rules, typed payload dependencies via `needs_payload_bodies`, and the probe-state model in `hook_effect_doctor` — six items the drafts planned that the tree already holds. Two draft figures were wrong and are not carried: the concern count is 56 rather than 72, and the estate is 1 rather than 8. Out of scope by decision: any policy-evaluation runtime, any event-vocabulary rename, and any promotion of a host to blocking enforcement.
+
+## Phase 1 — Say what is true today
+
+- [ ] **1.1 Rewrite the Copilot hook-surface claim at all six sites, not four.** `src/scripts/hook_manifest.yaml:629` and `:1322-1325`, `docs/enforcement-by-host.md:24`, `docs/contracts/host-tool-vocabulary.md:52`, `docs/contracts/hook-architecture-v1.md:424` and `:539-541`, `src/rules/autonomous-execution.md:70`, `src/rules/git-history-discipline.md:89` and `:91`. Each currently asserts the host carries no hook surface at all; the honest statement this tree can make is that this package binds nothing there and has measured nothing there. Neither rule is a kernel rule, so no slow-rollout gate applies. Tagged `corrected-from-reproduction` — the drafts counted four surfaces and the grep at HEAD returns six.
+      verify: `grep -rn "no hook surface\|has no pre-tool surface" src/ docs/` returns zero lines that assert host incapability rather than package non-binding.
+- [ ] **1.2 Remove the retired Python paths from user-visible output.** `src/scripts/hooks_status.ts:61-70` prints "hint: run src/scripts/install.py" for six hosts and its trailer at `:187` prints "Source of truth: scripts/hook_manifest.yaml"; `src/scripts/install.ts:2625` returns the string `src/scripts/install.py (self)`; `src/scripts/hook_manifest.yaml:2-5` names two `.py` consumers. None of those files has existed since the TypeScript port.
+      verify: `./agent-config hooks:status | grep -c "install.py"` returns 0, and `grep -rn "install\.py\|dispatch_hook\.py" src/ --include=*.ts --include=*.yaml` returns only historical-note lines that say the file was retired.
+- [ ] **1.3 Strike the false comment in the Cursor trampoline.** `src/scripts/hooks/cursor-dispatcher.sh:23-26` states "none of our concerns block"; the manifest carries eight `severity: blocking` concerns.
+      verify: the comment names the actual state (concerns that would block are not bound on this host) and `grep -c "severity: blocking" src/scripts/hook_manifest.yaml` matches the number the comment cites.
+- [ ] **1.4 Make the install smoke probe read the constant the installer writes.** `src/scripts/install.ts:1730` probes `['cursor','beforeShellExecution']`, an event `CURSOR_DISPATCHER_BINDINGS` (`:1133-1139`) never writes, so the probe cannot fail on a real regression.
+      verify: a test that removes one entry from `CURSOR_DISPATCHER_BINDINGS` makes the smoke probe fail; the probe list contains no event absent from the constant.
+
+## Phase 2 — One table instead of five constants
+
+- [ ] **2.1 Add `src/scripts/hooks/host_lowering.yaml`, keyed `(host, surface, slot)`.** Columns: `block_exit`, `json_shape`, `entry_shape`, `fail_policy`, `timeout_unit`, `timeout_default`, and `verified: {docs_at, docs_url, probe_at, host_version, expires}`. Claude rows are transcribed from the behaviour `host_semantics.ts` implements today, so the table starts as a description, not a proposal. Every other host starts `verified: null`, which is the honest reading of `VERIFIED_PLATFORMS = {"claude"}` at `host_semantics.ts:54`.
+      verify: `host_semantics.ts` reads `VERIFIED_PLATFORMS`, `isBlockCapable` and the emission shape from the table, and the Claude hook matrix generated from it is byte-identical to the one at HEAD.
+- [ ] **2.2 Collapse the five `*_DISPATCHER_BINDINGS` constants into the table.** `src/scripts/install.ts:1025, 1133, 1203, 1310, 1384` each hold a private binding list; only Claude's bridge is generated (`claude_settings_hooks.ts:92`). Generalize that generator to read the manifest plus the table for every host and delete the five constants.
+      verify: the five constant names return zero hits under `grep -rn "_DISPATCHER_BINDINGS" src/`, and golden files for each host bridge are unchanged from the pre-change output.
+- [ ] **2.3 Add `surface` as an envelope field, not a platform key.** `src/scripts/_lib/session_register.ts:180` states the capability lattice has no IDE/CLI dimension; the table above is keyed on one. Detect it from payload and environment, default `unknown`, and record it in the journal. `--platform` and the eight platform identifiers stay exactly as they are.
+      verify: a fixture payload carrying a background-agent marker resolves `surface: cloud`, an unmarked payload resolves `surface: unknown`, and `agent-config hooks:status` output for a known host is otherwise unchanged.
+
+## Phase 3 — Facts that expire
+
+- [ ] **3.1 Add an expiry to every host-capability fact.** `src/agent-src/contexts/execution/host-capability-manifest.md` requires a four-part citation (host, version, artefact, date) and no expiry — `grep -n "expir\|stale\|review_by\|lease"` over its 187 lines returns nothing. That absence is why the same stale claims returned across three rounds. Add the field to the observation protocol and to the `verified:` block from 2.1.
+      verify: the context file specifies the field, and a table row whose `expires` is in the past is reported by the lint below.
+- [ ] **3.2 Degrade an expired row to unverified.** A row past `expires` is treated exactly as `verified: null`: it cannot carry a blocking binding, and the lint names the row, the date and the re-establishment step.
+      verify: a fixture row with `expires` set to yesterday and a blocking binding attached makes `lint_hook_manifest` exit non-zero with a message naming that row; the same row without a blocking binding warns and passes.
+- [ ] **3.3 Re-establish or retire the Cursor CLI limitation claim.** `agents/settings/contexts/chat-history-platform-hooks.md:31, :214, :277` and `src/scripts/_lib/session_register.ts:178-180` assert the CLI fires only shell-execution hooks, sourced "as of 2026-01". This round could not verify the claim in either direction offline. Either attach a current four-part citation with an expiry, or replace the assertion with the package-side fact (this package binds no per-turn slot on that surface).
+      verify: no line in those four locations asserts a host limitation without a citation carrying a date and an `expires`.
+
+## Phase 4 — Prove the double-fire before guarding it
+
+- [ ] **4.1 Measure whether a second host actually executes the Claude-shaped hook entry.** The drafts treat cross-loading as established; this round confirmed only the tree-side half — no environment guard exists anywhere in `src/` — and could not verify the host-side half. Record one observation per host: install into a scratch project, run one turn under the other host, and read the dispatcher journal for two entries with the same session and different platform tags. Tagged `corrected-from-reproduction`.
+      verify: an evidence file records, per host, host version, date, and whether two journal entries appeared for one turn.
+- [ ] **4.2 Add the guard only for hosts where 4.1 observed a second firing.** The insertion point is the single concatenated command string at `src/scripts/_lib/claude_settings_hooks.ts:136-149`; the guard is one leading clause, not a block. Tagged `corrected-from-reproduction` — the draft budgeted ten lines for a one-line change and asked for the PR before the measurement.
+      verify: for each host 4.1 confirmed, a golden file shows the guard clause in the emitted command and a fixture with that host's environment variable set exits 0 before dispatch; for hosts 4.1 did not confirm, no guard is emitted.
+
+## Blockers
+
+### blocker: copilot-enforcement-promotion
+
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** nothing in this roadmap — it gates work deliberately excluded from it.
+- **Recommendation:** run the live deny probe against a real Copilot installation before ever considering promotion; until it passes cleanly, Copilot stays advisory-only, which is the safe default this roadmap already ships.
+- **If you do nothing:** Copilot stays advisory-only — the safe status quo — and the risk that a dispatcher crash reads as *deny* and locks every tool call is never tested, but also never triggered.
+- **What to do:**
+  1. Stand up a scratch workspace on a real Copilot installation and add one dedicated hook that always denies.
+  2. Run the probe: confirm the marker file it tries to create does not exist, and that the deny reason surfaced to the user; record host version, date and outcome in `host_lowering.yaml`'s `verified` field (Phase 2.1).
+- **Resolved when:** a live deny probe on a real Copilot installation is recorded (host version + date) in `host_lowering.yaml`'s `verified` field, confirming the marker never appears and the deny reason surfaces — or the owner records a decision not to pursue promotion.
+
+Promoting any host to blocking enforcement requires a live deny probe on that host — a scratch workspace, a marker file the probe tries to create, a dedicated hook that denies, and confirmation that the marker does not exist and the reason arrived. For the Copilot surface specifically, the failure mode of getting it wrong is that a dispatcher crash reads as *deny* and locks every tool call, because that host's pre-tool hook treats any non-zero exit as a denial. The probe must run on a real installation of that host, which no step in this roadmap can perform. Phases 1–4 deliberately add no blocking binding on any host; this blocker records why, and what would lift it.
+
+### blocker: gemini-exit-semantics-unverified
+
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** nothing in this roadmap — it gates work deliberately excluded from it.
+- **Recommendation:** run the same live deny-probe pattern against a real Gemini CLI installation once host access is available; until then `verified: null` is the correct and honest state, not a gap to rush.
+- **If you do nothing:** Gemini keeps the legacy exit-code pass-through with `verified: null` in `host_lowering.yaml`, and its alias row keeps six entries with no compaction alias — honest, but no capability claim can be made for it.
+- **What to do:**
+  1. When real Gemini CLI access becomes available, run the same scratch-workspace / marker-file / denying-hook probe described for Copilot above.
+  2. Record host version, date and outcome in `host_lowering.yaml`'s `verified` field for the Gemini rows; leave `verified: null` until then.
+- **Resolved when:** a live probe on a real Gemini CLI installation is recorded (host version + date) in `host_lowering.yaml`'s `verified` field — or the owner records a decision not to pursue verification.
+
+Gemini is absent from `VERIFIED_PLATFORMS` (`src/scripts/hooks/host_semantics.ts:54`) and therefore receives the legacy exit-code pass-through, and its alias row (`src/scripts/hook_manifest.yaml:1399-1405`) carries six entries with no compaction alias. Phase 2.1 gives it a `verified: null` row, which is honest but not useful. Establishing a real row needs the same live probe as the blocker above.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-09-05 | reviewer: claude/host -->
+
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | Table-driving `host_semantics` changes Claude behaviour | implementation | The one host that currently enforces is the one whose emitter is being refactored; a transcription error silently downgrades real enforcement to advisory. | Claude rows are transcribed from existing behaviour and gated on byte-identical generated output before the constants are deleted. | Phase 2 — One table instead of five constants |
+| 2 | Expiry turns green CI red on a date nobody chose | implementation | Rows expiring on a working day can block an unrelated PR. | 3.2 fails only where a blocking binding rests on the expired row; every other expiry warns. | Phase 3 — Facts that expire |
+| 3 | The unverified cross-load claim drives an unnecessary guard | implementation | Emitting an environment guard for a host that never double-fires adds a silent early exit to the enforcing host's own command string. | 4.2 emits a guard only for hosts where 4.1 recorded an actual second firing. | Phase 4 — Prove the double-fire before guarding it |
+| 4 | Correcting six surfaces weakens a claim a reader relies on | product | Two of the six are behavioural rules whose current wording tells the agent that a guard cannot bind on a host; a looser rewrite could read as permission. | 1.1 replaces host-incapability wording with package-non-binding wording, which is strictly narrower, and the verify grep asserts that direction. | Phase 1 — Say what is true today |
+| 5 | The subject returns a fourth time | product | Two prior rounds produced prose corrections and no table; a third prose-only pass would repeat that. | Phase 3 is the structural answer — a fact without an expiry cannot be relied on — and Phase 2's table is the single place a future round reads. | Phase 3 — Facts that expire |
+
+## Acceptance Criteria
+
+- [ ] AC-1 — No file under `src/` or `docs/` asserts that a host lacks a hook capability; every such statement is either a package-non-binding statement or a table row carrying a citation and an expiry.
+- [ ] AC-2 — `agent-config hooks:status` names no retired file path and no path that does not resolve from the repository root.
+- [ ] AC-3 — `src/scripts/hooks/host_lowering.yaml` is the only place a host's block-exit, emission shape and fail policy are written, and `grep -rn "_DISPATCHER_BINDINGS" src/` returns zero hits.
+- [ ] AC-4 — Every generated host bridge is byte-identical to its pre-change golden file.
+- [ ] AC-5 — A host-capability row past its `expires` cannot carry a blocking binding, and the lint that enforces this fails on a fixture row and passes at HEAD.
+- [ ] AC-6 — The install smoke probe fails when an entry is removed from the constant that writes the bridge.
+- [ ] AC-7 — No host gained a blocking binding in this roadmap; `VERIFIED_PLATFORMS` still resolves to the same single host it resolved to at 93d63073e.

--- a/agents/roadmaps/road-to-mcp-bridge-integrity-and-reach-truth.md
+++ b/agents/roadmaps/road-to-mcp-bridge-integrity-and-reach-truth.md
@@ -1,0 +1,133 @@
+---
+complexity: structural
+status: ready
+execution:
+  mode: phase-checkpoints
+estate_growth_exempt: "The MCP bridge is the one installed surface with an unpinned dependency resolution (`npx -y` fetches `latest` at every server start) and no update-repair path, and no active roadmap covers it — the estate holds one carrier and zero active roadmaps at 93d63073e."
+estate_offset_exempt: "Offsets nothing: every adjacent MCP roadmap is already archived at `measured-null` or parked in `later/`, so there is no active file whose retirement this could be exchanged against."
+---
+# Road to MCP bridge integrity and reach truth
+
+> **Source:** `agents/tmp.old/inbox-2026-09-k/` — verified against the tree at 93d63073e on 2026-09-05.
+
+## Goal
+
+The MCP bridge this package installs should resolve a pinned version rather than whatever `latest` happens to be at server start, should repair its own registration when the bridge shape changes under an update, should be documented in terms of the command the installer actually writes, should serve resources with the annotations the protocol defines, should record per host what MCP actually reaches and what consent residual remains, and should emit enough telemetry through the existing collector that the question "is the lite surface used at all" has an answer instead of an assumption. Someone else can tell whether this happened by reading `MCP_BRIDGE_ENTRY` for a version specifier, running the doc-drift check, reading `CAPABILITY_FIELDS` for the MCP axis, and querying the collector for `tools/call` rows.
+
+Work this roadmap does **not** contain, because verification showed it already done or already owned: the resources for rules, guidelines and contexts already exist and are already served (`docs/mcp-server.md:33-35`), so no new channel is built for them; the trigger matcher is already a single pinned implementation (`router_match.ts:1-19`, `router_match_parity.test.ts`), so no second matcher is written; `explain route` and `route:explain` already exist (`registry.ts:60`, `:93`), so no new explain verb is added; the activation IR already exists as `router.json` plus `triggers:` on 104 of 120 rules, so no parallel taxonomy is created; the delivery-path parity measurement is already pre-registered as `claim:delivery-path-parity` in `docs/CLAIMS.md` with its epsilon fixed, so no duplicate parity gate is defined; and SEP-2640 interop is already carried by `agents/roadmaps/stubs/road-to-sep-2640-skill-resources.md`. Four further items are blocked rather than built — see Blockers.
+
+## Phase 1 — Pin the bridge and repair it on update
+
+- [ ] **1.1 Pin the version in the MCP server entry.** `MCP_BRIDGE_ENTRY.args` is `['-y', '@event4u/agent-config', 'mcp-server']`, so every server start resolves the dist-tag `latest` from the network. Read the version from the package manifest at install time and emit `@event4u/agent-config@<version>`, so the server a consumer runs is the one the installer approved. Neither parent artefact caught this; it is the one finding in the round with no prior owner.
+      verify: `grep -n "args:" src/scripts/_lib/mcp_bridge.ts` shows a version specifier, and a unit test asserts the emitted entry's package spec equals the manifest version.
+- [ ] **1.2 Repair the registration on update.** `mcp_bridge.ts` exports only `makeEnsureMcpBridge`; its header describes install and uninstall and there is no path that compares a recorded entry against the current bridge shape. Add a migrate step that reads the lockfile's recorded pointer, compares it against the current `MCP_BRIDGE_ENTRY`, and rewrites only keys this package owns — a stale pin from 1.1 is otherwise frozen at the version of the install that wrote it.
+      verify: a test that writes an old-shape `.mcp.json`, runs the update path, and asserts the AC key changed while a hand-added neighbour server key is byte-identical.
+
+## Phase 2 — Make the MCP truth surfaces match the tree
+
+- [ ] **2.1 Replace the absolute `tsx` paths in the setup docs.** `docs/mcp-server.md:86`, `:105`, `:122` and `:138` document `"command": "/absolute/path/to/agent-config/node_modules/.bin/tsx"`, while the installer writes an `npx` invocation. A consumer following the docs and a consumer running the installer land on two different entries.
+      verify: `grep -c '/absolute/path/to/agent-config' docs/mcp-server.md` returns 0.
+- [ ] **2.2 Gate the drift.** Add a check that compares the command and args in the documented snippets against `MCP_BRIDGE_ENTRY`, so 2.1 cannot silently rot back. This compares two literals in the tree and asserts nothing about host behaviour.
+      verify: the check fails on a branch that edits `MCP_BRIDGE_ENTRY` without the doc, and passes on the tree with both edited.
+- [ ] **2.3 Serve the protocol's standard resource annotations.** `to_mcp_resource_meta` emits `_meta: { source, kind }` and nothing else (`src/scripts/mcp_server/resources.ts:266`). Emit `audience`, `priority` derived from the existing `tier`, and `lastModified`. This is protocol conformance with no effect claim attached — no shipped host is known to consume `priority` for selection, and this step must not be cited as evidence that one does.
+      verify: a unit test asserts the three annotation fields are present with the derived values, and no CLAIMS entry is added.
+
+## Phase 3 — Record what MCP actually reaches, per host
+
+- [ ] **3.1 Add the MCP axis to the host capability manifest.** `CAPABILITY_FIELDS` (`src/scripts/_lib/host_capability.ts:283-290`) holds six fields and none of them is about MCP, so no code can currently answer "does this host read a project MCP config" without guessing. Add the fields under the manifest's existing per-field source discipline, where an unanswered field reads as "nobody answered" rather than as "checked and absent".
+      verify: `grep -i mcp src/scripts/_lib/host_capability.ts` returns the new fields, and the existing sources snapshot test fails when a field is added without a source.
+- [ ] **3.2 Record and report the consent residual.** Carry per host what remains non-automatic after installation, and have the installer's closing report name exactly those residuals and nothing else — a checklist of things that did work is noise, a named residual is actionable. Start values come from vendor documentation and are marked as such; an observed value replaces one only after a session records it.
+      verify: `agent-config doctor --check` surfaces the residual per host, and a host with no observed value prints its source as vendor-doc rather than as fact.
+- [ ] **3.3 Register the MCP server on the hosts whose config file the installer already writes.** `mcpServers` appears zero times in `src/scripts/install.ts`; the entry reaches only `claude-code` via `ensure_mcp_bridge` at `:5151`, while `ensure_cursor_bridge` (`:1153`) and `ensure_gemini_bridge` (`:1417`) write the same consumers' config files for hooks alone. Add the MCP entry for each host the 3.1 axis records as reading one, under the existing `--tools` gate.
+      verify: an install into a scratch project with a given `--tools` set produces an MCP entry in each such host's config, and none in a host the axis marks as not reading one.
+
+## Phase 4 — Answer whether the lite surface is used
+
+- [ ] **4.1 Emit one collector row per `tools/call`.** `grep -rn 'telemetry\|collector\|journal\|record' src/cli/mcp/*.ts` is empty, so the two lite tools are invisible and every statement about their uptake is currently an assumption. Route one row — tool name, result class, host — through the collector that already backs `telemetry:record`, with no second sink and no new consent gate.
+      verify: a dispatch test asserts exactly one row per call and zero rows when telemetry is off.
+- [ ] **4.2 Surface the reading in the telemetry report.** Add an MCP-lite section reporting call counts per tool and per host. Publish whatever it says, including nothing — a null here is a result, and the adjacent archived roadmaps in this family closed at `measured-null` precisely because nulls were published rather than buried.
+      verify: `agent-config telemetry:report` renders the section, and renders it with an explicit zero on a machine with no calls recorded.
+
+## Blockers
+
+### blocker: mcp-user-scope-approval-consent
+
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** nothing in this roadmap — it gates work deliberately excluded from it.
+- **Recommendation:** none; this is the owner's call — the write blurs a security-consent boundary on a file shared by every project on the machine, and the artefact itself names that boundary as the thing not to blur.
+- **If you do nothing:** consumers keep seeing the interactive per-project MCP-server approval prompt on `init` — today's friction continues, but no consent boundary is touched.
+- **What to do:**
+  1. Decide whether adding `enabledMcpjsonServers: ["agent-config"]` to the managed block of the user-global host settings file is authorised, given the key applies to every project on the machine, not only this one.
+  2. Record the decision. If authorised, implement the write with `enableAllProjectMcpServers` left untouched and add a check that an existing `disabledMcpjsonServers` entry on any layer suppresses the write entirely; if rejected, record that so a future round does not re-litigate it without new evidence.
+- **Resolved when:** the owner records either an authorisation (with the untouched-key and `disabledMcpjsonServers` safeguards in place) or a rejection of the write.
+
+The round's headline lever is adding `enabledMcpjsonServers: ["agent-config"]` to the managed block in the user-global host settings file, which would let the project-scoped server start without the interactive approval. The tree confirms the gap is real — `enabledMcpjsonServers` and `enableAllProjectMcpServers` are both grep-null across `src/scripts/install.ts`. The artefact argues the write is the same act as the user running the host's own user-scope add command, triggered by the user who ran `init`. That may be right, and it is not a call this roadmap may make: the key carries a consent semantics on a file shared with every project on the machine, and the boundary between "zero configuration" and "zero security consent" is exactly what the artefact itself names as the thing not to blur. Resolution requires the owner to authorise the write, or to reject it. Whatever is decided, `enableAllProjectMcpServers` stays untouched and an existing `disabledMcpjsonServers` entry on any layer must suppress the write entirely.
+
+### blocker: mcp-runtime-resolver-reopen
+
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** nothing in this roadmap — it gates work deliberately excluded from it.
+- **Recommendation:** route the reopen to the AI council with the mechanism distinction stated explicitly (a pull-only tool a host may call versus the push-time resolver ADR-054 rejected) before writing any wrapper — a narrower scope is not grounds to bypass the council path a recorded decision already requires.
+- **If you do nothing:** the trigger matcher stays unreachable through any MCP tool path; the rest of this roadmap's MCP-truth work proceeds without it, and ADR-054's rejection stands unchallenged.
+- **What to do:**
+  1. Route the reopen to the AI council, stating explicitly the mechanism distinction between a pull-only read tool and the push-time resolver ADR-054 rejected, and cite the 0-of-67 candidate-failure null from `road-to-activation-evidence-or-refusal` as the standing evidence the reopen must address.
+  2. On council convergence to reopen, implement the thin read-only wrapper over `match_prompt`; on a non-reopen verdict, record that ADR-054 stands.
+- **Resolved when:** the AI council records a convergence verdict (reopen or confirm) on the mechanism-match question, filed per the council's own output-path convention.
+
+Both parent artefacts converge on exposing the trigger matcher through an MCP tool, and the consolidated draft narrows it to a thin read-only wrapper over the existing `match_prompt` rather than a second matcher. The narrowing is real and the gap it names is verified — the matcher is reachable through no consumer MCP path. It nevertheless meets a recorded decision head-on: `ADR-054` is `status: rejected`, `docs/contracts/rule-router.md:212` states there is no runtime resolver, and `agents/roadmaps/archive/road-to-activation-evidence-or-refusal.md` closed that question on 2026-08-02 with 0 of 67 candidate failures confirmed against a required 5. The recorded qualifier is that the refusal is "as designed, never permanently", and what it closes is the path from a restated complaint to a built resolver — which is precisely the shape this round arrives in. Under the decision-revisit gate this is a mechanism-match question the council decides before any wrapper is written, not one this roadmap settles by building the smaller version.
+
+Corrected step, carried from the reproduction: route the reopen to the council with the mechanism distinction stated explicitly — a pull-only tool a host may call versus the push-time resolver ADR-054 rejected — and with the 0/67 null as the standing evidence the reopen must address.
+
+### blocker: mcp-instructions-index-preregistration
+
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** nothing in this roadmap — it gates work deliberately excluded from it.
+- **Recommendation:** pre-register the evaluation (corpus, arms, effect floor, published-null branch) and obtain approval before raising the cap — three prior measurements in this family returned null, and building the index unevaluated would repeat that pattern.
+- **If you do nothing:** the `instructions` cap stays at 400 bytes and no generated family index is built — the fourth unevaluated entry in a null-measured family is not added, which is the safe default.
+- **What to do:**
+  1. Draft the pre-registration — corpus, arms (with/without index), effect floor, and the published-null branch — mirroring the two adjacent `measured-null` roadmaps in this family.
+  2. Obtain approval for that registration; only once approved, raise the cap and implement the generated index.
+- **Resolved when:** the pre-registered evaluation is approved and recorded, or the owner declines to pursue this fourth measurement and records that instead.
+
+The server `instructions` string is capped at 400 bytes (`src/cli/mcp/dispatch.ts:173`) against a larger host budget, and the artefact proposes raising the cap and filling it with a generated family index plus rule pointers. The cap figure is verified and the headroom is real. What is also verified is that this is the fourth entry in a family whose prior three measurements returned nothing: the reminder-injection apparatus measured a zero-point difference on both host tiers with a pre-committed teardown that was executed, and two adjacent roadmaps in this family closed at `measured-null`. Building the index before its evaluation is pre-registered would repeat the pattern the family's own record warns about.
+
+Corrected step, carried from the reproduction: pre-register the evaluation — corpus, arms, effect floor, and the published-null branch — and obtain approval for that registration before any byte of the cap is raised.
+
+### blocker: mcp-prompt-emission-scope
+
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** nothing in this roadmap — it gates work deliberately excluded from it.
+- **Recommendation:** wait for Phase 4's telemetry reading (step 4.2) before deciding whether to suppress the prompt catalogue on hosts that already carry a file listing — suppressing now would remove a surface consumers may be using, with no evidence either way.
+- **If you do nothing:** the prompt catalogue keeps duplicating the host's own skill listing on every such host indefinitely; the decision is simply deferred, not actively harmed by the delay.
+- **What to do:**
+  1. Read Phase 4's published reading: `agent-config telemetry:status --json` for the per-host `tools/call` rows, and the emission site at `src/cli/mcp/dispatch.ts`.
+  2. Pick one of three options and record it in `docs/decisions/`: (a) keep the prompt catalogue on every host, (b) suppress it only on hosts whose capability row already reports a native file listing, (c) drop it entirely and serve the listing through resources alone.
+- **Resolved when:** an ADR under `docs/decisions/` names one of options (a), (b) or (c) and cites the Phase 4 reading it rests on.
+
+The server emits a large prompt catalogue (`docs/mcp-server.md:31-32`, `:42-44`) beside the host's own skill listing, which the artefact reads as a duplicated menu and proposes suppressing on hosts that already carry a file listing. The duplication is real. Suppressing it removes a surface consumers may be using, with no telemetry today that could say whether they are — which is what Phase 4 exists to produce. The decision belongs to the owner and should wait for a reading from 4.2 rather than precede it.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-09-05 | reviewer: claude/host -->
+
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | Pinned version freezes on old installs | implementation | 1.1 pins the spec at install time, so a consumer who never updates keeps running an old server against a newer package. | 1.2 is the paired repair path and rotates the pin on update; the two steps ship together or neither does. | Phase 1 — Pin the bridge and repair it on update |
+| 2 | Update repair touches a neighbour's key | implementation | The repair rewrites entries in a config file consumers and other tools also write. | Repair only keys recorded as this package's own in the lockfile, and assert a hand-added neighbour key is byte-identical after the run. | Phase 1 — Pin the bridge and repair it on update |
+| 3 | Annotations read as an effect claim | product | Shipping `priority` invites a later reader to cite it as evidence that hosts prioritise this package's resources, which nothing measured. | 2.3 states the no-claim condition in the step and forbids a CLAIMS entry; the verify asserts none was added. | Phase 2 — Make the MCP truth surfaces match the tree |
+| 4 | Vendor-doc residuals harden into asserted facts | product | 3.2 seeds consent residuals from vendor documentation, which drifts and which nobody here observed. | Carry the source per field, print it, and let an observed value replace a documented one only after a session records it. | Phase 3 — Record what MCP actually reaches, per host |
+| 5 | New host registrations surprise consumers | implementation | 3.3 writes an MCP entry into config files that previously carried only hooks for those hosts. | Gate on the existing `--tools` selection and on the 3.1 axis, so a host is registered only where the axis records that it reads such a file. | Phase 3 — Record what MCP actually reaches, per host |
+| 6 | Telemetry reads near zero and is treated as failure | product | The lite surface may show almost no calls, and a low number invites a rushed default-flip or a rushed removal. | 4.2 publishes the reading including a zero; the two prompt- and cap-shaped decisions that would consume it are held in Blockers rather than wired to a threshold. | Phase 4 — Answer whether the lite surface is used |
+
+## Acceptance Criteria
+
+- [ ] AC-1 — The installed MCP server entry names an exact package version, and an update run rewrites that version while leaving every key this package does not own byte-identical.
+- [ ] AC-2 — No setup snippet in the MCP documentation contains a path the installer does not write, and a check fails when the documented command and the installed command diverge.
+- [ ] AC-3 — Served resources carry the protocol's `audience`, `priority` and `lastModified` annotations, and no claim in `docs/CLAIMS.md` cites them.
+- [ ] AC-4 — The host capability manifest carries MCP fields with a recorded source per field, and the installer's closing report names only the residuals that remain non-automatic.
+- [ ] AC-5 — Each host the manifest records as reading a project MCP config carries the server entry after an install selecting it, and no other host does.
+- [ ] AC-6 — A query against the collector returns per-tool, per-host call counts for the lite surface, and the telemetry report renders that section with an explicit zero on a machine with no calls.
+- [ ] AC-7 — Each of the four blockers is either resolved by a recorded owner or council decision, or still carries `Status: open` with its owner named.

--- a/agents/roadmaps/road-to-observed-learning-signal.md
+++ b/agents/roadmaps/road-to-observed-learning-signal.md
@@ -1,0 +1,145 @@
+---
+complexity: structural
+status: ready
+execution:
+  mode: phase-checkpoints
+estate_growth_exempt: "Carries the only five items of an inbox round that survived verification against a tree where the same subject already shipped once — the experience loop's machinery is built and its input stream is a producer constant, which no parked or archived roadmap covers and which a shipped experience card's falsifier names and has not fired."
+estate_offset_exempt: "Offsets nothing: it is a new plan, not a carried deferral, and it deliberately does not reopen either `later/` receiver of `road-to-experience-loop-broadening`, whose carry semantics cover their parent's own criteria and not unrelated work."
+---
+# Road to an observed learning signal
+
+> **Source:** `agents/tmp.old/inbox-2026-09-p/` — verified against the tree at `93d63073e` on 2026-09-05.
+
+## Goal
+
+The experience loop's machinery already exists and is starved. `road-to-experience-loop-broadening` closed with 44 of 47 boxes done and shipped every downstream reader this round's drafts proposed to build: the per-asset report that reports `unknown` as its own share and `win_rate` as `null` rather than `0`, the five activation/adherence states where `null` is not a pessimistic `false`, the ≥2-origin corroboration rule, the committed outcome-vocabulary module, the experience-card variant, and the one-file-per-record store. None of that is re-planned here. What did not close is AC-9, and its recorded reason is the whole subject of this roadmap: no failure pattern exists to mine, because every audit line ever written carries the same literal `rules_applied` value. This roadmap is done when the audit stream carries at least one field computed from what actually happened rather than from what the producer always writes; when a model-noticed observation has a durable, target-addressed place to wait for its second occurrence instead of being handed to a host-native tool no reader of this repository can query; when a roadmap parked in `later/` cannot pass its gate on a status word alone; and when the two documents that still assert a retired doctrine and a non-existent artefact have been corrected.
+
+## Phase 1 — Correct the two documents that mislead the next reader
+
+- [ ] **1.1 Remove the retired no-decay / no-runtime doctrine from the pipeline skill.** `src/skills/skill-improvement-pipeline/SKILL.md:84-86` states "no auto-write, no decay, no runtime (the writable per-project learning store stays rejected)". Both halves are contradicted in the tree: `src/scripts/learning_sidecar.ts:37` sets `HALF_LIFE_DAYS = 30` and computes a decay over a per-project intake store, and ADR-249 `:85-87` permits a supervised resident process in core, superseding the no-daemon clause it inherited. Rewrite the sentence to say what is actually true — no auto-write and no auto-promotion, decay and runtime governed rather than prohibited — and keep the no-auto-write half, which is still the live boundary.
+      verify: `grep -n "no decay\|no runtime" src/skills/skill-improvement-pipeline/SKILL.md` returns nothing, and the surviving sentence names `learning_sidecar.ts` or ADR-249 as the reason.
+- [ ] **1.2 Retire the `capture-learnings` name from the four documents that assert it exists.** `docs/contracts/rule-classification.md:110`, `docs/contracts/linear-ai-rules-inclusion.md:92`, `docs/guidelines/agent-infra/self-improvement-pipeline.md:8` and `docs/guidelines/agent-infra/naming.md:37` name it as a current artefact. Neither `src/rules/capture-learnings.md` nor `src/skills/capture-learnings/` exists; the live rule is `src/rules/skill-improvement-trigger.md` and the live skill is `skill-improvement-pipeline`. Replace each with the live name, or mark the line historical where it is describing a past state. Leave the string literal in `src/scripts/build_rule_trigger_matrix.ts:129` alone unless that matrix row is itself dead.
+      verify: for every remaining match of `grep -rn "capture-learnings" docs src`, the line either names a live artefact or is explicitly marked historical.
+
+## Phase 2 — Give the first model-noticed observation a target-addressed waiting room
+
+- [ ] **2.1 Add `model-noticed` as a third `DefectSource`.** `src/scripts/_lib/self_repair.ts:34` admits only `user-reported` and `self-detected`, both of which require a detector to have fired. A model that notices an edge case in a rule, or a methodology the user just explained that no skill carries, has no record type. Widen the union in place; the store, the fingerprint derivation at `:548-557` and the noclobber path are unchanged, and no second store is introduced.
+      verify: a unit test writes a `model-noticed` finding, reads it back through the existing store reader, and the record round-trips with its source intact.
+- [ ] **2.2 Add a closed `target` field and validate it against the tree at write time.** `suggested_surface` at `:62-63` is free text the agent writes, so no record can be joined to the asset it is about. Add `target: string[]` whose entries match `rule:<id> | skill:<id> | command:<id> | hook:<concern>`, validated against the tree when the record is written; an unresolvable target is written to a `proposes` field instead of being silently accepted. An empty target list stays legal — a real observation with no identified home is information, not an error.
+      verify: a fixture with `target: ["rule:does-not-exist"]` is rejected and lands in `proposes`; a fixture with `target: ["rule:scope-control"]` is accepted.
+- [ ] **2.3 Widen the status enum and require a wake condition on the parked state.** `:71` admits only `open | released`, so a declined record stays `open` in the queue line for ever and a partially actioned one cannot be expressed. Move to `open | candidate | actioned | declined | superseded | parked`, with `parked_until` required whenever the status is `parked`, and migrate existing `released` records to `actioned` carrying a resolution line that says the migration is why.
+      verify: a `parked` record without `parked_until` fails validation; the migration is idempotent, proven by running it twice over a fixture store and diffing.
+- [ ] **2.4 Count occurrences per target, not only per fingerprint.** `:70` counts occurrences against the fingerprint, which is class plus normalised evidence shape — so two different manifestations of one rule's weakness are two records with one occurrence each, and the escalation rule at `src/skills/skill-improvement-pipeline/SKILL.md:196-199` ("a third recurrence of the same violation class converts an observation into a deterministic gate") has nothing that could ever establish a third recurrence. Aggregate occurrences by target as a derived read over the record files, regenerable and gitignored.
+      verify: three records with distinct fingerprints and one shared target report a per-target count of three; deleting the derived index and rebuilding it is byte-stable.
+- [ ] **2.5 Replace the `remember` routing in the pipeline skill with the record write.** `src/skills/skill-improvement-pipeline/SKILL.md:59` sends the seen-once-but-generalizable learning to a host-native `remember` tool. That tool is not target-addressed, is not readable by anything in this repository, appears in no corroboration counter, and is simply absent on hosts that do not ship it — so the ≥2 counter at `src/scripts/learning_sidecar.ts:39` restarts at one every time and the second occurrence can never be recognised as the second. Route that branch to the `model-noticed` record from 2.1 instead.
+      verify: `grep -n "remember" src/skills/skill-improvement-pipeline/SKILL.md` returns no routing instruction, and the replacement line names the record write.
+
+## Phase 3 — Make the park gate read a condition instead of a status word
+
+Tagged `corrected-from-reproduction`: the round's drafts identified this gate as accepting the bare word `trigger` in 11 of 82 files. Reproducing the gate's own control flow showed a larger hole one branch earlier, and the steps below carry the corrected wording.
+
+- [ ] **3.1 Remove the status short-circuit that lets a parked roadmap carry no wake condition at all.** `src/scripts/lint_roadmap_later_disposition.ts:179` reads `if (status !== 'later' && !RESUME_RE.test(body))`, so a file whose frontmatter says `status: later` passes without any resume text being present. Measured over the current tree: 62 of 81 parked roadmaps pass on the status word alone, 8 on a real `Blocked until` / `Resume when`, and 11 on the bare word `trigger` — so 73 of 81 carry no machine-readable wake condition. Require a wake condition regardless of status.
+      verify: a fixture carrying `status: later` and no resume text is rejected; the current tree's violation count is reported and becomes the ratchet's starting floor rather than a silent pass.
+- [ ] **3.2 Read the structured `entry_condition` field and stop accepting the bare word `trigger`.** Three files already carry `entry_condition:` and the lint reads none of them (`check()` at `:150-192` consults only `status:` and `RESUME_RE` over the body). Make `entry_condition` the field the gate reads; drop `trigger` from `RESUME_RE`, keeping the four unambiguous phrases, so a body that merely mentions the word in passing no longer satisfies a governance gate.
+      verify: a fixture whose body says "the trigger fires on push" and carries no `entry_condition` is rejected; a fixture carrying `entry_condition` and no resume phrase passes.
+- [ ] **3.3 Require the wake condition to name what would change the decision, when it could arrive, and who would have to act.** A condition that cannot be observed is a deferral wearing a condition's clothes. Specify the three parts in the field's contract and check that all three are present and non-empty; `none` is a legal answer for the third and blankness is not.
+      verify: a fixture with a one-word `entry_condition` is rejected with a message naming the missing part.
+- [ ] **3.4 Require `review_by` in the frontmatter of every parked roadmap.** Measured: 13 of 81 carry it, 68 do not. Ratchet from the current count rather than failing the tree in one change.
+      verify: the gate reports 68 as its starting floor and refuses any increase.
+
+## Phase 4 — Make one field in the audit stream an observation
+
+- [ ] **4.1 Compute `rules_applied` from rules that actually fired, in both shipped producers.** `src/scripts/_lib/audit_field_provenance.ts:31-35` registers `rules_applied` as a producer constant with the value `['delegation-policy']`, and `agents/knowledge/experience-rules-applied-is-a-producer-constant.md` records the same as the tree's only experience card, with the falsifier "a producer computes `rules_applied` from rules that actually fired, and the mined pattern's count falls below the audit line count". The falsifier has not fired and the situation has worsened: mining the stream now returns exactly one pattern at count 1074 over 1104 lines, against 914 over 935 when the card was written. Every per-asset reader downstream — `src/scripts/_lib/experience_report.ts:116` included — is aggregating over a constant, so the corroboration and escalation machinery built in the previous roadmap has no varying input to work on. Change `_lib/orchestration_record.ts` and `_lib/review_skipped_record.ts` to write the rules the run actually carried; where a producer genuinely cannot know, write an empty list, which is an honest absence and is what `_lib/activation_receipt_producer.ts:300` already does.
+      verify: `./scripts-run src/scripts/extract_audit_patterns --min-count 2` over a fixture stream of mixed runs returns more than one pattern, and the top pattern's count is strictly below the fixture's line count.
+- [ ] **4.2 Retire the constant registration and the card together, in the same change, only once the falsifier has fired.** Removing the `PRODUCER_CONSTANT_FIELDS` row is the assertion that the field is now observed, and `:27-30` of that module says as much. Leaving the card standing after its falsifier fires would make the tree assert something false about itself, which is the failure the card exists to prevent.
+      verify: the row is absent from `PRODUCER_CONSTANT_FIELDS`, the card is marked retired with the run that falsified it, and the module's own test asserting that the named producers still match the registered value passes on the new shape.
+- [ ] **4.3 State plainly what does not follow.** A varying `rules_applied` does not make the loop productive; it makes it measurable. Record the residual honestly: whether the corroboration gate then mints anything at all is a question for the parked operational-proof roadmap, which is blocked on elapsed time rather than on effort, and this roadmap must not claim its criterion.
+      verify: the closing note names `agents/roadmaps/later/road-to-experience-lifecycle-operational-proof.md` as the holder of the operational criterion and claims nothing about it.
+
+## Phase 5 — Make the handoff carry falsifiable uncertainty
+
+- [ ] **5.1 Add four self-critique sections to the handoff contract.** The template at `src/domains/meta/agent-handoff/command.md:94-127` carries Done, Open, Resume pointer, Repeatable workflow, Errors + fixes, Feedback history, Key decisions and Relevant files — every one of them a statement about what happened, none about what the outgoing session is least sure of. Add `Least confident`, `Biggest thing missed`, `Breaks in three months because` and `Not done`, and require every line in them to carry a `verify:` naming the command or observable state that would confirm or kill it. An unverifiable line of self-doubt is filler.
+      verify: a fixture handoff with a `## Not done` line and no `verify:` is rejected by `src/scripts/lint_handoffs.ts`; `none` is accepted as the whole section body and blankness is not, matching the existing treatment of `## Open questions` at `:895-928`.
+- [ ] **5.2 Capture, do not chase.** A finding surfaced while writing a handoff becomes a `model-noticed` record from 2.1, never a fix inside the handoff turn — the handoff exists because the session is ending, and a fix started there is the least-verified change in the whole run.
+      verify: the contract states this and names the record write as the destination.
+
+## Blockers
+
+### blocker: estate-placement-of-this-roadmap
+
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** Phase 1 — Correct the two documents that mislead the next reader
+- **Recommendation:** keep it as one standalone roadmap rather than folding into either parked receiver — folding into a parked carrier is outside the carry semantics the archival contract grants it and would silently unpark work waiting on elapsed time; splitting across three files to dodge a threshold is the alternative nobody should take silently.
+- **If you do nothing:** the roadmap has no settled place in the estate, and Phase 1 lands without the estate-slot question ever having been answered.
+- **What to do:**
+  1. Decide standalone vs. fold vs. split, reading `agents/roadmaps/later/road-to-experience-lifecycle-operational-proof.md` and `agents/roadmaps/later/road-to-experience-loop-owner-decisions.md` first to confirm neither is a legal receiver.
+  2. Run `./scripts-run src/scripts/check_estate_count` to confirm the chosen placement holds against the measured floor before Phase 1 lands.
+- **Resolved when:** the owner records which placement (standalone / fold / split) this roadmap takes, and `check_estate_count` is green under that placement.
+
+Whether these five phases stand as one active roadmap or fold into an existing file is not a decision the analysis can take. The round's drafts recommend folding, on a premise that has since expired — they counted four active roadmaps at their pin and there is one at `93d63073e`. The two candidate receivers, `agents/roadmaps/later/road-to-experience-lifecycle-operational-proof.md` and `agents/roadmaps/later/road-to-experience-loop-owner-decisions.md`, are parked carriers of their parent's own criteria; adding unrelated work to a parked carrier is outside the carry semantics the archival contract grants them, and reopening either would also unpark work that is deliberately waiting on elapsed time. Standing alone costs one estate slot against a floor measured on the base ref per ADR-243 `:90-94`. The alternative nobody should take silently is splitting the five phases across three files to keep each below a threshold.
+
+### blocker: per-turn-injection-budget-for-record-overlay
+
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** nothing in this roadmap — it gates work deliberately excluded from it.
+- **Recommendation:** none; this is the owner's call — it turns on how much of the `skill-route` concern's per-turn budget the owner is willing to spend on a second payload, which is a policy trade-off, not a technical one.
+- **If you do nothing:** the overlay is never built, and the evidence-firewall risk it would create (a run treating its own record-overlay view as a second independent observation) stays theoretical rather than realized.
+- **What to do:**
+  1. Decide whether the `skill-route` concern's threshold at `src/scripts/hook_manifest.yaml:755-758` may carry a second payload alongside its 30/100 floor, or whether record visibility must reach the agent through a separate, lower-frequency carrier.
+  2. Record the decision (e.g. in `docs/decisions/` or an update to this blocker); if approved, adjust the threshold math to account for the added payload.
+- **Resolved when:** the owner states either that the `skill-route` slot may carry the overlay, or that record visibility routes through a different mechanism.
+
+The round's drafts propose surfacing open records at routing time, as an extra line on the `skill-route` concern. That concern's threshold is already tuned against a measured corpus — `src/scripts/hook_manifest.yaml:755-758` records a 30/100 floor at the p90 of 496 prompt lines, firing on 13.9 % of them, chosen explicitly because "a median floor would speak on half of all turns, which is the per-turn-reminder shape this estate has already measured failing". Adding a second payload to the same slot spends budget the owner set, and the retrieval it enables is also the mechanism the drafts' own evidence-firewall argument warns about: a run that has already seen a record's overlay is not an independent second observation of it. No step in this roadmap builds the overlay, and none should until the budget question is answered.
+
+### blocker: live-harness-evaluation-of-promoted-changes
+
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** nothing in this roadmap — it gates work deliberately excluded from it.
+- **Recommendation:** none; this is the owner's call — live multi-turn harness evaluation was already refused once in this estate's scouting work, and reopening it turns on evaluator-independence exposure only the owner can accept.
+- **If you do nothing:** only the single-turn half (`bench_ab_*`, `src/scripts/_lib/paired_verdict.ts`) validates promoted changes; no promoted change gets a live multi-turn check.
+- **What to do:**
+  1. Decide whether a live-harness, multi-turn evaluation path is worth reopening given the prior refusal, and if so, whether it wraps a third-party evaluator CLI or extends `src/scripts/_lib/paired_verdict.ts` in-house.
+  2. If approved, name the harness and cite the evaluator-independence guardrail (`src/rules/evaluator-independence.md`) it runs under before any roadmap schedules it.
+- **Resolved when:** the owner records either that live-harness evaluation stays out of scope, or the harness + guardrail choice that would let a future roadmap schedule it.
+
+Both parent drafts want every behavioural change validated in a real agent harness before promotion, one of them by wrapping external evaluation CLIs. Live evaluation floors are parked on evaluator independence, and shelling out to a third-party evaluator was already refused in this estate's scouting work. The single-turn half of the ask is not missing — `bench_ab_*` and `src/scripts/_lib/paired_verdict.ts` are the shipped mechanism — so what is blocked is specifically the multi-turn, live-harness half. This roadmap does not schedule it.
+
+### blocker: artefact-family-registry
+
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** nothing in this roadmap — it gates work deliberately excluded from it.
+- **Recommendation:** none; this is the owner's call — building the registry now would produce a measurement tool with no consumer, since `src/scripts/audit_skill_overlap.ts` already surfaces the clusters it would enumerate.
+- **If you do nothing:** a shared rule changed in one family member and not its siblings stays undetected until a human notices it by hand.
+- **What to do:**
+  1. Wait for one recorded instance of a shared-rule propagation failure (a change landed in one family member and not its siblings), or decide to build the registry preemptively without waiting for one.
+  2. If a real instance occurs, cite it in this blocker and open a roadmap that reads `audit_skill_overlap.ts`'s cluster output as the registry's seed data.
+- **Resolved when:** either a propagation-failure instance is recorded here, or the owner decides to build the registry without waiting for one.
+
+The drafts propose a declared family registry with shared and member-specific columns, so that a change to one member's shared rule is checked against its siblings. `src/scripts/audit_skill_overlap.ts` already surfaces the clusters a registry would enumerate, and nothing in the tree reads a registry today, so building one produces a measurement rather than a gate. It is recorded here rather than declined outright because the propagation failure it guards against is real and simply has no recorded instance yet; the condition that would reopen it is one recorded case of a shared rule being changed in one member and not its siblings.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-09-05 | reviewer: claude/host -->
+
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | A varying `rules_applied` still mints nothing | product | Phase 4 makes the field an observation, which is necessary and not sufficient: the stream may still be almost all `implement:success`, in which case the corroboration gate has more input and no failures to corroborate. The round's temptation is to read a fixed field as the whole cause of an empty loop | 4.3 requires the residual to be stated rather than claimed away, and points the operational criterion at the parked roadmap that owns it. The verify on 4.1 asserts variation in a fixture, never productivity in the real stream | Phase 4 — Make one field in the audit stream an observation |
+| 2 | The widened record becomes a queue nobody drains | implementation | Adding a third source and a sixth status multiplies what can sit open. The self-repair store is empty on at least one checkout today, so the failure mode is not volume but a queue that grows once and is never read | 2.3 makes `declined` and `superseded` expressible so a record can leave the queue, and requires `parked_until` so a parked one names when it returns. No step adds a prompt-time surface that would make an unread queue costly | Phase 2 — Give the first model-noticed observation a target-addressed waiting room |
+| 3 | Phase 3 reds the tree on the change that lands it | implementation | 73 of 81 parked roadmaps fail the corrected gate, and 68 lack `review_by`. A gate that fails its own tree on day one is reverted rather than adopted | 3.1 and 3.4 both ratchet from the measured current count instead of asserting a clean floor, which is how the shrink-only gates in this estate already work | Phase 3 — Make the park gate read a condition instead of a status word |
+| 4 | Target validation goes stale against a moving tree | implementation | 2.2 validates `target` against the tree at write time. A rule renamed later leaves records pointing at an id that no longer resolves, and a silent unresolvable target is worse than free text because it looks joined | The derived per-target index in 2.4 is regenerable, so a rebuild surfaces unresolvable targets as a countable set rather than as silent misses; the byte-stability verify makes that rebuild routine | Phase 2 — Give the first model-noticed observation a target-addressed waiting room |
+| 5 | The doctrine correction over-corrects | product | 1.1 removes "no decay, no runtime" because both are contradicted in the tree. The adjacent "no auto-write" clause is still the live boundary and reads as part of the same sentence, so a careless edit deletes a real constraint along with two retired ones | The step names the half to keep explicitly, and the verify checks that a surviving sentence remains and cites its authority | Phase 1 — Correct the two documents that mislead the next reader |
+| 6 | Handoff sections become ritual | product | Four new required sections invite `none` four times, which passes every check and carries nothing. The existing `## Open questions` treatment shows the estate already met this shape once | 5.1 requires a `verify:` command on every non-`none` line, so a line that says something must say how it would be killed; the fixture pins both directions | Phase 5 — Make the handoff carry falsifiable uncertainty |
+
+## Acceptance Criteria
+
+- [ ] AC-1 — No document in `docs/` or `src/` asserts a no-decay or no-runtime doctrine, and no document names `capture-learnings` as a current artefact.
+- [ ] AC-2 — A record written from a model's own noticing carries a source, a validated target or an explicit `proposes`, and a status drawn from a six-value closed enum, and it survives a round trip through the existing store with no second store present in the tree.
+- [ ] AC-3 — A per-target occurrence count exists as a regenerable derived read, so the third-recurrence escalation stated at `src/skills/skill-improvement-pipeline/SKILL.md:196-199` has a counter that could establish its own precondition.
+- [ ] AC-4 — The pipeline skill routes a seen-once generalizable learning to a record this repository can read, and no routing instruction in it names a host-native memory tool.
+- [ ] AC-5 — A roadmap under `agents/roadmaps/later/` cannot pass its gate on a frontmatter status word alone, on the bare word `trigger`, or on a wake condition that omits what would change the decision, when it could arrive, or who would act.
+- [ ] AC-6 — `rules_applied` is absent from `PRODUCER_CONSTANT_FIELDS`, the experience card asserting it is a constant is retired against the run that falsified it, and mining a mixed fixture stream returns more than one pattern.
+- [ ] AC-7 — A handoff carries four self-critique sections in which every substantive line names the command or observable state that would confirm or kill it, and an empty section is rejected while `none` is accepted.
+- [ ] AC-8 — The estate carries no new skill and no new hook concern as a result of this roadmap.

--- a/agents/roadmaps/road-to-one-motion-authority.md
+++ b/agents/roadmaps/road-to-one-motion-authority.md
@@ -1,0 +1,244 @@
+---
+complexity: structural
+status: ready
+execution:
+  mode: phase-checkpoints
+estate_growth_exempt: "Adds one active roadmap against an estate of one, to close a defect no prior roadmap recorded: six shipped carriers state contradictory motion durations and easings, and one of them supplies an elastic curve that a backed detector already flags. The contradiction is between shipped artefacts, so it is live today and no reader can tell which value wins. It cannot fold into the two later/ roadmaps that own the adjacent surface, because both are locked on evaluation validity for NEW detector rows and this roadmap adds none."
+estate_offset_exempt: "Offsets nothing because nothing it touches is scheduled anywhere. The detector-promotion and blind-judgment items an inbox draft proposed are excluded by name and left with their existing later/ owners; what remains -- an authority, its drift gate, three catalog columns, an evidence class, two brief fields and ten descriptions -- has no plan of record to displace."
+---
+# Road to one motion authority
+
+> **Source:** `agents/tmp.old/inbox-2026-09-l/` — verified against the tree at `93d63073e` on 2026-09-05.
+
+## Goal
+
+Six shipped carriers in this tree state motion timing and easing, and they
+disagree. `design-patterns.md:167` forbids elastic easing in UI and a `backed`
+detector enforces it, while `motion.csv` row 3 supplies `elastic.out(1,0.4)` as a
+hover recipe and row 8 supplies an overshoot curve for list stagger; the same
+file's hover band (150–200 ms) contradicts the decision tree's (100–160 ms) and
+its page-transition bands run to 800 ms against a stated ceiling of "above 500ms:
+almost never". `design-review` already declares one of the six "the timing source
+of truth", but that binding runs in one direction only and nothing tests it. This
+roadmap makes the declaration real: one carrier holds the numbers, the other five
+are checked against it by a gate that fails, the catalog gains the three columns
+that say what class a row is and how it is verified, and a perceptual evidence
+class is added so "technically correct, feels wrong" has somewhere to be recorded.
+It is done when a contradiction between any two motion carriers reds CI.
+
+Four bodies of work the inbox drafts proposed are **prevented, not deferred**, and
+none appears as a step below. Automatic activation on UI work already ships
+(`fe-design/SKILL.md:4`, the brief at `:49–51`). Experience-first variant
+comparison already ships (`design-variations/SKILL.md:70–78`). New `backed`
+detector rows are owned by `agents/roadmaps/later/road-to-tell-detector-promotions.md`
+under a 2/2 council verdict that they cannot make a truthful claim until the clean
+corpus carries a near-miss per signal, and blind-judgment benchmarking is owned by
+`agents/roadmaps/later/road-to-routing-assurance-live-floors.md` under an
+evaluator-independence lock. This roadmap adds no detector row and runs no
+judgment arm, so it neither reopens nor waits on either lock.
+
+## Phase 1 — One motion authority, and a gate that fails on drift
+
+- [ ] **1.1 Name the single motion carrier in its own section.** `design-patterns.md`
+      § Motion (`:153`) is already cited as the timing source of truth by
+      `design-review/SKILL.md:72–75`, but it does not say so about itself and the
+      five data carriers are bound to nothing. Add an opening line to that section
+      declaring it the sole carrier of duration bands, easing choice, and the
+      bounce prohibition, and listing the five dependent files by path.
+      verify: `grep -n 'sole carrier' src/skills/fe-design/references/design-patterns.md`
+      returns exactly one line inside the § Motion section, and the five paths that
+      follow it all resolve.
+- [ ] **1.2 Ship `lint_motion_authority_drift` over all six carriers.**
+      `corrected-from-reproduction` — the inbox step named five; the census found a
+      sixth, `src/skills/design-intelligence/data/motion.csv`, which no draft
+      mentions and which carries an explicit `Duration` and `Easing` column per row.
+      The gate parses duration bands and easing tokens out of
+      `design-rules-checklist.md`, `ux-guidelines.csv`, `app-interface.csv`,
+      `styles.csv` and `motion.csv`, and exits 2 when any of them states a band or
+      an easing family the authority does not permit.
+      verify: `./scripts-run src/scripts/lint_motion_authority_drift` exits non-zero
+      on the tree as it stands today, and its output names `motion.csv` rows 1, 3,
+      8, 11 and 12.
+- [ ] **1.3 Resolve the five contradictions the gate reds on.** motion.csv row 3
+      (`elastic.out(1,0.4)`) and row 8 (`back.out(1.4)`) violate the bounce
+      prohibition at `design-patterns.md:167` and catalog M1, whose detector sits at
+      `design_slop_rules.ts:680`; row 1's 150–200 ms hover band contradicts
+      `:169`'s 100–160 ms; rows 11 and 12 (400–600 ms, 500–800 ms) exceed the stated
+      page-transition ceiling. Each row is either brought inside the authority's
+      bands or carries the catalog's own override condition in a new column.
+      verify: `./scripts-run src/scripts/lint_motion_authority_drift` exits 0, and a
+      CSV read of `motion.csv` shows no `elastic.`/`back.` easing on a row without an
+      override value.
+- [ ] **1.4 Register the gate.** Add it to the CI pipeline and to the gate-coverage
+      ledger with its scanned scope and a self-test.
+      verify: `task ci` runs the gate; the gate-coverage row records a non-empty
+      `scanned` figure and a passing self-test.
+
+## Phase 2 — The catalog says what class a row is and how it is checked
+
+- [ ] **2.1 Add `class`, `remediation` and `verification` columns to every
+      antipattern catalog row.** Today the header is `# | Pattern | Why it reads as
+      AI-generated | Override condition` (`docs/guidelines/design-antipatterns.md:147`),
+      so a WCAG floor and a taste presumption are typographically identical. `class`
+      is one of floor · invariant · craft-presumption · style-preference ·
+      reference-constraint; `remediation` names the order to try (delete before
+      reduce before retune); `verification` is one of static · render · feel ·
+      judgment. This is a census pass — no row changes status.
+      verify: `./scripts-run src/scripts/lint_design_antipattern_parity` is green and
+      every catalog row has three non-empty new cells.
+- [ ] **2.2 Bind the two soft classes below existing precedence.** A
+      craft-presumption or a style-preference must never outrank a supplied
+      reference artifact, a coherent incumbent, or a project `DESIGN.md` — levels
+      4–6 of the precedence list at `src/scripts/_lib/ui_authority.ts:18–24`. Encode
+      it as a test on that module, not as prose.
+      verify: a test asserts that a class `craft-presumption` signal loses to a level-4
+      reference artifact and to a level-6 `DESIGN.md` register, and that a class
+      `floor` signal blocks.
+
+## Phase 3 — A perceptual evidence class
+
+- [ ] **3.1 Add a `feel` evidence type.** `docs/contracts/evidence-artifact-types.md:55–59`
+      carries `original-review`, `current-binding`, `declared-skip`, `honest-null`
+      and `analysis` — every one of them mechanical or textual. Motion that is
+      technically correct and still wrong has no type. Add `feel` with a closed
+      method vocabulary (`slow-motion` · `frame-step` · `device` · `next-day`); its
+      result may be unbacked, but the line may not be absent when motion shipped.
+      verify: `grep -n 'evidence-type: feel' docs/contracts/evidence-artifact-types.md`
+      returns the row, and `lint_evidence_artifacts` accepts a fixture carrying it.
+- [ ] **3.2 Add the motion floor.** `craft-floor.md` § The floors carries twelve
+      numbered floors and none mentions motion — the only occurrence of the word on
+      the page is in "what is NOT on this page". Add floor 13: shipped motion carries
+      a `feel` line naming its method.
+      verify: `src/skills/fe-design/references/craft-floor.md` § The floors shows
+      thirteen numbered floors and the thirteenth names motion.
+
+## Phase 4 — Frequency is declared, never inferred
+
+- [ ] **4.1 Add `frequency` and `initiation` to the design brief.** The brief covers
+      five keys today (`src/skills/fe-design/SKILL.md:49–51`) and there is no
+      frequency or input-modality field anywhere in the tree — `interaction_profile`
+      has zero occurrences under `src/`. Add both as declared fields, prefilled from
+      a role-default table (command palette, tooltip, modal, onboarding, toast, table
+      row) and overridden only on evidence. No resolver, no inference from handlers.
+      verify: `fe-design/SKILL.md` § Brief lists seven keys and the role-default table
+      carries at least six rows.
+- [ ] **4.2 Make the Motion taste dial read those fields.** The dial is a 1–10 scalar
+      with no trigger (`context-and-registers.md:63–90`); a keyboard-initiated or
+      100-plus-per-day surface should not reach a high dial value whatever the brief
+      signal says.
+      verify: the Dial Inference Table shows a disqualifier row for
+      keyboard-initiated and high-frequency surfaces, and the § Taste Dials text names
+      the two brief fields.
+
+## Phase 5 — The design family becomes router-visible
+
+- [ ] **5.1 Give each of the ten design-family descriptions one named sibling.** All
+      ten (`design-review`, `existing-ui-audit`, `fe-design`, `design-variations`,
+      `design-intelligence`, `ui-apply-generic`, `react-shadcn-ui`,
+      `tailwind-engineer`, `ui-component-architect`, `canvas-design`) currently name
+      zero, and the description-lint checks that would catch it are dormant by
+      construction because the cluster set is empty
+      (`src/scripts/lint_skill_descriptions.ts:40–44`). The router reads the
+      description, not the body. Rewrite inside the 200-character cap
+      (`src/scripts/skill_linter.ts:1541`); the cap does not move.
+      verify: each of the ten descriptions contains the `name:` value of another
+      shipped skill, and `./scripts-run src/scripts/skill_linter` reports no
+      description over 200 characters.
+- [ ] **5.2 Publish the sibling matcher with its number.**
+      `corrected-from-reproduction` — an inbox census claimed "44/299 descriptions
+      name a sibling" with no definition of naming and no script, and a companion
+      figure of "218/299 bodies" that no reading of the tree reproduces (the literal
+      phrase appears 12 times; the loosest variant 79). Ship the matcher that
+      produces the figure so it is falsifiable next time.
+      verify: the script prints a count and the per-skill list, and rerunning it
+      reproduces the same number on an unchanged tree.
+
+## Phase 6 — The modern primitives the tree has never named
+
+- [ ] **6.1 Extend § Motion with the entry/exit and scripted-animation primitives.**
+      The census over `src/` returns zero occurrences of `@starting-style` and zero
+      of the scripted web-animation API, one of `transform-origin`, one of `scale(0)`
+      and one of the hover-capability media query. That is a knowledge gap, not a
+      contradiction: the section can state when a CSS transition suffices, when
+      entry/exit needs the newer at-rule and top-layer handling, and when scripted
+      animation or a view transition is the right mechanism.
+      verify: `grep -ri '@starting-style' src/` returns at least one hit inside
+      `design-patterns.md` § Motion, and the same for the scripted-animation API.
+- [ ] **6.2 Keep the new lines under the authority.** Everything added in 6.1 lives in
+      the single carrier from 1.1 and is covered by the 1.2 gate; no second file
+      gains a duration or easing statement.
+      verify: `./scripts-run src/scripts/lint_motion_authority_drift` is green after 6.1.
+
+## Blockers
+
+### blocker: exit-easing-authority
+
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** Phase 1 — One motion authority, and a gate that fails on drift
+- **Recommendation:** preference only, not a finding — keep the tree's existing asymmetric position (B): `ease-out` on enter, `ease-in` on exit at roughly 60–70 percent of the enter duration. `design-rules-checklist.md`'s `exit-faster-than-enter` row already implies it, and it touches fewer carriers than switching to symmetric `ease-out`; the field itself has no settled answer, so treat this as a default to override, not a verdict.
+- **If you do nothing:** 1.1 cannot write the authority's easing rule, and 1.2's drift gate has no easing family to check the six carriers against.
+- **What to do:**
+  1. Choose (A) `ease-out` on both enter and exit, or (B) keep the asymmetric easing with exit at ~60–70 percent of enter duration.
+  2. Update all six carriers under the Phase 1 gate to match: `design-patterns.md:164–165`, `design-rules-checklist.md:153`, `ux-guidelines.csv:15`, `app-interface.csv`, `styles.csv`, and `motion.csv`.
+- **Resolved when:** the owner records which of (A)/(B) the authority states, and `design-patterns.md` § Motion carries that value.
+
+Phase 1.1 cannot write the authority's easing rule without settling one value.
+The tree states, in three places, that entering elements use `ease-out` and
+exiting elements use `ease-in` (`design-patterns.md:164–165`,
+`design-rules-checklist.md:153`, `ux-guidelines.csv:15`). The external
+design-craft reference this round came from holds the opposite for exits —
+`ease-out` on both sides. Both positions are held by serious practitioners; the
+field has no settled answer, and the inbox drafts correctly refused to state one
+as fact. The two candidates are (A) `ease-out` on both enter and exit, or (B)
+keep acceleration on exit at roughly 60–70 percent of the enter duration, which is
+what `design-rules-checklist.md`'s `exit-faster-than-enter` row already implies.
+Whichever is chosen propagates to all six carriers under the Phase 1 gate. This
+is a taste decision with no evidence that decides it, so it is not the council's
+and not the agent's.
+
+### blocker: motion-specialist-skill-estate
+
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** nothing in this roadmap — it gates work deliberately excluded from it.
+- **Recommendation:** none; this is the owner's call — the suite ships 299 skills against a zero-growth-allowance ratchet, so each new skill spends a slot the agent may not allocate on its own judgment, and several of the thirteen proposed skills would overlap `fe-design`, `design-review`, `existing-ui-audit` and `design-variations`.
+- **If you do nothing:** none of the thirteen proposed skills gets built, and the overlap question against the four existing skills stays unexamined.
+- **What to do:**
+  1. Decide whether any of the thirteen proposed skills (build, review, audit, opportunity-finding, vocabulary, platform-fluidity, mobile motion, prototyping, library selection, component-library expert, expert lens, new language skill) earns an estate-growth exemption.
+  2. For each one approved, name which existing skill (`fe-design`, `design-review`, `existing-ui-audit`, `design-variations`) it does not duplicate, and open a separate roadmap for it.
+- **Resolved when:** the owner records a yes/no per proposed skill, or explicitly defers the whole set with a revisit condition.
+
+The round's source material asks for up to thirteen new skills — build, review,
+audit, opportunity-finding, vocabulary, platform-fluidity, mobile motion,
+prototyping, library selection, a component-library expert, an expert lens, and a
+new language skill. The suite ships 299 skills against a ratchet with zero growth
+allowance, so each one costs its own growth-exemption claim, and several would
+duplicate jobs `fe-design`, `design-review`, `existing-ui-audit` and
+`design-variations` already own. This roadmap creates none and takes no position
+on whether any should exist; it only records that the question is open and
+owner-reserved, because the estate ratchet is a budget the agent may not spend on
+its own judgment.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-09-05 | reviewer: claude/host -->
+
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | Drift gate over-fires on prose | implementation | Four of the six carriers are prose or CSV free text, not structured fields. A parser looking for duration bands and easing tokens can red on a sentence that is describing a rule rather than stating one, and a noisy gate gets disabled. | Parse only the two structured carriers (`motion.csv`, `styles.csv`) mechanically; check the three prose carriers against an explicit allowlist of the sentences that carry a number, and fail on an unrecognised numeric statement rather than guessing. Ship the gate red on today's tree first, so its true-positive set is known before its false-positive set. | Phase 1 — One motion authority, and a gate that fails on drift |
+| 2 | Fixing motion.csv rows changes generated design output | product | Rows 3 and 8 are recipes a generator may already be emitting. Removing the elastic and overshoot curves changes what shipped surfaces look like, which is a design decision wearing a lint fix's clothes. | Route both rows through the catalog's existing override condition (M1 permits an intentional playful affordance) rather than deleting them: the curve survives where a project declares a playful register and is refused elsewhere. Nothing is silently dropped. | Phase 1 — One motion authority, and a gate that fails on drift |
+| 3 | The class column becomes a status column | implementation | The catalog already carries a status ledger (`backed` / `floor` / `judgment-only` / `deferred`). A second axis named `class` invites the two to be conflated, and a parity gate that already checks the ledger could start disagreeing with itself. | State in the header row that `class` is a property of the rule and status is a property of its enforcement, and add a parity assertion that the two axes are independent — a `floor` class row may be `judgment-only` status and the gate must accept it. | Phase 2 — The catalog says what class a row is and how it is checked |
+| 4 | Description rewrites lose trigger coverage | implementation | The ten design-family descriptions are the router's only signal, and rewriting them to fit a sibling name inside 200 characters means removing words that currently match user phrasings. | Each rewrite is scored against the skill's existing trigger corpus before adoption, and a rewrite that loses a matching query is rejected rather than merged. | Phase 5 — The design family becomes router-visible |
+| 5 | A `feel` evidence type with no producer | implementation | An evidence class nothing emits is a vocabulary entry, not a control, and the floor in 3.2 could be satisfied by writing the word. | The floor requires the method token, not the word: a `feel` line names one of the four closed methods and its outcome, and an outcome of `unbacked` is legal. The gate checks the token is from the closed set. | Phase 3 — A perceptual evidence class |
+
+## Acceptance Criteria
+
+- [ ] AC-1 — Exactly one file in the tree states motion duration bands and easing choice as authority, and it says so in its own text; the other five carriers state nothing the authority does not permit.
+- [ ] AC-2 — A contradiction introduced into any of the six carriers fails CI, demonstrated by a fixture that reds and a fixture that passes.
+- [ ] AC-3 — No row in `motion.csv` supplies a bounce or overshoot easing outside the catalog's declared override condition, and no duration band in it falls outside the authority's bands.
+- [ ] AC-4 — Every antipattern catalog row carries a class, a remediation order and a verification mode, and the parity gate is green.
+- [ ] AC-5 — A craft-presumption signal provably loses to a supplied reference artifact and to a project `DESIGN.md`, asserted by a test on the precedence module.
+- [ ] AC-6 — `feel` is a recorded evidence type with a closed method vocabulary, and the craft floors require a `feel` line for shipped motion.
+- [ ] AC-7 — The design brief carries declared frequency and initiation fields with a role-default table, and the Motion taste dial disqualifies decorative motion on keyboard-initiated and high-frequency surfaces.
+- [ ] AC-8 — Each of the ten design-family skill descriptions names at least one sibling, all remain at or under 200 characters, and no trigger-corpus match was lost.
+- [ ] AC-9 — The suite's skill count is unchanged at the ratchet, and no new rule, command or persona was added by this roadmap.

--- a/agents/roadmaps/road-to-scan-that-fails-closed.md
+++ b/agents/roadmaps/road-to-scan-that-fails-closed.md
@@ -1,0 +1,178 @@
+---
+complexity: structural
+status: ready
+execution:
+  mode: phase-checkpoints
+estate_growth_exempt: "Repairs a reproduced fail-open in the one security gate whose exit code `docs/CLAIMS.md:255` cites as evidence — a crashed child linter currently reports clean — and adds zero new gate scripts and zero hook concerns, extending five existing surfaces in place."
+estate_offset_exempt: "Offsets nothing: it archives no roadmap and supersedes none. The active estate is one carrier file that shares no path with any surface touched here."
+---
+# Road to a self-scan that fails closed
+
+> **Source:** `agents/tmp.old/inbox-2026-09-o/` — verified against the tree at `5c539505d` on 2026-09-05.
+
+## Goal
+
+The security umbrella `src/scripts/lint_agent_security.ts` spawns five child linters and
+throws away every child's exit code at `:209`, while `:67` turns unparsable child stdout
+into zero findings. A child that crashes, fails to spawn, or prints a stack trace is
+therefore indistinguishable from a child that ran and found nothing: the umbrella prints
+✅ and exits 0. That exit code is what `docs/CLAIMS.md:255` offers as evidence for the
+claim that every shipped artifact is machine-scanned for hidden-instruction payloads. The
+goal is that no child outcome other than a completed run can produce an aggregate pass,
+that the umbrella publishes how much it actually read, and that the prose surfaces stop
+asserting things the tree contradicts. Someone else can tell whether this happened by
+making a child linter exit non-zero and observing that `lint_agent_security` names it and
+exits 1, and by finding the umbrella listed in `src/config/gate-coverage.yml` with a
+floor it actually meets.
+
+Substantial parts of the source round were **already built** and are deliberately absent
+below, which is why this roadmap is six phases rather than the drafts' seventeen. The
+"Inspection Ledger" the round proposes as a new subsystem is `src/config/gate-coverage.yml`
+plus `check_gate_coverage.ts` and the `scanned: <N>` convention, shipped since 2026-07-29
+against the identical failure — so Phase 3 registers the umbrella in it rather than
+building a second one. The host-layer digest comparison the round asks for exists at
+`src/install/partitionEligibility.ts:137-145`. `npm audit` and Dependabot exist. The
+SARIF **upload** is stub-tracked at `agents/roadmaps/stubs/road-to-sarif-and-stateful-residual-row.md:45-60`
+with its own probe and a named producer, and is blocked on a repo-settings surface no
+step here can supply, so it appears in no phase. A sink-coincidence detector was dropped
+outright: reproduction showed its only worked example cannot fire it.
+
+## Phase 1 — Truth surfaces before any mechanism
+
+Prose and one data row. No behaviour changes, so this phase can land while the rest is
+still being designed.
+
+- [ ] **1.1 Add a `non_inference` field to the `shipped-artifacts-hidden-instruction-scanned` claim.** `docs/CLAIMS.md:255` offers `exec:lint_agent_security -> 0` as evidence, and until Phase 2 lands that exit code does not establish that all five children ran. State that limitation on the entry rather than withdrawing the claim.
+      verify: `./scripts-run src/scripts/check_claims` exits 0 and the entry carries a `non_inference` line naming the child-completion gap.
+- [ ] **1.2 Correct the two stale assertions in the threat model.** `docs/threat-model.md:3` calls the package "no-runtime", which ADR-249 supersedes by permitting a supervised resident process under governance. Row b at `:14` asserts three things the tree contradicts: no Dependabot automation (`.github/dependabot.yml` exists), no `npm audit` in a CI gate (`.github/workflows/tests.yml:443,447` and `release-validation.yml:393,407-408`), and `requirements.txt` as a pinning control (the file does not exist).
+      verify: `grep -n "no-runtime" docs/threat-model.md` returns nothing at `:3`; `grep -c "requirements.txt" docs/threat-model.md` returns 0; Row b's Gap cell names only gaps that survive a `grep` of `.github/`.
+- [ ] **1.3 Register the umbrella's own state in the assurance registry.** `src/config/assurance-capability-registry.json` carries 19 entries and a `self` axis, but its only `security-scan` entry is `axis: target` (`:148`). Add `self-security-scan` with `axis: self`, `state: degraded`, `owner_surface: src/scripts/lint_agent_security.ts`, `limitations` naming the discarded child exit code (`:209`) and the swallowed parse failure (`:67`), and `revisit_if` pointing at Phase 2.2.
+      verify: the registry schema test passes; `grep -c "self-security-scan" src/config/assurance-capability-registry.json` returns 1; the entry's `state` is `degraded` and not `available`.
+
+## Phase 2 — The umbrella fails closed
+
+`corrected-from-reproduction` — the child count in this phase is five, not the four the
+source round asserts; `lint_mcp_config_security` is the fifth (`src/scripts/lint_agent_security.ts:45-51`).
+
+- [ ] **2.1 Freeze the failure corpus first.** Fixtures for each way a child can fail to answer: exit non-zero with empty stdout, exit 0 with unparsable stdout, failure to spawn (`proc.status === null`), and — as the negative control — exit non-zero with valid findings, which must still be reported as findings and not as a run failure.
+      verify: each fixture runs green against today's code, proving it reproduces the current fail-open; the negative control is the one that must stay green afterwards.
+- [ ] **2.2 Give each child a closed terminal outcome and make a failed one block.** `completed | failed | skipped(reason)`, with the skip reasons a constant in the runner rather than configuration. Stop discarding the return code at `:209`; a child that is missing, unspawnable, exits outside the finding contract, or emits unparsable stdout makes the umbrella print the child's name and exit 1.
+      verify: the Phase 2.1 fixtures flip from green to red, each naming its child; `./scripts-run src/scripts/lint_agent_security` still exits 0 on the real tree.
+- [ ] **2.3 Carry execution state in the SARIF invocation object.** Where `--sarif` is passed, emit one SARIF-native `invocation` per child with `executionSuccessful` and `exitCode`. Do not add a parallel metadata block alongside it.
+      verify: a run with a deliberately broken child produces SARIF in which that child's `invocation.executionSuccessful` is `false`, and the existing byte-identical-output tests at `tests/scripts/lint_agent_security.test.ts:41,50` still pass.
+- [ ] **2.4 Undo the Phase 1 hedges that Phase 2 has now made false.** Remove the `non_inference` line from 1.1 and move the registry entry from `state: degraded` to `available` — and only once 2.2 is merged, since the entry's own `revisit_if` names that step.
+      verify: `check_claims` green with the field removed; the registry entry reads `available`; both edits sit in the same change as a passing 2.1 corpus.
+
+## Phase 3 — The umbrella publishes what it read
+
+`src/config/gate-coverage.yml:1-33` exists because gates that scanned an emptied tree
+reported success and were believed. `lint_agent_security` is absent from it and emits no
+count, so the same failure is open on the security gate specifically.
+
+- [ ] **3.1 Emit a machine-readable scan count.** One line `scanned: <N>` on stdout or stderr, N being the artifacts the children actually inspected — not the number of children. The manifest's rule 1 is explicit that the guard never parses human output.
+      verify: `./scripts-run src/scripts/lint_agent_security 2>&1 | grep -c '^scanned: [0-9]\+$'` returns 1 and N is greater than the number of children.
+- [ ] **3.2 Register the gate with a CI-identical invocation and a real floor.** Add the row to `src/config/gate-coverage.yml` with `argv` matching how the Taskfile and CI call it, and `min_scanned` set below the true corpus but far above a collapse, per the manifest's rule 3.
+      verify: `./scripts-run src/scripts/check_gate_coverage` exits 0 and reports the umbrella's count above its floor.
+- [ ] **3.3 Prove the floor can fail.** A new coverage row owes a negative control: point the gate at an empty scope and confirm `check_gate_coverage` fails rather than passing on a zero count.
+      verify: a self-test or fixture drives the count below the floor and the guard exits non-zero, naming the gate.
+
+## Phase 4 — The scout's security gate actually reads content
+
+`corrected-from-reproduction` — five children, not four, and the gate keeps its current
+name throughout: it is already called `security_licence` (`src/scripts/skill_scout.ts:82,86,401`),
+so the source round's rename-then-rename-back is dropped.
+
+- [ ] **4.1 Give all five children a bounded root mode.** A `--root` flag that scopes the scan, with each linter's current default root retained when the flag is absent.
+      verify: `grep -c -- '--root' src/scripts/lint_{hidden_unicode,confusables,instruction_smuggling,mcp_config_security,skill_frontmatter_safety}.ts` returns a non-zero count for each of the five; a run with no flag scans the same corpus it scans today.
+- [ ] **4.2 Build the candidate corpus before wiring the scout.** Quarantine fixtures carrying a zero-width injection, a disclosure-suppression imperative, and a dangerous frontmatter key, plus one clean candidate.
+      verify: against today's `intake()` all four are accepted, reproducing the gap — `src/scripts/skill_scout.ts:272-299` refuses only on symlink, extension, exec-bit and size.
+- [ ] **4.3 Make the scout run the rooted scan on the quarantine directory.** The gate refuses a candidate whose content a child linter flags, and the refusal names the linter.
+      verify: the three payload fixtures from 4.2 are refused with the linter named; the clean fixture is still accepted; the existing scout rejection tests are unchanged.
+
+## Phase 5 — Suppressions bound to the evidence they accept
+
+`src/scripts/_lib/security_lint.ts:168-170` — `pragma_allows` is a key lookup, so a
+pragma suppresses its check for the whole file with no location and no content binding,
+as `:16-17` documents.
+
+- [ ] **5.1 Extend the pragma grammar with a content fingerprint.** `<!-- security-lint: allow <check> "<reason>" sha256:<hex> -->`, hashing the normalized matched evidence and its location identity rather than incidental whole-file content. A pragma without a hash still works and reports itself as `legacy-pragma`.
+      verify: a mutation fixture — accept a benign match, then alter only the matched text into a malicious one, and the suppression stops applying while the reason string stays human-readable.
+- [ ] **5.2 Migrate the existing population and ratchet it to zero.** There are exactly 8 pragma instances across 8 files under `src/` and `docs/`; bind each by hand and read each reason as you go.
+      verify: `grep -rn '<!--\s*security-lint:\s*allow' src/ docs/ | grep -vc 'sha256:'` returns 0.
+- [ ] **5.3 Add no second suppression system.** No new allowlist file in any change belonging to this roadmap.
+      verify: `git diff --stat` across the roadmap's changes introduces no file matching `*_allowlist.json`.
+
+## Phase 6 — The published surface is classified, not just measured
+
+`src/scripts/check_pack_size.ts` already runs `npm pack --json` and parses the file list
+(`:60`, `:83`) but classifies nothing by type — greps for `binary`, `archive`, `dotfile`
+and `magic` return zero. The plumbing exists; only the classification is missing.
+
+- [ ] **6.1 Classify each packed entry by type.** Extend the existing parse to bucket entries as `text | dotfile | no-extension | binary | archive`, deciding binary and archive by magic bytes rather than by extension.
+      verify: the check prints a per-class count for the real tarball, and a fixture containing a planted archive is classified `archive` rather than `text`.
+- [ ] **6.2 Ratchet the classes that should be empty.** `binary` and `archive` at zero, with any dotfile or extensionless entry carried by a path-and-size-bound pragma in the Phase 5 grammar rather than a generic allowlist.
+      verify: adding a binary file to the packed surface makes the check fail and name the file; removing it makes the check pass again.
+
+## Blockers
+
+### blocker: capability-inventory-second-consumer
+
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** nothing in this roadmap — it gates work deliberately excluded from it.
+- **Recommendation:** none; this is the owner's call — it turns on whether a per-skill capability manifest is worth building before a real non-security consumer exists to read it, which is a scope decision, not a technical one.
+- **If you do nothing:** the manifest is never built, and 247 of 299 skills keep declaring no `execution:` block with no inventory surfacing that fact.
+- **What to do:**
+  1. Find or name a concrete non-security consumer for the manifest and state which fields it reads and what decision they feed.
+  2. If none exists, leave `agents/roadmaps/later/road-to-capability-native-execution.md` parked and revisit only when one appears.
+- **Resolved when:** a named non-security consumer states which manifest fields it reads and what decision they feed.
+- The source round's largest proposal is a generated per-skill manifest carrying component
+  digests, declared tools, observed capability classes and script sinks. Its own final
+  draft gates promotion on a second, non-security consumer existing — otherwise a security
+  detector silently becomes an authorization policy. At HEAD there is no such consumer:
+  `agents/roadmaps/later/road-to-capability-native-execution.md` is parked, and 247 of 299
+  skills declare no `execution:` block at all, so an underdeclaration finding would have
+  no defined meaning for five sixths of the corpus. This blocker exists so a future reader
+  does not mistake the omission for an oversight. It resolves when a named non-security
+  consumer states which fields it will read and what decision they feed.
+
+### blocker: mcp-fingerprint-slot
+
+- **Status:** open
+- **Owner:** maintainer
+- **Blocks:** nothing in this roadmap — it gates work deliberately excluded from it.
+- **Recommendation:** none; this is the owner's call — pre-use interception changes the tool invocation path in a way that observe-only recording does not, and that trade-off belongs to the owner.
+- **If you do nothing:** `src/scripts/mcp_tool_fingerprint.ts` stays complete but unbound, so its protection level stays zero.
+- **What to do:**
+  1. Choose pre-use interception (a `pre_tool_use` binding) or observe-only recording (a `post_tool_use` binding) for `mcp_tool_fingerprint.ts`.
+  2. Wire the chosen slot in `src/scripts/hook_manifest.yaml` and confirm `grep -c mcp_tool_fingerprint src/scripts/hook_manifest.yaml` returns a non-zero count.
+- **Resolved when:** the owner picks a slot and `mcp_tool_fingerprint.ts` is bound in `hook_manifest.yaml`.
+- `src/scripts/mcp_tool_fingerprint.ts` is complete and bound to no hook slot —
+  `grep -c mcp_tool_fingerprint src/scripts/hook_manifest.yaml` returns 0, and its only
+  importer is its own test. Its protection level is therefore zero. Choosing the slot is a
+  trade-off between pre-use interception and observe-only recording that changes the tool
+  invocation path, which is owner-reserved rather than council-decidable. This roadmap
+  carries the decision package and deliberately wires nothing.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-09-05 | reviewer: claude/host -->
+
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | Fail-closed turns a flaky child into a blocked pipeline | implementation | Once a non-zero child exit blocks, any transient spawn failure — a busy runner, a tsx resolution hiccup — reddens CI on a change that touched nothing security-relevant, and the pressure will be to weaken the check rather than fix the flake. | The closed vocabulary includes `skipped(reason)` with reasons as a runner constant, so a genuinely non-applicable child has a legal terminal state that is not `failed`; the Phase 2.1 negative control fixes that a child exiting non-zero *with valid findings* is findings, not a run failure. | Phase 2 — The umbrella fails closed |
+| 2 | The scan count is chosen to clear its own floor | implementation | `scanned: N` is emitted by the same script the floor judges, so a definition of N that counts children rather than artifacts would satisfy the guard while measuring nothing — precisely the failure `gate-coverage.yml` exists to stop. | 3.1's verify requires N to exceed the child count; 3.3 requires a negative control that drives the count below the floor and observes the guard fail. | Phase 3 — The umbrella publishes what it read |
+| 3 | Rooted scanning silently narrows the default scan | implementation | Adding `--root` to five linters risks a refactor in which the default root is computed differently, shrinking the real corpus while every test still passes. | 4.1's verify pins that a flagless run scans the same corpus as today; Phase 3's floor, landed first, turns any silent narrowing into a gate failure rather than a green run. | Phase 4 — The scout's security gate actually reads content |
+| 4 | Fingerprint migration mis-binds a pragma and hides a real finding | implementation | Hashing the wrong unit — whole file instead of the matched evidence — would preserve today's over-broad suppression under a new name and be harder to audit. | 5.1 fixes the hashed unit as the normalized match plus location identity and requires a mutation fixture that proves the binding is content-sensitive; the population is 8 instances, small enough to read by hand as 5.2 requires. | Phase 5 — Suppressions bound to the evidence they accept |
+| 5 | The prose corrections land and the mechanism does not | product | Phase 1 is cheap and Phase 2 is not; a plausible outcome is that the honest hedges ship, the claim is downgraded, and the repair stalls — leaving the package with a documented weakness instead of a fixed one. | 1.3's registry entry carries a `revisit_if` naming Phase 2.2, and 2.4 makes removing the hedges a step of the mechanism phase rather than an optional tidy-up, so `state: degraded` stays visible in a generated surface until the defect is actually closed. | Phase 1 — Truth surfaces before any mechanism |
+| 6 | Publish-surface classification blocks a legitimate release | product | A magic-byte classifier that mislabels a legitimate packed file as `binary` fails the publish path at the worst moment. | 6.2 routes exceptional entries through the Phase 5 bound-pragma grammar rather than a generic allowlist, so an accepted entry is recorded with a reason and a content binding and a later change to that entry re-fires the check. | Phase 6 — The published surface is classified, not just measured |
+
+## Acceptance Criteria
+
+- [ ] AC-1 — No terminal outcome of any of the five umbrella children other than a completed run can produce an aggregate pass; each failure class has a fixture that was green before the repair and names its child after it.
+- [ ] AC-2 — `lint_agent_security` emits one `scanned: <N>` line counting inspected artifacts, is listed in `src/config/gate-coverage.yml` with a CI-identical `argv`, and a negative control drives its count below the floor and reddens `check_gate_coverage`.
+- [ ] AC-3 — `src/config/assurance-capability-registry.json` carries a `self-security-scan` entry whose `state` is `available`, and it reached `available` only after the fail-closed repair merged.
+- [ ] AC-4 — A quarantined candidate carrying a zero-width injection, a disclosure-suppression imperative, or a dangerous frontmatter key is refused by the scout with the flagging linter named, and a clean candidate is still accepted.
+- [ ] AC-5 — Every `security-lint: allow` pragma under `src/` and `docs/` carries a content fingerprint, altering the matched content stops the suppression from applying, and no allowlist file was added.
+- [ ] AC-6 — The packed tarball is classified by type with `binary` and `archive` at zero, and any dotfile or extensionless entry is carried by a path-and-size-bound pragma rather than a generic allowlist.
+- [ ] AC-7 — `docs/CLAIMS.md` and `docs/threat-model.md` assert nothing about dependency auditing, Python pinning, or runtime posture that a grep of `.github/` and the repo root contradicts.
+- [ ] AC-8 — No new gate script, no new hook concern, no new CLI verb, and no second suppression system exists in the tree as a result of this roadmap.

--- a/agents/roadmaps/stubs/road-to-gate-preauth-authorization.md
+++ b/agents/roadmaps/stubs/road-to-gate-preauth-authorization.md
@@ -5,6 +5,8 @@ review_by: 2026-12-24
 
 # Stub: road to a gate pre-authorisation the agent cannot sign
 
+> **Arrivals:** 4 (at least) — latest `inbox-2026-09-m` (2026-09-05); earlier: agents/roadmaps/archive/road-to-gate-autonomy.md, agents/roadmaps/archive/road-to-user-out-of-the-loop.md, one untracked prior round.
+
 > **Stub — not active work.** Drain-run transfer, 2026-08-20, from
 > [`road-to-gate-autonomy.md`](../road-to-gate-autonomy.md) step 2.3.
 > Council disposition **B**, outcome state **transferred**, per the framework of

--- a/agents/roadmaps/stubs/road-to-instructions-loaded-observer.md
+++ b/agents/roadmaps/stubs/road-to-instructions-loaded-observer.md
@@ -6,6 +6,8 @@ probe: none
 
 # Stub: road to the InstructionsLoaded observer, and the fork it would decide
 
+> **Arrivals:** 3 — latest `inbox-2026-09-k` (2026-09-05); earlier: `inbox-2026-09-i` (2026-09-05), agents/roadmaps/archive/road-to-standing-context-40k.md.
+
 > **Stub — not active work.** Drain-run transfer, 2026-08-21, from
 > [`road-to-standing-context-40k.md`](../archive/road-to-standing-context-40k.md)
 > steps 3.0 and 3.1 plus blocker `b-rules-efficiency-signal`. Council

--- a/agents/roadmaps/stubs/road-to-owner-authority-decisions.md
+++ b/agents/roadmaps/stubs/road-to-owner-authority-decisions.md
@@ -6,6 +6,8 @@ probe: none
 
 # Stub: road to the owner-reserved authority decisions
 
+> **Arrivals:** 4 (at least) — latest `inbox-2026-09-m` (2026-09-05); earlier: agents/roadmaps/archive/road-to-gate-autonomy.md, agents/roadmaps/archive/road-to-user-out-of-the-loop.md, one untracked prior round.
+
 > **Stub — not active work.** A **drain-run transfer**, created 2026-08-22 when
 > [`road-to-evidence-based-adr-governance.md`](../archive/road-to-evidence-based-adr-governance.md)
 > was drained. It carries the three decisions that roadmap could not take,

--- a/agents/roadmaps/stubs/road-to-sarif-and-stateful-residual-row.md
+++ b/agents/roadmaps/stubs/road-to-sarif-and-stateful-residual-row.md
@@ -16,6 +16,8 @@ probe: none
 >
 > **Source:** agents/tmp.old/godmod3/road-to-perturbation-family-assurance-and-review-independence.md
 
+> **Arrivals:** 2 — latest `inbox-2026-09-o` (2026-09-05); earlier: the round of 2026-08-24 that created this stub.
+
 ## Why the parent did not land
 
 Roughly 85 percent of the parent draft was already built or already decided.

--- a/agents/roadmaps/stubs/road-to-sep-2640-skill-resources.md
+++ b/agents/roadmaps/stubs/road-to-sep-2640-skill-resources.md
@@ -5,6 +5,8 @@ review_by: 2026-12-24
 
 # Stub: SEP-2640 (`skill://` resources) — a quarterly date carrier
 
+> **Arrivals:** 4 (at least) — latest `inbox-2026-09-k` (2026-09-05); earlier: agents/roadmaps/archive/road-to-skill-delivery-over-mcp.md, agents/roadmaps/archive/road-to-activation-evidence-or-refusal.md, agents/roadmaps/archive/road-to-routing-assurance.md.
+
 > **Stub — not active work, and not deferred work either.** A **date carrier**,
 > like [`road-to-adr-134-expiry.md`](road-to-adr-134-expiry.md): there is no step
 > to promote, only a recurring external check that must stay reachable by grep


### PR DESCRIPTION
Nine inbox rounds drained in one pass. Each round was a transcript plus three to
four model-authored roadmap drafts — claims about a tree that had since moved.
Each was verified against the tree, its steps reproduced rather than read, and
consolidated into exactly one roadmap. Nine roadmaps land, all `status: ready`.

## Point ledger — the coverage figure, not the output figure

| | extracted | disposition |
|---|---|---|
| claims | 255 | still-true 189 · overtaken 11 · never-true 22 · unverifiable 13 |
| instructions | 188 | reproduced 50 · diverged 21 · unexecutable 10 · out-of-bound 35 · not-attempted 72 |
| demands | 76 | adopted 22 · already-satisfied 22 · declined 16 · owner-decision 16 |

`not-attempted` is the selection bound plus the per-round ceilings, named in
each round's own analysis record.

## What verification prevented

The most valuable finding class is `already-fixed`, because it deletes work
before it is planned:

- Round h — the analysis engine, the crypto resolver, the gitignored landing
  zone and the pre-registered measurement all already exist. Four phases dropped.
- Round i — six planned items already ship (concern dispatcher, five `hooks:*`
  verbs, `--json` coverage, injection budget, typed payload deps, probe state).
- Round k — the master's own audit killed 16 parent items; verification
  confirmed the load-bearing ones. Roughly two thirds never reached a step.
- Round n — ten proposed new modules exist today under `scripts/ai_council/`
  and `_lib/`; the "no separate money-vs-entitlement budget" claim is false,
  both budgets predate the draft.
- Round o — the proposed "Inspection Ledger" is `src/config/gate-coverage.yml`.
  An entire phase deleted; the roadmap adds zero gates and zero concerns.
- Round p — `archive/road-to-experience-loop-broadening.md` already delivered
  seven of the nine claimed gaps.

## Corrections carried into the roadmaps

Twenty-one steps diverged on reproduction and ship corrected, tagged
`corrected-from-reproduction`. The load-bearing ones:

- concern count is 56, not 72 · active estate is 1, not the 5/6/7/8 the drafts
  variously assumed · the stale-host claim touches six surfaces, not four
- round l's "218 of 299 skills carry a When-NOT-to-use" census reproduces at 12
  literal or 79 loosest — no reading yields 218; its sibling "44 of 299" figure
  has no matcher defined anywhere and was dropped
- round n's "22 scripts depend on `ask_transport`" is 4; the freeze it cites was
  ADR-211 struck by ADR-216, not either of the two ADRs it names
- round p found two fabricated quotations: ADR-109 has no "amendment only"
  clause, and the word *curator* appears nowhere in the tree

## Three TERMINAL honest-nulls re-proposed and refused

- `recursive-verification` — attempt/critic/re-attempt, capability delta 0,
  McNemar p = 1.0
- `adversarial-council-finding-coverage` — `resolved-null`, default-off
  permanently; the drafts re-propose it without the new corpus its own re-open
  condition requires
- the activation resolver — 0 of 67 adjudicated failures, plus `ADR-054:
  rejected` and `rule-router.md`'s "no runtime resolver"

None became a step. Where the work is still wanted it is a blocker naming the
null as the lock.

## Reconciled mid-flight against ADR-254

`ADR-254-git-authorization-enforcement-removed` landed on `main` while round m
was being analysed, deleting the `block-unauthorized-git` concern and the
enforcing half of its script. Round m's roadmap planned to extend exactly that.
It was rebuilt against the post-merge tree: the advisory ledger survives and
keeps its work, the gate-shaped items became one blocker quoting ADR-254's own
"explicitly NOT a trigger" clause, and every citation was re-pinned. Seven
further citations in round i moved with the same merge and were corrected.

## Estate

`active_roadmaps` 1 → 10, `open_blockers` 29 → 54. Every roadmap carries both
`estate_growth_exempt` and `estate_offset_exempt` with a real reason, and
`check_estate_count` passes with the nine claims printed.

## Owner decisions waiting

Twenty-five blockers, all `Status: open`, owner `maintainer`, each with a
decidable `Resolved when`. The reserved ones — lowering the Hard Floor's scope,
flipping the autonomy default, kernel-rule and governance self-amendment,
lowering the tool-safety floor, reopening a rejected ADR, and every
spend-bearing council decision — are blockers by construction and never steps.

## Source handling

The nine inbox directories arrived under speaking names, one of them a living
person's. All were renamed to opaque round ids before analysis; the true source
of each is recorded once, `ENC1:`-encrypted, in that round's intake note under
the gitignored inbox. No roadmap names an external repository, project or
person. `check_no_external_sources` passes.

## Not fixed here

The `block-speaking-inbox-dir` guard denies a compliant opaque round id when the
inbox path is written through a shell variable rather than spelled out. The guard
scans the literal command text, so an unexpanded variable in the final path
segment reads as a speaking name and the call is refused even though every id it
could produce is opaque. Reproduced four times this run — twice on a `mv` that
was moving files *out* of the inbox, and once on the first draft of this very
paragraph. Worked around by spelling all nine paths out; reported rather than
fixed, because editing a `pre_tool_use` guard is outside this change's scope.
