### PR TITLE
fix(release): make the curated-head refusal recoverable from where it stops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,26 @@ Entry-shape contract: [`docs/contracts/CHANGELOG-conventions.md`](docs/contracts
 
 ### Fixed
 
+- **The curated-head refusal is recoverable again — its own remedy was refused
+  by the preflight.** `guard_release_curation` stops between step 2 and step 3,
+  leaving HEAD on the local `release/X.Y.Z` with the generated section
+  uncommitted, and tells the operator to curate the head and re-run
+  `task release`. Measured on 14.19.0, every spelling of that re-run died
+  *before step 1*: a plain run on `release must run from 'main'`, and
+  `--resume` on `working tree is not clean` — against the pipeline's own
+  step-2 output. The only way through was to hand-craft the `release: X.Y.Z`
+  commit the pipeline makes for itself one step later.
+  `docs/release-runbook.md` claimed this had been closed on 2026-09-03; that
+  fix landed in `checkout_release_branch`, which is step 1 and therefore
+  unreachable from the position the guard creates — the claim was not wrong
+  about step 1, it was wrong that step 1 was reachable. The start position is
+  now one pure verdict, `preflightPosition`: `release/{target}` is legal with
+  or without `--resume`, and a dirty tree is accepted **there only**, with the
+  swept files printed. A dirty `main` still refuses, because there the same
+  tree is an operator's unrelated work about to enter a release commit. Pinned
+  by `tests/scripts/release.test.ts` § `preflightPosition`, including a wiring
+  assertion so a pure verdict nobody calls cannot pass.
+
 - **Release gates now refuse before the push, not on the release PR.** 14.17.0
   (PR #1856) failed `check_release_highlights` on a missing
   `> **Governance mix:**` line — an assertion reproducible locally in under two

--- a/agents/evidence/release-findings/14.19.0.json
+++ b/agents/evidence/release-findings/14.19.0.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "release": "14.19.0",
+  "review_independence": "unknown",
+  "context_relation": "unknown",
+  "acceptance_status": "provisional",
+  "assurance": "unreviewed",
+  "reviewers": [],
+  "no_findings_reason": "NOT REVIEWED — the finding set is empty because no review produced one, not because a review produced none. The self-review gate ran on release/14.19.0 as workflow run 34064367158 and its live-advisory job went NEUTRAL: the Anthropic call returned HTTP 400 `prompt is too long: 450336 tokens > 200000 maximum` (request_id req_011CenywEpYsmsgvvRq91Ggo), after which the upload step logged `No files were found with the provided path: /tmp/self-review-findings.json` and uploaded no artifact. PR #1886 carries no `release-findings-json` machine block, so there is nothing to ingest from either surface. THIRD CONSECUTIVE RELEASE with this cause and the prompt is GROWING: 14.18.0 measured 413191 tokens against the same 200000 cap, 14.19.0 measures 450336. Recording the reason is what the closed roadmap road-to-the-ledger-two-releases-skipped did; it does not shrink the prompt, so 14.20.0 will reproduce this unless the gate learns to chunk or scope the release-span diff. Falsifiable: if run 34064367158's log shows a completed model call, or an artifact or machine block for 14.19.0 is produced, this reason is wrong and the ledger must be re-ingested. Recorded 2026-09-07 while landing the release-preflight start-position fix; the two are unrelated defects from the same release run.",
+  "findings": []
+}

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -191,14 +191,34 @@ doing it, so a crash localises to a step.
 An existing `release/X.Y.Z` is checked out whether or not `--resume` was
 passed, and if it is behind `origin/main` the default branch is merged in
 right there. Both arms used to be gated on `resume`, so a plain re-run over an
-existing branch fell through to `git checkout -b` and died with exit 128 — the
-exact state the curated-head guard leaves behind, while its own message says to
-re-run `task release`. A branch cut from an older `main` also used to survive
-until the pre-push preflight reported `branch is BEHIND origin/main`, six steps
-after the cheapest moment to fix it. A NEW branch is now cut from current
-`origin/main` rather than from whatever the local ref happened to be, which is
-the same defect from its third side. Pinned by the drill scenarios
+existing branch fell through to `git checkout -b` and died with exit 128. A
+branch cut from an older `main` also used to survive until the pre-push
+preflight reported `branch is BEHIND origin/main`, six steps after the cheapest
+moment to fix it. A NEW branch is now cut from current `origin/main` rather
+than from whatever the local ref happened to be, which is the same defect from
+its third side. Pinned by the drill scenarios
 `plain-run-reuses-an-existing-branch` and `stale-branch-merges-main-at-step-1`.
+
+**Corrected 2026-09-07 — the paragraph above used to end by claiming this also
+closed the curated-head guard's remedy. It did not, and 14.19.0 measured it.**
+`guard_release_curation` stops between step 2 and step 3, leaving HEAD on the
+local `release/X.Y.Z` with the generated section uncommitted in the tree, and
+says to re-run `task release`. Every spelling of that re-run was refused by the
+**preflight**, which runs *before* step 1 and therefore never reached the code
+the 2026-09-03 fix had repaired:
+
+| re-run | refusal, before step 1 |
+|---|---|
+| `task release` | `release must run from 'main', currently on 'release/X.Y.Z'` |
+| `task release -- --resume` | `working tree is not clean; commit or stash first` |
+
+The only way through was to hand-craft the `release: X.Y.Z` commit the pipeline
+makes for itself one step later. The start position is now one pure function,
+`preflightPosition` in `src/scripts/release.ts`: `release/{target}` is a legal
+start with or without `--resume`, and a dirty tree is accepted **there only**,
+with the files printed — on `main` that same tree still refuses, because there
+it is an operator's unrelated work about to be swept into a release commit.
+Pinned by `tests/scripts/release.test.ts` § `preflightPosition`.
 
 `--resume` is still the right flag when a run left a COMMIT, a PR, a tag or a
 Release behind: those skips are what it is for. It is no longer the difference
@@ -213,6 +233,11 @@ between a re-run working and crashing.
 
 ## 6. What can go wrong (known checkpoints)
 
+- **`the X.Y.Z release highlights are still the generator's draft`** → the
+  curated-head / governance-mix obligation. Edit the `## [X.Y.Z]` section in
+  `CHANGELOG.md` **on the `release/X.Y.Z` branch you are already standing on**,
+  then re-run `task release`. Nothing has been committed or pushed; the dirty
+  tree is expected and is swept into the release commit by step 3.
 - **Release PR checks stuck "expected"** → the approve-workflows checkpoint in
   § 3.A step 3. Not a failure; click approve.
 - **Consistency check red on the release PR** → step 4's `task release-prepare`

--- a/src/scripts/_lib/release_position.ts
+++ b/src/scripts/_lib/release_position.ts
@@ -1,0 +1,96 @@
+/**
+ * Where a release may START — the branch it may run from, and whether a dirty
+ * working tree is tolerated there.
+ *
+ * Its own module because `release.ts` sits 456 lines over the 1500-line source
+ * ratchet, so growing it is a gate failure by construction. `_lib/` is where
+ * `release_highlights.ts` and `release_material.ts` already put the predicates
+ * the pipeline and its gates share.
+ */
+
+export interface PositionVerdict {
+    proceed: boolean;
+    /** Printed before the run continues. Never a refusal. */
+    notice?: string;
+    /** Printed on refusal (no trailing newline). */
+    message?: string;
+}
+
+/**
+ * Where a release may START, resolved as a pure verdict (no I/O, so it is
+ * unit-testable — same shape as `confirmGate`).
+ *
+ * THE DEADLOCK THIS REMOVES.
+ *
+ * `guard_release_curation` refuses BETWEEN step 2 and step 3: step 1 has
+ * already created and checked out `release/{target}`, step 2 has already
+ * written the bump, the changelog section and every regenerated derived file,
+ * and nothing is committed yet. Its message says to curate the head and re-run
+ * `task release`. Measured on 14.19.0, neither re-run reached step 1:
+ *
+ *   - `task release`            → `release must run from 'main'` (this check)
+ *   - `task release --resume`   → `working tree is not clean` (this check)
+ *
+ * So the guard prescribed a remedy the preflight refused, in both spellings,
+ * and the only way through was to hand-craft the `release: X.Y.Z` commit the
+ * pipeline makes for itself one step later.
+ *
+ * `docs/release-runbook.md` already claimed this was closed on 2026-09-03 and
+ * the drill pins `plain-run-reuses-an-existing-branch` for it. Both were true
+ * of the fix that landed — in `checkout_release_branch`, which is STEP 1. The
+ * preflight runs before step 1, so from the release branch the run never
+ * arrived at the code that had been repaired. The claim was not wrong about
+ * step 1; it was wrong that step 1 was reachable from that position.
+ *
+ * Why `release/{target}` is a legitimate start, with or without `--resume`:
+ *
+ * It is the position the pipeline itself leaves behind. `--resume` remains
+ * meaningful for what it was always for — skipping a COMMIT, a PR, a tag or a
+ * Release that already exists — and the `!resume` tag-exists check in
+ * `preflight` still refuses a plain re-run of an already-tagged version.
+ *
+ * Why a dirty tree is accepted THERE and nowhere else:
+ *
+ * On `release/{target}` the dirt is this pipeline's own step-2 output, and
+ * step 3 sweeps it with `git add -A` regardless. Refusing it can therefore
+ * only ever fire against the tool's own state. On `main` the same tree is an
+ * operator's unrelated work about to be swept into a release commit, so the
+ * refusal stays exactly as it was. The accepted files are PRINTED rather than
+ * absorbed silently, and `check_release_pr_shape` still refuses anything
+ * outside the version-bump allowlist on the resulting PR — two nets under the
+ * one place this relaxes.
+ */
+export function preflightPosition(opts: {
+    branch: string;
+    mainBranch: string;
+    releaseBranch: string;
+    porcelain: string;
+}): PositionVerdict {
+    const { branch, mainBranch, releaseBranch, porcelain } = opts;
+    if (branch !== mainBranch && branch !== releaseBranch) {
+        return {
+            proceed: false,
+            message:
+                `release must run from '${mainBranch}' or '${releaseBranch}', ` +
+                `currently on '${branch}'`,
+        };
+    }
+    if (!porcelain.trim()) {
+        return { proceed: true };
+    }
+    if (branch === mainBranch) {
+        return { proceed: false, message: 'working tree is not clean; commit or stash first' };
+    }
+    return {
+        proceed: true,
+        notice:
+            `working tree is not clean, and on '${releaseBranch}' that is this pipeline's own ` +
+            'step-2 output — step 3 commits it with `git add -A`. Files that will be swept ' +
+            'into the release commit:\n' +
+            porcelain
+                .split('\n')
+                .filter((l) => l.trim())
+                .map((l) => `      ${l}`)
+                .join('\n'),
+    };
+}

--- a/src/scripts/release.ts
+++ b/src/scripts/release.ts
@@ -49,8 +49,10 @@
  * Idempotency: pass `--resume` to recover from a partial failure. Each
  * step then probes existing state (branch, commit, PR, tag, GitHub
  * Release) and skips work that is already done, instead of erroring out.
- * Without `--resume` the pipeline still mutates git/network state, so
- * re-running on a dirty tree needs `--resume` (or a manual cleanup). The
+ * Re-running from `release/{target}` needs neither the flag nor a clean
+ * tree — that position, dirty, is the state `guard_release_curation` leaves
+ * behind, and `preflightPosition` accepts it (a dirty `main` still refuses).
+ * The
  * two entry points guard against colliding with each other via these same
  * probes plus the CI workflow's concurrency group — whichever starts
  * second sees the other's in-progress state and skips or refuses cleanly.
@@ -781,20 +783,106 @@ export function assert_scheduled_deprecations_clear(
 
 // ─── preflight ────────────────────────────────────────────────────────────────
 
+export interface PositionVerdict {
+    proceed: boolean;
+    /** Printed before the run continues. Never a refusal. */
+    notice?: string;
+    /** Printed on refusal (no trailing newline). */
+    message?: string;
+}
+
+/**
+ * Where a release may START, resolved as a pure verdict (no I/O, so it is
+ * unit-testable — same shape as `confirmGate`).
+ *
+ * ## The deadlock this removes
+ *
+ * `guard_release_curation` refuses BETWEEN step 2 and step 3: step 1 has
+ * already created and checked out `release/{target}`, step 2 has already
+ * written the bump, the changelog section and every regenerated derived file,
+ * and nothing is committed yet. Its message says to curate the head and re-run
+ * `task release`. Measured on 14.19.0, neither re-run reached step 1:
+ *
+ *   - `task release`            → `release must run from 'main'` (this check)
+ *   - `task release --resume`   → `working tree is not clean` (this check)
+ *
+ * So the guard prescribed a remedy the preflight refused, in both spellings,
+ * and the only way through was to hand-craft the `release: X.Y.Z` commit the
+ * pipeline makes for itself one step later.
+ *
+ * `docs/release-runbook.md` already claimed this was closed on 2026-09-03 and
+ * the drill pins `plain-run-reuses-an-existing-branch` for it. Both were true
+ * of the fix that landed — in `checkout_release_branch`, which is STEP 1. The
+ * preflight runs before step 1, so from the release branch the run never
+ * arrived at the code that had been repaired. The claim was not wrong about
+ * step 1; it was wrong that step 1 was reachable from that position.
+ *
+ * ## Why `release/{target}` is a legitimate start, with or without `--resume`
+ *
+ * It is the position the pipeline itself leaves behind. `--resume` remains
+ * meaningful for what it was always for — skipping a COMMIT, a PR, a tag or a
+ * Release that already exists — and the `!resume` tag-exists check in
+ * `preflight` still refuses a plain re-run of an already-tagged version.
+ *
+ * ## Why a dirty tree is accepted THERE and nowhere else
+ *
+ * On `release/{target}` the dirt is this pipeline's own step-2 output, and
+ * step 3 sweeps it with `git add -A` regardless. Refusing it can therefore
+ * only ever fire against the tool's own state. On `main` the same tree is an
+ * operator's unrelated work about to be swept into a release commit, so the
+ * refusal stays exactly as it was. The accepted files are PRINTED rather than
+ * absorbed silently, and `check_release_pr_shape` still refuses anything
+ * outside the version-bump allowlist on the resulting PR — two nets under the
+ * one place this relaxes.
+ */
+export function preflightPosition(opts: {
+    branch: string;
+    mainBranch: string;
+    releaseBranch: string;
+    porcelain: string;
+}): PositionVerdict {
+    const { branch, mainBranch, releaseBranch, porcelain } = opts;
+    if (branch !== mainBranch && branch !== releaseBranch) {
+        return {
+            proceed: false,
+            message:
+                `release must run from '${mainBranch}' or '${releaseBranch}', ` +
+                `currently on '${branch}'`,
+        };
+    }
+    if (!porcelain.trim()) {
+        return { proceed: true };
+    }
+    if (branch === mainBranch) {
+        return { proceed: false, message: 'working tree is not clean; commit or stash first' };
+    }
+    return {
+        proceed: true,
+        notice:
+            `working tree is not clean, and on '${releaseBranch}' that is this pipeline's own ` +
+            'step-2 output — step 3 commits it with `git add -A`. Files that will be swept ' +
+            'into the release commit:\n' +
+            porcelain
+                .split('\n')
+                .filter((l) => l.trim())
+                .map((l) => `      ${l}`)
+                .join('\n'),
+    };
+}
+
 /**
  * Fail fast on conditions that would break the release mid-flight.
  *
- * In `--resume` mode two invariants are relaxed:
+ * The start position — which branch, and whether a dirty tree is tolerated —
+ * is `preflightPosition` above, and it is NO LONGER gated on `--resume`:
+ * `release/{target}` is where `guard_release_curation` leaves the operator, so
+ * refusing it there made the guard's own remedy unreachable. Read that
+ * function's header for the measurement.
  *
- * - The starting branch may be `release/{target}` in addition to `main` —
- *   both are valid resume positions (mid-pipeline crash after step 1 leaves
- *   you on the release branch).
- * - The target-tag-exists check is dropped — execute() probes for existing
- *   tags/releases and skips them.
+ * `--resume` still relaxes ONE invariant here: the target-tag-exists check is
+ * dropped, because execute() probes for existing tags/releases and skips them.
  *
- * Tree cleanliness, gh auth, and `main` in-sync with origin are still
- * enforced, so resuming has the same starting posture as a fresh run; only
- * step-level outcomes differ.
+ * gh auth and `main` in-sync with origin are enforced either way.
  *
  * `opts.ci` swaps the gh-auth probe (see below) for the CI-mode variant —
  * everything else is identical between the two entry points.
@@ -832,20 +920,17 @@ function preflight(target: string, opts: { resume?: boolean; ci?: boolean } = {}
 
     const branch = git(['rev-parse', '--abbrev-ref', 'HEAD'], { capture: true });
     const release_branch = `release/${target}`;
-    const allowed = resume ? new Set([MAIN_BRANCH, release_branch]) : new Set([MAIN_BRANCH]);
-    if (!allowed.has(branch)) {
-        if (resume) {
-            die(
-                `resume must run from '${MAIN_BRANCH}' or '${release_branch}', ` +
-                    `currently on '${branch}'`,
-            );
-        }
-        die(`release must run from '${MAIN_BRANCH}', currently on '${branch}'`);
+    const position = preflightPosition({
+        branch,
+        mainBranch: MAIN_BRANCH,
+        releaseBranch: release_branch,
+        porcelain: git(['status', '--porcelain'], { capture: true }),
+    });
+    if (!position.proceed) {
+        die(position.message ?? `release cannot start from '${branch}'`);
     }
-
-    const porcelain = git(['status', '--porcelain'], { capture: true });
-    if (porcelain) {
-        die('working tree is not clean; commit or stash first');
+    if (position.notice) {
+        process.stdout.write(`\u26a0\ufe0f  ${position.notice}\n`);
     }
 
     // --force lets the remote's tag positions win over stale local tags.

--- a/src/scripts/release.ts
+++ b/src/scripts/release.ts
@@ -126,6 +126,7 @@ import {
     derive_category_hits,
     render_derived_head_values,
 } from './_lib/release_highlights.js';
+import { preflightPosition } from './_lib/release_position.js';
 import {
     RELEASE_HEAD_DEFAULT,
     extract_changelog_section,
@@ -783,98 +784,12 @@ export function assert_scheduled_deprecations_clear(
 
 // ─── preflight ────────────────────────────────────────────────────────────────
 
-export interface PositionVerdict {
-    proceed: boolean;
-    /** Printed before the run continues. Never a refusal. */
-    notice?: string;
-    /** Printed on refusal (no trailing newline). */
-    message?: string;
-}
-
-/**
- * Where a release may START, resolved as a pure verdict (no I/O, so it is
- * unit-testable — same shape as `confirmGate`).
- *
- * ## The deadlock this removes
- *
- * `guard_release_curation` refuses BETWEEN step 2 and step 3: step 1 has
- * already created and checked out `release/{target}`, step 2 has already
- * written the bump, the changelog section and every regenerated derived file,
- * and nothing is committed yet. Its message says to curate the head and re-run
- * `task release`. Measured on 14.19.0, neither re-run reached step 1:
- *
- *   - `task release`            → `release must run from 'main'` (this check)
- *   - `task release --resume`   → `working tree is not clean` (this check)
- *
- * So the guard prescribed a remedy the preflight refused, in both spellings,
- * and the only way through was to hand-craft the `release: X.Y.Z` commit the
- * pipeline makes for itself one step later.
- *
- * `docs/release-runbook.md` already claimed this was closed on 2026-09-03 and
- * the drill pins `plain-run-reuses-an-existing-branch` for it. Both were true
- * of the fix that landed — in `checkout_release_branch`, which is STEP 1. The
- * preflight runs before step 1, so from the release branch the run never
- * arrived at the code that had been repaired. The claim was not wrong about
- * step 1; it was wrong that step 1 was reachable from that position.
- *
- * ## Why `release/{target}` is a legitimate start, with or without `--resume`
- *
- * It is the position the pipeline itself leaves behind. `--resume` remains
- * meaningful for what it was always for — skipping a COMMIT, a PR, a tag or a
- * Release that already exists — and the `!resume` tag-exists check in
- * `preflight` still refuses a plain re-run of an already-tagged version.
- *
- * ## Why a dirty tree is accepted THERE and nowhere else
- *
- * On `release/{target}` the dirt is this pipeline's own step-2 output, and
- * step 3 sweeps it with `git add -A` regardless. Refusing it can therefore
- * only ever fire against the tool's own state. On `main` the same tree is an
- * operator's unrelated work about to be swept into a release commit, so the
- * refusal stays exactly as it was. The accepted files are PRINTED rather than
- * absorbed silently, and `check_release_pr_shape` still refuses anything
- * outside the version-bump allowlist on the resulting PR — two nets under the
- * one place this relaxes.
- */
-export function preflightPosition(opts: {
-    branch: string;
-    mainBranch: string;
-    releaseBranch: string;
-    porcelain: string;
-}): PositionVerdict {
-    const { branch, mainBranch, releaseBranch, porcelain } = opts;
-    if (branch !== mainBranch && branch !== releaseBranch) {
-        return {
-            proceed: false,
-            message:
-                `release must run from '${mainBranch}' or '${releaseBranch}', ` +
-                `currently on '${branch}'`,
-        };
-    }
-    if (!porcelain.trim()) {
-        return { proceed: true };
-    }
-    if (branch === mainBranch) {
-        return { proceed: false, message: 'working tree is not clean; commit or stash first' };
-    }
-    return {
-        proceed: true,
-        notice:
-            `working tree is not clean, and on '${releaseBranch}' that is this pipeline's own ` +
-            'step-2 output — step 3 commits it with `git add -A`. Files that will be swept ' +
-            'into the release commit:\n' +
-            porcelain
-                .split('\n')
-                .filter((l) => l.trim())
-                .map((l) => `      ${l}`)
-                .join('\n'),
-    };
-}
-
 /**
  * Fail fast on conditions that would break the release mid-flight.
  *
  * The start position — which branch, and whether a dirty tree is tolerated —
- * is `preflightPosition` above, and it is NO LONGER gated on `--resume`:
+ * is `preflightPosition` in `_lib/release_position.ts`, and it is NO LONGER
+ * gated on `--resume`:
  * `release/{target}` is where `guard_release_curation` leaves the operator, so
  * refusing it there made the guard's own remedy unreachable. Read that
  * function's header for the measurement.

--- a/src/scripts/release_publication.ts
+++ b/src/scripts/release_publication.ts
@@ -731,8 +731,12 @@ export function guard_release_curation(version: string, prMerged = false): void 
                   marked.join('\n')
                 : '') +
             '\n    Stopped BEFORE committing — no release commit, no branch on ' +
-            `${REMOTE}, no pull request, no tag. Curate the ` +
-            '`### Release highlights` head, then re-run `task release`.',
+            `${REMOTE}, no pull request, no tag. HEAD is on the LOCAL ` +
+            `\`release/${version}\` branch and the generated section is in the working ` +
+            'tree: curate the `### Release highlights` head in `CHANGELOG.md` there, then ' +
+            're-run `task release`. That re-run works from this position — `preflightPosition` ' +
+            'accepts the release branch with the uncommitted step-2 output, which it did not ' +
+            'until 2026-09-07 (both spellings of the re-run were refused before step 1).',
     );
 }
 

--- a/tests/scripts/release.test.ts
+++ b/tests/scripts/release.test.ts
@@ -54,6 +54,7 @@ import {
     SEMVER_RE,
     _RELEASE_BRANCH_RE,
     confirmGate,
+    preflightPosition,
     resolve_split_decision,
 } from '../../src/scripts/release.js';
 import {
@@ -692,6 +693,93 @@ describe('confirmGate — pre-execute confirmation verdict', () => {
         expect(v.stream).toBe('stderr');
         expect(v.message).toContain('--yes');
         expect(v.message).not.toMatch(/^aborted\.?$/); // actionable, not a bare silent abort
+    });
+});
+
+// ─── preflight start position — the curated-head refusal must be recoverable ──
+// Regression lock for the deadlock measured on 14.19.0. `guard_release_curation`
+// stops BETWEEN step 2 (writes the bump + the changelog section) and step 3
+// (commits them), leaving HEAD on the local `release/X.Y.Z` with a dirty tree,
+// and its own message says to re-run `task release`. Both spellings of that
+// re-run were then refused by the preflight, before step 1:
+//
+//   task release           → "release must run from 'main'"
+//   task release --resume  → "working tree is not clean"
+//
+// `docs/release-runbook.md` claimed this was closed on 2026-09-03; that fix
+// landed in `checkout_release_branch`, which is step 1 — unreachable from the
+// position the guard creates. These cases pin the position rule itself, which
+// is what the guard's remedy actually depends on.
+describe('preflightPosition — where a release may start', () => {
+    const base = { mainBranch: 'main', releaseBranch: 'release/9.0.0' };
+
+    it('THE DEADLOCK: release branch + dirty tree proceeds, and names what gets swept', () => {
+        const v = preflightPosition({
+            ...base,
+            branch: 'release/9.0.0',
+            porcelain: ' M CHANGELOG.md\n M package.json',
+        });
+        expect(v.proceed).toBe(true);
+        expect(v.message).toBeUndefined();
+        // The files are printed, never absorbed silently — that is the whole
+        // reason this is a `notice` and not just a dropped check.
+        expect(v.notice).toContain('CHANGELOG.md');
+        expect(v.notice).toContain('package.json');
+    });
+
+    it('the same position with no --resume equivalent: the rule is not resume-gated', () => {
+        // `preflightPosition` takes no `resume` argument by construction. If a
+        // future edit reintroduces one, this case is what notices.
+        expect(preflightPosition({ ...base, branch: 'release/9.0.0', porcelain: '' })).toEqual({
+            proceed: true,
+        });
+    });
+
+    it('a dirty tree on main still refuses — that dirt is the operator\'s, not the pipeline\'s', () => {
+        const v = preflightPosition({ ...base, branch: 'main', porcelain: ' M src/foo.ts' });
+        expect(v.proceed).toBe(false);
+        expect(v.message).toBe('working tree is not clean; commit or stash first');
+    });
+
+    it('a clean main proceeds with no notice', () => {
+        expect(preflightPosition({ ...base, branch: 'main', porcelain: '' })).toEqual({
+            proceed: true,
+        });
+    });
+
+    it('any other branch refuses, and the message names both legal positions', () => {
+        const v = preflightPosition({ ...base, branch: 'feat/whatever', porcelain: '' });
+        expect(v.proceed).toBe(false);
+        expect(v.message).toContain("'main'");
+        expect(v.message).toContain("'release/9.0.0'");
+        expect(v.message).toContain("'feat/whatever'");
+    });
+
+    it('a release branch for a DIFFERENT target is not a start position', () => {
+        const v = preflightPosition({ ...base, branch: 'release/8.9.9', porcelain: '' });
+        expect(v.proceed).toBe(false);
+        expect(v.message).toContain("currently on 'release/8.9.9'");
+    });
+
+    it('whitespace-only porcelain is clean, not dirty', () => {
+        expect(preflightPosition({ ...base, branch: 'main', porcelain: '\n  \n' })).toEqual({
+            proceed: true,
+        });
+    });
+
+    // A pure verdict nothing calls is the failure mode this pair of assertions
+    // exists for: the seven cases above would stay green while `preflight` kept
+    // its own inline refusals. Structural rather than behavioural because the
+    // real `preflight` reaches `gh api user`, a network fetch and a tag probe,
+    // none of which belong in a unit test.
+    it('is WIRED — preflight delegates the position rule instead of re-implementing it', () => {
+        const src = fs.readFileSync(TS_SCRIPT, 'utf-8');
+        const body = src.slice(src.indexOf('function preflight(target: string'));
+        expect(body).toContain('preflightPosition({');
+        // The two refusals that produced the deadlock must live in the pure
+        // function only — never a second copy inside preflight.
+        expect(body).not.toContain("die('working tree is not clean");
+        expect(body).not.toContain('release must run from');
     });
 });
 

--- a/tests/scripts/release.test.ts
+++ b/tests/scripts/release.test.ts
@@ -24,6 +24,8 @@ import { fileURLToPath } from 'node:url';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { preflightPosition } from '../../src/scripts/_lib/release_position.js';
+
 import {
     RELEASE_HEAD_CAP_LINES,
     dedupe_commit_lines,
@@ -54,7 +56,6 @@ import {
     SEMVER_RE,
     _RELEASE_BRANCH_RE,
     confirmGate,
-    preflightPosition,
     resolve_split_decision,
 } from '../../src/scripts/release.js';
 import {
@@ -774,6 +775,7 @@ describe('preflightPosition — where a release may start', () => {
     // none of which belong in a unit test.
     it('is WIRED — preflight delegates the position rule instead of re-implementing it', () => {
         const src = fs.readFileSync(TS_SCRIPT, 'utf-8');
+        expect(src).toContain("from './_lib/release_position.js'");
         const body = src.slice(src.indexOf('function preflight(target: string'));
         expect(body).toContain('preflightPosition({');
         // The two refusals that produced the deadlock must live in the pure


### PR DESCRIPTION
## The defect

`guard_release_curation` stops **between step 2 and step 3**: step 1 has already created and checked out `release/X.Y.Z`, step 2 has written the bump + the changelog section + every regenerated derived file, and nothing is committed. Its message says to curate the head and re-run `task release`.

Measured on the 14.19.0 release, every spelling of that re-run died **before step 1**:

| re-run | refusal |
|---|---|
| `task release` | `release must run from 'main', currently on 'release/14.19.0'` |
| `task release -- --resume` | `working tree is not clean; commit or stash first` |

The second fires against the pipeline's **own** step-2 output. The only way through was to hand-craft the `release: X.Y.Z` commit the pipeline makes for itself one step later — which is what unblocked 14.19.0.

`docs/release-runbook.md:190-199` already claimed this was closed on 2026-09-03, and the drill pins `plain-run-reuses-an-existing-branch` for it. Both are true of the fix that landed — in `checkout_release_branch`, which is **step 1**. The preflight runs before step 1, so from the release branch the run never reached the repaired code. The claim was not wrong about step 1; it was wrong that step 1 was reachable from that position.

## The change

The start position becomes one pure verdict, `preflightPosition` in `src/scripts/release.ts`:

- `release/{target}` is a legal start **with or without** `--resume` — it is the position the pipeline itself leaves behind. `--resume` keeps its real job (skipping an existing commit / PR / tag / Release), and the `!resume` tag-exists check still refuses a plain re-run of an already-tagged version.
- A dirty tree is accepted **there only**, and the files are **printed**, not absorbed silently. On `main` the identical tree still refuses, because there it is an operator's unrelated work about to be swept into a release commit. `check_release_pr_shape` remains the second net on the resulting PR.
- `guard_release_curation`'s message now names the position it leaves and states that the re-run works from it.

## Evidence

`tests/scripts/release.test.ts` § `preflightPosition` — 8 cases. Sensitivity checked in both directions before the fix was kept:

- reverting the dirty-tree rule reds `THE DEADLOCK: release branch + dirty tree proceeds` (1 failed / 6 passed)
- reverting the branch rule reds that plus `the rule is not resume-gated` (2 failed / 5 passed)

One case is structural rather than behavioural and says so: a **wiring assertion** that `preflight` delegates to the verdict instead of keeping its own copies of the two refusals — the seven behavioural cases would otherwise stay green while nothing called the function. The real `preflight` reaches `gh api user`, a network fetch and a tag probe, which do not belong in a unit test.

`tests/scripts/release.test.ts` (112) + `release_drill.test.ts` + `release_push_failure_masking.test.ts` = 146 passed. `tsc --noEmit` clean, `eslint` clean on the three touched sources.

## What this deliberately does NOT change

The curated-head / governance-mix obligation itself. `ADR-253` and `docs/contracts/CHANGELOG-conventions.md § Governance-versus-product response` require a **human** sentence, and the placeholder sentinel exists precisely so a generator cannot discharge its own written-answer obligation. This PR makes that refusal recoverable; it does not make it cheaper to ignore.

## Known limitation, not addressed here

`## [Unreleased]` in `CHANGELOG.md` still carries entries that shipped in 14.19.0 — it was already stale at the 14.18.0 tag, so it is pre-existing and out of this diff's scope.