### PR TITLE
fix(roadmaps): drop the reversed depends edge on the parked cost roadmap

### DIFF
--- a/agents/roadmaps/road-to-delivery-for-every-host.md
+++ b/agents/roadmaps/road-to-delivery-for-every-host.md
@@ -4,13 +4,13 @@ status: ready
 execution:
   mode: phase-checkpoints
 owner: maintainer
-depends: road-to-mixed-trigger-activation-cost
 relates:
   - slug: road-to-mixed-trigger-activation-cost
-    relation: depends
+    relation: disjoint
     note: >
       Parked. Phase 2 labels exactly the mixed triggers that roadmap prices; its
-      cost model consumes this file's corpus, not the reverse.
+      cost model consumes this file's corpus, not the reverse — the edge runs the
+      other way, so this file declares no dependency and waits on nothing parked.
   - slug: road-to-host-enforcement-truth
     relation: extends
     note: >


### PR DESCRIPTION
## What

`agents/roadmaps/road-to-delivery-for-every-host.md` carried a top-level `depends: road-to-mixed-trigger-activation-cost` plus a mirrored `relation: depends` row. The direction was inverted — the parked roadmap's cost model consumes this file's corpus, not the reverse, which that row's own note already stated.

Mechanically harmless: `depends:` only orders members **inside a set run** (templates/roadmaps.md:193-209), and a `later/` roadmap is never a set member, so nothing was blocked. But a reader following the line concludes this file waits on something parked.

## Why not the literal reviewer fix

The review asked to "remove the top-level `depends:` and keep only the `relates:` row". That alone reds `lint_roadmap_complexity.ts:492`, which requires every `relation: depends` row to mirror into `depends:` (rule 18 — `relates:` never becomes a second dependency source).

So the row moves to `relation: disjoint`, which is what the other two parked neighbours in the same block already carry, and the note now names the direction explicitly.

## Diff

3 lines in one file. No acceptance criterion, phase, blocker, status, or estate claim changed.

## Verification

Run in the worktree at `f9301bfce`:

| Gate | Result |
|---|---|
| `lint_roadmap_complexity` | 9 roadmaps complexity-clean |
| `check_estate_count` | OK |
| `check_roadmap_trackable` | OK |
| `lint_empty_roadmaps` | OK |
| `lint_roadmap_blockers` | OK |
| `lint_roadmap_family_cap` | OK |
| `lint_roadmap_later_disposition` | OK |
| `check_no_roadmap_refs` | OK |

Downstream sweep: `grep` for `mixed-trigger-activation-cost` across `agents/`, `docs/`, `src/` — no other active roadmap or evidence file declares an edge in either direction, so nothing mirrors this change.