### PR TITLE
fix(self-review): partition the release span into budgeted requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,40 @@ Entry-shape contract: [`docs/contracts/CHANGELOG-conventions.md`](docs/contracts
 
 ## [Unreleased]
 
+### Fixed
+
+- **The self-review gate reviews again — it had reviewed nothing for four
+  consecutive releases.** 14.17.0, 14.18.0, 14.19.0 and 14.20.0 each returned
+  `HTTP 400 prompt is too long` and each recorded an honest null in
+  `agents/evidence/release-findings/`. The release path sets the analysis base
+  to the previous tag, so the whole release span went into **one** request:
+  413191, 450336 and 260998 input tokens against a 200000 cap on the three
+  releases that recorded a figure. The smallest still exceeded the cap by 30 %,
+  which is what made it structural rather than a run of large releases —
+  `buildPlan` already computed `promptChars` and only *reported* it, so nothing
+  consulted the number before spending the call.
+  The diff is now partitioned **per file** into requests under a character
+  budget, each is reviewed, and findings are merged and deduplicated on the
+  finding id the ledger already uses. Verified against the live span that had
+  been failing: 505087 estimated input tokens across 4 requests, no path left
+  out.
+  **Nothing is truncated**, and that is the load-bearing decision: a silently
+  shortened diff yields findings about a fragment while reading as a review of
+  the whole change, which is the false green this repository's honest-null
+  discipline exists to prevent. So a single file larger than one request is
+  **named as unreviewed** rather than cut mid-hunk, a per-run request ceiling
+  bounds the spend and reports its remainder, a chunk whose call fails no longer
+  discards the chunks that succeeded, and the rendered PR comment carries a
+  **Coverage** block stating what was not read — including the sentence that
+  absence of a finding for an unreviewed path is not evidence about that path.
+  `--dry-run` now prints the request count rather than only a token estimate,
+  because this gate spends per request, and it warns when a span sits at the
+  ceiling, where the next slightly larger one would start losing its remainder.
+  The budget factor is a deliberately pessimistic character proxy and says so:
+  the cap is enforced by the provider's tokenizer, which this repository cannot
+  run, so a call that still overflows a budgeted chunk falsifies the factor
+  rather than the partitioning.
+
 ### Added
 
 - **A push no longer ships a branch whose tree contradicts its own commits.**

--- a/src/scripts/self_review_gate.ts
+++ b/src/scripts/self_review_gate.ts
@@ -125,6 +125,23 @@ function diffText(baseRef: string, files: string[], cwd: string = REPO_ROOT): st
 }
 
 /** Sum of added+deleted lines across `files` (binary files count 0). */
+/**
+ * The diff split per file, so it can be packed into budgeted requests.
+ *
+ * One `git diff` per file rather than one call parsed apart: a `diff --git`
+ * split over the combined output has to re-derive path boundaries from the
+ * text, and a path containing the separator (or a rename header) breaks that
+ * parse silently. N cheap subprocesses cost milliseconds and cannot mis-parse.
+ */
+function perFileDiffs(baseRef: string, files: readonly string[], cwd: string = REPO_ROOT): FileDiff[] {
+    const out: FileDiff[] = [];
+    for (const path of files) {
+        const diff = diffText(baseRef, [path], cwd);
+        if (diff !== '') out.push({ path, diff });
+    }
+    return out;
+}
+
 function changedLineCount(baseRef: string, files: string[], cwd: string = REPO_ROOT): number {
     if (files.length === 0) return 0;
     const r = spawnSync('git', ['diff', '--numstat', `${baseRef}...HEAD`, '--', ...files], {
@@ -241,10 +258,132 @@ function buildSystemPrompt(release?: ReleaseInfo, baseRef?: string): string {
     return release && baseRef ? base + releaseNoteText(release, baseRef) : base;
 }
 
+// Prompt budget and partitioning.
+//
+// Measured across FOUR consecutive releases (14.17.0, 14.18.0, 14.19.0,
+// 14.20.0): the live call returned `HTTP 400 prompt is too long` every time and
+// the gate reviewed nothing. The release path sets `analysisBase` to the
+// previous tag, so the whole release span goes into one request — 413191,
+// 450336 and 260998 input tokens against a 200000 cap on the three releases
+// that recorded a figure. The smallest of them still exceeds the cap by 30 %,
+// so this is structural: no release span observed to date fits in one call, and
+// waiting for smaller spans is not a fix.
+//
+// `promptChars` was already computed and only REPORTED. Nothing consulted it
+// before spending the call.
+//
+// What this deliberately does NOT do is truncate. A silently shortened diff
+// produces findings about a fragment while reading as a review of the whole
+// change, which is a false green — the failure mode this repository's
+// honest-null discipline exists to prevent. Instead the diff is partitioned per
+// FILE, each chunk is reviewed, findings are merged, and whatever did not fit
+// is NAMED as unreviewed.
+
+/**
+ * Input budget for one request, in characters.
+ *
+ * A character proxy, and the reason it is a proxy rather than a measurement:
+ * the cap is enforced by the provider's own tokenizer, which this repository
+ * cannot run — `js-tiktoken` is a DIFFERENT tokenizer and agreeing with it
+ * would prove nothing. So the factor is deliberately pessimistic. Diff text is
+ * dense in punctuation and short tokens, where 3 chars/token is a conservative
+ * floor rather than the ~4 that prose averages; 190000 leaves headroom under
+ * the 200000 cap for the system prompt and for the tokenizer disagreeing with
+ * this estimate.
+ *
+ * A call that still returns `prompt is too long` for a chunk built under this
+ * budget falsifies the factor, not the partitioning.
+ */
+export const PROMPT_BUDGET_CHARS = 190_000 * 3;
+
+/**
+ * Cost ceiling, in requests per run.
+ *
+ * The gate is advisory and single-maintainer-funded, so an unbounded chunk
+ * count would turn one failed call into an arbitrary bill. Four is chosen
+ * against the measured span sizes: the largest recorded (450336 tokens) needs
+ * three chunks at this budget, so four covers every span measured with one to
+ * spare. A span that needs more is reviewed up to the ceiling and the remainder
+ * is reported unreviewed — a partial review that says so, never a silent one.
+ */
+export const MAX_REVIEW_CHUNKS = 4;
+
+export interface FileDiff {
+    path: string;
+    diff: string;
+}
+
+export interface DiffPartition {
+    /** Each chunk is the concatenated diff text for one request. */
+    chunks: string[];
+    /** Files no chunk carries, with the reason — rendered into the review. */
+    unreviewed: { path: string; reason: string }[];
+}
+
+/**
+ * Pack per-file diffs into as few chunks as fit the budget.
+ *
+ * Deterministic: input order is preserved and the fill is greedy, so the same
+ * span always partitions the same way and a finding's chunk is reproducible.
+ *
+ * A single file larger than the whole budget is NOT split. A diff cut at an
+ * arbitrary byte offset produces half a hunk, and a reviewer reading half a
+ * hunk reports on code that does not exist — worse than not reading it, because
+ * the finding looks authoritative. Such a file is reported unreviewed instead.
+ */
+export function partitionDiff(
+    files: readonly FileDiff[],
+    budgetChars: number = PROMPT_BUDGET_CHARS,
+    maxChunks: number = MAX_REVIEW_CHUNKS,
+): DiffPartition {
+    const chunks: string[] = [];
+    const unreviewed: { path: string; reason: string }[] = [];
+    let current = '';
+
+    for (const f of files) {
+        if (f.diff.length > budgetChars) {
+            unreviewed.push({
+                path: f.path,
+                reason:
+                    `single-file diff of ${String(f.diff.length)} chars exceeds the ` +
+                    `${String(budgetChars)}-char request budget; not split, because a diff cut ` +
+                    'mid-hunk yields findings about code that does not exist',
+            });
+            continue;
+        }
+        if (current !== '' && current.length + f.diff.length > budgetChars) {
+            chunks.push(current);
+            current = '';
+        }
+        current += f.diff;
+    }
+    if (current !== '') chunks.push(current);
+
+    if (chunks.length > maxChunks) {
+        // Which FILES fall outside the ceiling cannot be recovered from the
+        // packed strings, so the dropped chunks are reported as a count and the
+        // renderer says so — naming a file it cannot identify would be worse
+        // than an honest aggregate.
+        const dropped = chunks.length - maxChunks;
+        chunks.length = maxChunks;
+        unreviewed.push({
+            path: `(${String(dropped)} further chunk(s))`,
+            reason:
+                `the span needs ${String(dropped + maxChunks)} requests at this budget and the ` +
+                `per-run ceiling is ${String(maxChunks)}; the remainder was not sent`,
+        });
+    }
+    return { chunks, unreviewed };
+}
+
 // ── Plan (dry-run) ────────────────────────────────────────────────────
 export interface ReviewPlan {
     skills: string[];
     files: string[];
+    /** Model calls the live run will make — one per budgeted chunk. */
+    requests: number;
+    /** Files no request will carry, with the reason. */
+    unreviewed: { path: string; reason: string }[];
     promptChars: number;
     note: string;
     escalation: string[];
@@ -277,7 +416,14 @@ export function buildPlan(baseRef: string, cwd: string = REPO_ROOT): ReviewPlan 
     const diff = diffText(analysisBase, files, cwd);
     const escalation = escalationReasons(files, changedLineCount(analysisBase, files, cwd));
     const systemPrompt = buildSystemPrompt(release, baseRef);
+    // The same partition the live path will use, so `--dry-run` previews the
+    // REQUEST COUNT rather than only a token estimate. This gate spends money
+    // per request, and a plan that reports "~N tokens" without saying how many
+    // calls that becomes hides the number the maintainer is deciding about.
+    const partition = partitionDiff(perFileDiffs(analysisBase, files, cwd));
     return {
+        requests: partition.chunks.length,
+        unreviewed: partition.unreviewed,
         skills: [...REVIEW_SKILLS],
         files,
         analysisBase,
@@ -289,7 +435,10 @@ export function buildPlan(baseRef: string, cwd: string = REPO_ROOT): ReviewPlan 
                 ? 'No reviewable (non-generated) files changed — the live review would no-op.'
                 : `${files.length} reviewable file(s); live review would send ~${Math.ceil(
                       (systemPrompt.length + diff.length) / 4,
-                  )} input tokens.`,
+                  )} input tokens across ${partition.chunks.length} request(s)` +
+                  (partition.unreviewed.length > 0
+                      ? `, leaving ${partition.unreviewed.length} path(s) UNREVIEWED.`
+                      : '.'),
     };
 }
 
@@ -320,6 +469,28 @@ function parseFindings(text: string): Finding[] {
         }));
 }
 
+/**
+ * Collapse findings that two chunks both reported.
+ *
+ * Chunks are disjoint by file, so a duplicate means the same defect was
+ * described from two files' diffs — a shared helper and one of its callers, for
+ * instance. `findingId` is sha256(kind|title|file), already the identity the
+ * ledger and the rendered table use, so deduplicating on it keeps the id in the
+ * comment matching the id in the artifact. First occurrence wins, which keeps
+ * the order deterministic for a given partition.
+ */
+export function dedupeFindings(findings: readonly Finding[]): Finding[] {
+    const seen = new Set<string>();
+    const out: Finding[] = [];
+    for (const f of findings) {
+        const id = findingId(f);
+        if (seen.has(id)) continue;
+        seen.add(id);
+        out.push(f);
+    }
+    return out;
+}
+
 /** Advisory escalation banner, appended when a diff warrants full ai-council. */
 function escalationBlock(reasons: readonly string[]): string {
     if (reasons.length === 0) return '';
@@ -332,14 +503,46 @@ function escalationBlock(reasons: readonly string[]): string {
     );
 }
 
-export function renderReview(findings: Finding[], enforce: boolean, escalation: readonly string[] = []): string {
+/**
+ * What the review did NOT read, stated in the comment itself.
+ *
+ * Without this line a chunked review is indistinguishable from a whole-span
+ * one, which is the false green the partitioning exists to avoid — the reader
+ * of the PR comment is the person who has to know the coverage, and they never
+ * see the workflow log.
+ */
+export function coverageBlock(coverage?: ReviewCoverage): string {
+    if (!coverage) return '';
+    const parts = [
+        `\n\n**Coverage.** ${String(coverage.chunks)} request(s) over ` +
+            `${String(coverage.filesReviewed)} file(s).`,
+    ];
+    if (coverage.unreviewed.length > 0) {
+        parts.push(
+            ` **NOT reviewed (${String(coverage.unreviewed.length)}):**\n` +
+                coverage.unreviewed.map((u) => `- \`${u.path}\` — ${u.reason}`).join('\n') +
+                '\nFindings above cover the reviewed part only; absence of a finding for an ' +
+                'unreviewed path is not evidence about that path.',
+        );
+    }
+    return parts.join('');
+}
+
+export interface ReviewCoverage {
+    chunks: number;
+    filesReviewed: number;
+    unreviewed: { path: string; reason: string }[];
+}
+
+export function renderReview(findings: Finding[], enforce: boolean, escalation: readonly string[] = [], coverage?: ReviewCoverage): string {
     const banner =
         '> HUMAN REVIEW REQUIRED — dogfooded AI adversarial-review + security gate. ' +
         'Findings are decision support, not a guarantee; detection is probabilistic. ' +
         'This is a floor, **not** independent human review.';
     const esc = escalationBlock(escalation);
+    const cov = coverageBlock(coverage);
     if (findings.length === 0) {
-        return `${banner}\n\n✅ Self-review gate: no findings.${esc}`;
+        return `${banner}\n\n✅ Self-review gate: no findings.${cov}${esc}`;
     }
     const blocking = findings.filter(classifyBlocking);
     // Each row carries an explicit (Blocking)/(Advisory) marker so a
@@ -372,7 +575,7 @@ export function renderReview(findings: Finding[], enforce: boolean, escalation: 
     const machine = `\n\n<!-- release-findings-json: ${JSON.stringify(
         findings.map((f) => ({ finding_id: findingId(f), severity: f.severity, kind: f.kind, title: f.title, file: f.file ?? null })),
     )} -->`;
-    return `${banner}\n\n${verdictLine}\n\n| id | severity | kind | file | finding |\n|---|---|---|---|---|\n${rows}${idNote}${esc}${machine}`;
+    return `${banner}\n\n${verdictLine}\n\n| id | severity | kind | file | finding |\n|---|---|---|---|---|\n${rows}${idNote}${cov}${esc}${machine}`;
 }
 
 function postReview(body: string): void {
@@ -417,6 +620,20 @@ export function main(argv: string[]): 0 | 2 {
                       `packaging diff ${plan.release.packagingFiles.length} file(s))\n`
                     : '') +
                 `  files:  ${plan.files.length}\n` +
+                `  calls:  ${plan.requests} (budget ${String(PROMPT_BUDGET_CHARS)} chars/request, ` +
+                `ceiling ${String(MAX_REVIEW_CHUNKS)})\n` +
+                (plan.unreviewed.length > 0
+                    ? `  UNREVIEWED: ${plan.unreviewed.map((u) => u.path).join(', ')}\n`
+                    : '') +
+                // At the ceiling nothing is lost YET, and the next slightly
+                // larger span loses its remainder silently apart from the
+                // coverage line. Saying so while it is still a warning is the
+                // only cheap moment: the alternative is reading it in a
+                // published review's coverage block.
+                (plan.requests >= MAX_REVIEW_CHUNKS && plan.unreviewed.length === 0
+                    ? `  ⚠️  at the per-run ceiling (${String(MAX_REVIEW_CHUNKS)}) — a larger span ` +
+                      'would leave its remainder unreviewed\n'
+                    : '') +
                 `  ${plan.note}\n` +
                 (plan.escalation.length
                     ? `  escalation: ${plan.escalation.join('; ')} → recommend /council:pr (run-time authorized)\n`
@@ -455,15 +672,58 @@ export function main(argv: string[]): 0 | 2 {
     // findings returns 2 — an error is not a finding.)
     try {
         const client = new AnthropicClient({ api_key: key });
-        const resp = client.ask(buildSystemPrompt(plan.release, baseRef), diffText(plan.analysisBase, plan.files), 4096);
-        if (resp.error) {
+        const systemPrompt = buildSystemPrompt(plan.release, baseRef);
+        const partition = partitionDiff(perFileDiffs(plan.analysisBase, plan.files));
+
+        if (partition.chunks.length === 0) {
+            // Every file individually over budget. Reviewing nothing while
+            // saying nothing is the state four releases were already in, so it
+            // is reported as NEUTRAL with the reason rather than as a pass.
             process.stdout.write(
-                `::warning::self-review-gate NEUTRAL — model call did not complete (${resp.error}); ` +
-                    'nothing was reviewed, not a blocker.\n',
+                '::warning::self-review-gate NEUTRAL — every changed file exceeds the per-request ' +
+                    'budget, nothing was reviewed, not a blocker.\n',
             );
-            return 0; // no credit / transport / API error → never blocks the merge
+            return 0;
         }
-        const findings = parseFindings(resp.text);
+
+        // One request per chunk, findings merged. A chunk that fails does NOT
+        // discard the chunks that succeeded: four releases produced no review at
+        // all because one failure was the whole review, and a partial review
+        // that names its coverage is worth more than another honest null.
+        const findings: Finding[] = [];
+        const unreviewed = [...partition.unreviewed];
+        let reviewedChunks = 0;
+        for (const [i, chunk] of partition.chunks.entries()) {
+            const resp = client.ask(systemPrompt, chunk, 4096);
+            if (resp.error) {
+                process.stdout.write(
+                    `::warning::self-review-gate — chunk ${String(i + 1)}/` +
+                        `${String(partition.chunks.length)} did not complete (${resp.error}); ` +
+                        'continuing with the remaining chunks.\n',
+                );
+                unreviewed.push({
+                    path: `(chunk ${String(i + 1)} of ${String(partition.chunks.length)})`,
+                    reason: `the model call did not complete: ${resp.error}`,
+                });
+                continue;
+            }
+            reviewedChunks += 1;
+            findings.push(...parseFindings(resp.text));
+        }
+
+        if (reviewedChunks === 0) {
+            process.stdout.write(
+                '::warning::self-review-gate NEUTRAL — no chunk completed, nothing was reviewed, ' +
+                    'not a blocker.\n',
+            );
+            return 0;
+        }
+
+        const coverage: ReviewCoverage = {
+            chunks: reviewedChunks,
+            filesReviewed: plan.files.length - partition.unreviewed.length,
+            unreviewed,
+        };
         const outIdx = argv.indexOf('--findings-out');
         if (outIdx >= 0 && argv[outIdx + 1]) {
             // Durable ingestion input for the disposition ledger (release-truth
@@ -478,17 +738,21 @@ export function main(argv: string[]): 0 | 2 {
                     {
                         schema_version: 1,
                         ...independenceFields(['anthropic']),
-                        findings: findings.map((f) => ({ finding_id: findingId(f), ...f })),
+                        coverage,
+                        findings: dedupeFindings(findings).map((f) => ({
+                            finding_id: findingId(f),
+                            ...f,
+                        })),
                     },
                     null,
                     2,
                 ) + '\n',
             );
         }
-        const body = renderReview(findings, enforce, plan.escalation);
+        const body = renderReview(dedupeFindings(findings), enforce, plan.escalation, coverage);
         postReview(body);
 
-        const code = gateVerdict(findings, { enforce });
+        const code = gateVerdict(dedupeFindings(findings), { enforce });
         if (code === 2) {
             process.stdout.write('::error::self-review-gate — merge-blocking findings under enforce mode.\n');
         }

--- a/tests/scripts/self_review_prompt_budget.test.ts
+++ b/tests/scripts/self_review_prompt_budget.test.ts
@@ -1,0 +1,167 @@
+// Regression lock for a gate that reviewed NOTHING for four consecutive
+// releases while reporting itself as merely neutral.
+//
+// Measured (14.17.0, 14.18.0, 14.19.0, 14.20.0): the release path sets the
+// analysis base to the previous tag, so the whole release span went into ONE
+// request and the provider answered `HTTP 400 prompt is too long` every time.
+// The three releases that recorded a figure measured 413191, 450336 and 260998
+// input tokens against a 200000 cap — the SMALLEST still 30 % over, which is
+// what makes this structural rather than a run of bad luck.
+//
+// `promptChars` was already computed by buildPlan and only reported. Nothing
+// consulted it before spending the call.
+//
+// The fixtures below are those three measurements, not invented sizes, because
+// the property under test is "the spans this repository actually produces fit"
+// — a partitioner proven only on round numbers proves nothing about them.
+import { describe, expect, it } from 'vitest';
+
+import {
+    MAX_REVIEW_CHUNKS,
+    PROMPT_BUDGET_CHARS,
+    coverageBlock,
+    dedupeFindings,
+    partitionDiff,
+    renderReview,
+} from '../../src/scripts/self_review_gate.js';
+
+/** Chars at the pessimistic 3-chars-per-token floor the budget is built on. */
+const chars = (tokens: number): number => tokens * 3;
+
+/** A span as it actually arrives: many files, none of them enormous. */
+const spanOf = (totalChars: number, perFile = 50_000): { path: string; diff: string }[] =>
+    Array.from({ length: Math.ceil(totalChars / perFile) }, (_, i) => ({
+        path: `f${String(i)}.ts`,
+        diff: 'x'.repeat(Math.min(perFile, totalChars - i * perFile)),
+    }));
+
+describe('self-review prompt budget — the measured spans must fit', () => {
+    it.each([
+        ['14.18.0', 413_191],
+        ['14.19.0', 450_336],
+        ['14.20.0', 260_998],
+    ])('%s (%i input tokens) partitions into chunks that all fit', (_rel, tokens) => {
+        const { chunks, unreviewed } = partitionDiff(spanOf(chars(tokens as number)));
+        expect(chunks.length).toBeGreaterThan(0);
+        expect(unreviewed).toEqual([]);
+        for (const c of chunks) expect(c.length).toBeLessThanOrEqual(PROMPT_BUDGET_CHARS);
+    });
+
+    it('needs more than one request for every span measured — the defect was assuming one', () => {
+        // If this ever drops to 1 for all three, the budget grew or the spans
+        // shrank; either way the single-call assumption would be worth
+        // revisiting rather than silently relied on again.
+        const counts = [413_191, 450_336, 260_998].map(
+            (t) => partitionDiff(spanOf(chars(t))).chunks.length,
+        );
+        expect(Math.min(...counts)).toBeGreaterThan(1);
+    });
+
+    it('packs greedily and deterministically — same input, same partition', () => {
+        const files = spanOf(chars(450_336));
+        expect(partitionDiff(files)).toEqual(partitionDiff(files));
+    });
+
+    it('NEVER splits a single over-budget file — it names it instead', () => {
+        // A diff cut at an arbitrary offset yields half a hunk, and a finding
+        // about half a hunk describes code that does not exist. Not reading it
+        // is the lesser failure, and it is only the lesser failure if it is
+        // reported.
+        const { chunks, unreviewed } = partitionDiff([
+            { path: 'giant.ts', diff: 'y'.repeat(PROMPT_BUDGET_CHARS + 1) },
+        ]);
+        expect(chunks).toEqual([]);
+        expect(unreviewed).toHaveLength(1);
+        expect(unreviewed[0]?.path).toBe('giant.ts');
+        expect(unreviewed[0]?.reason).toContain('not split');
+    });
+
+    it('keeps an over-budget file from starving its in-budget neighbours', () => {
+        const { chunks, unreviewed } = partitionDiff([
+            { path: 'ok-a.ts', diff: 'a'.repeat(10) },
+            { path: 'giant.ts', diff: 'y'.repeat(PROMPT_BUDGET_CHARS + 1) },
+            { path: 'ok-b.ts', diff: 'b'.repeat(10) },
+        ]);
+        expect(chunks).toHaveLength(1);
+        expect(chunks[0]).toBe(`${'a'.repeat(10)}${'b'.repeat(10)}`);
+        expect(unreviewed.map((u) => u.path)).toEqual(['giant.ts']);
+    });
+
+    it('honours the cost ceiling and reports the remainder as a count', () => {
+        const many = Array.from({ length: 40 }, (_, i) => ({
+            path: `g${String(i)}.ts`,
+            diff: 'z'.repeat(PROMPT_BUDGET_CHARS - 1),
+        }));
+        const { chunks, unreviewed } = partitionDiff(many);
+        expect(chunks).toHaveLength(MAX_REVIEW_CHUNKS);
+        // The dropped FILES are unrecoverable from packed strings, so an honest
+        // aggregate beats naming paths the partitioner cannot identify.
+        expect(unreviewed).toHaveLength(1);
+        expect(unreviewed[0]?.reason).toContain('per-run ceiling');
+    });
+
+    it('an empty span produces no chunks and no complaint', () => {
+        expect(partitionDiff([])).toEqual({ chunks: [], unreviewed: [] });
+    });
+});
+
+describe('merged findings', () => {
+    const f = (title: string, file = 'a.ts') => ({
+        severity: 'high' as const,
+        kind: 'security' as const,
+        title,
+        detail: '',
+        file,
+    });
+
+    it('collapses a finding two chunks both reported', () => {
+        expect(dedupeFindings([f('dup'), f('dup'), f('other')])).toHaveLength(2);
+    });
+
+    it('keeps the same title in two different files — those are two defects', () => {
+        expect(dedupeFindings([f('same', 'a.ts'), f('same', 'b.ts')])).toHaveLength(2);
+    });
+
+    it('keeps first occurrence, so order is deterministic', () => {
+        const out = dedupeFindings([f('first'), f('second'), f('first')]);
+        expect(out.map((x) => x.title)).toEqual(['first', 'second']);
+    });
+});
+
+describe('coverage is stated in the comment, not only in the log', () => {
+    it('names what was NOT reviewed and refuses to read as whole-span', () => {
+        const block = coverageBlock({
+            chunks: 2,
+            filesReviewed: 30,
+            unreviewed: [{ path: 'giant.ts', reason: 'over budget' }],
+        });
+        expect(block).toContain('NOT reviewed');
+        expect(block).toContain('giant.ts');
+        // The load-bearing sentence: without it a reader treats a missing
+        // finding for an unreviewed path as evidence about that path.
+        expect(block).toContain('not evidence about that path');
+    });
+
+    it('says nothing when there is nothing to disclose', () => {
+        expect(coverageBlock(undefined)).toBe('');
+        expect(coverageBlock({ chunks: 1, filesReviewed: 3, unreviewed: [] })).not.toContain(
+            'NOT reviewed',
+        );
+    });
+
+    it('reaches the rendered review on BOTH paths — findings and no findings', () => {
+        // The no-findings path is the one that matters: "no findings" over a
+        // partial read is exactly the false green the partitioning exists to
+        // prevent, and it is the path a reader is least likely to question.
+        const cov = { chunks: 2, filesReviewed: 5, unreviewed: [{ path: 'g.ts', reason: 'big' }] };
+        expect(renderReview([], false, [], cov)).toContain('NOT reviewed');
+        expect(
+            renderReview(
+                [{ severity: 'high', kind: 'security', title: 't', detail: '', file: 'a.ts' }],
+                false,
+                [],
+                cov,
+            ),
+        ).toContain('NOT reviewed');
+    });
+});


### PR DESCRIPTION
The self-review gate reviewed **nothing** for four consecutive releases, and recorded an honest null each time instead of a review.

## The defect

14.17.0, 14.18.0, 14.19.0, 14.20.0 — every one returned `HTTP 400 prompt is too long`. The release path sets the analysis base to the previous tag, so the entire release span went into **one** request:

| release | input tokens | cap |
|---|---:|---:|
| 14.18.0 | 413,191 | 200,000 |
| 14.19.0 | 450,336 | 200,000 |
| 14.20.0 | 260,998 | 200,000 |

The **smallest** still exceeds the cap by 30 %, which is what makes this structural rather than a run of large releases. And `buildPlan` already computed `promptChars` — it only *reported* it, so nothing consulted the number before spending the call.

## The fix

The diff is split **per file** and packed into requests under a character budget; each is reviewed and the findings merged, deduplicated on the same `findingId` the ledger and the rendered table already use.

**Nothing is truncated, and that is the load-bearing decision.** A silently shortened diff produces findings about a fragment while reading as a review of the whole change — a false green, which is *worse* than the honest null it would replace. So:

- a single file over one request's budget is **named unreviewed**, never cut mid-hunk — a finding about half a hunk describes code that does not exist;
- a per-run request **ceiling** bounds the spend and reports its remainder as a count (the dropped *files* are unrecoverable from packed strings, so an honest aggregate beats naming paths the partitioner cannot identify);
- a chunk whose call fails **no longer discards the chunks that succeeded** — four releases produced nothing because one failure was the whole review;
- the PR comment carries a **Coverage** block naming what was not read, including the sentence that *absence of a finding for an unreviewed path is not evidence about that path*.

`--dry-run` now prints the **request count**, not only a token estimate — this gate spends per request, and a plan reporting "~N tokens" hides the number the maintainer is deciding about. It also warns when a span sits *at* the ceiling, where the next slightly larger one starts losing its remainder.

## Evidence

Verified against the live span that had been failing:

```
mode:   release (14.20.0; feature range 14.19.0...HEAD; packaging diff 316 file(s))
calls:  4 (budget 570000 chars/request, ceiling 4)
⚠️  at the per-run ceiling (4) — a larger span would leave its remainder unreviewed
316 reviewable file(s); ~505087 input tokens across 4 request(s).
```

15 cases, with the three real measurements as fixtures rather than round numbers — a partitioner proven only on invented sizes proves nothing about the spans this repo actually produces. **All five mechanisms checked for sensitivity** by neutralising each and confirming a named test goes red: the budget check, the never-split rule, the cost ceiling, the coverage block, and the dedupe. Restored afterwards, 15 green.

`npm run typecheck` clean, `eslint` clean, `lint_code_comments` clean, 56 tests across the three touched suites.

## Honest limits

- **The budget is a character proxy, not a measurement.** The cap is enforced by the provider's tokenizer, which this repository cannot run — `js-tiktoken` is a *different* tokenizer and agreeing with it would prove nothing. The factor (3 chars/token) is a pessimistic floor for diff text. A call that still overflows a budgeted chunk falsifies the factor, not the partitioning.
- **The live span already sits at the ceiling (4/4).** Nothing is lost yet; the dry-run warns, and a larger span would report its remainder rather than hide it. Raising the ceiling is a spend decision and deliberately not taken here.
- **This does not make the gate independent.** It is still one Anthropic client, and the findings artifact still declares itself single-member and provisional.