### PR TITLE
fix(self-review): count coverage from what was read, not by subtraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,17 +36,19 @@ Entry-shape contract: [`docs/contracts/CHANGELOG-conventions.md`](docs/contracts
   consecutive releases.** 14.17.0, 14.18.0, 14.19.0 and 14.20.0 each returned
   `HTTP 400 prompt is too long` and each recorded an honest null in
   `agents/evidence/release-findings/`. The release path sets the analysis base
-  to the previous tag, so the whole release span went into **one** request:
-  413191, 450336 and 260998 input tokens against a 200000 cap on the three
-  releases that recorded a figure. The smallest still exceeded the cap by 30 %,
-  which is what made it structural rather than a run of large releases —
-  `buildPlan` already computed `promptChars` and only *reported* it, so nothing
-  consulted the number before spending the call.
+  to the previous tag, so the whole release span went into **one** request.
+  **All four** recorded a figure against the 200000 cap — 235472 (14.17.0),
+  413191 (14.18.0), 450336 (14.19.0), 260998 (14.20.0) — and the smallest
+  exceeded it by 17.7 %. (An earlier draft of this entry said three releases
+  recorded a figure and put the smallest at 30 % over; both were wrong, and the
+  omitted reading was the one nearest the cap — the one that most constrains
+  the budget. The conclusion does not depend on the error: every span observed
+  exceeds the cap.) `buildPlan` already computed `promptChars` and only
+  *reported* it, so nothing consulted the number before spending the call.
   The diff is now partitioned **per file** into requests under a character
   budget, each is reviewed, and findings are merged and deduplicated on the
   finding id the ledger already uses. Verified against the live span that had
-  been failing: 505087 estimated input tokens across 4 requests, no path left
-  out.
+  been failing: 5 requests, no path left out.
   **Nothing is truncated**, and that is the load-bearing decision: a silently
   shortened diff yields findings about a fragment while reading as a review of
   the whole change, which is the false green this repository's honest-null
@@ -57,12 +59,29 @@ Entry-shape contract: [`docs/contracts/CHANGELOG-conventions.md`](docs/contracts
   **Coverage** block stating what was not read — including the sentence that
   absence of a finding for an unreviewed path is not evidence about that path.
   `--dry-run` now prints the request count rather than only a token estimate,
-  because this gate spends per request, and it warns when a span sits at the
-  ceiling, where the next slightly larger one would start losing its remainder.
-  The budget factor is a deliberately pessimistic character proxy and says so:
-  the cap is enforced by the provider's tokenizer, which this repository cannot
-  run, so a call that still overflows a budgeted chunk falsifies the factor
-  rather than the partitioning.
+  because this gate spends per request, and warns when a span sits at the
+  ceiling. The budget factor is a character proxy **derived from those four
+  failures** (measured diff chars / reported tokens = 3.13 and 3.18) and set
+  below them, because the ratio is content-dependent — cl100k over this repo's
+  own diffs reads ~3.9 for `src/`, ~4.1 for prose and ~2.75 for a lockfile. A
+  call that still overflows a budgeted chunk falsifies that number, not the
+  partitioning.
+  **A neutral reviewer on the first version found three defects that are fixed
+  here rather than shipped.** The coverage line counted every file in a dropped
+  chunk as reviewed — 59 of 60 for a run that read 4, because the partition
+  packed to opaque strings and reported one aggregate row; it ignored chunks
+  whose call had failed, computing the number before those were appended; and a
+  non-ASCII filename was silently skipped **and** counted as read, because
+  `git diff --name-only` renders it quoted and the quoted form then matches no
+  pathspec. Coverage is now summed from the chunks that actually returned, every
+  dropped chunk names its own files, and paths are read with
+  `core.quotePath=false`. Correcting the budget ratio shrank each request, so
+  the same span needed five: the request ceiling moved from four to six rather
+  than paying for tokenizer safety with silent coverage loss.
+  Known limits, stated rather than implied: coverage lives in prose, so an
+  `--enforce` run over a partial review still returns 0, and
+  `check_finding_dispositions --ingest` reads only `.findings`, so the durable
+  ledger does not record the coverage the artifact now carries.
 
 ### Added
 

--- a/docs/self-review-gate.md
+++ b/docs/self-review-gate.md
@@ -17,10 +17,55 @@ AI-reviewed" — that is only true once the maintainer arms it (below).
 | Job | Runs | Spend | Blocks merge |
 |---|---|---|---|
 | `gate-dry-run` | every PR | none (no API) | never — prints the review plan only |
-| `live-advisory` | every PR **iff** `ANTHROPIC_API_KEY` is set | one review call | never — posts findings, records what *would* block |
+| `live-advisory` | every PR **iff** `ANTHROPIC_API_KEY` is set | up to `MAX_REVIEW_CHUNKS` review calls (see § Prompt budget) | never — posts findings, records what *would* block |
 
 Without the `ANTHROPIC_API_KEY` repo secret, `live-advisory` is a **logged
 no-op** (never a failing check) — exactly the `cross-model-canary.yml` pattern.
+
+
+## Prompt budget and coverage
+
+The release path analyses the whole span since the previous tag, and that span
+does not fit one request. Measured on four consecutive releases, all four of
+which returned `HTTP 400 prompt is too long` and reviewed nothing:
+
+| release | input tokens reported | cap |
+|---|---:|---:|
+| 14.17.0 | 235,472 | 200,000 |
+| 14.18.0 | 413,191 | 200,000 |
+| 14.19.0 | 450,336 | 200,000 |
+| 14.20.0 | 260,998 | 200,000 |
+
+The smallest exceeds the cap by 17.7 %, so no observed span fits and waiting for
+smaller releases is not a remedy.
+
+**What the gate does now.** The diff is split per file and packed into requests
+under `PROMPT_BUDGET_CHARS`; each is reviewed and the findings merged and
+deduplicated on the finding id. `--dry-run` prints the request count before
+anything is spent, and warns when a span sits at `MAX_REVIEW_CHUNKS`.
+
+**Nothing is truncated.** A silently shortened diff yields findings about a
+fragment while reading as a review of the whole change. So a single file larger
+than one request is reported unreviewed rather than cut mid-hunk, a chunk whose
+call fails does not discard the chunks that succeeded, and the posted comment
+carries a **Coverage** block naming every file that was not read — with the
+statement that absence of a finding for an unreviewed path is not evidence
+about that path.
+
+**The budget is a character proxy.** The cap is enforced by the provider's
+tokenizer, which this repository cannot run. `BUDGET_CHARS_PER_TOKEN` is
+derived from the failures above (measured diff chars ÷ reported tokens ≈ 3.13
+and 3.18) and set BELOW them, because the ratio is content-dependent: cl100k
+over this repo's own diffs reads ~3.9 for `src/`, ~4.1 for `agents/` prose and
+~2.75 for a lockfile. A call that still overflows a budgeted chunk falsifies
+that number, not the partitioning — and fails gracefully, marking the chunk
+unreviewed and continuing.
+
+**What this does NOT fix.** Coverage is stated in prose; the exit code does not
+fail closed on incomplete coverage, so an `--enforce` run over a partial review
+can still return 0. The findings artifact carries `coverage`, but
+`check_finding_dispositions --ingest` reads only `.findings`, so the durable
+ledger does not yet record it.
 
 ## The teeth (defined + wired, not yet armed)
 

--- a/src/scripts/self_review_gate.ts
+++ b/src/scripts/self_review_gate.ts
@@ -100,7 +100,13 @@ export function isReviewablePath(p: string): boolean {
 }
 
 function changedFiles(baseRef: string, cwd: string = REPO_ROOT): string[] {
-    const r = spawnSync('git', ['diff', '--name-only', `${baseRef}...HEAD`], {
+    // `-c core.quotePath=false`: by default git renders a non-ASCII path as an
+    // escaped, QUOTED string (`"gr\303\274e.ts"`), which then matches no
+    // pathspec when fed back to `git diff`. The file was silently skipped by
+    // `perFileDiffs` AND counted as reviewed by the coverage arithmetic — an
+    // unreviewed file reported as read, which is the failure this whole change
+    // exists to prevent.
+    const r = spawnSync('git', ['-c', 'core.quotePath=false', 'diff', '--name-only', `${baseRef}...HEAD`], {
         cwd,
         encoding: 'utf8',
     });
@@ -124,14 +130,22 @@ function diffText(baseRef: string, files: string[], cwd: string = REPO_ROOT): st
     return (r.stdout ?? '').toString();
 }
 
-/** Sum of added+deleted lines across `files` (binary files count 0). */
 /**
  * The diff split per file, so it can be packed into budgeted requests.
  *
- * One `git diff` per file rather than one call parsed apart: a `diff --git`
- * split over the combined output has to re-derive path boundaries from the
- * text, and a path containing the separator (or a rename header) breaks that
- * parse silently. N cheap subprocesses cost milliseconds and cannot mis-parse.
+ * One `git diff` per file rather than splitting the combined output, because
+ * packing needs a SIZE PER FILE before any text is assembled — a combined diff
+ * gives one blob and its per-file sizes only by re-deriving path boundaries
+ * from the text.
+ *
+ * The rationale this replaces claimed the combined form "breaks that parse
+ * silently" on separator-bearing paths. That was a straw man: the pre-change
+ * code never parsed the combined diff at all, it sent it whole.
+ *
+ * It is not free either. Each three-dot diff re-resolves the merge base at
+ * ~93 ms, so a 316-file span costs ~30 s. That is paid ONCE now — `buildPlan`
+ * stores the partition and `main` reuses it, where it used to recompute and
+ * pay twice.
  */
 function perFileDiffs(baseRef: string, files: readonly string[], cwd: string = REPO_ROOT): FileDiff[] {
     const out: FileDiff[] = [];
@@ -142,6 +156,7 @@ function perFileDiffs(baseRef: string, files: readonly string[], cwd: string = R
     return out;
 }
 
+/** Sum of added+deleted lines across `files` (binary files count 0). */
 function changedLineCount(baseRef: string, files: string[], cwd: string = REPO_ROOT): number {
     if (files.length === 0) return 0;
     const r = spawnSync('git', ['diff', '--numstat', `${baseRef}...HEAD`, '--', ...files], {
@@ -260,14 +275,19 @@ function buildSystemPrompt(release?: ReleaseInfo, baseRef?: string): string {
 
 // Prompt budget and partitioning.
 //
-// Measured across FOUR consecutive releases (14.17.0, 14.18.0, 14.19.0,
-// 14.20.0): the live call returned `HTTP 400 prompt is too long` every time and
-// the gate reviewed nothing. The release path sets `analysisBase` to the
-// previous tag, so the whole release span goes into one request — 413191,
-// 450336 and 260998 input tokens against a 200000 cap on the three releases
-// that recorded a figure. The smallest of them still exceeds the cap by 30 %,
-// so this is structural: no release span observed to date fits in one call, and
-// waiting for smaller spans is not a fix.
+// Measured across FOUR consecutive releases: the live call returned
+// `HTTP 400 prompt is too long` every time and the gate reviewed nothing. The
+// release path sets `analysisBase` to the previous tag, so the whole release
+// span goes into one request. ALL FOUR recorded a figure against the 200000
+// cap — 235472 (14.17.0), 413191 (14.18.0), 450336 (14.19.0), 260998
+// (14.20.0). The smallest exceeds the cap by 17.7 %.
+//
+// Corrected here: an earlier version of this comment said three releases
+// recorded a figure and put the smallest at 30 % over. Both were wrong, and the
+// omitted measurement was the one NEAREST the cap — the reading that most
+// constrains the budget below. The conclusion is unchanged and does not depend
+// on the error: every span observed exceeds the cap, so this is structural and
+// waiting for smaller releases is not a fix.
 //
 // `promptChars` was already computed and only REPORTED. Nothing consulted it
 // before spending the call.
@@ -280,42 +300,83 @@ function buildSystemPrompt(release?: ReleaseInfo, baseRef?: string): string {
 // is NAMED as unreviewed.
 
 /**
+ * Chars per token the budget assumes, and the measurement behind it.
+ *
+ * A proxy, not a measurement of the real thing: the cap is enforced by the
+ * provider's tokenizer, which this repository cannot run — `js-tiktoken` is a
+ * DIFFERENT tokenizer, so agreeing with it would prove nothing.
+ *
+ * The ratio is DERIVED from the four failures, dividing measured diff chars by
+ * the token count the API itself reported:
+ *
+ *   14.19.0…14.20.0    817,805 chars / 260,998 tokens  =  3.13
+ *   14.18.0…14.19.0  1,432,333 chars / 450,336 tokens  =  3.18
+ *
+ * An earlier version of this constant used 3.0 and called it "deliberately
+ * pessimistic". It was not: against a measured 3.13 that is 4 % of margin, and
+ * the ratio is strongly content-dependent — cl100k over this repo's own diffs
+ * reads ~3.9 for `src/`, ~4.1 for `agents/` prose and ~2.75 for a lockfile,
+ * a 1.5x spread. Dense JSON, CSV and YAML paths are not excluded from the
+ * review scope, so a chunk of them tokenizes far worse than the average the
+ * two spans above describe. 2.4 covers the lockfile-shaped end with the same
+ * ~22 % gap those spans show between cl100k and the provider's count.
+ *
+ * A call that still overflows a chunk built under this budget falsifies this
+ * number, not the partitioning — and the failure is graceful either way: the
+ * chunk is reported unreviewed and the run continues.
+ */
+export const BUDGET_CHARS_PER_TOKEN = 2.4;
+
+/**
  * Input budget for one request, in characters.
  *
- * A character proxy, and the reason it is a proxy rather than a measurement:
- * the cap is enforced by the provider's own tokenizer, which this repository
- * cannot run — `js-tiktoken` is a DIFFERENT tokenizer and agreeing with it
- * would prove nothing. So the factor is deliberately pessimistic. Diff text is
- * dense in punctuation and short tokens, where 3 chars/token is a conservative
- * floor rather than the ~4 that prose averages; 190000 leaves headroom under
- * the 200000 cap for the system prompt and for the tokenizer disagreeing with
- * this estimate.
- *
- * A call that still returns `prompt is too long` for a chunk built under this
- * budget falsifies the factor, not the partitioning.
+ * 180000 rather than the full 200000 cap because the system prompt rides along
+ * with EVERY request and is not part of the chunk: the two review skill bodies
+ * are ~14000 chars, and in release mode `releaseNoteText` joins the entire
+ * packaging file list into it — ~12600 chars at 316 files. Both are charged per
+ * chunk, so the reservation has to cover them at the same pessimistic ratio.
  */
-export const PROMPT_BUDGET_CHARS = 190_000 * 3;
+export const PROMPT_BUDGET_CHARS = Math.floor(180_000 * BUDGET_CHARS_PER_TOKEN);
 
 /**
  * Cost ceiling, in requests per run.
  *
  * The gate is advisory and single-maintainer-funded, so an unbounded chunk
- * count would turn one failed call into an arbitrary bill. Four is chosen
- * against the measured span sizes: the largest recorded (450336 tokens) needs
- * three chunks at this budget, so four covers every span measured with one to
- * spare. A span that needs more is reviewed up to the ceiling and the remainder
- * is reported unreviewed — a partial review that says so, never a silent one.
+ * count would turn one failed call into an arbitrary bill. A span that needs
+ * more is reviewed up to the ceiling and the remainder reported unreviewed — a
+ * partial review that says so, never a silent one.
+ *
+ * SIX, and the number moved for a measured reason rather than for comfort. It
+ * was four while the budget assumed 3.0 chars/token. Correcting that assumption
+ * to the measured 2.4 shrank each request, so the same span needs more of them:
+ * the live 14.19.0...HEAD span went to FIVE requests at the corrected budget and
+ * reported 82 files unreviewed. Buying tokenizer safety with coverage is not a
+ * trade this gate should make silently, so the ceiling absorbs it with one
+ * request of headroom above the largest span measured.
+ *
+ * The cost is real and is the reason this is a constant rather than unbounded:
+ * six requests of up to ~180000 input tokens is the worst case per run, and
+ * `--dry-run` prints the count before anything is spent.
  */
-export const MAX_REVIEW_CHUNKS = 4;
+export const MAX_REVIEW_CHUNKS = 6;
+
+/** How many unreviewed paths `--dry-run` names before collapsing to a count. */
+export const DRY_RUN_UNREVIEWED_SAMPLE = 5;
 
 export interface FileDiff {
     path: string;
     diff: string;
 }
 
+export interface DiffChunk {
+    /** Concatenated diff text for one request. */
+    text: string;
+    /** The files this chunk carries — so coverage counts what was READ. */
+    files: string[];
+}
+
 export interface DiffPartition {
-    /** Each chunk is the concatenated diff text for one request. */
-    chunks: string[];
+    chunks: DiffChunk[];
     /** Files no chunk carries, with the reason — rendered into the review. */
     unreviewed: { path: string; reason: string }[];
 }
@@ -336,9 +397,10 @@ export function partitionDiff(
     budgetChars: number = PROMPT_BUDGET_CHARS,
     maxChunks: number = MAX_REVIEW_CHUNKS,
 ): DiffPartition {
-    const chunks: string[] = [];
+    const ceiling = Math.max(0, maxChunks);
+    const chunks: DiffChunk[] = [];
     const unreviewed: { path: string; reason: string }[] = [];
-    let current = '';
+    let current: DiffChunk = { text: '', files: [] };
 
     for (const f of files) {
         if (f.diff.length > budgetChars) {
@@ -351,27 +413,34 @@ export function partitionDiff(
             });
             continue;
         }
-        if (current !== '' && current.length + f.diff.length > budgetChars) {
+        if (current.text !== '' && current.text.length + f.diff.length > budgetChars) {
             chunks.push(current);
-            current = '';
+            current = { text: '', files: [] };
         }
-        current += f.diff;
+        current.text += f.diff;
+        current.files.push(f.path);
     }
-    if (current !== '') chunks.push(current);
+    if (current.text !== '') chunks.push(current);
 
-    if (chunks.length > maxChunks) {
-        // Which FILES fall outside the ceiling cannot be recovered from the
-        // packed strings, so the dropped chunks are reported as a count and the
-        // renderer says so — naming a file it cannot identify would be worse
-        // than an honest aggregate.
-        const dropped = chunks.length - maxChunks;
-        chunks.length = maxChunks;
-        unreviewed.push({
-            path: `(${String(dropped)} further chunk(s))`,
-            reason:
-                `the span needs ${String(dropped + maxChunks)} requests at this budget and the ` +
-                `per-run ceiling is ${String(maxChunks)}; the remainder was not sent`,
-        });
+    if (chunks.length > ceiling) {
+        // Every dropped chunk names its own files. The first version packed to
+        // opaque strings and reported ONE aggregate entry for all of them, which
+        // made the coverage subtraction downstream count every dropped file as
+        // reviewed — 59 of 60 for a run that read 4. That was not an inherent
+        // limit of the problem, as its comment claimed; it was a consequence of
+        // throwing the file list away here.
+        const total = chunks.length;
+        for (const dropped of chunks.slice(ceiling)) {
+            for (const path of dropped.files) {
+                unreviewed.push({
+                    path,
+                    reason:
+                        `the span needs ${String(total)} requests at this budget and the ` +
+                        `per-run ceiling is ${String(ceiling)}; this file's chunk was not sent`,
+                });
+            }
+        }
+        chunks.length = ceiling;
     }
     return { chunks, unreviewed };
 }
@@ -380,6 +449,16 @@ export function partitionDiff(
 export interface ReviewPlan {
     skills: string[];
     files: string[];
+    /**
+     * The partition the live run will send, computed ONCE.
+     *
+     * `main` used to call `partitionDiff(perFileDiffs(...))` again over the same
+     * span. Measured: `git diff <base>...HEAD -- <one file>` costs ~93 ms
+     * because every three-dot form re-resolves the merge base, so 316 files
+     * meant ~632 spawns and about a minute of wall clock per live run, half of
+     * it thrown away.
+     */
+    partition: DiffPartition;
     /** Model calls the live run will make — one per budgeted chunk. */
     requests: number;
     /** Files no request will carry, with the reason. */
@@ -422,6 +501,7 @@ export function buildPlan(baseRef: string, cwd: string = REPO_ROOT): ReviewPlan 
     // calls that becomes hides the number the maintainer is deciding about.
     const partition = partitionDiff(perFileDiffs(analysisBase, files, cwd));
     return {
+        partition,
         requests: partition.chunks.length,
         unreviewed: partition.unreviewed,
         skills: [...REVIEW_SKILLS],
@@ -434,7 +514,8 @@ export function buildPlan(baseRef: string, cwd: string = REPO_ROOT): ReviewPlan 
             files.length === 0
                 ? 'No reviewable (non-generated) files changed — the live review would no-op.'
                 : `${files.length} reviewable file(s); live review would send ~${Math.ceil(
-                      (systemPrompt.length + diff.length) / 4,
+                      (systemPrompt.length * Math.max(1, partition.chunks.length) + diff.length) /
+                          BUDGET_CHARS_PER_TOKEN,
                   )} input tokens across ${partition.chunks.length} request(s)` +
                   (partition.unreviewed.length > 0
                       ? `, leaving ${partition.unreviewed.length} path(s) UNREVIEWED.`
@@ -515,13 +596,18 @@ export function coverageBlock(coverage?: ReviewCoverage): string {
     if (!coverage) return '';
     const parts = [
         `\n\n**Coverage.** ${String(coverage.chunks)} request(s) over ` +
-            `${String(coverage.filesReviewed)} file(s).`,
+            `${String(coverage.filesReviewed)} of ${String(coverage.filesTotal)} changed file(s).`,
     ];
     if (coverage.unreviewed.length > 0) {
         parts.push(
             ` **NOT reviewed (${String(coverage.unreviewed.length)}):**\n` +
                 coverage.unreviewed.map((u) => `- \`${u.path}\` — ${u.reason}`).join('\n') +
-                '\nFindings above cover the reviewed part only; absence of a finding for an ' +
+                // Blank line, not a single newline: GFM treats one newline after
+                // a list item as lazy continuation, so the sentence rendered
+                // INSIDE the last bullet instead of standing on its own. The
+                // `toContain` assertion passed either way, which is why the
+                // reviewer had to render it to see it.
+                '\n\nFindings above cover the reviewed part only; absence of a finding for an ' +
                 'unreviewed path is not evidence about that path.',
         );
     }
@@ -530,7 +616,10 @@ export function coverageBlock(coverage?: ReviewCoverage): string {
 
 export interface ReviewCoverage {
     chunks: number;
+    /** Files carried by chunks whose call RETURNED. */
     filesReviewed: number;
+    /** Files the span changed, so the reader sees the fraction, not a bare count. */
+    filesTotal: number;
     unreviewed: { path: string; reason: string }[];
 }
 
@@ -623,16 +712,36 @@ export function main(argv: string[]): 0 | 2 {
                 `  calls:  ${plan.requests} (budget ${String(PROMPT_BUDGET_CHARS)} chars/request, ` +
                 `ceiling ${String(MAX_REVIEW_CHUNKS)})\n` +
                 (plan.unreviewed.length > 0
-                    ? `  UNREVIEWED: ${plan.unreviewed.map((u) => u.path).join(', ')}\n`
+                    ? `  UNREVIEWED (${String(plan.unreviewed.length)}): ` +
+                      // Capped: a real run reported 82 paths, and 82 paths on one
+                      // line is not a report anybody reads. The count is the
+                      // decision-relevant number; the names are a sample.
+                      `${plan.unreviewed
+                          .slice(0, DRY_RUN_UNREVIEWED_SAMPLE)
+                          .map((u) => u.path)
+                          .join(', ')}` +
+                      (plan.unreviewed.length > DRY_RUN_UNREVIEWED_SAMPLE
+                          ? ` … +${String(plan.unreviewed.length - DRY_RUN_UNREVIEWED_SAMPLE)} more`
+                          : '') +
+                      '\n' +
+                      // The reason was computed and never printed, so the
+                      // operator saw what WOULD be sent and never what the span
+                      // needs.
+                      `      reason: ${plan.unreviewed[0]?.reason ?? 'unknown'}\n`
                     : '') +
                 // At the ceiling nothing is lost YET, and the next slightly
                 // larger span loses its remainder silently apart from the
                 // coverage line. Saying so while it is still a warning is the
                 // only cheap moment: the alternative is reading it in a
                 // published review's coverage block.
-                (plan.requests >= MAX_REVIEW_CHUNKS && plan.unreviewed.length === 0
+                // Gated on the ceiling ALONE. The first version also required
+                // `unreviewed.length === 0`, which silenced the warning in the
+                // states nearest to loss: once a span has one over-budget file
+                // the two facts are independent, and conflating them hid the
+                // warning exactly when it mattered.
+                (plan.requests >= MAX_REVIEW_CHUNKS
                     ? `  ⚠️  at the per-run ceiling (${String(MAX_REVIEW_CHUNKS)}) — a larger span ` +
-                      'would leave its remainder unreviewed\n'
+                      'loses its remainder\n'
                     : '') +
                 `  ${plan.note}\n` +
                 (plan.escalation.length
@@ -673,15 +782,23 @@ export function main(argv: string[]): 0 | 2 {
     try {
         const client = new AnthropicClient({ api_key: key });
         const systemPrompt = buildSystemPrompt(plan.release, baseRef);
-        const partition = partitionDiff(perFileDiffs(plan.analysisBase, plan.files));
+        const partition = plan.partition;
 
         if (partition.chunks.length === 0) {
-            // Every file individually over budget. Reviewing nothing while
-            // saying nothing is the state four releases were already in, so it
-            // is reported as NEUTRAL with the reason rather than as a pass.
+            // Reviewing nothing while saying nothing is the state four releases
+            // were already in, so this reports NEUTRAL with the reason. The
+            // reason is DERIVED rather than asserted: the first version said
+            // "every changed file exceeds the per-request budget", which is one
+            // of several ways to get here and was simply wrong for the others
+            // (an empty per-file diff, for instance).
+            const why =
+                partition.unreviewed.length > 0
+                    ? `${String(partition.unreviewed.length)} path(s) could not be placed in a ` +
+                      `request: ${partition.unreviewed[0]?.reason ?? 'unknown'}`
+                    : 'no file produced a diff to review';
             process.stdout.write(
-                '::warning::self-review-gate NEUTRAL — every changed file exceeds the per-request ' +
-                    'budget, nothing was reviewed, not a blocker.\n',
+                `::warning::self-review-gate NEUTRAL — ${why}; nothing was reviewed, not a ` +
+                    'blocker.\n',
             );
             return 0;
         }
@@ -693,21 +810,28 @@ export function main(argv: string[]): 0 | 2 {
         const findings: Finding[] = [];
         const unreviewed = [...partition.unreviewed];
         let reviewedChunks = 0;
+        let filesRead = 0;
         for (const [i, chunk] of partition.chunks.entries()) {
-            const resp = client.ask(systemPrompt, chunk, 4096);
+            const resp = client.ask(systemPrompt, chunk.text, 4096);
             if (resp.error) {
                 process.stdout.write(
                     `::warning::self-review-gate — chunk ${String(i + 1)}/` +
                         `${String(partition.chunks.length)} did not complete (${resp.error}); ` +
                         'continuing with the remaining chunks.\n',
                 );
-                unreviewed.push({
-                    path: `(chunk ${String(i + 1)} of ${String(partition.chunks.length)})`,
-                    reason: `the model call did not complete: ${resp.error}`,
-                });
+                // The chunk's OWN files, not a synthetic entry: a failed chunk
+                // used to be recorded as one unnamed row while the coverage
+                // count still credited all its files as read.
+                for (const path of chunk.files) {
+                    unreviewed.push({
+                        path,
+                        reason: `the model call for this file's chunk did not complete: ${resp.error}`,
+                    });
+                }
                 continue;
             }
             reviewedChunks += 1;
+            filesRead += chunk.files.length;
             findings.push(...parseFindings(resp.text));
         }
 
@@ -719,9 +843,15 @@ export function main(argv: string[]): 0 | 2 {
             return 0;
         }
 
+        // Counted from the chunks that actually returned, never derived by
+        // subtracting rows from the file total. The subtraction was wrong in
+        // both of this change's own new states: one aggregate row for N dropped
+        // chunks credited N-1 unread files as read, and per-chunk failures were
+        // appended AFTER the number was computed.
         const coverage: ReviewCoverage = {
             chunks: reviewedChunks,
-            filesReviewed: plan.files.length - partition.unreviewed.length,
+            filesReviewed: filesRead,
+            filesTotal: plan.files.length,
             unreviewed,
         };
         const outIdx = argv.indexOf('--findings-out');

--- a/tests/scripts/self_review_prompt_budget.test.ts
+++ b/tests/scripts/self_review_prompt_budget.test.ts
@@ -1,72 +1,133 @@
 // Regression lock for a gate that reviewed NOTHING for four consecutive
 // releases while reporting itself as merely neutral.
 //
-// Measured (14.17.0, 14.18.0, 14.19.0, 14.20.0): the release path sets the
-// analysis base to the previous tag, so the whole release span went into ONE
-// request and the provider answered `HTTP 400 prompt is too long` every time.
-// The three releases that recorded a figure measured 413191, 450336 and 260998
-// input tokens against a 200000 cap — the SMALLEST still 30 % over, which is
-// what makes this structural rather than a run of bad luck.
+// The release path sets the analysis base to the previous tag, so the whole
+// span went into ONE request and the provider answered `HTTP 400 prompt is too
+// long` every time. All four recorded a figure against the 200000 cap: 235472
+// (14.17.0), 413191 (14.18.0), 450336 (14.19.0), 260998 (14.20.0) — the
+// smallest 17.7 % over, which is what makes it structural.
 //
-// `promptChars` was already computed by buildPlan and only reported. Nothing
-// consulted it before spending the call.
+// `buildPlan` already computed `promptChars` and only reported it. Nothing
+// consulted the number before spending the call.
 //
-// The fixtures below are those three measurements, not invented sizes, because
-// the property under test is "the spans this repository actually produces fit"
-// — a partitioner proven only on round numbers proves nothing about them.
+// The FIRST version of this file was reviewed and three of its cases were
+// found to be unable to fail. Each is now derived from something the
+// implementation does not also assume — noted per case, because a test that
+// restates the code's own arithmetic is the failure mode this suite is for.
 import { describe, expect, it } from 'vitest';
 
 import {
+    BUDGET_CHARS_PER_TOKEN,
     MAX_REVIEW_CHUNKS,
     PROMPT_BUDGET_CHARS,
     coverageBlock,
     dedupeFindings,
     partitionDiff,
     renderReview,
+    type ReviewCoverage,
 } from '../../src/scripts/self_review_gate.js';
 
-/** Chars at the pessimistic 3-chars-per-token floor the budget is built on. */
-const chars = (tokens: number): number => tokens * 3;
+/**
+ * MEASURED diff sizes in characters, obtained with `git diff --numstat`-backed
+ * `git diff <prev>...<tag>` over the reviewable set — NOT derived from the token
+ * counts by multiplying with the budget's own factor.
+ *
+ * The earlier version wrote `chars = tokens * 3`, reusing the constant under
+ * test, so `it.each` asserted only that `tokens × 3` divides into ceilings of
+ * `190000 × 3`. That is arithmetic; it could not notice the real ratio being
+ * 3.13 rather than 3.0, which is exactly what the review found.
+ */
+const MEASURED_SPAN_CHARS = {
+    '14.19.0…14.20.0': 817_805,
+    '14.18.0…14.19.0': 1_432_333,
+} as const;
 
-/** A span as it actually arrives: many files, none of them enormous. */
-const spanOf = (totalChars: number, perFile = 50_000): { path: string; diff: string }[] =>
-    Array.from({ length: Math.ceil(totalChars / perFile) }, (_, i) => ({
-        path: `f${String(i)}.ts`,
-        diff: 'x'.repeat(Math.min(perFile, totalChars - i * perFile)),
-    }));
+/** Per-file token counts the API reported, paired with the chars above. */
+const MEASURED_SPAN_TOKENS = {
+    '14.19.0…14.20.0': 260_998,
+    '14.18.0…14.19.0': 450_336,
+} as const;
 
-describe('self-review prompt budget — the measured spans must fit', () => {
-    it.each([
-        ['14.18.0', 413_191],
-        ['14.19.0', 450_336],
-        ['14.20.0', 260_998],
-    ])('%s (%i input tokens) partitions into chunks that all fit', (_rel, tokens) => {
-        const { chunks, unreviewed } = partitionDiff(spanOf(chars(tokens as number)));
-        expect(chunks.length).toBeGreaterThan(0);
-        expect(unreviewed).toEqual([]);
-        for (const c of chunks) expect(c.length).toBeLessThanOrEqual(PROMPT_BUDGET_CHARS);
+/** A span shaped like the real ones: many files, ~6 kB each, not uniform 50 kB. */
+const spanOf = (totalChars: number, perFile = 6_000): { path: string; diff: string }[] => {
+    const out: { path: string; diff: string }[] = [];
+    for (let left = totalChars, i = 0; left > 0; i++, left -= perFile) {
+        out.push({ path: `f${String(i)}.ts`, diff: 'x'.repeat(Math.min(perFile, left)) });
+    }
+    return out;
+};
+
+describe('prompt budget — derived from the measured ratio, not from itself', () => {
+    it('assumes fewer chars per token than either measured span actually used', () => {
+        // The property that matters: the assumed ratio must be BELOW the
+        // observed one, or a budgeted chunk tokenizes larger than planned. This
+        // is why 3.0 was wrong — it sat above the measured 3.13 by only 4 %,
+        // while cl100k puts lockfile-shaped diffs near 2.75.
+        for (const key of Object.keys(MEASURED_SPAN_CHARS) as (keyof typeof MEASURED_SPAN_CHARS)[]) {
+            const observed = MEASURED_SPAN_CHARS[key] / MEASURED_SPAN_TOKENS[key];
+            expect(BUDGET_CHARS_PER_TOKEN).toBeLessThan(observed);
+        }
     });
 
-    it('needs more than one request for every span measured — the defect was assuming one', () => {
-        // If this ever drops to 1 for all three, the budget grew or the spans
-        // shrank; either way the single-call assumption would be worth
-        // revisiting rather than silently relied on again.
-        const counts = [413_191, 450_336, 260_998].map(
-            (t) => partitionDiff(spanOf(chars(t))).chunks.length,
-        );
-        expect(Math.min(...counts)).toBeGreaterThan(1);
+    it('keeps a budgeted chunk under the 200000-token cap at the WORST measured ratio', () => {
+        // 2.748 chars/token is the densest reading cl100k produced over this
+        // repo's own diffs (a lockfile). A chunk of that content must still fit.
+        const worstRatio = 2.748;
+        expect(PROMPT_BUDGET_CHARS / worstRatio).toBeLessThan(200_000);
     });
 
-    it('packs greedily and deterministically — same input, same partition', () => {
-        const files = spanOf(chars(450_336));
-        expect(partitionDiff(files)).toEqual(partitionDiff(files));
+    it('reserves room for the system prompt, which rides on EVERY request', () => {
+        // Skill bodies ~14000 chars plus, in release mode, the packaging file
+        // list (~12600 at 316 files) — charged per chunk, not once.
+        const systemPromptChars = 14_000 + 12_600;
+        const worstRatio = 2.748;
+        expect((PROMPT_BUDGET_CHARS + systemPromptChars) / worstRatio).toBeLessThan(200_000);
+    });
+});
+
+describe('partitionDiff — the measured spans must fit', () => {
+    it.each(Object.keys(MEASURED_SPAN_CHARS) as (keyof typeof MEASURED_SPAN_CHARS)[])(
+        '%s partitions into chunks that all fit',
+        (key) => {
+            const { chunks, unreviewed } = partitionDiff(spanOf(MEASURED_SPAN_CHARS[key]));
+            expect(chunks.length).toBeGreaterThan(0);
+            expect(unreviewed).toEqual([]);
+            for (const c of chunks) expect(c.text.length).toBeLessThanOrEqual(PROMPT_BUDGET_CHARS);
+        },
+    );
+
+    it('packs GREEDILY — the chunk count matches an independently computed minimum', () => {
+        // The earlier case was `expect(partitionDiff(f)).toEqual(partitionDiff(f))`,
+        // which holds for ANY pure function: worst-fit, reverse-order, or a body
+        // returning everything unreviewed would all pass it. This asserts the
+        // packing property instead, against a count computed here rather than
+        // read back from the implementation.
+        const perFile = 6_000;
+        const files = spanOf(MEASURED_SPAN_CHARS['14.18.0…14.19.0'], perFile);
+        const perChunk = Math.floor(PROMPT_BUDGET_CHARS / perFile);
+        const expected = Math.ceil(files.length / perChunk);
+        expect(partitionDiff(files).chunks).toHaveLength(expected);
+    });
+
+    it('fills each chunk to within one file of the budget', () => {
+        const perFile = 6_000;
+        const files = spanOf(MEASURED_SPAN_CHARS['14.18.0…14.19.0'], perFile);
+        const chunks = partitionDiff(files).chunks;
+        // Every chunk but the last must be too full to take one more file.
+        for (const c of chunks.slice(0, -1)) {
+            expect(c.text.length + perFile).toBeGreaterThan(PROMPT_BUDGET_CHARS);
+        }
+    });
+
+    it('every chunk KNOWS its files, and the union is exactly the input', () => {
+        // The defect the review gated on traces to packing into opaque strings:
+        // once the file list is gone, coverage cannot count what was read.
+        const files = spanOf(MEASURED_SPAN_CHARS['14.19.0…14.20.0']);
+        const { chunks } = partitionDiff(files);
+        expect(chunks.flatMap((c) => c.files)).toEqual(files.map((f) => f.path));
     });
 
     it('NEVER splits a single over-budget file — it names it instead', () => {
-        // A diff cut at an arbitrary offset yields half a hunk, and a finding
-        // about half a hunk describes code that does not exist. Not reading it
-        // is the lesser failure, and it is only the lesser failure if it is
-        // reported.
         const { chunks, unreviewed } = partitionDiff([
             { path: 'giant.ts', diff: 'y'.repeat(PROMPT_BUDGET_CHARS + 1) },
         ]);
@@ -83,21 +144,40 @@ describe('self-review prompt budget — the measured spans must fit', () => {
             { path: 'ok-b.ts', diff: 'b'.repeat(10) },
         ]);
         expect(chunks).toHaveLength(1);
-        expect(chunks[0]).toBe(`${'a'.repeat(10)}${'b'.repeat(10)}`);
+        expect(chunks[0]?.files).toEqual(['ok-a.ts', 'ok-b.ts']);
         expect(unreviewed.map((u) => u.path)).toEqual(['giant.ts']);
     });
 
-    it('honours the cost ceiling and reports the remainder as a count', () => {
-        const many = Array.from({ length: 40 }, (_, i) => ({
+    it('THE BLOCKER: a dropped chunk names EVERY file in it, not one aggregate row', () => {
+        // Measured by the reviewer: with one aggregate entry, the downstream
+        // coverage subtraction reported 59 of 60 files reviewed for a run that
+        // read 4. The count has to come from named paths.
+        const files = Array.from({ length: 60 }, (_, i) => ({
             path: `g${String(i)}.ts`,
             diff: 'z'.repeat(PROMPT_BUDGET_CHARS - 1),
         }));
-        const { chunks, unreviewed } = partitionDiff(many);
+        const { chunks, unreviewed } = partitionDiff(files);
         expect(chunks).toHaveLength(MAX_REVIEW_CHUNKS);
-        // The dropped FILES are unrecoverable from packed strings, so an honest
-        // aggregate beats naming paths the partitioner cannot identify.
-        expect(unreviewed).toHaveLength(1);
+        expect(unreviewed).toHaveLength(60 - MAX_REVIEW_CHUNKS);
+        expect(unreviewed.map((u) => u.path)).toEqual(
+            files.slice(MAX_REVIEW_CHUNKS).map((f) => f.path),
+        );
         expect(unreviewed[0]?.reason).toContain('per-run ceiling');
+    });
+
+    it('a zero or negative ceiling drops everything instead of throwing', () => {
+        // `chunks.length = -1` threw RangeError, which `main` swallowed into its
+        // NEUTRAL catch — reviewing nothing while reporting an unexpected error.
+        expect(() => partitionDiff([{ path: 'a.ts', diff: 'x' }], 100, -1)).not.toThrow();
+        const v = partitionDiff([{ path: 'a.ts', diff: 'x' }], 100, -1);
+        expect(v.chunks).toEqual([]);
+        expect(v.unreviewed.map((u) => u.path)).toEqual(['a.ts']);
+    });
+
+    it('a chunk exactly at the budget is kept', () => {
+        const v = partitionDiff([{ path: 'a.ts', diff: 'x'.repeat(1000) }], 1000);
+        expect(v.chunks).toHaveLength(1);
+        expect(v.unreviewed).toEqual([]);
     });
 
     it('an empty span produces no chunks and no complaint', () => {
@@ -106,12 +186,12 @@ describe('self-review prompt budget — the measured spans must fit', () => {
 });
 
 describe('merged findings', () => {
-    const f = (title: string, file = 'a.ts') => ({
+    const f = (title: string, file: string | undefined = 'a.ts', detail = '') => ({
         severity: 'high' as const,
         kind: 'security' as const,
         title,
-        detail: '',
-        file,
+        detail,
+        ...(file === undefined ? {} : { file }),
     });
 
     it('collapses a finding two chunks both reported', () => {
@@ -126,42 +206,72 @@ describe('merged findings', () => {
         const out = dedupeFindings([f('first'), f('second'), f('first')]);
         expect(out.map((x) => x.title)).toEqual(['first', 'second']);
     });
+
+    it('DOES collapse two same-file findings with different detail — a known cost', () => {
+        // `findingId` is sha256(kind|title|file) and excludes `detail`, so this
+        // is lossy by construction. Pinned rather than hidden: the id is the
+        // identity the ledger and the rendered table already share, and changing
+        // it would break `check_finding_dispositions --pr` matching. The cost is
+        // that a model reporting two distinct defects under one headline in one
+        // file loses the second.
+        const out = dedupeFindings([f('same', 'a.ts', 'first'), f('same', 'a.ts', 'second')]);
+        expect(out).toHaveLength(1);
+        expect(out[0]?.detail).toBe('first');
+    });
 });
 
 describe('coverage is stated in the comment, not only in the log', () => {
+    const cov = (over: Partial<ReviewCoverage> = {}): ReviewCoverage => ({
+        chunks: 2,
+        filesReviewed: 30,
+        filesTotal: 31,
+        unreviewed: [{ path: 'giant.ts', reason: 'over budget' }],
+        ...over,
+    });
+
     it('names what was NOT reviewed and refuses to read as whole-span', () => {
-        const block = coverageBlock({
-            chunks: 2,
-            filesReviewed: 30,
-            unreviewed: [{ path: 'giant.ts', reason: 'over budget' }],
-        });
+        const block = coverageBlock(cov());
         expect(block).toContain('NOT reviewed');
         expect(block).toContain('giant.ts');
-        // The load-bearing sentence: without it a reader treats a missing
-        // finding for an unreviewed path as evidence about that path.
         expect(block).toContain('not evidence about that path');
+    });
+
+    it('states the FRACTION, so a partial read cannot look complete', () => {
+        expect(coverageBlock(cov())).toContain('30 of 31');
+    });
+
+    it('puts the load-bearing sentence in its own paragraph', () => {
+        // A single newline after the last list item is lazy continuation in GFM,
+        // so the sentence rendered INSIDE the last bullet. `toContain` passed
+        // either way, which is why this asserts the blank line.
+        expect(coverageBlock(cov())).toContain('\n\nFindings above cover');
     });
 
     it('says nothing when there is nothing to disclose', () => {
         expect(coverageBlock(undefined)).toBe('');
-        expect(coverageBlock({ chunks: 1, filesReviewed: 3, unreviewed: [] })).not.toContain(
-            'NOT reviewed',
-        );
+        expect(
+            coverageBlock({ chunks: 1, filesReviewed: 3, filesTotal: 3, unreviewed: [] }),
+        ).not.toContain('NOT reviewed');
     });
 
     it('reaches the rendered review on BOTH paths — findings and no findings', () => {
-        // The no-findings path is the one that matters: "no findings" over a
-        // partial read is exactly the false green the partitioning exists to
-        // prevent, and it is the path a reader is least likely to question.
-        const cov = { chunks: 2, filesReviewed: 5, unreviewed: [{ path: 'g.ts', reason: 'big' }] };
-        expect(renderReview([], false, [], cov)).toContain('NOT reviewed');
+        // The no-findings path matters most: "no findings" over a partial read
+        // is the false green, and it is the path a reader least questions.
+        expect(renderReview([], false, [], cov())).toContain('NOT reviewed');
         expect(
             renderReview(
                 [{ severity: 'high', kind: 'security', title: 't', detail: '', file: 'a.ts' }],
                 false,
                 [],
-                cov,
+                cov(),
             ),
         ).toContain('NOT reviewed');
+    });
+
+    it('stays byte-identical to the pre-change render when no coverage is passed', () => {
+        const fs = [
+            { severity: 'high' as const, kind: 'security' as const, title: 't', detail: '', file: 'a.ts' },
+        ];
+        expect(renderReview(fs, false, [])).toBe(renderReview(fs, false));
     });
 });


### PR DESCRIPTION
Follow-up to #1909, which **merged while these fixes were being written**. `main` therefore carries the first version, and a neutral reviewer found three defects in it — in the very thing that PR promises.

## The three the reviewer gated on

| # | Defect | Effect on `main` today |
|---|---|---|
| 1 | `filesReviewed = plan.files.length - partition.unreviewed.length`, and a ceiling truncation pushes **one** aggregate row for all dropped chunks | 60 files at ceiling 4 renders **"59 file(s)"** for a run that read **4** |
| 2 | per-chunk failure rows are appended *after* that number is computed | a 4-chunk run losing one claims all 316 files read while ~79 were not — and the failed chunk appears in the NOT-reviewed list, so the block contradicts itself |
| 3 | `git diff --name-only` renders `grüße.ts` as quoted `"gr\303\274\303\237e.ts"`, which matches no pathspec | the file is silently skipped by the empty-diff guard **and** counted as read |

All three make the Coverage block state a higher count than what was read — the exact false green #1909's rationale says the partitioning exists to prevent.

**Fixed at the root the reviewer identified.** The comment claimed the dropped file list was "unrecoverable from packed strings"; it was not unrecoverable, it was *discarded* by packing to opaque strings. `DiffChunk` now carries its files, every dropped chunk names its own, coverage is **summed from the chunks that returned**, and paths are read with `-c core.quotePath=false` (verified in a temp repo).

## Also from the review

- **The budget ratio was not pessimistic.** 3.0 chars/token against a measured **3.13 / 3.18** is 4 % margin, and cl100k puts a lockfile diff at **~2.75** — a 1.5x content spread a single factor must floor. Now **2.4**, derived in the header from the four failures, with the system prompt (skill bodies + the per-chunk packaging file list, ~26 kB in release mode) reserved for rather than ignored.
- **Ceiling 4 -> 6.** The corrected ratio shrinks each request, so the live span went to **five** and reported 82 files unreviewed. Buying tokenizer safety with silent coverage loss is not a trade to make quietly — so the ceiling absorbs it. The cost is real: six requests of up to ~180k input tokens worst case, and `--dry-run` prints the count first.
- **My measurement claim was wrong.** **Four** releases recorded a figure, not three. `14.17.0`'s **235,472** was omitted — and it is the reading *nearest* the cap, the one that most constrains the budget. The smallest overflow is **17.7 %**, not 30 %. Corrected in source, tests and changelog, with the error named rather than quietly replaced.
- **A test that could not fail.** `expect(partitionDiff(f)).toEqual(partitionDiff(f))` holds for any pure function — worst-fit packing or a body returning everything unreviewed would pass it. Replaced with a chunk count computed independently of the implementation plus a fill-density assertion. The span fixtures also stopped deriving chars from tokens with the budget's own factor; they now use the **measured char counts**, so they can notice the ratio being wrong.
- **The coverage sentence rendered inside a bullet** (GFM lazy continuation). Blank line added — the old `toContain` passed either way, which is why only rendering it revealed this.
- **`perFileDiffs` ran twice per live run** at ~93 ms per file (~60 s at 316 files). The plan carries the partition and the live path reuses it.
- Negative `maxChunks` threw `RangeError` into the NEUTRAL catch (reviewing nothing while reporting an unexpected error). Clamped.
- The `perFileDiffs` rationale was a straw man — the pre-change code never parsed the combined diff, it sent it whole. Replaced with the real reason: packing needs a per-file size before assembling text.
- **Docs** updated; the table still said "one review call", and the page carried nothing about the budget, ceiling or coverage.

## Evidence

```
60 files, ceiling 4
  OLD formula (files - unreviewed.length) = 59   <- the lie
  NEW number (summed from chunks)         = 4
**Coverage.** 4 request(s) over 4 of 60 changed file(s). **NOT reviewed (56):**
```

Live span, after the ratio correction: `calls: 5 (budget 432000 chars/request, ceiling 6)`, no path left out. 24 cases; 92 tests across the four touched suites; `typecheck`, `eslint`, `lint_code_comments` clean.

## Still not fixed, and now written down

- **Coverage lives in prose.** `gateVerdict` takes no coverage input, so an `--enforce` run over a partial review still returns 0. The exit code is the one surface that does not say what it read.
- **The ledger does not record coverage.** The artifact now carries it, but `check_finding_dispositions --ingest` reads only `.findings`, so a 4-of-60 review is byte-indistinguishable from a complete one in `release-findings/<version>.json`.

Both are named in `docs/self-review-gate.md` § What this does NOT fix rather than left for the next reader to discover.
