### PR TITLE
roadmap: record why the two carrier roadmaps were not executed

### DIFF
--- a/agents/roadmaps/road-to-continuity-retirement-sequencing.md
+++ b/agents/roadmaps/road-to-continuity-retirement-sequencing.md
@@ -40,6 +40,77 @@ executed as written — `chat-history:checkpoint` reaches a real handler
 producers (`install-hooks.sh:408-424`), and the append it performs is
 chat-history capture, which the parent's goal places out of scope by decision.
 
+## Drain-run disposition, 2026-09-08 — NOT EXECUTED, and this is the record
+
+An autonomous drain run was instructed to carry **every** active roadmap under
+`agents/roadmaps/` to completion, deciding every blocker by AI council rather
+than by reaching the user. It reached this file, read the promoting probe, and
+**stopped**. This section is what it recorded instead of executing.
+
+**Council verdict: (a) No — a `status: carrier` roadmap is human-gated and an
+autonomous run may not execute, promote, close, or advance it.** Two seats, deep
+tier, unanimous on the verdict and convergent on every sub-ruling.
+
+**The argument, in one line:** *scope is not authority*. The drain instruction
+sets what the run should look at; this file sets who may act on it. "Nothing here
+is scheduled work", "a human flips it to `ready`", and the stub's explicit owner
+reservation are a narrower authority boundary than the word "every", and a run
+that is the interested party must not resolve that ambiguity by enlarging its own
+authority.
+
+**What "active" means here, and why this file is not it.** This roadmap's own
+header states that `carrier` keeps it off the dashboard, out of
+`check_roadmap_trackable` and out of the plan risk register. One seat made that
+the operative point rather than an aside: those exclusions *define* what active
+means in this system, so a file deliberately excluded from active tracking is not
+active for execution purposes regardless of where it sits on disk.
+
+**The probe as measured, 2026-09-07 — unchanged and re-read rather than assumed:
+P1 FALSE · P2 PARTIAL · P3 FALSE · P4 FALSE.** None of the three handlers exists
+as a concern, no shadow writer exists, and `install-hooks.sh:408-424` still emits
+the retired name with no migration path.
+
+### Four rulings that bind a future run, not just this one
+
+1. **The P1 / step-3.1 overlap makes the gate MISDRAWN, not soft.** P1 cannot
+   become true without substantially performing carried step 3.1. Both seats
+   ruled that circular authorisation language is a **drafting defect its owner
+   repairs** — circularity does not manufacture authority for whoever notices it.
+2. **Probe-true does not equal promoted.** Even with P1-P4 all true, a human
+   still flips `carrier` → `ready`. The probe tests readiness preconditions; it
+   does not grant promotion authority, and *"may execute it once the probe reads
+   true"* means "when promoted AND probe-true", never "promote when probe-true".
+3. **The measured-null exit is owner-reserved.** This file permits closing in the
+   other direction, and that exit is **not** available to an autonomous run. Both
+   seats were explicit: a run that may close a roadmap by declaring its work not
+   worth doing holds *more* authority than one that may build it, not less.
+4. **The run owes evidence anyway.** One seat added an affirmative obligation:
+   staying silent about evidence bearing on measured-null fails the maintainer,
+   even though the run cannot adopt that closure. Discharged below.
+
+### The evidence this run owes, per ruling 4
+
+**No measured-null is recommended, and the reason is not neutrality.** P1, P3 and
+P4 are all FALSE and all three are **internal, buildable and reversible** —
+splitting three writers into separate concerns with kill switches, a shadow
+writer plus a recorded parity comparison, and a migration path in
+`install-hooks.sh`. Nothing external is being waited on and no dependency is
+missing. Evidence that a retirement is not worth the migration would have to
+look like an unavailable prerequisite or a cost that exceeds the benefit, and
+neither is present. **What the readings show is unbuilt work, not a dead end** —
+which argues for doing it under a human promotion, not for closing it.
+
+The one cost worth putting in front of the owner: the parent's Risk 1 — *the
+record is added and nothing is retired* — has been live since the parent
+archived, and every day this stays `carrier` is a day that risk stands. That is
+an argument for **promoting** this file, not for closing it.
+
+*Reopening:* a human flips `status` to `ready`, or the owner records a
+measured-null closure. Neither is this run's to do.
+
+Council record: `2026-09-08-carrier-roadmaps-in-an-autonomous-drain.md` under
+`agents/runtime/council/responses/` — local-only, since `agents/runtime/` is
+gitignored, so the substance is transcribed here rather than linked.
 ## Carried steps
 
 - [ ] **3.1 One concern writes the record at the moments context ends.** Carried

--- a/agents/roadmaps/road-to-council-topology-evidence-followups.md
+++ b/agents/roadmaps/road-to-council-topology-evidence-followups.md
@@ -71,6 +71,40 @@ parent_roadmap: road-to-inbox-harvest-2026-08-e-council-topology-evidence
 > closed it, so the pointer that stood here is deliberately not replaced with
 > another.
 
+## Drain-run disposition, 2026-09-08 — NOT EXECUTED, and this is the record
+
+An autonomous drain run instructed to carry **every** active roadmap under
+`agents/roadmaps/` to completion reached this file and **stopped**. This section
+is what it recorded instead of executing 38 carried items.
+
+**Council verdict: (a) No — a `status: carrier` roadmap is human-gated and an
+autonomous run may not execute, promote, close, or advance it.** Two seats, deep
+tier, unanimous. Decided alongside `road-to-continuity-retirement-sequencing`,
+whose disposition section carries the full reasoning; only what is specific to
+**this** file is recorded here, so the two records cannot drift.
+
+**What is specific here: this file has no promoting probe at all** — its sole
+stated transition is *"a human flips it to `ready`"*. The council was asked
+directly whether that absence makes the file **more** protected or **less**,
+because the two readings are opposite and a run must not pick the convenient one.
+
+**Both seats: MORE protected.** A file with a probe at least offers an objective
+condition a future reader can evaluate. This one offers none, so there is no
+autonomous transition to satisfy — "a human flips it" is the whole path, and
+reading an absent condition as an open door inverts what the absence means.
+
+**The measured-null exit is not available here either.** The run may collect
+evidence bearing on whether these 38 items are still worth doing and recommend
+that outcome; it may not adopt it. No such recommendation is made: the run did
+not read the three stubs these groups name, so it has no evidence about the
+items' current worth and says so rather than inferring one from the file's age.
+
+*Reopening:* a human flips `status` to `ready`. Nothing else.
+
+Council record: `2026-09-08-carrier-roadmaps-in-an-autonomous-drain.md` under
+`agents/runtime/council/responses/` — local-only, since `agents/runtime/` is
+gitignored, so the substance is transcribed here and in the sibling carrier
+rather than linked.
 ## Why one receiver rather than three, and the council split behind it
 
 AI council 2026-09-01, members **anthropic (claude-sonnet-4-5)** and **openai


### PR DESCRIPTION
The autonomous drain run reached `road-to-continuity-retirement-sequencing` (0/9) and `road-to-council-topology-evidence-followups` (0/38), read them, and **stopped**. This PR records that as a decision with a verdict behind it, rather than as two files quietly skipped.

## The question, and why it went to the council

The run was instructed to carry **every** active roadmap to completion, deciding every blocker by AI council rather than by reaching the user. Both files say the opposite in their own bodies:

> `status: carrier` keeps it off the roadmap dashboard, out of `check_roadmap_trackable` and out of the plan risk register until a human flips it to `ready`. … **Nothing here is scheduled work**, and nothing here may start until the probe reads true.

Both readings are real, and the run is the interested party in reading its own instruction broadly — which is exactly why it did not decide this itself.

## Verdict: (a) No. Two seats, deep tier, unanimous.

A `status: carrier` roadmap is human-gated. An autonomous run may **inspect and account for** it; it may not execute, promote, close, or advance it. Recording the blocked state discharges the run's obligation to *process* every roadmap. It does **not** complete these two, and they stay at 0/9 and 0/38.

**The argument in one line: scope is not authority.** The drain instruction sets what the run looks at; these files set who may act on them.

**What "active" means here.** One seat made an aside into the operative point: this roadmap's own header lists the things `carrier` excludes it from — the dashboard, `check_roadmap_trackable`, the plan risk register. Those exclusions *define* active in this system, so a file deliberately excluded from active tracking is not active for execution purposes regardless of where it sits on disk.

## Four rulings that bind future runs, not only this one

1. **The P1 / step-3.1 overlap makes the continuity carrier's gate MISDRAWN, not soft.** P1 ("three independent handlers exist as separate concerns") cannot become true without substantially performing carried step 3.1 — the step it gates. Both seats: circular authorisation language is a **drafting defect its owner repairs**; circularity does not manufacture authority for whoever notices it.
2. **Probe-true is not promoted.** Even with P1–P4 all true, a human still flips `carrier` → `ready`. The probe tests readiness *preconditions*; it does not grant promotion authority. *"May execute it once the probe reads true"* means "when promoted **and** probe-true", never "promote when probe-true".
3. **The measured-null exit is owner-reserved.** The continuity carrier explicitly permits closing in the other direction, and that exit is not available to an autonomous run — a run that may close a roadmap by declaring its work not worth doing holds *more* authority than one that may build it, not less.
4. **A missing probe protects MORE, not less.** The topology carrier has no promoting probe at all; its sole stated transition is "a human flips it to `ready`". Asked directly which way the absence cuts, both seats said more protected: there is no autonomous condition to satisfy, and reading an absent condition as an open door inverts what the absence means.

## The affirmative half — evidence the run owes even where it cannot act

One seat added an obligation the run would otherwise have skipped: staying silent about evidence bearing on measured-null fails the maintainer, even though the run cannot adopt that closure. Discharged in both files:

- **Continuity carrier — the evidence points the other way, and that is stated rather than left as neutrality.** The probe as measured 2026-09-07 reads **P1 FALSE · P2 PARTIAL · P3 FALSE · P4 FALSE**, and P1, P3 and P4 are each **internal, buildable and reversible** — splitting three writers into separate concerns with kill switches, a shadow writer plus a recorded parity comparison, a migration path in `install-hooks.sh:408-424`. Nothing external is being waited on. Evidence for a measured null would have to be an unavailable prerequisite or a cost exceeding the benefit; neither is present. The readings show **unbuilt work, not a dead end**. The one cost worth putting in front of the owner: the parent's Risk 1 — *the record is added and nothing is retired* — has been live since the parent archived, and every day this stays `carrier` is a day that risk stands. **That argues for promoting the file, not for closing it.**
- **Topology carrier — no recommendation is made**, and the reason is stated: the run did not read the three stubs its groups name, so it has no evidence about the items' current worth and will not infer one from the file's age.

## Consequence for the run, stated plainly

**The roadmap directory cannot be emptied by this run.** Two of its files are human-gated by design, and the council ruled that gate binds the run. That is a legitimate terminal state under the run's own fallback clause, not a failure to finish — and this record is what a human needs in order to unblock them: flip `status` to `ready`, or record a measured-null closure.

Gates green: `lint_roadmap_blockers`, `lint_roadmap_complexity`, `lint_roadmap_ci_steps`, `check_roadmap_trackable`, `check_no_roadmap_refs`, `lint_empty_roadmaps`, `lint_roadmap_later_disposition`, `lint_carrier_integrity`, `lint_plan_risk_register`. No checkbox was ticked and no `status` was changed.
