### PR TITLE
roadmap: record the K6 disposition on delivery-on-hook-hosts (it stays active)

### DIFF
--- a/agents/roadmaps/road-to-delivery-on-hook-hosts.md
+++ b/agents/roadmaps/road-to-delivery-on-hook-hosts.md
@@ -388,6 +388,60 @@ admission. Cowork is excluded by the existing measurement.
 - **Resolved when:** at least one host carries an `observed-true` row in `src/config/host-injection-effect.json` with a full citation (host version, transcript pointer, date), and `report_host_injection_effect` regenerates the census with that row admissible.
 - **Review trigger:** re-read when the blocker above resolves, since `delivery` going live is its precondition; otherwise 2026-12-08, matching the expiry the host table already carries for this observation state.
 
+## Disposition, 2026-09-08 — K6 is honoured; this roadmap stays active
+
+An autonomous drain run instructed to carry every roadmap to completion reached
+this file, found both blockers undischargeable by any action available to it, and
+put the disposition to an AI council under the maintainer's written delegation.
+The council was **`⚠️ DEGRADED`, 1 of 2 seats** — the anthropic seat returned
+`exit_1` and did not answer — so what follows is a considered single-seat opinion,
+not convergence, and is recorded at that strength.
+
+**Verdict: Q2-a — honour K6.** The affected lines stay `[ ]`, both blockers stay
+open and accurate, and this roadmap does **not** move to `later/` and is **not**
+re-scoped so it can close. The active directory does not empty, and that is the
+correct outcome rather than a missed step.
+
+Three things the seat said that this file did not already say:
+
+1. **"PR #1923 merged" is an insufficient wake condition.** The real ordering is
+   `compatible predecessor merged` → `lean_projection.hosts` available →
+   `delivery` enabled → qualifying live session → admissible observation →
+   host-dependent acceptance criteria evaluated. A merge does not prove the merged
+   revision carries the expected schema, that Phase 4.2 is live, or that any
+   qualifying observation has occurred.
+2. **Q2-c (re-scope so the roadmap can close) is rejected outright.** Rewriting
+   the acceptance criteria to exclude the missing implementation and evidence
+   *"would convert an unfinished delivery obligation into a completed
+   documentation exercise. That is precisely the false closure K6 guards
+   against."*
+3. **A fourth revisit condition, which this file was missing.** If repeated
+   qualifying sessions produce no `observed-true` result, that calls the
+   acceptance premise itself into question — requiring an `observed-true` outcome
+   makes closure depend on obtaining a *desired empirical result* rather than on
+   conducting a valid observation. The roadmap must be able to distinguish
+   "feature assumption falsified" from "evidence still missing". It cannot today,
+   and that is now on the record rather than latent.
+
+**What a kill-register entry is worth, answered generally because the shape
+recurs:** it is a **binding local decision constraint, defeasible through explicit
+supersession** — more than advice, since ordinary roadmap execution must obey it;
+less than absolute, since a council holding delegated disposition authority can
+overrule it. But *authority alone is not a rationale*. A valid override must
+record the original failure mode, the changed or disproven premise, the
+replacement safeguard, rollback criteria, and a falsifier. Here no premise behind
+K6 has changed, so overruling it merely to empty a directory would be arbitrary.
+
+**Falsifier for this disposition:** an equivalent, stable implementation of
+`lean_projection.hosts` already exists independently of PR #1923, or repository
+history shows K6 addressed a former dependency shape that no longer exists.
+
+**Live state at the time of writing, read rather than recalled:** PR #1923
+(`drain/delivery-for-every-host`) is `OPEN`, `mergeable: CONFLICTING`,
+`mergeStateStatus: DIRTY`, last updated `2026-09-08T06:51:58Z`. Its mergeability
+has been observed to flip within the same run, so read it live rather than from
+this line.
+
 ## Kill register
 
 - **K1** Admitting a host from documentation or by analogy to Claude.


### PR DESCRIPTION
Records a **disposition, not a closure**, for `road-to-delivery-on-hook-hosts`.
The roadmap stays active at 9/16 with both blockers open. That is the outcome, and
this PR exists so the reasoning is on the record rather than re-derived by the
next run that reaches this file.

## Why a drain run is landing a PR that closes nothing

An autonomous drain instructed to carry **every** roadmap to completion reached
this file and found both blockers undischargeable by any action available to it:

- **`predecessor-delivery-for-every-host-unmerged`** — steps 2.1 limb (b), 4.2's
  second half and 1.1's precondition need `lean_projection.hosts`, which exists
  only on the unmerged branch of PR #1923. That PR belongs to another lane; this
  lane does not push to another lane's branch, and merging to a production trunk
  is a hard floor no standing instruction lifts.
- **`no-host-observed-true-injection`** — needs at least one `observed-true` row
  in `src/config/host-injection-effect.json`. The census records **1
  `observed-false` and 8 `unobserved` across nine hosts**, and `admissibleUnderE3`
  returns true for nothing (a test pins that). Producing the row requires a live
  session with `delivery` enabled — and `delivery` going live in this repository
  *is* the unmerged predecessor's Phase 4.2 flip. Blocker 2 cannot be discharged
  before blocker 1.

So the question went to an AI council under the maintainer's written delegation.

## The verdict — Q2-a, honour K6

The roadmap's own kill register carries **K6**: *"Moving this file to `later/` or
descoping to a carrier. Unobserved hosts are recorded as unobserved and the file
stays active with those lines `[ ]` and the observation protocol named."*

**The council honoured it.** The lines stay `[ ]`, both blockers stay open and
accurate, the file does not move to `later/`, and it is not re-scoped so it can
close. The active directory does not empty, and that is correct rather than a
missed step.

**Degradation, stated plainly:** the council was **`⚠️ DEGRADED`, 1 of 2 seats** —
the anthropic seat returned `exit_1` and did not answer. A single-seat verdict is
a considered opinion, not convergence between independent seats. The disposition
section in the roadmap says so at the point of citation, not in a footnote.

## Three things the seat added that the file did not already say

1. **"PR #1923 merged" is an insufficient wake condition.** The real ordering is
   `compatible predecessor merged` → `lean_projection.hosts` available →
   `delivery` enabled → qualifying live session → admissible observation →
   host-dependent acceptance criteria evaluated. A merge does not prove the merged
   revision carries the expected schema, that Phase 4.2 is live, or that any
   qualifying observation occurred. The roadmap previously implied the single
   condition.

2. **Q2-c — re-scope so the roadmap can close — is rejected outright.** Rewriting
   the acceptance criteria to exclude the missing implementation and evidence
   *"would convert an unfinished delivery obligation into a completed
   documentation exercise. That is precisely the false closure K6 guards
   against."* This is the option a directory-emptying mandate most wants to take,
   which is why the rejection is quoted rather than paraphrased.

3. **A fourth revisit condition the file was missing.** If repeated qualifying
   sessions produce **no** `observed-true` result, that calls the acceptance
   premise itself into question: requiring an `observed-true` outcome makes
   closure depend on obtaining a *desired empirical result* rather than on
   conducting a valid observation. The roadmap cannot today distinguish "feature
   assumption falsified" from "evidence still missing" — now on the record rather
   than latent.

## What a kill-register entry is worth — answered generally

The shape recurs, so the council was asked for a general rule and gave one:

> A kill-register entry is a **binding local decision constraint, defeasible
> through explicit supersession.** More than advice — ordinary roadmap execution
> must obey it. Less than absolute — a council holding delegated disposition
> authority can overrule it. But **authority alone is not a rationale.** A valid
> override must record the original failure mode, the changed or disproven
> premise, the replacement safeguard, rollback criteria, and a falsifier.

Here no premise behind K6 has changed, so overruling it merely to empty a
directory would be arbitrary.

## Falsifier for this disposition

An equivalent, stable implementation of `lean_projection.hosts` already exists
independently of PR #1923, or repository history shows K6 addressed a former
dependency shape that no longer exists. Either would make honouring K6 the wrong
call and is the observation to look for.

## Live state, read rather than recalled

PR #1923 (`drain/delivery-for-every-host`) at the time of writing: `OPEN`,
`mergeable: CONFLICTING`, `mergeStateStatus: DIRTY`, updated
`2026-09-08T06:51:58Z`. Its mergeability has been observed to flip inside a single
run — the blocker entry already says to read it live rather than from any recorded
line, and this PR body is no exception to that.

## Gates

| Gate | Result |
|---|---|
| `lint_roadmap_blockers` | pass — 10 roadmaps blocker-contract-clean, 0 decidability violations |
| `lint_plan_risk_register` | pass — 10 ready roadmaps |
| `check_estate_count` | pass — within ratchet |
| `check_references` | pass — none broken |

## What this PR does not do

It does not advance a single step, and it does not touch PR #1923. It changes the
roadmap's *record*, not its progress: a later reader now meets the reasoning, the
corrected wake ordering, the rejected option with its rationale, and the missing
revisit condition — instead of an undischargeable blocker with no note about why
three separate runs left it alone.
