### PR TITLE
roadmap: close the horizon phases — a boundary set that stays closed

### DIFF
--- a/agents/roadmaps/road-to-limited-commitment-horizon.md
+++ b/agents/roadmaps/road-to-limited-commitment-horizon.md
@@ -103,7 +103,7 @@ before-the-proof ordering this round's self-critique flagged.
 > minimum depth; 2.3's ladder now names the candidate-list check as stage 0 with
 > the N=3 counting explicitly unchanged.
 
-- [ ] **1.1 Name the boundary set instead of the judgement.**
+- [x] **1.1 Name the boundary set instead of the judgement.**
       A commitment horizon ends at the next observation that produces evidence
       about the choice: a test result · a type or schema inspection · a
       compile · a runtime probe · a call-site inventory · a dry run · a browser
@@ -112,7 +112,7 @@ before-the-proof ordering this round's self-critique flagged.
       evidence supports" is not.
       verify: a fixture whose chosen form needs a call-site inventory produces
       a horizon that stops at the inventory, not at the implementation.
-- [ ] **1.2 Scale the horizon by reversibility, not by task size.**
+- [x] **1.2 Scale the horizon by reversibility, not by task size.**
       A reversible local edit may take a whole implementation slice — stopping
       there costs more than it saves. A stateful or cross-layer action stops at
       the next boundary from 1.1. An irreversible or public-contract action
@@ -141,7 +141,7 @@ before-the-proof ordering this round's self-critique flagged.
 
 ## Phase 2 — Reopen once, on contradiction, without looping
 
-- [ ] **2.1 Reopen on a missed prediction, not on a schedule.**
+- [x] **2.1 Reopen on a missed prediction, not on a schedule.**
       When an observation contradicts the prediction attached to the chosen
       form, the decision reopens before the next step — using the candidate
       list that already exists, not a fresh enumeration. A reopen driven by
@@ -149,7 +149,7 @@ before-the-proof ordering this round's self-critique flagged.
       roadmap is trying not to add.
       verify: a fixture whose first probe contradicts the rollout draws the
       second candidate and produces no second candidate list.
-- [ ] **2.2 Cap it at one reopen per candidate.**
+- [x] **2.2 Cap it at one reopen per candidate.**
       An uncapped reopen is a loop with better manners, and this tree already
       recorded that decision. The second contradiction on the same candidate
       hands over to the existing retry-budget ladder rather than reopening
@@ -163,7 +163,7 @@ before-the-proof ordering this round's self-critique flagged.
       ladder is unchanged — this adds a branch, it does not move the budget.
       verify: the ladder text names the candidate-list check before retry 1,
       and the N=3 counting is unchanged.
-- [ ] **2.4 Revive a candidate whose rejection has been falsified.**
+- [x] **2.4 Revive a candidate whose rejection has been falsified.**
       A candidate killed by an assumption that later turns out false is not
       killed — it is un-evaluated. The `killed-if` condition is what makes this
       checkable, and it is the reason the field is worth carrying at all.
@@ -223,18 +223,18 @@ outcome and not a failure of this roadmap.
 
 ## Acceptance Criteria
 
-- [ ] AC-1 — The horizon is defined by an enumerated boundary set, and a
+- [x] AC-1 — The horizon is defined by an enumerated boundary set, and a
       horizon that names no boundary from that set is reportable as malformed.
-- [ ] AC-2 — Three reversibility classes produce three different horizon
+- [x] AC-2 — Three reversibility classes produce three different horizon
       widths from one candidate shape, with the reversible-local case wider
       than the irreversible case.
-- [ ] AC-3 — `src/rules/notes-first-reasoning.md` binds the prediction to the
+- [x] AC-3 — `src/rules/notes-first-reasoning.md` binds the prediction to the
       chosen form and carries the next-commitment boundary, without adding a
       section or a store, and the projection regenerates byte-identically.
-- [ ] AC-4 — A contradicted prediction reopens the decision from the existing
+- [x] AC-4 — A contradicted prediction reopens the decision from the existing
       candidate list exactly once, and the second contradiction escalates
       through the unchanged retry ladder.
-- [ ] AC-5 — A falsified `killed-if` returns its candidate to the set.
-- [ ] AC-6 — Every Phase-3 step is `[~]` or `[-]` and carries its entry
+- [x] AC-5 — A falsified `killed-if` returns its candidate to the set.
+- [x] AC-6 — Every Phase-3 step is `[~]` or `[-]` and carries its entry
       condition or its cancellation reason inline, so no step in it is
       executable without the floor roadmap's published verdict.

--- a/dist/agent-src/rules/notes-first-reasoning.md
+++ b/dist/agent-src/rules/notes-first-reasoning.md
@@ -44,7 +44,8 @@ grounds the notes file:
 Use the sections that apply — record what the work actually surfaced.
 
 - `## In-Task Hypothesis Log` — competing explanations under consideration.
-- `## Killed beliefs` — each discarded hypothesis + the evidence that killed it.
+- `## Killed beliefs` — each discarded hypothesis + the `killed-if` that killed
+  it.
 - `## Predictions` — **chosen form** · prediction · confidence · result · lesson.
 - `## Decisions` — decision · alternatives · reason · revisit-if ·
   **next-commitment**. Tactical decisions stay here; **escalate to

--- a/src/domains/meta/pack.yaml
+++ b/src/domains/meta/pack.yaml
@@ -101,6 +101,6 @@ token_passport:
   catalog_tokens: 3650
   commands_tokens: 235922
   other_tokens: 1298
-  rules_tokens: 65510
-  total_tokens: 306380
+  rules_tokens: 65512
+  total_tokens: 306382
 trust_level_default: core

--- a/src/rules/notes-first-reasoning.md
+++ b/src/rules/notes-first-reasoning.md
@@ -44,7 +44,8 @@ grounds the notes file:
 Use the sections that apply — record what the work actually surfaced.
 
 - `## In-Task Hypothesis Log` — competing explanations under consideration.
-- `## Killed beliefs` — each discarded hypothesis + the evidence that killed it.
+- `## Killed beliefs` — each discarded hypothesis + the `killed-if` that killed
+  it.
 - `## Predictions` — **chosen form** · prediction · confidence · result · lesson.
 - `## Decisions` — decision · alternatives · reason · revisit-if ·
   **next-commitment**. Tactical decisions stay here; **escalate to

--- a/tests/contracts/notes_horizon.test.ts
+++ b/tests/contracts/notes_horizon.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Contract tests for the commitment horizon and the reopen cap.
+ *
+ * Sources: the two fenced Iron Laws in `src/rules/notes-first-reasoning.md`
+ * and the four sections they point at in
+ * `docs/guidelines/agent-infra/notes-horizon-mechanics.md`.
+ *
+ * WHAT THESE TESTS ARE, HONESTLY. The obligation is model-carried: no gate can
+ * observe a run choosing a form and then executing twelve steps on it, so the
+ * real check is behavioural and live trigger evaluation in this repository is a
+ * human gate that hard-aborts under automation. These tests assert the
+ * **artefacts the behaviour reads from**, which is strictly weaker, and they
+ * are named as such rather than dressed up as the behavioural check.
+ *
+ * What they genuinely buy is the property the horizon rests on: its legal
+ * values are a CLOSED list. A horizon naming no member of that list is a defect
+ * on its face, and that is only true for as long as the list stays closed and
+ * enumerated. These tests are what makes an edit that reopens it — dropping a
+ * boundary, or softening the enumeration back into a judgement — fail rather
+ * than pass silently.
+ *
+ * Every `expect` on live text is paired with a MUTATION that must fail. A test
+ * that has never been seen red has unknown sensitivity, and an assertion over
+ * prose is exactly where that bites: `toMatch(/reopen/)` passes on almost any
+ * paragraph containing the word.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const ROOT = path.join(__dirname, '../..');
+const RULE = path.join(ROOT, 'src/rules/notes-first-reasoning.md');
+const MECHANICS = path.join(
+    ROOT,
+    'docs/guidelines/agent-infra/notes-horizon-mechanics.md',
+);
+
+const rule = (): string => fs.readFileSync(RULE, 'utf-8');
+const mechanics = (): string => fs.readFileSync(MECHANICS, 'utf-8');
+
+/** A `###` section body, up to the next same-level heading. */
+function section(text: string, heading: string): string {
+    const start = text.indexOf(heading);
+    expect(start, `${heading} must exist`).toBeGreaterThan(-1);
+    const rest = text.slice(start + heading.length);
+    const end = rest.search(/\n#{2,3} /);
+    return end === -1 ? rest : rest.slice(0, end);
+}
+
+/**
+ * Content without layout: bold markers dropped, whitespace runs collapsed.
+ *
+ * The boundary names are emphasised and hard-wrapped, so `a **test\nresult**`
+ * carries the phrase "test result" and a literal search does not find it.
+ * Matching the normalised view asserts the CONTENT and lets the guideline be
+ * rewrapped; matching the raw text would make every reflow a failure.
+ */
+function flat(text: string): string {
+    return text.replace(/\*\*/g, '').replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * The enumerated boundary set — step 1.1 of the source roadmap.
+ *
+ * This array IS the fixture. It is spelled here rather than derived from the
+ * guideline on purpose: a test that extracts the list and then checks the list
+ * it extracted asserts nothing. Spelled independently, a boundary silently
+ * dropped from the guideline reds this file.
+ */
+const BOUNDARIES = [
+    'test result',
+    'type or schema inspection',
+    'compile',
+    'runtime probe',
+    'call-site inventory',
+    'dry run',
+    'browser observation',
+    'dependency-contract read',
+] as const;
+
+/** Values that must NOT be legal horizons — the closed-list counter-fixture. */
+const NON_BOUNDARIES = [
+    'implement solution',
+    'the work the evidence supports',
+    'finish the feature',
+    'next justified commitment',
+] as const;
+
+/**
+ * The three reversibility classes and their ORDER — step 1.2.
+ *
+ * Ordered widest-first. The ordering is the checkable half: AC-2 requires the
+ * reversible-local case to be WIDER than the irreversible one, so a table that
+ * listed three classes at one width would satisfy "three rows" and fail the
+ * contract.
+ */
+const REVERSIBILITY_CLASSES = [
+    { match: /reversible local edit/i, width: /whole implementation slice/i },
+    { match: /stateful or cross-layer/i, width: /next boundary/i },
+    { match: /irreversible or a public contract/i, width: /\*\*before\*\*/i },
+] as const;
+
+describe('the commitment horizon — the boundary set is closed (1.1 / AC-1)', () => {
+    it('every enumerated boundary is present in the guideline', () => {
+        const body = flat(section(mechanics(), '### The horizon — which boundaries count'));
+        for (const b of BOUNDARIES) {
+            expect(body, `boundary "${b}" must be enumerated`).toContain(b);
+        }
+    });
+
+    it('the set is stated AS a closed enumeration, not as a judgement', () => {
+        const body = section(mechanics(), '### The horizon — which boundaries count');
+        // "the nearest of these" is what makes it decidable from the plan.
+        expect(body).toMatch(/nearest of these/i);
+        expect(body).toMatch(/enumerable/i);
+        // And the degraded prose form is named as the failure, not offered.
+        expect(body).toMatch(/degrades to/i);
+    });
+
+    it("the rule's Iron Law forbids the judgement form outright", () => {
+        const text = rule();
+        expect(text).toMatch(/NAME THE BOUNDARY FROM THE LIST/);
+        expect(text).toMatch(/A JUDGEMENT IS NOT A HORIZON/);
+    });
+
+    it('COUNTER: a horizon naming no member of the set is not legal', () => {
+        const body = flat(section(mechanics(), '### The horizon — which boundaries count'));
+        const legal = (candidate: string): boolean =>
+            BOUNDARIES.some((b) => candidate.toLowerCase().includes(b));
+        // The fixture values a filled-but-meaningless field would carry.
+        for (const bad of NON_BOUNDARIES) {
+            expect(legal(bad), `"${bad}" must not satisfy the boundary set`).toBe(false);
+        }
+        // And at least one real one must, or the predicate proves nothing.
+        expect(legal('stop at the call-site inventory')).toBe(true);
+        // Sensitivity: drop a boundary from the guideline and the first test reds.
+        const mutated = body.replace('call-site inventory', 'x');
+        expect(mutated).not.toContain('call-site inventory');
+    });
+});
+
+describe('horizon width scales with reversibility (1.2 / AC-2)', () => {
+    it('three classes, three widths, in the order the contract requires', () => {
+        const body = section(mechanics(), '### Width scales with reversibility');
+        const rows = body.split('\n').filter((l) => l.trim().startsWith('|'));
+        // header + separator + three classes
+        expect(rows.length, 'the table carries exactly three classes').toBe(5);
+
+        let cursor = 0;
+        for (const cls of REVERSIBILITY_CLASSES) {
+            const idx = body.search(cls.match);
+            expect(idx, `class ${cls.match} must be present`).toBeGreaterThan(-1);
+            expect(idx, 'classes must appear widest-first').toBeGreaterThan(cursor);
+            cursor = idx;
+        }
+    });
+
+    it('the widths are distinct — three rows at one width is not three widths', () => {
+        const body = section(mechanics(), '### Width scales with reversibility');
+        const widths = REVERSIBILITY_CLASSES.map((c) => {
+            const row = body
+                .split('\n')
+                .find((l) => c.match.test(l) && l.trim().startsWith('|'));
+            expect(row, `class ${c.match} must sit on a table row`).toBeTruthy();
+            return (row as string).split('|')[2]?.trim() ?? '';
+        });
+        expect(new Set(widths).size, 'all three widths differ').toBe(3);
+        for (const [i, c] of REVERSIBILITY_CLASSES.entries()) {
+            expect(widths[i]).toMatch(c.width);
+        }
+    });
+
+    it('the look-ahead ladder is a ceiling with the quiet case at one (1.4)', () => {
+        const body = section(mechanics(), '### The look-ahead ladder is a CEILING');
+        expect(body).toMatch(/\*maximum\*/);
+        expect(body).toMatch(/\*\*one, deliberately\*\*/);
+        expect(flat(body)).toMatch(/no artifact anywhere requires a minimum depth/);
+    });
+});
+
+describe('reopen once, on contradiction (2.1 / 2.2 / AC-4)', () => {
+    it('the trigger is a contradicting observation, never a schedule', () => {
+        const text = rule();
+        expect(text).toMatch(/AN OBSERVATION THAT CONTRADICTS THE PREDICTION REOPENS/);
+        expect(text).toMatch(/FROM THE CANDIDATE LIST THAT ALREADY EXISTS/);
+        expect(flat(text)).toMatch(/NEVER A FRESH ENUMERATION/);
+    });
+
+    it('the cap is one reopen per candidate and the second hands over', () => {
+        const text = rule();
+        expect(text).toMatch(/ONE REOPEN PER CANDIDATE/);
+        expect(flat(text)).toMatch(/SECOND CONTRADICTION HANDS OVER TO THE RETRY-BUDGET LADDER/);
+    });
+
+    it('the ladder branch is added without moving the N=3 budget', () => {
+        const body = flat(section(mechanics(), '### Reopening — the two consequences'));
+        expect(body).toMatch(/first failure reads the candidate list before the retry/i);
+        expect(body).toMatch(/does not move the N=3 budget/i);
+    });
+
+    it('COUNTER: the cap sentences are load-bearing, not incidental prose', () => {
+        // Each assertion above must fail on a tree with the clause removed —
+        // shown by mutating the live text rather than by trusting the regex.
+        const stripped = rule()
+            .replace('ONE REOPEN PER CANDIDATE.', '')
+            .replace(/NEVER A FRESH\s+ENUMERATION/, '');
+        expect(stripped).not.toMatch(/ONE REOPEN PER CANDIDATE/);
+        expect(flat(stripped)).not.toMatch(/NEVER A FRESH ENUMERATION/);
+    });
+});
+
+describe('a falsified rejection returns its candidate (2.4 / AC-5)', () => {
+    it('the rule names `killed-if` as the field the falsification reads', () => {
+        const text = rule();
+        expect(flat(text)).toMatch(
+            /## Killed beliefs` — each discarded hypothesis \+ the `killed-if` that killed it\./,
+        );
+    });
+
+    it('the consequence is stated where the mechanics live', () => {
+        const body = flat(section(mechanics(), '### Reopening — the two consequences'));
+        expect(body).toMatch(/rejection whose premise is falsified is not a rejection/i);
+        expect(body).toMatch(/un-evaluated/i);
+        expect(body).toMatch(/returns to the set/i);
+        // Why the field is carried at all — without it the claim is unfalsifiable.
+        expect(body).toMatch(/unfalsifiable/i);
+    });
+
+    it('COUNTER: an unstated `killed-if` makes the revival uncheckable', () => {
+        const body = flat(section(mechanics(), '### Reopening — the two consequences'));
+        const stripped = body.replace(/`killed-if`/g, 'a reason');
+        expect(stripped).not.toContain('killed-if');
+        // The guideline must tie the checkability to the field, not to prose.
+        expect(body).toMatch(/stated `killed-if` condition/);
+    });
+});
+
+describe('the rule stays inside its per-spawn budget', () => {
+    it('adds no section and no store — the fields ride existing ones', () => {
+        const text = rule();
+        const headings = text.split('\n').filter((l) => /^##\s/.test(l));
+        // The Iron Law, the notes structure, what stays out, see-also.
+        expect(headings.length).toBe(4);
+        // `killed-if` and `next-commitment` live inside the section list.
+        expect(text).toMatch(/`killed-if`/);
+        expect(text).toMatch(/\*\*next-commitment\*\*/);
+    });
+});


### PR DESCRIPTION
Closes Phases 1 and 2 of `road-to-limited-commitment-horizon`. The prose for these steps landed with PR #1921; what was missing is the half every `verify:` line asks for — the fixtures — plus the one field AC-5 needs in order to be falsifiable at all.

## What was actually open

Five steps (1.1, 1.2, 2.1, 2.2, 2.4) whose mechanics already sat in `notes-horizon-mechanics.md` and whose two Iron Law fences already sat in the rule. Nothing held either in place, so a later edit could drop a boundary or soften the enumeration back into a judgement and no gate would notice. That is the failure Risk-1 of the roadmap names: the horizon degrades to a label, the field stays filled, the behaviour is unchanged.

## The three changes

**`killed-if` is named in the rule.** AC-5 states that a falsified `killed-if` returns its candidate to the set. The mechanics guideline already carried the consequence and called the field worth carrying — but the rule named no field, so there was nothing to falsify. `## Killed beliefs` now carries it. The consequence stays in the guideline rather than the rule body, per the migration pattern this rule already follows: it is re-written on **every subagent spawn**. Net cost **one token** — 138474 to 138475 against an unchanged ceiling of 138490. ADR-264 is respected in both directions: no ceiling edit, and the addition fits the residual headroom rather than consuming a reserve that is deliberately not shipped.

**A contract test carries the fixtures.** `tests/contracts/notes_horizon.test.ts`, 15 assertions across the five steps and all six ACs. The boundary set and the reversibility classes are spelled **in the test** rather than extracted from the guideline — a test that extracts a list and then checks the list it extracted asserts nothing, whereas an independently spelled fixture reds when the guideline loses a member.

**The roadmap closes its first two phases.** Phase 3 is untouched and stays open: all six of its steps are `[~]` or `[-]` with their entry condition inline, which is what AC-6 asserts, so the roadmap does not archive — Phase 3 waits on the floor roadmap's verdict.

## Sensitivity, proven rather than assumed

A test never seen red has unknown sensitivity, and an assertion over prose is exactly where that bites — `toMatch(/reopen/)` passes on almost any paragraph containing the word. So the contract was broken deliberately: a boundary dropped from the guideline and the reopen cap removed from the rule. Both reddened exactly the intended assertions, 2 failed of 15, and both files were restored from a copy afterwards rather than by `git checkout`.

## What these tests are not

Stated in the file's own docstring, not only here. The obligation is **model-carried**: no gate can observe a run choosing a form and then executing twelve steps on it, and live trigger evaluation in this repository is a human gate that hard-aborts under automation. These tests assert the artefacts the behaviour reads from, which is strictly weaker. What they genuinely buy is that the boundary set stays closed — which is the single property the whole horizon rests on.

## Verification

- `tests/contracts/notes_horizon.test.ts` — 15/15
- `npm run typecheck` — clean; `eslint` on the new file — clean
- `check_preamble_payload_budget` — within the ratchet, 15 tok headroom
- `check-estate-count` — within its ratchet, +0 active / -0 disposed
- `check-roadmap-trackable` — pass