### PR TITLE
fix(archival): a blocker cannot hide in the archive

### DIFF
--- a/agents/roadmaps/archive/road-to-a-blocker-that-cannot-hide-in-the-archive.md
+++ b/agents/roadmaps/archive/road-to-a-blocker-that-cannot-hide-in-the-archive.md
@@ -109,19 +109,171 @@ candidates differ in what they would have caught:
 (1) is the narrowest fix that would have caught the observed defect. (3) is the
 cheapest way to stop the ratchet-by-archiving hole. They are not exclusive.
 
+## The decision — taken 2026-09-08
+
+```
+CHOSEN: (1b) + (1a) AT THE TRANSITION, AND (4) OVER THE TREE.
+REJECTED: (3) THE RATCHET AT 23. REJECTED: (2) AS ORIGINALLY SCOPED.
+CORRECTED: (1) AS WRITTEN ABOVE IS INVERTED AND WOULD HAVE BEEN A NO-OP.
+```
+
+**The AI council decided this, not the run.** 2 seats present (2/2 quorum,
+`anthropic/claude-sonnet-4-5` + `openai/gpt-4o`, api transport, USD 0.0780 spent
+against a USD 0.4192 estimate), 2026-09-08. Both seats converged on
+(1b) + (1a) as the primary fix and both rejected (3); the anthropic seat
+supplied the (4) refinement and the (2) refutation, and the openai seat's
+"periodic review session" proposal was set aside as a process rather than an
+assertion.
+
+### (1) as written above is factually inverted
+
+Option (1) says *"make it re-read the file it is about to move from the working
+tree rather than trusting the index"*. The archival sweep **already** reads the
+working tree: `parse_roadmap` (`src/agent-src/scripts/update_roadmap_progress.ts:645`)
+uses `fs.readFileSync`, and `archive_completed` refuses on
+`stats.open_blockers.length > 0` computed from that reading. Implementing (1) as
+described would have changed nothing.
+
+The mechanism runs the other way. `git mv` renames the working-tree file **and
+moves the index entry**, which still holds whatever was staged; the sweep never
+`git add`s the destination. So the reading that was validated is the working
+tree and the content that gets committed is the index. On 2026-09-08 the
+unstaged removal meant those two disagreed, and the commit shipped the index.
+
+That correction also settles a second thing: **(4) is unreachable as a
+transition check.** The sweep already refuses to archive a roadmap carrying any
+open blocker in the working tree, so at the moment of archival there is never an
+open blocker to overlap with. (4) is therefore implemented as a tree-wide
+assertion, which is where the class it catches actually lives.
+
+### What shipped
+
+| # | Assertion | Where | Day-one findings |
+|---|---|---|---|
+| 1b | Refuse archival when the **staged** and **working-tree** blocker id→status maps of the file being moved disagree | `archive_completed_roadmaps.ts` — `_blockerDivergence`, checked after the changed-only skip and before `git mv` | **0** — fires only on a future archival |
+| 1a | `git add` the destination after a tracked `git mv`, so the commit carries the content the checks read | same file, immediately after the move | **0** — not an assertion |
+| 4 | No blocker id may be declared `Status: open` in **both** an active and an archived roadmap | `lint_roadmap_blockers.ts` — `_archiveOverlap`, hard, no baseline | **0**, measured |
+
+### How the day-one count was measured
+
+Not asserted — computed, twice, by two independent readers that agree:
+
+```
+# ad-hoc measurement, before the gate existed (base 5ef117448, 2026-09-08)
+active open blocker ids:   12
+archived open blocker ids: 33
+OVERLAP (open in both an active and an archived roadmap): 0
+```
+
+```
+# the shipped gate, same tree
+$ ./scripts-run src/scripts/lint_roadmap_blockers
+✅  13 roadmap(s) blocker-contract-clean
+✅  0 blocker id(s) open in both an active and an archived roadmap (699 archived file(s) read)
+✅  lint_roadmap_blockers:decidability: 0 violation(s), no baseline needed.
+```
+
+Zero, so (4) ships **hard and without a baseline** — the bar 1.1's verify sets.
+The 193 / 23 figures from § The gap, measured were re-derived on this tree and
+both still hold; they count *files*, while 33 counts *ids*, and 23 files
+carrying 33 open ids is consistent.
+
+### Why (3) was rejected
+
+A shrink-only baseline at 23 pins a number over a corpus nothing else reads, and
+its two possible readings are both bad: if the 23 are genuine history the ratchet
+forbids future genuine history, and if they are stale it preserves the staleness.
+Both seats rejected it independently. The hole it was meant to close —
+`open_blockers` being satisfiable by archiving rather than resolving — is closed
+by (4) instead, which asserts the contradiction rather than pinning the count.
+
+### Why (2) was rejected as originally scoped
+
+*"No blocker id may appear with `Status: open` in more than one file"* forbids a
+legitimate state: one cross-cutting blocker declared open in two **active**
+roadmaps. (4) narrows it to active-vs-archived, which is the pair that
+contradicts itself.
+
+### What this leaves uncovered — named, not closed
+
+- **Two blocker ids are declared open in more than one *archived* file**
+  (`background-continuation-probe`, `benchmark-spend-authorization`). In scope
+  for a hypothetical archive-vs-archive assertion, out of scope here for exactly
+  the day-one reason § The fix is a decision gives: a hard gate there would red
+  the build on 2 records this change did not create.
+- **The 23 archived files carrying open blockers are still unread.** (4) proves
+  none of them collides with the active tree, which is strictly weaker than
+  "none of them is stale".
+- **An untracked new roadmap during archival** — the council's option (1c). A
+  roadmap written but never staged can hold the same blocker while an archival
+  moves it; (1b) reads the index of the file being *moved* and sees nothing.
+  Left as a follow-up because refuse-vs-warn scoping needs its own decision.
+- **A blocker copied into an archived file with `Status: resolved`** while the
+  active copy stays open. Not a contradiction by (4)'s definition, and
+  deliberately so: a closed record of work planned elsewhere is legitimate.
+
 ## Phase 1 — Decide and implement
 
-- [ ] **1.1 Pick among (1), (2), (3)** above — or a fourth the reader sees — and
+- [x] **1.1 Pick among (1), (2), (3)** above — or a fourth the reader sees — and
       say in the same change which day-one finding count the choice carries and
       how it was measured.
       verify: the chosen assertion is implemented, its gate exits 0 on this tree
       **without a baseline** if the choice claims zero day-one findings, or with
       a baseline whose note states the measured count if it does not.
-- [ ] **1.2 A sensitivity case, not just a green run.** Reconstruct this run's
+- [x] **1.2 A sensitivity case, not just a green run.** Reconstruct this run's
       defect — an archived roadmap whose working-tree content and index content
       disagree about a blocker — and prove the new assertion goes red on it.
       verify: neutralising the assertion turns that case green again, so the
       case is known to have teeth rather than assumed to.
+
+## The sensitivity probes — each mechanism seen red
+
+Every mechanism this change adds was neutralised, watched fail, and restored by
+a reverse edit (never `git checkout` — a checkout of a file under an unstaged
+sabotage discards the surrounding work with it). Three mechanisms, three probes,
+2026-09-08:
+
+| Mechanism | Neutralisation | Result |
+|---|---|---|
+| (1b) `_blockerDivergence` | early-return `[]` unconditionally | the reconstruction test goes **red**; the other three stay green |
+| (1a) `git add` of the destination | guard the call with `false &&` | the staging-hygiene test goes **red**; the other three stay green |
+| (4) `_archiveOverlap` | guard the overlap push with `false &&` | the overlap test goes **red**; 34 of 35 stay green |
+
+The "others stay green" column is the half that matters: it shows each test is
+watching its own mechanism rather than all four failing together on any edit.
+
+After all three restores: **69 tests green** across
+`archive_index_divergence`, `lint_roadmap_blockers`, `archive_completed_roadmaps`
+and `archive_deferral_resolution` — the last two unchanged by this work, run to
+prove the transition check did not regress the sweep.
+
+The premise itself was reproduced before any test was written, so the mechanism
+is measured rather than reasoned about — see the header comment of
+`tests/scripts/archive_index_divergence.test.ts` for the six commands.
+
+### (1a) confirmed on this roadmap's own archival
+
+The sweep that archived this file exercised (1a) against the real defect shape,
+which is stronger evidence than the fixture. At the moment of the move the
+roadmap's working tree carried every edit above and the index carried the
+version committed on `main` — the two disagreed, exactly as they did on
+2026-09-08. After the sweep:
+
+```
+$ git diff --name-only -- agents/roadmaps/archive/road-to-a-blocker-…-archive.md
+(empty)
+$ git show :agents/roadmaps/archive/road-to-a-blocker-…-archive.md | grep -c 'The decision — taken 2026-09-08'
+1
+```
+
+No unstaged residue, and the staged content is the edited one. Without the
+`git add`, the index would have held the pre-edit file and the commit would have
+archived this roadmap with none of the decision it records — the same class of
+loss, on the change that fixes it.
+
+(1b) stayed silent here, correctly: this roadmap declares no blockers on either
+side, so there was no blocker disagreement to refuse. That is the narrow
+scoping doing its job rather than the check failing to fire.
 
 ## What this roadmap is NOT
 
@@ -132,6 +284,15 @@ cheapest way to stop the ratchet-by-archiving hole. They are not exclusive.
 - **Not owner-reserved.** Unlike its sibling receiver, nothing here needs an
   owner ruling: no floor is lowered and no ratchet is moved. `owner: maintainer`
   marks who should choose the assertion, not a permission gate.
+
+**AC-1 is ambiguous and both readings are met.** The council's sharpest finding
+was that *"detected by a gate"* does not distinguish **reporting** the defect
+from **preventing** it, and that the observed defect was in fact visible in
+`git status` — what failed was prevention. The criterion is left as written
+rather than rewritten mid-run, because the bar a run is measured against is not
+the run's to move. It is satisfied on both readings: (1b) refuses the archival
+with a diagnostic naming the id and both statuses, and (4) reports the
+contradiction wherever else it arrives.
 
 ## Provenance
 
@@ -155,8 +316,8 @@ cheapest way to stop the ratchet-by-archiving hole. They are not exclusive.
 
 ## Acceptance Criteria
 
-- [ ] AC-1 An archived roadmap carrying `Status: open` is detected by a gate
+- [x] AC-1 An archived roadmap carrying `Status: open` is detected by a gate
       rather than by a human reading `git status`.
-- [ ] AC-2 The chosen assertion's day-one finding count on this tree is measured
+- [x] AC-2 The chosen assertion's day-one finding count on this tree is measured
       and recorded, and is zero unless a baseline note states otherwise.
-- [ ] AC-3 The sensitivity case from 1.2 exists and has been seen red.
+- [x] AC-3 The sensitivity case from 1.2 exists and has been seen red.

--- a/dist/agent-src/scripts/archive_completed_roadmaps.ts
+++ b/dist/agent-src/scripts/archive_completed_roadmaps.ts
@@ -58,7 +58,11 @@ import * as path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
-import { collect } from './update_roadmap_progress.js';
+import {
+    blocker_is_resolved,
+    collect,
+    parse_blockers,
+} from './update_roadmap_progress.js';
 import { guardedBaselineProblems, parseGuardedBaselines } from './guarded_baseline.js';
 
 import { isCliEntry } from './_cli_entry.js';
@@ -263,6 +267,80 @@ function _git_mv(root: string, src_rel: string, dst_rel: string, dry_run: boolea
     } catch {
         return { ok: false, tracked: false };
     }
+}
+
+// ---------------------------------------------------------------------
+// The index/working-tree blocker divergence check (1b) + staging (1a)
+// ---------------------------------------------------------------------
+//
+// The open-blocker refusal below reads the file with `fs.readFileSync`, i.e.
+// the WORKING TREE. `git mv` then moves the INDEX ENTRY, which still carries
+// whatever was staged. When the two disagree the commit ships the index
+// content — content this gate never read.
+//
+// Measured, once, at full cost (2026-09-08): an edit removing a roadmap's
+// blocker was made and never staged; `git mv` moved the stale index entry; the
+// archived file shipped a blocker declared `Status: open` that had already been
+// relocated to an active roadmap. The same blocker was open in two files at
+// once, one of them archived, and it was caught by a human reading
+// `git status` rather than by any gate.
+//
+// The check is scoped to blocker id → status and deliberately NOT to whole-file
+// equality. An unstaged typo fix in a roadmap title has nothing to do with the
+// defect, and refusing archival for it trains `git add -A`, which destroys the
+// staging discipline this check depends on. AI council 2026-09-08, 2/2 present
+// (anthropic/claude-sonnet-4-5 + openai/gpt-4o), on that scoping specifically:
+// broad scoping is "user-hostile, trains developers to `git add -A`
+// reflexively, defeating staging discipline".
+
+/** Blocker id → status, as the archive-transition check compares them. */
+function _blockerStatuses(text: string): Map<string, string> {
+    const out = new Map<string, string>();
+    for (const b of parse_blockers(text)) {
+        out.set(b.id, blocker_is_resolved(b) ? 'resolved' : 'open');
+    }
+    return out;
+}
+
+/**
+ * `git show :<rel>` — the STAGED content of a path, or null when the path has
+ * no index entry.
+ *
+ * Null is the untracked / pre-first-commit case, which `_git_mv` already
+ * handles by falling back to a plain rename. There is no index entry to
+ * disagree with, so the divergence check has nothing to assert and says so by
+ * returning null rather than by guessing at an empty string — an empty staged
+ * file and an absent one differ, and only the second is legitimate here.
+ */
+function _indexContent(root: string, rel: string): string | null {
+    const cp = _run(['git', 'show', `:${rel}`], root);
+    return cp.returncode === 0 ? cp.stdout : null;
+}
+
+/**
+ * Human-readable disagreements between the staged and working-tree blocker
+ * maps of one path. Empty array = the two agree, or there is no index entry.
+ */
+function _blockerDivergence(root: string, rel: string, workTreeText: string): string[] {
+    const staged = _indexContent(root, rel);
+    if (staged === null) {
+        return [];
+    }
+    const wt = _blockerStatuses(workTreeText);
+    const idx = _blockerStatuses(staged);
+    const ids = [...new Set([...wt.keys(), ...idx.keys()])].sort();
+    const out: string[] = [];
+    for (const id of ids) {
+        const a = idx.get(id);
+        const b = wt.get(id);
+        if (a === b) {
+            continue;
+        }
+        out.push(
+            `blocker '${id}': staged=${a ?? 'absent'} vs working tree=${b ?? 'absent'}`,
+        );
+    }
+    return out;
 }
 
 /**
@@ -547,9 +625,8 @@ function archive_completed(
         // and invisible in a sweep that only reports what it moved; a MALFORMED
         // one on `[x]` would otherwise archive with an annotation claiming the
         // opposite. Both are named here instead.
-        const guarded = parseGuardedBaselines(
-            fs.readFileSync(path.join(roadmap_root, stats.rel), 'utf-8'),
-        );
+        const roadmapText = fs.readFileSync(path.join(roadmap_root, stats.rel), 'utf-8');
+        const guarded = parseGuardedBaselines(roadmapText);
         if (guarded.length > 0) {
             process.stderr.write(
                 `  ⚠️  ${stats.rel}: ${guarded.length} guarded-baseline step(s) — ` +
@@ -603,11 +680,36 @@ function archive_completed(
         if (changed_only && !(touched as Set<string>).has(old_rel)) {
             continue; // complete, but not this branch's work
         }
+        // The gate above validated the WORKING TREE; `git mv` ships the INDEX.
+        // When they disagree about a blocker, the validated content is not the
+        // content that gets committed — see § the index/working-tree blocker
+        // divergence check above for the measured failure.
+        const divergence = _blockerDivergence(root, old_rel, roadmapText);
+        if (divergence.length > 0) {
+            process.stderr.write(
+                `  ⚠️  ${stats.rel}: staged and working-tree blockers disagree ` +
+                    `(${divergence.length}) — not archived. \`git mv\` would commit ` +
+                    'the staged content, which this sweep never validated. Stage or ' +
+                    'discard the change, then re-run.\n',
+            );
+            for (const d of divergence) {
+                process.stderr.write(`        · ${d}\n`);
+            }
+            continue;
+        }
         const new_rel = `agents/roadmaps/archive/${stats.rel}`;
         const mv = _git_mv(root, old_rel, new_rel, dry_run);
         if (!mv.ok) {
             process.stderr.write(`  ⚠️  could not archive ${old_rel} (mv failed)\n`);
             continue;
+        }
+        // `git mv` moved the index ENTRY, not the working-tree content. Staging
+        // the destination makes what gets committed identical to what the checks
+        // above read — the divergence check refuses a disagreement that exists
+        // BEFORE the move, and this closes one created by an edit between the
+        // move and the commit.
+        if (!dry_run && mv.tracked) {
+            _run(['git', 'add', '--', new_rel], root);
         }
         const refs = _inbound_ref_rewrite(root, old_rel, new_rel, dry_run, mv.tracked);
         // Stage rewritten refs only in a tracked repo; an untracked consumer's

--- a/src/agent-src/scripts/archive_completed_roadmaps.ts
+++ b/src/agent-src/scripts/archive_completed_roadmaps.ts
@@ -58,7 +58,11 @@ import * as path from 'node:path';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 
-import { collect } from './update_roadmap_progress.js';
+import {
+    blocker_is_resolved,
+    collect,
+    parse_blockers,
+} from './update_roadmap_progress.js';
 import { guardedBaselineProblems, parseGuardedBaselines } from './guarded_baseline.js';
 
 import { isCliEntry } from './_cli_entry.js';
@@ -263,6 +267,80 @@ function _git_mv(root: string, src_rel: string, dst_rel: string, dry_run: boolea
     } catch {
         return { ok: false, tracked: false };
     }
+}
+
+// ---------------------------------------------------------------------
+// The index/working-tree blocker divergence check (1b) + staging (1a)
+// ---------------------------------------------------------------------
+//
+// The open-blocker refusal below reads the file with `fs.readFileSync`, i.e.
+// the WORKING TREE. `git mv` then moves the INDEX ENTRY, which still carries
+// whatever was staged. When the two disagree the commit ships the index
+// content — content this gate never read.
+//
+// Measured, once, at full cost (2026-09-08): an edit removing a roadmap's
+// blocker was made and never staged; `git mv` moved the stale index entry; the
+// archived file shipped a blocker declared `Status: open` that had already been
+// relocated to an active roadmap. The same blocker was open in two files at
+// once, one of them archived, and it was caught by a human reading
+// `git status` rather than by any gate.
+//
+// The check is scoped to blocker id → status and deliberately NOT to whole-file
+// equality. An unstaged typo fix in a roadmap title has nothing to do with the
+// defect, and refusing archival for it trains `git add -A`, which destroys the
+// staging discipline this check depends on. AI council 2026-09-08, 2/2 present
+// (anthropic/claude-sonnet-4-5 + openai/gpt-4o), on that scoping specifically:
+// broad scoping is "user-hostile, trains developers to `git add -A`
+// reflexively, defeating staging discipline".
+
+/** Blocker id → status, as the archive-transition check compares them. */
+function _blockerStatuses(text: string): Map<string, string> {
+    const out = new Map<string, string>();
+    for (const b of parse_blockers(text)) {
+        out.set(b.id, blocker_is_resolved(b) ? 'resolved' : 'open');
+    }
+    return out;
+}
+
+/**
+ * `git show :<rel>` — the STAGED content of a path, or null when the path has
+ * no index entry.
+ *
+ * Null is the untracked / pre-first-commit case, which `_git_mv` already
+ * handles by falling back to a plain rename. There is no index entry to
+ * disagree with, so the divergence check has nothing to assert and says so by
+ * returning null rather than by guessing at an empty string — an empty staged
+ * file and an absent one differ, and only the second is legitimate here.
+ */
+function _indexContent(root: string, rel: string): string | null {
+    const cp = _run(['git', 'show', `:${rel}`], root);
+    return cp.returncode === 0 ? cp.stdout : null;
+}
+
+/**
+ * Human-readable disagreements between the staged and working-tree blocker
+ * maps of one path. Empty array = the two agree, or there is no index entry.
+ */
+function _blockerDivergence(root: string, rel: string, workTreeText: string): string[] {
+    const staged = _indexContent(root, rel);
+    if (staged === null) {
+        return [];
+    }
+    const wt = _blockerStatuses(workTreeText);
+    const idx = _blockerStatuses(staged);
+    const ids = [...new Set([...wt.keys(), ...idx.keys()])].sort();
+    const out: string[] = [];
+    for (const id of ids) {
+        const a = idx.get(id);
+        const b = wt.get(id);
+        if (a === b) {
+            continue;
+        }
+        out.push(
+            `blocker '${id}': staged=${a ?? 'absent'} vs working tree=${b ?? 'absent'}`,
+        );
+    }
+    return out;
 }
 
 /**
@@ -547,9 +625,8 @@ function archive_completed(
         // and invisible in a sweep that only reports what it moved; a MALFORMED
         // one on `[x]` would otherwise archive with an annotation claiming the
         // opposite. Both are named here instead.
-        const guarded = parseGuardedBaselines(
-            fs.readFileSync(path.join(roadmap_root, stats.rel), 'utf-8'),
-        );
+        const roadmapText = fs.readFileSync(path.join(roadmap_root, stats.rel), 'utf-8');
+        const guarded = parseGuardedBaselines(roadmapText);
         if (guarded.length > 0) {
             process.stderr.write(
                 `  ⚠️  ${stats.rel}: ${guarded.length} guarded-baseline step(s) — ` +
@@ -603,11 +680,36 @@ function archive_completed(
         if (changed_only && !(touched as Set<string>).has(old_rel)) {
             continue; // complete, but not this branch's work
         }
+        // The gate above validated the WORKING TREE; `git mv` ships the INDEX.
+        // When they disagree about a blocker, the validated content is not the
+        // content that gets committed — see § the index/working-tree blocker
+        // divergence check above for the measured failure.
+        const divergence = _blockerDivergence(root, old_rel, roadmapText);
+        if (divergence.length > 0) {
+            process.stderr.write(
+                `  ⚠️  ${stats.rel}: staged and working-tree blockers disagree ` +
+                    `(${divergence.length}) — not archived. \`git mv\` would commit ` +
+                    'the staged content, which this sweep never validated. Stage or ' +
+                    'discard the change, then re-run.\n',
+            );
+            for (const d of divergence) {
+                process.stderr.write(`        · ${d}\n`);
+            }
+            continue;
+        }
         const new_rel = `agents/roadmaps/archive/${stats.rel}`;
         const mv = _git_mv(root, old_rel, new_rel, dry_run);
         if (!mv.ok) {
             process.stderr.write(`  ⚠️  could not archive ${old_rel} (mv failed)\n`);
             continue;
+        }
+        // `git mv` moved the index ENTRY, not the working-tree content. Staging
+        // the destination makes what gets committed identical to what the checks
+        // above read — the divergence check refuses a disagreement that exists
+        // BEFORE the move, and this closes one created by an edit between the
+        // move and the commit.
+        if (!dry_run && mv.tracked) {
+            _run(['git', 'add', '--', new_rel], root);
         }
         const refs = _inbound_ref_rewrite(root, old_rel, new_rel, dry_run, mv.tracked);
         // Stage rewritten refs only in a tracked repo; an untracked consumer's

--- a/src/scripts/lint_roadmap_blockers.ts
+++ b/src/scripts/lint_roadmap_blockers.ts
@@ -360,6 +360,130 @@ function _countRoadmapTree(dir: string): number {
     return n;
 }
 
+/**
+ * Blocker ids declared `Status: open` in one file, by id.
+ *
+ * Reads exactly one fact per blocker — id and open-ness. It is deliberately
+ * NOT `_scanBoth`: the five-field contract, the class taxonomy and the
+ * decidability ratchet are not applied here, because the corpus this runs over
+ * includes `archive/` and applying the contract there lands 23 findings on day
+ * one against a change that caused none of them. That shape has been reverted
+ * twice in this repository — `lint_roadmap_later_disposition` at 68 files and
+ * `check_no_new_legacy_path` at 46 — and the exclusion also protects a true
+ * thing an archived roadmap is allowed to say: a blocker genuinely unresolved
+ * when its roadmap closed is history, not a defect.
+ */
+function _openBlockerIds(text: string): Set<string> {
+    const stripped = _stripFencedCode(text);
+    const out = new Set<string>();
+    const sectionMatch = BLOCKERS_SECTION_RE.exec(stripped);
+    if (!sectionMatch) {
+        return out;
+    }
+    const sectionStart = sectionMatch.index + sectionMatch[0].length;
+    const rest = stripped.slice(sectionStart);
+    const h2 = NEXT_H2_RE.exec(rest);
+    const section = stripped.slice(sectionStart, h2 ? sectionStart + h2.index : stripped.length);
+
+    BLOCKER_HEADING_RE.lastIndex = 0;
+    const heads: Array<{ end: number; start: number; id: string }> = [];
+    let hm: RegExpExecArray | null;
+    while ((hm = BLOCKER_HEADING_RE.exec(section)) !== null) {
+        heads.push({ start: hm.index, end: hm.index + hm[0].length, id: (hm[1] as string).trim() });
+        if (hm.index === BLOCKER_HEADING_RE.lastIndex) {
+            BLOCKER_HEADING_RE.lastIndex++;
+        }
+    }
+    for (let i = 0; i < heads.length; i++) {
+        const cur = heads[i] as { end: number; start: number; id: string };
+        const bodyEnd =
+            i + 1 < heads.length ? (heads[i + 1] as { start: number }).start : section.length;
+        const body = section.slice(cur.end, bodyEnd);
+        // Resolved is a prefix test for the same reason `blocker_is_resolved`
+        // makes it one: `resolved 2026-09-08 by …` is resolved.
+        if (!/^-[ \t]*\*\*Status:\*\*[ \t]*resolved\b/im.test(body)) {
+            out.add(cur.id);
+        }
+    }
+    return out;
+}
+
+/** Sorted `*.md` directly under the archive directory. */
+function _globArchivedRoadmaps(): string[] {
+    const dir = path.join(REPO_ROOT, 'agents', 'roadmaps', 'archive');
+    let entries: fs.Dirent[];
+    try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+        return [];
+    }
+    return entries
+        .filter((e) => e.isFile() && e.name.endsWith('.md'))
+        .map((e) => path.join(dir, e.name))
+        .sort();
+}
+
+interface Overlap {
+    id: string;
+    active: string[];
+    archived: string[];
+}
+
+/** id → the files (repo-relative, sorted by input order) declaring it open. */
+function _openIdIndex(files: string[]): Map<string, string[]> {
+    const index = new Map<string, string[]>();
+    for (const f of files) {
+        const rel = _relPosix(f, REPO_ROOT);
+        for (const id of _openBlockerIds(fs.readFileSync(f, 'utf-8'))) {
+            const hits = index.get(id);
+            if (hits === undefined) {
+                index.set(id, [rel]);
+            } else {
+                hits.push(rel);
+            }
+        }
+    }
+    return index;
+}
+
+/**
+ * Blocker ids declared open in BOTH an active and an archived roadmap.
+ *
+ * The assertion is the one an archived record cannot legitimately make: a
+ * blocker still being decided in the active tree, simultaneously declared open
+ * in a file that says the work closed. The transition check in
+ * `archive_completed_roadmaps` catches the archival that produces this state;
+ * this catches it however else it arrives — a hand edit, a bad merge, or a
+ * commit that shipped stale index content.
+ *
+ * `open_blockers` is a shrink-only ratchet over the ACTIVE tree only, so
+ * without this the count is satisfiable by archiving rather than by resolving.
+ *
+ * Deliberately NOT "no id open in more than one file". Two ACTIVE roadmaps may
+ * legitimately share one cross-cutting blocker, and forbidding that would break
+ * a real pattern to catch a different defect (AI council 2026-09-08, 2/2
+ * present: the unscoped form "forbids legitimate cross-cutting blockers in
+ * multiple active roadmaps"). Two ARCHIVED files sharing an open id is out of
+ * scope for the same day-one reason as the contract itself: measured at 2 on
+ * this tree, so a hard assertion there would red the build on records this
+ * change did not create.
+ */
+function _archiveOverlap(
+    activeFiles: string[] = _globRoadmaps(),
+    archivedFiles: string[] = _globArchivedRoadmaps(),
+): Overlap[] {
+    const active = _openIdIndex(activeFiles);
+    const archived = _openIdIndex(archivedFiles);
+    const out: Overlap[] = [];
+    for (const [id, activeHits] of [...active.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+        const archivedHits = archived.get(id);
+        if (archivedHits !== undefined) {
+            out.push({ id, active: activeHits, archived: archivedHits });
+        }
+    }
+    return out;
+}
+
 function main(): number {
     try {
         assertScanned({
@@ -411,6 +535,38 @@ function main(): number {
         return 1;
     }
 
+    // An archived roadmap says the work closed. An open blocker declared in one
+    // AND in an active roadmap therefore contradicts itself, and the shrink-only
+    // `open_blockers` ratchet reads the active tree only — so without this the
+    // count is satisfiable by archiving rather than by resolving.
+    //
+    // HARD rather than ratcheted, and measured before it shipped: 0 overlapping
+    // ids on this tree at 2026-09-08 (12 active open ids, 33 archived), so on
+    // the day it lands it fires on nothing and there is no backlog to
+    // grandfather — the same argument the `Class:` contract above makes.
+    const overlap = _archiveOverlap();
+    if (overlap.length > 0) {
+        process.stderr.write(
+            `\n❌  ${overlap.length} blocker id(s) declared open in both an active ` +
+                'and an archived roadmap\n',
+        );
+        for (const o of overlap) {
+            process.stderr.write(`    ${o.id}\n`);
+            for (const rel of o.active) {
+                process.stderr.write(`        active:   ${rel}\n`);
+            }
+            for (const rel of o.archived) {
+                process.stderr.write(`        archived: ${rel}\n`);
+            }
+        }
+        process.stderr.write(
+            '\n    Resolve it in one place. An archived record may keep a blocker that\n' +
+                '    was genuinely unresolved when its roadmap closed; it may not keep one\n' +
+                '    the active tree is still deciding.\n',
+        );
+        return 1;
+    }
+
     // The decidability ratchet. A blocker that names no option, no command and
     // no recommendation is a research task handed to the person with the least
     // context — the defect this half of the gate exists to stop growing.
@@ -434,6 +590,10 @@ function main(): number {
     }
     if (!QUIET) {
         process.stdout.write(`\n✅  ${roadmaps.length} roadmap(s) blocker-contract-clean\n`);
+        process.stdout.write(
+            `✅  0 blocker id(s) open in both an active and an archived roadmap ` +
+                `(${_globArchivedRoadmaps().length} archived file(s) read)\n`,
+        );
         process.stdout.write(`✅  ${verdict.message}\n`);
     }
     return 0;
@@ -477,6 +637,9 @@ export {
     _scan,
     _scanBoth,
     _globRoadmaps,
+    _globArchivedRoadmaps,
+    _openBlockerIds,
+    _archiveOverlap,
     main,
 };
-export type { Violation, ScanResult };
+export type { Violation, ScanResult, Overlap };

--- a/tests/scripts/archive_index_divergence.test.ts
+++ b/tests/scripts/archive_index_divergence.test.ts
@@ -1,0 +1,188 @@
+// The index/working-tree blocker divergence check (1b) and the staging of the
+// moved path (1a) — `road-to-a-blocker-that-cannot-hide-in-the-archive` Phase 1.
+//
+// The defect these reconstruct shipped on 2026-09-08. An edit removing a
+// roadmap's blocker was made in the working tree and never staged; `git mv`
+// renamed the file AND moved the stale index entry; the archival sweep had
+// validated the working tree (no blocker) while the commit carried the index
+// (blocker present, `Status: open`). The archived roadmap therefore declared a
+// blocker open that had already been relocated to an active roadmap, and a
+// human reading `git status` caught it rather than any gate.
+//
+// Reproduced in six commands before the test was written, so the premise is
+// measured rather than assumed:
+//
+//   git init; printf 'line1\nBLOCKER\n' > a.md; git add a.md; git commit
+//   printf 'line1\n' > a.md          # unstaged removal
+//   git mv a.md b.md                 # exit 0
+//   cat b.md      → line1            # working tree
+//   git show :b.md → line1 BLOCKER   # index — this is what a commit ships
+//
+// TS-only (the Python twin was deleted in ADR-200), so there is no byte-parity
+// obligation and these drive the `.ts` engine alone.
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '..', '..', '..');
+const TS_SCRIPT = path.join(REPO_ROOT, 'src', 'agent-src', 'scripts', 'archive_completed_roadmaps.ts');
+const TSX_BIN = path.join(
+    REPO_ROOT,
+    'node_modules',
+    '.bin',
+    process.platform === 'win32' ? 'tsx.cmd' : 'tsx',
+);
+
+function hasGit(): boolean {
+    return spawnSync('git', ['--version'], { encoding: 'utf8' }).status === 0;
+}
+
+function git(cwd: string, ...args: string[]): SpawnSyncReturns<string> {
+    return spawnSync('git', args, { cwd, encoding: 'utf8' });
+}
+
+function runTs(args: string[], cwd: string): SpawnSyncReturns<string> {
+    return spawnSync(TSX_BIN, [TS_SCRIPT, ...args], {
+        cwd,
+        env: { ...process.env, COLUMNS: '80' },
+        encoding: 'utf8',
+    });
+}
+
+const ROADMAP_REL = 'agents/roadmaps/road-to-complete.md';
+const ARCHIVED_REL = 'agents/roadmaps/archive/road-to-complete.md';
+
+/** A complete roadmap (every box `[x]`) carrying one OPEN blocker. */
+const WITH_OPEN_BLOCKER = [
+    '# Complete but undecided',
+    '',
+    '## Phase 1 — All',
+    '- [x] all done',
+    '',
+    '## Blockers',
+    '',
+    '### blocker: b-relocated',
+    '- **Status:** open',
+    '- **Owner:** maintainer',
+    '- **Blocks:** nothing in this roadmap',
+    '- **What to do:** decide the mechanism',
+    '- **Resolved when:** an ADR records the choice',
+    '',
+].join('\n');
+
+/** The same roadmap after the blocker section is removed. */
+const BLOCKER_REMOVED = ['# Complete but undecided', '', '## Phase 1 — All', '- [x] all done', ''].join(
+    '\n',
+);
+
+/** The same roadmap with an unrelated prose edit and the blocker untouched. */
+const PROSE_EDITED = WITH_OPEN_BLOCKER.replace('# Complete but undecided', '# Complete, retitled');
+
+function initCommitted(dir: string, files: Record<string, string>): void {
+    fs.mkdirSync(dir, { recursive: true });
+    git(dir, 'init', '-q');
+    git(dir, 'config', 'user.email', 'divergence@test.local');
+    git(dir, 'config', 'user.name', 'divergence');
+    write(dir, files);
+    git(dir, 'add', '-A');
+    git(dir, 'commit', '-qm', 'init');
+}
+
+function write(dir: string, files: Record<string, string>): void {
+    for (const [rel, body] of Object.entries(files)) {
+        const fp = path.join(dir, rel);
+        fs.mkdirSync(path.dirname(fp), { recursive: true });
+        fs.writeFileSync(fp, body, 'utf-8');
+    }
+}
+
+describe.runIf(hasGit())('archive_completed_roadmaps — index vs working tree', () => {
+    let tmp: string;
+    beforeEach(() => {
+        tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'acr-divergence-'));
+    });
+    afterEach(() => {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    });
+
+    // The reconstruction. Without (1b) this archives: the working tree carries
+    // no blocker, so the open-blocker refusal passes, and the commit then ships
+    // the index — a blocker declared open inside an archived roadmap.
+    it('REFUSES to archive when the staged blocker section disagrees with the working tree', () => {
+        const repo = path.join(tmp, 'unstaged-removal');
+        initCommitted(repo, { [ROADMAP_REL]: WITH_OPEN_BLOCKER });
+        // The defect: remove the blocker, do NOT stage it.
+        write(repo, { [ROADMAP_REL]: BLOCKER_REMOVED });
+
+        const ts = runTs(['--all'], repo);
+
+        expect(ts.status, 'exit').toBe(0);
+        expect(ts.stderr).toMatch(/staged and working-tree blockers disagree/);
+        expect(ts.stderr).toMatch(/blocker 'b-relocated': staged=open vs working tree=absent/);
+        // Still in the active tree — the refusal is the whole point.
+        expect(fs.existsSync(path.join(repo, ROADMAP_REL))).toBe(true);
+        expect(fs.existsSync(path.join(repo, ARCHIVED_REL))).toBe(false);
+    });
+
+    // Polarity. The same edit, staged, is a resolved blocker and archives — so
+    // the refusal above is about the DISAGREEMENT and not about the blocker.
+    it('archives the same removal once it is staged', () => {
+        const repo = path.join(tmp, 'staged-removal');
+        initCommitted(repo, { [ROADMAP_REL]: WITH_OPEN_BLOCKER });
+        write(repo, { [ROADMAP_REL]: BLOCKER_REMOVED });
+        git(repo, 'add', '--', ROADMAP_REL);
+
+        const ts = runTs(['--all'], repo);
+
+        expect(ts.status, 'exit').toBe(0);
+        expect(ts.stderr).not.toMatch(/staged and working-tree blockers disagree/);
+        expect(fs.existsSync(path.join(repo, ARCHIVED_REL))).toBe(true);
+        expect(fs.existsSync(path.join(repo, ROADMAP_REL))).toBe(false);
+    });
+
+    // Scoping, asserted rather than assumed. A whole-file comparison would
+    // refuse here, and refusing archival over an unstaged typo trains
+    // `git add -A`, which destroys the staging discipline (1b) depends on.
+    it('does NOT refuse on an unstaged edit that leaves the blockers alone', () => {
+        const repo = path.join(tmp, 'prose-only');
+        initCommitted(repo, { [ROADMAP_REL]: PROSE_EDITED.replace('## Blockers', '## Notes') });
+        // Retitle in the working tree only; no `## Blockers` section anywhere.
+        write(repo, {
+            [ROADMAP_REL]: PROSE_EDITED.replace('## Blockers', '## Notes').replace(
+                '# Complete, retitled',
+                '# Complete, retitled twice',
+            ),
+        });
+
+        const ts = runTs(['--all'], repo);
+
+        expect(ts.status, 'exit').toBe(0);
+        expect(ts.stderr).not.toMatch(/staged and working-tree blockers disagree/);
+        expect(fs.existsSync(path.join(repo, ARCHIVED_REL))).toBe(true);
+    });
+
+    // (1a). The move relocates the index ENTRY, so without the `git add` the
+    // destination is committed with the stale staged content even when (1b)
+    // legitimately allowed the difference through.
+    it('stages the moved path so the commit carries the working-tree content', () => {
+        const repo = path.join(tmp, 'staging-hygiene');
+        const noBlockers = WITH_OPEN_BLOCKER.replace('## Blockers', '## Notes');
+        initCommitted(repo, { [ROADMAP_REL]: noBlockers });
+        // An unstaged, blocker-irrelevant edit — allowed past (1b) by design.
+        write(repo, { [ROADMAP_REL]: noBlockers.replace('all done', 'all done, really') });
+
+        const ts = runTs(['--all'], repo);
+        expect(ts.status, 'exit').toBe(0);
+        expect(fs.existsSync(path.join(repo, ARCHIVED_REL))).toBe(true);
+
+        // Nothing left unstaged for the moved path: index === working tree.
+        const unstaged = git(repo, 'diff', '--name-only', '--', ARCHIVED_REL);
+        expect(unstaged.stdout.trim(), 'unstaged residue on the archived path').toBe('');
+        // And what is staged is the edited content, not the committed one.
+        const staged = git(repo, 'show', `:${ARCHIVED_REL}`);
+        expect(staged.stdout).toContain('all done, really');
+    });
+});

--- a/tests/scripts/lint_roadmap_blockers.test.ts
+++ b/tests/scripts/lint_roadmap_blockers.test.ts
@@ -4,11 +4,17 @@
 // pure `_scan(text)` function directly (no filesystem / CLI plumbing —
 // REPO_ROOT is fixed relative to the script location, same convention as
 // the sibling linters in this family).
-import { describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
+    _archiveOverlap,
     _blockerClass,
     _hasExecutableSubstance,
+    _openBlockerIds,
     _scan,
     _scanBoth,
 } from '../../src/scripts/lint_roadmap_blockers.js';
@@ -348,5 +354,100 @@ describe('lint_roadmap_blockers — _scan', () => {
         const violations = _scan(text);
         expect(violations.length).toBe(1);
         expect(violations[0]!.message).toContain("blocker 'incomplete-one' missing");
+    });
+});
+// The active-vs-archived open-blocker overlap assertion
+// (`road-to-a-blocker-that-cannot-hide-in-the-archive` Phase 1).
+//
+// `_archiveOverlap` takes its two corpora as arguments so the polarity can be
+// driven from fixtures. Its defaults read the real tree, where the answer is
+// permanently 0 — a test against that would assert nothing, which is the
+// gate-scanning-nothing shape this repository rejects elsewhere.
+describe('lint_roadmap_blockers — active/archived open-blocker overlap', () => {
+    let tmp: string;
+    beforeEach(() => {
+        tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'lrb-overlap-'));
+    });
+    afterEach(() => {
+        fs.rmSync(tmp, { recursive: true, force: true });
+    });
+
+    function fixture(name: string, ...ids: Array<[string, 'open' | 'resolved']>): string {
+        const lines = ['# Fixture', '', '## Blockers', ''];
+        for (const [id, status] of ids) {
+            lines.push(
+                `### blocker: ${id}`,
+                `- **Status:** ${status}`,
+                '- **Owner:** maintainer',
+                '- **Blocks:** nothing',
+                '- **What to do:** decide',
+                '- **Resolved when:** decided',
+                '',
+            );
+        }
+        const fp = path.join(tmp, name);
+        fs.writeFileSync(fp, lines.join('\n'), 'utf-8');
+        return fp;
+    }
+
+    it('reports an id declared open in both an active and an archived roadmap', () => {
+        const active = fixture('active.md', ['b-relocated', 'open']);
+        const archived = fixture('archived.md', ['b-relocated', 'open']);
+
+        const overlap = _archiveOverlap([active], [archived]);
+
+        expect(overlap.length).toBe(1);
+        expect(overlap[0]!.id).toBe('b-relocated');
+        expect(overlap[0]!.active.length).toBe(1);
+        expect(overlap[0]!.archived.length).toBe(1);
+    });
+
+    it('reports nothing when the ids differ', () => {
+        const active = fixture('active.md', ['b-one', 'open']);
+        const archived = fixture('archived.md', ['b-two', 'open']);
+        expect(_archiveOverlap([active], [archived])).toEqual([]);
+    });
+
+    // The exclusion the archive is entitled to: a blocker genuinely unresolved
+    // when its roadmap closed is history. Only an OPEN pair contradicts itself.
+    it('reports nothing when the archived copy is resolved', () => {
+        const active = fixture('active.md', ['b-shared', 'open']);
+        const archived = fixture('archived.md', ['b-shared', 'resolved']);
+        expect(_archiveOverlap([active], [archived])).toEqual([]);
+    });
+
+    // Two ACTIVE roadmaps sharing one cross-cutting blocker is legitimate, and
+    // the unscoped "no id open in more than one file" form would forbid it.
+    it('reports nothing for an id open in two ACTIVE roadmaps', () => {
+        const a1 = fixture('a1.md', ['b-crosscutting', 'open']);
+        const a2 = fixture('a2.md', ['b-crosscutting', 'open']);
+        expect(_archiveOverlap([a1, a2], [])).toEqual([]);
+    });
+
+    it('_openBlockerIds treats a `resolved <date> by …` status as resolved', () => {
+        const text = [
+            '## Blockers',
+            '',
+            '### blocker: b-closed',
+            '- **Status:** resolved 2026-09-08 by the council',
+            '',
+            '### blocker: b-live',
+            '- **Status:** open',
+            '',
+        ].join('\n');
+        expect([..._openBlockerIds(text)]).toEqual(['b-live']);
+    });
+
+    it('_openBlockerIds ignores a fenced documentation example', () => {
+        const text = [
+            '## Blockers',
+            '',
+            '```',
+            '### blocker: example-only',
+            '- **Status:** open',
+            '```',
+            '',
+        ].join('\n');
+        expect([..._openBlockerIds(text)]).toEqual([]);
     });
 });


### PR DESCRIPTION
Closes `road-to-a-blocker-that-cannot-hide-in-the-archive` — 5/5 steps, 3/3 acceptance criteria, archived in this branch.

## The defect

The archival sweep refuses to archive a roadmap carrying an open blocker. It reads the file with `fs.readFileSync` — the **working tree**. `git mv` then moves the **index entry**, which still holds whatever was staged, and the sweep never stages the destination. When the two disagree, the commit ships content the gate never read.

Measured once at full cost on 2026-09-08: an edit removing a roadmap's blocker was made and never staged; `git mv` moved the stale index entry; the archived file shipped a blocker declared `Status: open` that had already been relocated to an active roadmap. The same blocker was open in two files at once, one of them archived, and a human reading `git status` caught it rather than any gate.

Reproduced in six commands before any code was written:

```
git init; printf 'line1\nBLOCKER\n' > a.md; git add a.md; git commit
printf 'line1\n' > a.md          # unstaged removal
git mv a.md b.md                 # exit 0
cat b.md      → line1            # working tree
git show :b.md → line1 BLOCKER   # index — this is what a commit ships
```

## What shipped

| # | Assertion | Where | Day-one findings |
|---|---|---|---|
| 1b | Refuse archival when the **staged** and **working-tree** blocker id→status maps of the file being moved disagree | `archive_completed_roadmaps.ts` | **0** — fires only on a future archival |
| 1a | `git add` the destination after a tracked `git mv`, so the commit carries what the checks read | same file | **0** — not an assertion |
| 4 | No blocker id may be declared `Status: open` in **both** an active and an archived roadmap | `lint_roadmap_blockers.ts`, hard, no baseline | **0**, measured |

The gate is green on this tree with **no baseline**:

```
✅  12 roadmap(s) blocker-contract-clean
✅  0 blocker id(s) open in both an active and an archived roadmap (701 archived file(s) read)
```

## The roadmap's option (1) was factually inverted

Option (1) said *"re-read the file from the working tree rather than trusting the index"*. The sweep already reads the working tree, so implementing that would have been a no-op — the index is what ships and was never read. The correction is recorded in the roadmap, and it also settles why (4) is a tree-wide assertion rather than a transition one: the sweep already refuses any roadmap with an open blocker in the working tree, so at the moment of archival there is never an open blocker left to overlap with.

## The obvious fix, refused

Extending either gate's corpus to `archive/` wholesale lands **23 findings on day one** against a change that caused none of them — the shape this repository has reverted twice (`lint_roadmap_later_disposition` at 68 files, `check_no_new_legacy_path` at 46). It would also falsify history: a blocker genuinely unresolved when its roadmap closed is a true thing for an archived record to say. (4) therefore reads the archive for exactly one fact — id and open-ness — and applies neither the five-field contract, the class taxonomy, nor the decidability ratchet there.

## Council

AI council, 2026-09-08, 2 seats present (`anthropic/claude-sonnet-4-5` + `openai/gpt-4o`, api transport, quorum 2/2, USD 0.0780 spent against a USD 0.4192 estimate). Both seats converged on (1b) + (1a) and both rejected option (3), the shrink-only baseline pinned at 23: it encodes a number over a corpus nothing reads, and both readings are bad — if the 23 are genuine history the ratchet forbids future genuine history, and if they are stale it preserves staleness. The anthropic seat supplied the (4) refinement and refuted (2) as originally scoped (it forbids one cross-cutting blocker open in two *active* roadmaps, which is legitimate).

The narrow scoping of (1b) is theirs too: a whole-file comparison would refuse archival over an unstaged typo, which *"trains developers to `git add -A` reflexively, defeating staging discipline"* — the very discipline the check depends on.

## Sensitivity — every mechanism seen red

| Mechanism | Neutralisation | Result |
|---|---|---|
| (1b) `_blockerDivergence` | early-return `[]` unconditionally | the reconstruction test goes **red**; the other three stay green |
| (1a) `git add` of the destination | guard the call with `false &&` | the staging-hygiene test goes **red**; the other three stay green |
| (4) `_archiveOverlap` | guard the overlap push with `false &&` | the overlap test goes **red**; 34 of 35 stay green |

The "others stay green" column is the half that matters: each test watches its own mechanism rather than all failing together on any edit. All three restored by reverse edit (never `git checkout` — that discards the surrounding work with the sabotage).

**(1a) is additionally confirmed on this roadmap's own archival**, which is stronger than the fixture: at the moment of the move the working tree carried every closure edit and the index carried the version on `main`. After the sweep there is no unstaged residue on the archived path and the staged content carries the decision section. Without the `git add`, this PR would have archived the roadmap with none of the decision it records.

## What this leaves uncovered — named, not closed

- **Two blocker ids are open in more than one *archived* file** (`background-continuation-probe`, `benchmark-spend-authorization`). Out of scope for the same day-one reason: a hard assertion there would red the build on 2 records this change did not create.
- **The 23 archived files carrying open blockers are still unread.** (4) proves none collides with the active tree, which is strictly weaker than "none is stale".
- **An untracked new roadmap during archival** — the council's option (1c). Left as a follow-up because refuse-vs-warn scoping needs its own decision.
- **A blocker copied into an archived file with `Status: resolved`** while the active copy stays open. Not a contradiction by (4)'s definition, deliberately: a closed record of work planned elsewhere is legitimate.

## Verification

- `task typecheck-ts` — clean
- `task preflight` — exit 0
- `task consistency` — exit 0 (derived outputs byte-exact)
- `./scripts-run src/scripts/lint_roadmap_blockers` — green, no baseline
- `./scripts-run src/scripts/check_estate_count` — within ratchet (`active_roadmaps 8`, floor 9, −1)
- `./scripts-run src/scripts/lint_code_comments` — clean
- `./scripts-run src/scripts/check_source_size_budget` — 17,963 at baseline, no new excess
- `npx vitest run tests/scripts/` — 19,294 passed, 1 failed: `reach_doctor.test.ts:769`, the known depth-8 environment failure of that test's own premise (`path.resolve` clamps at `/`, so a checkout ≥ 8 directories deep lands the traversal fixture *inside* a permitted root). Pre-existing, unrelated to this diff, green in CI where the checkout is shallow.
