### PR TITLE
Apply E7: archive the two token-saving roadmaps, carry the residue to a stub

### DIFF
--- a/agents/roadmaps/archive/road-to-token-saving-HUMAN-MEASUREMENT.md
+++ b/agents/roadmaps/archive/road-to-token-saving-HUMAN-MEASUREMENT.md
@@ -1,5 +1,5 @@
 ---
-status: later
+status: archived
 slug: token-saving-human-measurement
 title: "token-saving — human-measurement track: verdict-gated phases split off the autonomous parent"
 parent_roadmap: token-saving
@@ -7,6 +7,16 @@ parent_roadmap: token-saving
 <!-- check-refs: skip -->
 
 # Road to Token-Saving — Human-Measurement Track
+
+> **ARCHIVED 2026-09-09 under owner ruling E7** (`road-to-delivery-for-every-host`
+> § Owner rulings, executed by its step 7.3), together with its parent
+> `road-to-token-saving.md`. The rule-layer motivation is discharged by the
+> `delivery` projection flip; the judge gate this track was filed for is already
+> recorded closed by measurement above. Its four open boxes are carried, with
+> per-item promotion probes, into `agents/roadmaps/stubs/road-to-token-saving-residue.md` —
+> including the one that is an unexecuted OWNER decision rather than residue:
+> the `telegraph-speak` removal, measured RED with a council recommending
+> removal and waiting only on authorization.
 
 > Split off `road-to-token-saving.md` per the autonomous-mandate master-plan
 > council (claude-sonnet-4-5 + gpt-4o, deep, 2026-06-23,

--- a/agents/roadmaps/archive/road-to-token-saving.md
+++ b/agents/roadmaps/archive/road-to-token-saving.md
@@ -1,9 +1,22 @@
 ---
 complexity: structural
-status: later
+status: archived
 ---
 
 # Road to token saving — measure, then cut, at constant quality
+
+> **ARCHIVED 2026-09-09 under owner ruling E7** (`road-to-delivery-for-every-host`
+> § Owner rulings, executed by its step 7.3). The rule-layer motivation is
+> discharged by a different mechanism — `lean_projection.mode: delivery` for
+> `claude-code` cut `.claude/rules` from 99,598 tok to 24,166 tok (−75.7 %) with
+> every non-Claude host byte-identical — and the thin lever this file chased is
+> separately dead by measurement (two pre-registered length-neutral judge runs,
+> both inconclusive, gate CLOSED-BY-DIAGNOSIS). The open boxes below are NOT
+> dropped: each one is carried, with its own promotion probe, into
+> `agents/roadmaps/stubs/road-to-token-saving-residue.md`. Nothing here was edited on
+> archival except the `phase-0-golden-set` status token, which read
+> `RESOLVED NEGATIVE` and now reads `resolved` so the machine-readable half
+> matches the prose that was already beside it.
 
 > **Parked (2026-07-12, later/ disposition).** Every remaining open step is
 > operator-gated; nothing is agent-workable now. **Resume when the operator
@@ -591,7 +604,7 @@ stale candidates.
 ## Blockers
 
 ### blocker: phase-0-golden-set
-- **Status:** RESOLVED NEGATIVE (2026-07-12) — the length-neutral judge RERUN (pre-registered: ±15% token-band pairing, double blind judges claude-opus-4-8 + gpt-4o both orders, κ floor 0.60) produced a SECOND inconclusive; the gate is **CLOSED-BY-DIAGNOSIS**: thin-vs-eager is not resolvable by LLM-paired judging on this corpus (see docs/benchmark.md § Length-neutral judge RERUN). Only re-open path: deterministic anchor-scoring against `must_include`/`must_not`. Consequence for this roadmap: the thin lever stays dead; the remaining open steps are operator-gated only (RTK validation + live trigger-eval), not judge-gated.
+- **Status:** resolved (2026-07-12) — RESOLVED NEGATIVE: the length-neutral judge RERUN (pre-registered: ±15% token-band pairing, double blind judges claude-opus-4-8 + gpt-4o both orders, κ floor 0.60) produced a SECOND inconclusive; the gate is **CLOSED-BY-DIAGNOSIS**: thin-vs-eager is not resolvable by LLM-paired judging on this corpus (see docs/benchmark.md § Length-neutral judge RERUN). Only re-open path: deterministic anchor-scoring against `must_include`/`must_not`. Consequence for this roadmap: the thin lever stays dead; the remaining open steps are operator-gated only (RTK validation + live trigger-eval), not judge-gated.
 - **Owner:** maintainer
 - **Blocks:** Phase 0 Steps 1 + 2 (golden set + host-compliance probe), Phase 1 Step 1 (RTK golden-set run), Phase 8 Step 2 (quality-elbow threshold), and Phase 10 Step 1 (tier-conditional loading)
 - **What to do:**

--- a/agents/roadmaps/later/road-to-catalogue-host-fit.md
+++ b/agents/roadmaps/later/road-to-catalogue-host-fit.md
@@ -96,6 +96,16 @@ selection-accuracy baseline for the rewritten skill descriptions, satisfies a
 resume condition on `road-to-cost-parity-1-rule-payload-diet`, and satisfies a
 resume gate on `later/road-to-token-saving`. Three roadmaps unblock from one run.
 
+> **Corrected 2026-09-09 — the third of those three has moved, and the run is
+> still worth the same.** `road-to-token-saving` was archived under owner ruling
+> E7 (`road-to-delivery-for-every-host` step 7.3): its rule-layer motivation was
+> discharged by the `delivery` projection flip, not by this eval. The live
+> trigger-eval obligation it carried was NOT dropped — it is item R2 of
+> `agents/roadmaps/stubs/road-to-token-saving-residue.md`, whose promotion probe
+> is exactly this run. So the arithmetic below is unchanged in substance: one
+> operator session still discharges three things, one of which is now a stub
+> item rather than a parked roadmap.
+
 - [~] **0.1** Run the human-gated live trigger eval per its own pre-registration —
       request count and shape coverage are set there, not here — and commit its
       baseline. Blocked on `b-live-trigger-eval`.
@@ -425,7 +435,9 @@ Phase 3.
   highest-leverage human action in the estate and the arithmetic is not close: one
   run commits the selection-accuracy baseline, satisfies a resume condition on
   `road-to-cost-parity-1-rule-payload-diet`, and satisfies a resume gate on
-  `later/road-to-token-saving`. Option (b) is strictly slower for the same spend and
+  `later/road-to-token-saving` (archived 2026-09-09; that gate is now R2 of
+  `stubs/road-to-token-saving-residue.md` — see the correction in Phase 0).
+  Option (b) is strictly slower for the same spend and
   makes three roadmaps wait on a mechanism that does not exist yet. Option (c)
   strands all three indefinitely.
 - **If you do nothing:** three roadmaps stay blocked on a command whose only human

--- a/agents/roadmaps/road-to-delivery-for-every-host.md
+++ b/agents/roadmaps/road-to-delivery-for-every-host.md
@@ -723,9 +723,36 @@ Defects this roadmap repairs:
       What is missing is the generator that reads a host-aware census into the contract, and
       the host-aware census is the thing 4.4 is blocked on. Closes when that surface
       decision is taken.
-- [ ] **7.3 Apply E7** to the two `later/` token roadmaps.
+- [x] **7.3 Apply E7** to the two `later/` token roadmaps.
       verify: both files have a disposition;
       `./scripts-run src/scripts/lint_roadmap_later_disposition` green.
+      Done 2026-09-09, in its own change for the reason the AC below already
+      gave: archiving a roadmap here moves three ratchets — the estate count,
+      the risk-register floor and the archive index — and folding that into the
+      commit that carried the default flip, an ADR and a schema repair would
+      have made a revert of any one a revert of all.
+      Both files are now at `agents/roadmaps/archive/`. Each carries an
+      ARCHIVED-under-E7 banner naming the mechanism that discharged it: the
+      `delivery` flip took `.claude/rules` from 99,598 tok to 24,166 tok
+      (−75.7 %) with every non-Claude host byte-identical, and the thin lever
+      both files chased is separately dead by measurement (two pre-registered
+      length-neutral judge runs, both inconclusive, CLOSED-BY-DIAGNOSIS).
+      **The non-rule-layer residue E7 names is carried, not dropped**, into
+      `agents/roadmaps/stubs/road-to-token-saving-residue.md` with a `review_by`
+      and one promotion probe per item: R1 the RTK golden-set validation and the
+      kernel promotion behind it (operator-gated, and a kernel edit besides),
+      R2 the live trigger-eval pass, R3 the `telegraph-speak` removal —
+      **owner-reserved, measured RED with a council recommending removal and
+      waiting only on authorization, so it is an unexecuted owner decision
+      rather than residue and this run did not take it** — R4 the zero-cost
+      dormancy flag nobody set, R5 the 26 remaining `.agent-src.uncondensed`
+      prose references, R6 the measured-before/after bar.
+      One byte changed inside an archived file, named so it is not read as
+      silent editing: `phase-0-golden-set`'s status token read `RESOLVED
+      NEGATIVE` and now reads `resolved`, so the machine-readable half matches
+      the prose that was already beside it.
+      Verify output: `lint_roadmap_later_disposition` green, and both
+      wake-condition ratchets moved DOWN with the two files leaving `later/`.
 
 ## Kill register (this roadmap's IDs)
 

--- a/agents/roadmaps/stubs/road-to-token-saving-residue.md
+++ b/agents/roadmaps/stubs/road-to-token-saving-residue.md
@@ -1,0 +1,98 @@
+---
+complexity: lightweight
+review_by: 2026-12-09
+---
+
+# Stub: the token-saving residue E7 did not archive
+
+> **Stub — not active work.** Created 2026-09-09 executing step 7.3 of
+> `road-to-delivery-for-every-host`, which applies owner ruling **E7**:
+> `later/road-to-token-saving.md` and
+> `later/road-to-token-saving-HUMAN-MEASUREMENT.md` are *"archived for the rule
+> layer once Phase 7.1 flips the claim; any non-rule-layer residue moves to a
+> stub with a `review_by`."* Phase 7.1 flipped the claim on 2026-09-07, so the
+> precondition was met; the archival was deliberately deferred to its own change
+> because it moves three ratchets (the estate count, the risk-register floor and
+> the archive index) that were not that change's subject. This is that change,
+> and this file is the receiver E7 names.
+
+## Why the rule layer is discharged, stated so the archive is not read as a drop
+
+Both roadmaps existed to cut the standing rule payload. That was delivered by a
+different mechanism: `lean_projection.mode: delivery` for `claude-code`, which
+took `.claude/rules` from **99,598 tok to 24,166 tok, −75.7 %, 114 files on both
+sides** (measured on a clean consumer-shaped root, `road-to-delivery-for-every-host`
+step 4.2), while every non-Claude host keeps a byte-identical tree. The thin
+lever those roadmaps were chasing is separately dead by measurement: two
+pre-registered length-neutral judge runs returned inconclusive, and the gate is
+recorded CLOSED-BY-DIAGNOSIS (`docs/benchmark.md` § Length-neutral judge RERUN).
+
+So the rule-layer question is answered, not abandoned. What follows is what those
+two files still carried that the delivery flip does not answer.
+
+## The residue, one item per open box
+
+**R1 — RTK golden-set validation, and the kernel promotion behind it.**
+`road-to-token-saving.md`: run the Phase 0 golden set through RTK and confirm no
+output-completeness regression (ANSI/structured output, the `git diff`
+truncation denylist); clean → promote RTK wrapping to always-on, otherwise keep
+it profile-gated and record the failing case. Doubly gated and neither gate is
+this repository's to open: the validation run needs the RTK binary against live
+outputs and is operator/cost-gated, and the promotion is a **kernel-rule edit**,
+which `scope-control` gives its own PR and a ≥ 24 h soak that no autonomy lifts.
+*Probe:* an operator runs the golden set and records the result.
+
+**R2 — the live trigger-eval pass.** `road-to-token-saving.md`: the static
+reconciliation is done; the LIVE trigger evaluation is a human gate. *Probe:* a
+live pass is recorded, or the obligation is dropped with a reason.
+
+**R3 — `telegraph-speak` removal, awaiting owner authorization.**
+`road-to-token-saving-HUMAN-MEASUREMENT.md`: both the H2 (telegraph-speak) and
+H3 (condensation-ROI) gates were measured RED and a council said remove both.
+What is missing is the authorization to execute, not the measurement.
+Deliberately carried here rather than left to lapse in an archive: an unexecuted
+owner decision is not residue the delivery flip discharges. Note the correction
+that file already carries — there is **no** CI gate for it
+(`validate_telegraph_carveouts.ts` appears in no Taskfile target and no
+workflow), so the deletable surface is 5 scripts, 4 test files and the rule.
+*Probe:* the owner authorizes or declines; either closes it.
+**Owner-reserved. This stub does not execute it and no mandate lets it.**
+
+**R4 — zero-cost dormancy is available and was never taken.** Same file:
+`COMPILE_TIME_TOGGLES['telegraph-speak']` gates on `telegraph.enabled` /
+`telegraph.speak` and never reads `speak_scope`, so `speak_scope: off` kills the
+behaviour while leaving the ~982-token cost, whereas `telegraph.speak: false`
+omits the rule from `dist/router.json` entirely. A settings decision, not a
+deletion. *Probe:* the flag is set either way, or R3 lands and moots it.
+
+**R5 — 26 artifacts still reference the dead `.agent-src.uncondensed` tree**
+(13 rules, 13 skills). The functional subset — 8 `path_prefix` trigger entries
+compiled into `dist/router.json` — is already fixed. The remainder are prose
+citations and declared `validator_ignore` exemptions, several deliberate with
+stated reasons, so they need per-case judgement rather than a sweep. *Probe:* a
+per-case pass lands, or the remainder is declared intentional.
+
+**R6 — the unmeasured-lever acceptance.** "Every shipped lever carries a measured
+before/after at held-constant quality." Kept because it is the criterion that
+made both roadmaps honest, and because the delivery flip satisfies it for the
+lever that actually shipped: the −75.7 % reading above is a before/after on the
+tree a host loads. *Probe:* none needed for the shipped lever; it stays here as
+the bar any future lever must clear.
+
+## What this stub is NOT
+
+Not a plan to resume the token-saving roadmaps. The rule-layer motivation is
+discharged and the thin lever is dead by measurement; promoting this stub back
+to an active roadmap would need a NEW reason, not these six items. Five of the
+six are gated on an operator, a human pass or an owner decision — none of them
+on engineering this repository is withholding.
+
+## Provenance
+
+Both source files are at
+`agents/roadmaps/archive/road-to-token-saving.md` and
+`agents/roadmaps/archive/road-to-token-saving-HUMAN-MEASUREMENT.md`, archived
+with their full history intact; nothing in them was edited on the way except the
+`phase-0-golden-set` blocker's status token, which read `RESOLVED NEGATIVE` and
+now reads `resolved` so the machine-readable half matches the prose that was
+already there.


### PR DESCRIPTION
Executes **step 7.3** of `road-to-delivery-for-every-host` — owner ruling **E7**: the two
`later/` token-saving roadmaps are archived for the rule layer, and their non-rule-layer
residue moves to a stub with a `review_by`.

**In its own change, for the reason the step already gave.** Archiving a roadmap here moves
three ratchets (estate count, risk-register floor, archive index); folding that into the
commit that carried the default flip, an ADR and a schema repair would have made a revert of
any one a revert of all. The precondition — Phase 7.1 flipping the claim — landed 2026-09-07.

## Why the rule layer is discharged, and not merely abandoned

Both files existed to cut the standing rule payload. **A different mechanism delivered it:**
`lean_projection.mode: delivery` for `claude-code` took `.claude/rules` from **99,598 tok to
24,166 tok (−75.7 %, 114 files on both sides)**, with every non-Claude host byte-identical.
The thin lever both roadmaps chased is separately dead by measurement — two pre-registered
length-neutral judge runs, both inconclusive, gate recorded CLOSED-BY-DIAGNOSIS.

## The residue is carried, with a probe each

`agents/roadmaps/stubs/road-to-token-saving-residue.md`:

| | Item | Gate |
|---|---|---|
| R1 | RTK golden-set validation → the tier_2→kernel promotion | operator + cost gated, **and** a kernel edit (own PR, ≥24 h soak) |
| R2 | the live trigger-eval pass | human gate |
| R3 | `telegraph-speak` removal | **owner-reserved, not executed** |
| R4 | zero-cost dormancy flag nobody set | a settings decision |
| R5 | 26 remaining `.agent-src.uncondensed` prose refs | per-case judgement (the 8 functional trigger entries are already fixed) |
| R6 | the measured-before/after bar | kept as the criterion any future lever must clear |

**R3 is the one that mattered most to carry.** It was measured RED with a council
recommending removal and is waiting only on authorization — an unexecuted *owner decision*,
not residue. Leaving it to lapse inside an archive is exactly the silent drop Iron Law 3
exists to stop, so it is written out with its own probe and an explicit note that this run
did not take it.

**R2 has a second consumer.** `later/road-to-catalogue-host-fit` names it as one of three
things a single operator session discharges, so that file is corrected in place rather than
left pointing at an archived path. Its arithmetic is unchanged in substance — one of the
three is now a stub item.

## Two edits inside archived files, named rather than silent

- `phase-0-golden-set`'s status token read `RESOLVED NEGATIVE` and now reads `resolved`, so
  the machine-readable half matches the prose that was already beside it.
- Both files take `status: archived` in place of `status: later`, which
  `lint_roadmap_later_disposition` refuses outside `later/`, plus an ARCHIVED-under-E7 banner
  naming the mechanism that discharged them.

## Verification

`lint_roadmap_later_disposition` green · `lint_roadmap_blockers` clean · `check_references` no
broken refs · `build_archive_index` 704 · `check_estate_count` `later_roadmaps 83 (floor 85,
−2)`, every other dimension +0 · `task sync-check` in sync · `task preflight` exit 0.

**The two `lint_roadmap_later_disposition` baselines now read loose (17/18 and 66/68) and are
deliberately NOT lowered.** A gate inviting a lowering is reporting its own count in its own
environment; this repository has already paid once for taking that invitation as evidence.
Only CI's reading may move a baseline, and headroom costs nothing.
