### PR TITLE
feat(ci-settle): refuse a verdict about a head that stopped mattering

### DIFF
--- a/dist/agent-src/skills/git-workflow/references/push-closes-its-loop.md
+++ b/dist/agent-src/skills/git-workflow/references/push-closes-its-loop.md
@@ -68,6 +68,15 @@ returned 0, the turn closed, and the red arrived where the user found it.
   ending the turn silently on one is what the reminder exists to stop. Whether
   the reminder changes behavior is unmeasured — it ships as a carrier, not as a
   claim.
+- **`ci_settle` will not answer for a head that stopped mattering.** Since
+  2026-09-08 it reads the PR's `state` and compares its recorded head against
+  `git ls-remote` — before the wait and again at verdict time — and exits 2 with
+  a reason when the PR is merged, closed, or record-behind-branch. A green names
+  the head it is about. The measured reason: a merged PR's rollup kept answering
+  with its merge-time checks, so the tool reported `SETTLED GREEN — 40 check(s)`
+  for a commit that had zero check runs. The check does not apply to a fork PR
+  whose ref is not under this `origin`, and the line says so instead of claiming
+  it passed.
 - **Neither reaches a host without the slot.** `agent-config hooks:status`
   answers which slots are bound where you actually are; `post_tool_use` is
   unbound on windsurf and copilot, and there the settle obligation is

--- a/src/scripts/ci_settle.ts
+++ b/src/scripts/ci_settle.ts
@@ -18,10 +18,20 @@
  * every agent's head: `not settled` and `settled` are different from `could not
  * read`, and only the first two may end a wait.
  *
- * Exit codes: 0 = settled, every check succeeded (or was skipped) ·
+ * A verdict also has to be ABOUT SOMETHING, which is the second half of the
+ * same rule and was missing until 2026-09-08: the rollup answers about the head
+ * the PR *record* carries, and that head stops tracking the branch when the PR
+ * is merged or when the record lags a push. Both then look like a healthy
+ * green. {@link classifyTarget} refuses those, before the wait and again at
+ * verdict time. Measured cost of not having it: a `SETTLED GREEN — 40 check(s)`
+ * for a head with literally zero check runs.
+ *
+ * Exit codes: 0 = settled green, and the head it is about is named ·
  *             1 = settled, at least one check failed ·
- *             2 = did not settle within the budget, or the API could not be
- *                 read — NEVER a verdict, and the reason is printed.
+ *             2 = did not settle within the budget, the API could not be read,
+ *                 or the target is not a PR a verdict can be about (merged,
+ *                 closed, or head-diverged) — NEVER a verdict, and the reason
+ *                 is printed.
  *
  * Usage: ./scripts-run src/scripts/ci_settle <pr> [--timeout-min N] [--interval-sec N]
  *
@@ -56,6 +66,121 @@ export type PollState =
     | { kind: 'unreadable'; reason: string }
     | { kind: 'pending'; total: number; done: number }
     | { kind: 'settled'; failing: string[]; total: number };
+
+/**
+ * What `git ls-remote` said about the PR branch's tip.
+ *
+ * `absent` and `unreadable` are different answers and must not collapse: a
+ * cross-repo fork PR legitimately has no ref under this `origin`, while a
+ * transport failure means nobody knows. Collapsing them either disables the
+ * divergence check for forks silently, or blocks every fork PR forever.
+ */
+export type RemoteTip =
+    | { kind: 'found'; sha: string }
+    | { kind: 'absent' }
+    | { kind: 'unreadable'; reason: string };
+
+/**
+ * Whether the PR this wait is about still decides anything.
+ *
+ * `refuse` is NOT a verdict — it exits 2 like every other non-verdict, because
+ * the wait produced no readable statement about the head that matters.
+ */
+export type TargetState =
+    | { kind: 'open'; head: string; ref: string; divergenceChecked: boolean }
+    | { kind: 'unreadable'; reason: string }
+    | { kind: 'refuse'; reason: string };
+
+/**
+ * Decide whether a green from {@link classifyPoll} may be reported at all.
+ *
+ * WHY THIS EXISTS, measured 2026-09-08 on PR #1949 and paid for twice in one
+ * session. `gh pr view --json statusCheckRollup` answers about the head the PR
+ * *record* carries, and that head stops tracking the branch in two situations
+ * this script previously could not tell apart from a healthy wait:
+ *
+ * 1. **The PR is already merged or closed.** A push to its branch fires no
+ *    `pull_request` event, so no checks are created for the new commits and the
+ *    rollup keeps returning the merge-time head's checks. The script reported
+ *    `SETTLED GREEN — 40 check(s)` for a head that had stopped mattering, and
+ *    the only thing that exposed it was a hand-written
+ *    `/commits/<sha>/check-runs` query answering `0`. Reported at face value
+ *    that green authorises a merge of content nobody checked.
+ * 2. **The PR record lags the branch ref.** Same shape, different cause
+ *    (recorded on PR #710): `git ls-remote` shows the new SHA while the record
+ *    keeps the old one, and merging then lands the PR WITHOUT the newer
+ *    commits — silently, which is what makes it worse than a red.
+ *
+ * Both are answered by the same two facts, which is why one function decides
+ * them: the PR's `state`, and whether its head equals the branch tip. Pure, so
+ * the failure is testable without a network — feed it a merged PR and it must
+ * answer `refuse`, never `open`.
+ */
+export function classifyTarget(
+    stdout: string,
+    stderr: string,
+    status: number | null,
+    tip: RemoteTip,
+): TargetState {
+    const combined = `${stdout}\n${stderr}`.toLowerCase();
+    for (const marker of _UNREADABLE_MARKERS) {
+        if (combined.includes(marker.toLowerCase())) {
+            return { kind: 'unreadable', reason: marker };
+        }
+    }
+    if (status !== 0) {
+        return { kind: 'unreadable', reason: `gh exited ${String(status)}` };
+    }
+    let state: string;
+    let head: string;
+    let ref: string;
+    try {
+        const parsed = JSON.parse(stdout) as {
+            state?: unknown;
+            headRefOid?: unknown;
+            headRefName?: unknown;
+        };
+        if (
+            typeof parsed.state !== 'string' ||
+            typeof parsed.headRefOid !== 'string' ||
+            typeof parsed.headRefName !== 'string'
+        ) {
+            return { kind: 'unreadable', reason: 'no state / headRefOid / headRefName in response' };
+        }
+        state = parsed.state.toUpperCase();
+        head = parsed.headRefOid;
+        ref = parsed.headRefName;
+    } catch {
+        return { kind: 'unreadable', reason: 'unparseable JSON' };
+    }
+    if (state !== 'OPEN') {
+        return {
+            kind: 'refuse',
+            reason:
+                `the PR is ${state}, not OPEN. Its rollup describes head ${head.slice(0, 9)} as of ` +
+                'that transition; pushes after it create no checks, so a green here would be about ' +
+                'a head that no longer decides anything',
+        };
+    }
+    if (tip.kind === 'unreadable') {
+        return { kind: 'unreadable', reason: `branch tip: ${tip.reason}` };
+    }
+    if (tip.kind === 'absent') {
+        // A fork PR's ref is not under this origin. Say the check did not apply
+        // rather than pretending it passed.
+        return { kind: 'open', head, ref, divergenceChecked: false };
+    }
+    if (tip.sha !== head) {
+        return {
+            kind: 'refuse',
+            reason:
+                `the PR record is at head ${head.slice(0, 9)} but origin/${ref} is at ` +
+                `${tip.sha.slice(0, 9)}. Merging in this state lands the PR WITHOUT the newer ` +
+                'commits (recorded on PR #710), and any verdict here is about the wrong head',
+        };
+    }
+    return { kind: 'open', head, ref, divergenceChecked: true };
+}
 
 /** Markers that mean the API did not answer — not that nothing is pending. */
 const _UNREADABLE_MARKERS = [
@@ -126,6 +251,41 @@ function poll(pr: string): PollState {
     return classifyPoll(r.stdout ?? '', r.stderr ?? '', r.status);
 }
 
+/**
+ * Read the branch tip from the remote, not from a local ref.
+ *
+ * A local `origin/<ref>` is only as fresh as the last fetch, and the divergence
+ * this guards against is created by somebody else's push — so a stale local ref
+ * would report agreement exactly when it matters most.
+ */
+function readTip(ref: string): RemoteTip {
+    const r = spawnSync('git', ['ls-remote', 'origin', `refs/heads/${ref}`], {
+        encoding: 'utf-8',
+        timeout: 60_000,
+    });
+    if (r.status !== 0) {
+        const why = (r.stderr ?? '').trim().split('\n')[0] ?? `git exited ${String(r.status)}`;
+        return { kind: 'unreadable', reason: why };
+    }
+    const line = (r.stdout ?? '').trim();
+    if (line === '') return { kind: 'absent' };
+    const sha = line.split(/\s+/)[0] ?? '';
+    return sha === '' ? { kind: 'unreadable', reason: 'empty sha in ls-remote output' } : { kind: 'found', sha };
+}
+
+function readTarget(pr: string): TargetState {
+    const r = spawnSync('gh', ['pr', 'view', pr, '--json', 'state,headRefOid,headRefName'], {
+        encoding: 'utf-8',
+        timeout: 60_000,
+    });
+    // The ref name comes from the same read, so the tip lookup needs it first;
+    // classifyTarget is called twice rather than plumbing a callback through a
+    // pure function.
+    const shape = classifyTarget(r.stdout ?? '', r.stderr ?? '', r.status, { kind: 'absent' });
+    if (shape.kind !== 'open') return shape;
+    return classifyTarget(r.stdout ?? '', r.stderr ?? '', r.status, readTip(shape.ref));
+}
+
 function sleepSync(seconds: number): void {
     // Deliberately synchronous: this is a CLI whose whole job is to block.
     spawnSync(process.execPath, ['-e', `setTimeout(()=>{}, ${String(seconds * 1000)})`], {
@@ -164,18 +324,58 @@ export function main(argv: readonly string[]): number {
     }
     const intervalSec = num('--interval-sec', 60);
 
+    // Up front, because waiting nine minutes to learn the PR was merged before
+    // the wait began is the expensive way to find out.
+    const before = readTarget(pr);
+    if (before.kind === 'refuse') {
+        process.stdout.write(`ci_settle: REFUSING TO WAIT — ${before.reason}. No verdict is claimed.\n`);
+        return 2;
+    }
+    if (before.kind === 'unreadable') {
+        process.stdout.write(
+            `ci_settle: could not read the PR's target state (${before.reason}) — NOT a verdict, waiting anyway; ` +
+                'the pre-verdict re-check below still applies.\n',
+        );
+    } else if (!before.divergenceChecked) {
+        process.stdout.write(
+            `ci_settle: origin carries no refs/heads/${before.ref} (a fork PR) — the head-divergence check does not apply here.\n`,
+        );
+    }
+
     const deadline = Date.now() + timeoutMin * 60_000;
     let unreadableStreak = 0;
 
     for (;;) {
         const state = poll(pr);
         if (state.kind === 'settled') {
+            // The rollup is about the record's head. Re-read that head at
+            // VERDICT time, not only at start: a push or a merge during the
+            // wait makes the rollup describe something the caller is not about
+            // to act on, and this is the last moment a wrong verdict is still
+            // preventable.
+            const at = readTarget(pr);
+            if (at.kind === 'refuse') {
+                process.stdout.write(
+                    `ci_settle: WITHHOLDING A VERDICT — ${at.reason}. The checks that settled are not about ` +
+                        'the head that matters now.\n',
+                );
+                return 2;
+            }
+            if (at.kind === 'unreadable') {
+                process.stdout.write(
+                    `ci_settle: WITHHOLDING A VERDICT — could not confirm the target head (${at.reason}). ` +
+                        'A verdict needs to name the head it is about.\n',
+                );
+                return 2;
+            }
             if (state.failing.length === 0) {
-                process.stdout.write(`ci_settle: SETTLED GREEN — ${String(state.total)} check(s)\n`);
+                process.stdout.write(
+                    `ci_settle: SETTLED GREEN — ${String(state.total)} check(s) on ${at.head.slice(0, 9)}\n`,
+                );
                 return 0;
             }
             process.stdout.write(
-                `ci_settle: SETTLED RED — ${String(state.failing.length)} of ${String(state.total)} failing:\n` +
+                `ci_settle: SETTLED RED — ${String(state.failing.length)} of ${String(state.total)} failing on ${at.head.slice(0, 9)}:\n` +
                     state.failing.map((f) => `  ${f}\n`).join(''),
             );
             return 1;

--- a/src/scripts/hooks/push_settle_hook.ts
+++ b/src/scripts/hooks/push_settle_hook.ts
@@ -191,8 +191,9 @@ export function buildReminder(branch: string, pr: number | null): { reason: stri
     `own exit code.\n\n` +
     `Before this turn ends:\n` +
     `  1. Settle it:\n     ${settle}\n` +
-    `     Exit 0 = settled green · 1 = settled, something failed · 2 = NOT a verdict ` +
-    `(timed out or unreadable — never report 2 as green).\n` +
+    `     Exit 0 = settled green, and the line names the head it is about · 1 = settled, ` +
+    `something failed · 2 = NOT a verdict (timed out, unreadable, or the PR is merged / ` +
+    `closed / head-diverged — never report 2 as green).\n` +
     `  2. Red? Read only the failing part:\n` +
     `     gh run view --job <id> --log-failed | grep -E '×|FAIL|Error'\n` +
     `     then fix it and push again (fix-what-you-see: the author is irrelevant).\n` +

--- a/src/skills/git-workflow/references/push-closes-its-loop.md
+++ b/src/skills/git-workflow/references/push-closes-its-loop.md
@@ -68,6 +68,15 @@ returned 0, the turn closed, and the red arrived where the user found it.
   ending the turn silently on one is what the reminder exists to stop. Whether
   the reminder changes behavior is unmeasured — it ships as a carrier, not as a
   claim.
+- **`ci_settle` will not answer for a head that stopped mattering.** Since
+  2026-09-08 it reads the PR's `state` and compares its recorded head against
+  `git ls-remote` — before the wait and again at verdict time — and exits 2 with
+  a reason when the PR is merged, closed, or record-behind-branch. A green names
+  the head it is about. The measured reason: a merged PR's rollup kept answering
+  with its merge-time checks, so the tool reported `SETTLED GREEN — 40 check(s)`
+  for a commit that had zero check runs. The check does not apply to a fork PR
+  whose ref is not under this `origin`, and the line says so instead of claiming
+  it passed.
 - **Neither reaches a host without the slot.** `agent-config hooks:status`
   answers which slots are bound where you actually are; `post_tool_use` is
   unbound on windsurf and copilot, and there the settle obligation is

--- a/tests/scripts/ci_settle.test.ts
+++ b/tests/scripts/ci_settle.test.ts
@@ -7,7 +7,12 @@
 // must never classify as settled.
 import { describe, expect, it } from 'vitest';
 
-import { classifyPoll, FOREGROUND_CEILING_MIN } from '../../src/scripts/ci_settle.js';
+import {
+    classifyPoll,
+    classifyTarget,
+    FOREGROUND_CEILING_MIN,
+    type RemoteTip,
+} from '../../src/scripts/ci_settle.js';
 
 const roll = (rows: unknown[]): string => JSON.stringify({ statusCheckRollup: rows });
 
@@ -119,5 +124,87 @@ describe('foreground deadline', () => {
     it('is a number, not a comment — a documented ceiling nobody reads is the old state', () => {
         expect(Number.isInteger(FOREGROUND_CEILING_MIN)).toBe(true);
         expect(FOREGROUND_CEILING_MIN).toBeGreaterThan(0);
+    });
+});
+
+// The second half of "never report a verdict it did not read": a verdict has to
+// be ABOUT something. Measured 2026-09-08 on PR #1949 — the PR had been merged
+// at 18:29, pushes to its branch created no checks, and the rollup kept
+// answering with the merge-time head's 40 green checks while
+// `/commits/<sha>/check-runs` for the actual branch tip answered 0. Read at face
+// value that green authorises merging content nobody checked.
+//
+// The load-bearing assertions are the two negatives: a merged PR and a diverged
+// head must classify `refuse`, never `open`.
+describe('classifyTarget', () => {
+    const pr = (state: string, head: string, ref = 'feat/x'): string =>
+        JSON.stringify({ state, headRefOid: head, headRefName: ref });
+    const found = (sha: string): RemoteTip => ({ kind: 'found', sha });
+    const sha = 'a'.repeat(40);
+
+    it('refuses a MERGED PR instead of letting its stale rollup through', () => {
+        const t = classifyTarget(pr('MERGED', sha), '', 0, found(sha));
+        expect(t.kind).toBe('refuse');
+        if (t.kind === 'refuse') expect(t.reason).toContain('MERGED');
+    });
+
+    it('refuses a CLOSED PR for the same reason', () => {
+        expect(classifyTarget(pr('CLOSED', sha), '', 0, found(sha)).kind).toBe('refuse');
+    });
+
+    it('refuses when the record head and the branch tip disagree', () => {
+        const t = classifyTarget(pr('OPEN', sha), '', 0, found('b'.repeat(40)));
+        expect(t.kind).toBe('refuse');
+        // The message must name BOTH heads — a refusal the reader cannot act on
+        // is the same dead end as no refusal.
+        if (t.kind === 'refuse') {
+            expect(t.reason).toContain(sha.slice(0, 9));
+            expect(t.reason).toContain('b'.repeat(9));
+        }
+    });
+
+    it('accepts an OPEN PR whose head equals the tip, and says the check ran', () => {
+        const t = classifyTarget(pr('OPEN', sha), '', 0, found(sha));
+        expect(t.kind).toBe('open');
+        if (t.kind === 'open') {
+            expect(t.head).toBe(sha);
+            expect(t.divergenceChecked).toBe(true);
+        }
+    });
+
+    it('does not collapse an absent ref into agreement — a fork PR passes, flagged', () => {
+        const t = classifyTarget(pr('OPEN', sha), '', 0, { kind: 'absent' });
+        expect(t.kind).toBe('open');
+        // Not silently "checked": a fork's ref is not under this origin, and
+        // claiming the check applied would be the coverage inflation the whole
+        // exit-code contract exists to avoid.
+        if (t.kind === 'open') expect(t.divergenceChecked).toBe(false);
+    });
+
+    it('reads an unreadable tip as unreadable, never as agreement', () => {
+        const t = classifyTarget(pr('OPEN', sha), '', 0, { kind: 'unreadable', reason: 'connection refused' });
+        expect(t.kind).toBe('unreadable');
+    });
+
+    it('reads a transport failure on the PR read as unreadable, never as open', () => {
+        for (const text of ['error connecting to api.github.com', 'HTTP 502 Bad Gateway']) {
+            expect(classifyTarget('', text, 1, found(sha)).kind, text).toBe('unreadable');
+        }
+    });
+
+    it('reads a response missing any of the three fields as unreadable', () => {
+        const partials = [
+            JSON.stringify({ state: 'OPEN', headRefOid: sha }),
+            JSON.stringify({ state: 'OPEN', headRefName: 'feat/x' }),
+            JSON.stringify({ headRefOid: sha, headRefName: 'feat/x' }),
+            'not json at all',
+        ];
+        for (const body of partials) {
+            expect(classifyTarget(body, '', 0, found(sha)).kind, body).toBe('unreadable');
+        }
+    });
+
+    it('is case-insensitive on state, so a lowercase `open` is not refused', () => {
+        expect(classifyTarget(pr('open', sha), '', 0, found(sha)).kind).toBe('open');
     });
 });


### PR DESCRIPTION
## The defect, measured

`ci_settle` already refused to call an unreadable API a settle. It had no notion
of the verdict being **about** something, and that half cost real money on
2026-09-08 — twice in one session.

PR #1949 was merged at 18:29. Pushes to its branch afterwards fired no
`pull_request` event, so **no checks were created for them**, and
`gh pr view --json statusCheckRollup` kept answering with the merge-time head's
checks. `ci_settle` reported:

```
ci_settle: SETTLED GREEN — 40 check(s)
```

for a commit whose `/commits/<sha>/check-runs` answered `0`. Taken at face value
that green authorises merging content nobody checked. The only thing that
exposed it was a hand-written commit-level query — i.e. the tool was wrong and
the workaround was the safeguard.

Same shape, different cause, recorded earlier on PR #710: the PR record lags the
branch ref, and merging then lands the PR **without** the newer commits.
Silently, which is what makes it worse than a red.

## The fix

Both cases are decided by the same two facts, so one pure function decides them.
`classifyTarget` reads the PR's `state` and compares its recorded head against
`git ls-remote` — the **remote**, not a local `origin/<ref>`, because a stale
local ref would report agreement exactly when somebody else's push made it
false.

It runs **twice**, and both are load-bearing:

- **before the wait** — so nine minutes are not spent learning the PR was
  already merged;
- **at verdict time** — because a merge or a push *during* the wait makes the
  rollup describe something the caller is not about to act on. That call is the
  last moment a wrong verdict is still preventable.

Refusal exits **2**, which is the existing contract rather than a new one: `2`
has always meant *no verdict is claimed*. A green now names the head it is
about, so a bare `SETTLED GREEN` with no SHA identifies an older build.

## What it deliberately does not do

`absent` and `unreadable` are separate `RemoteTip` states. A fork PR has no ref
under this `origin`; collapsing the two would either disable the check for forks
silently or block every fork PR forever. The fork case passes with
`divergenceChecked: false` and the run **says** the check did not apply rather
than claiming it passed.

## Tests, and their sensitivity

Ten new tests. The three load-bearing ones are negatives — merged, closed,
diverged — and their sensitivity was **verified, not assumed**: replacing
`state !== 'OPEN'` and `tip.sha !== head` with unreachable comparisons turns
exactly those three red and leaves the other seventeen green. A test never seen
red has unknown sensitivity.

## Doc-impact

Both surfaces that state the exit contract move with it, because both are read
by an agent deciding whether a push is finished:

- `push_settle_hook.ts` — the reminder listed exit 2 as "timed out or
  unreadable"; it now names the third class and the head-in-the-green-line.
- `git-workflow/references/push-closes-its-loop.md` — one bullet under *What
  each one does NOT do*, with the measured reason and the fork carve-out.

## Verification

`vitest` 34 passed over both affected files, run root confirmed to be this
worktree · `typecheck-ts` · `lint-ts` · `lint-code-comments` (scanned 2) ·
`lint-output-slop` · `consistency` (byte-exact `dist/agent-src/`) ·
`check_branch_freshness` current with `e666d4784`.
