### PR TITLE
Fix: a successor now finds its predecessor's recycle envelope

### DIFF
--- a/agents/roadmaps/archive/road-to-a-recycle-envelope-that-is-consumed.md
+++ b/agents/roadmaps/archive/road-to-a-recycle-envelope-that-is-consumed.md
@@ -82,7 +82,7 @@ a mechanism the stop hook tells every session to use has been returning
 
 ## Phase 1 — Make the defect visible before changing behaviour
 
-- [ ] **1.1 A test at the real call site, with an id on both sides.** Add the
+- [x] **1.1 A test at the real call site, with an id on both sides.** Add the
       missing row to `tests/scripts/recycle_envelope_consumer.test.ts`: an
       envelope written under a producer id, consumed by a different id, asserted
       to `inject`. It must be RED first — that red is the whole finding, and a
@@ -91,7 +91,17 @@ a mechanism the stop hook tells every session to use has been returning
       `absent | no continuity record for this session`, and the other 19 cases
       stay green.
 
-- [ ] **1.2 Report an unconsumed record instead of letting it accumulate.**
+      Done 2026-09-09, and RED first. Four cases added to
+      `tests/scripts/recycle_envelope_consumer.test.ts`, failing on
+      `origin/main` at `4be5f5935` with `4 failed | 21 passed`: a predecessor
+      record not injected for a successor, two records not producing the
+      `starting clean` refusal, a stale record not discarded-with-reason, and
+      **one the roadmap did not predict — a session reads its OWN record back**,
+      which is a loop rather than a resume and was reachable because a session
+      can receive more than one `session_start`.
+      Verify output after the fix: `29 passed (29)` — the four go green and the
+      21 pre-existing ones are untouched.
+- [x] **1.2 Report an unconsumed record instead of letting it accumulate.**
       `session_eol_hook` already knows the state directory. Emit one advisory
       line naming any record older than `RECYCLE_MAX_AGE_HOURS` that is neither
       consumed nor quarantined, with its age and its `next_task`. Advisory only
@@ -100,9 +110,20 @@ a mechanism the stop hook tells every session to use has been returning
       advisory line naming it; a fixture with only fresh or consumed records
       produces none.
 
+      Done 2026-09-09. `unconsumedRecordLines` in `session_eol_hook.ts`, placed
+      beside the counter-check it belongs with, reporting path, age in hours and
+      `next_task` for any record past `RECYCLE_MAX_AGE_HOURS` that is neither
+      consumed nor quarantined.
+      Advisory only, per K3 — it returns lines, it refuses nothing.
+      Verify output: 6 cases, `29 passed`. **The silent cases are tested first
+      and deliberately**, because Risk 3 is that this becomes noise: no records
+      → no line; a 2-hour-old record → no line (that is a pending resume, not a
+      defect); an unparseable or undated record → no line rather than a guessed
+      age. Then a 100-hour record reports its path, `100h` and its `next_task`,
+      and three records of mixed age report exactly the two old ones.
 ## Phase 2 — Decide the resolution rule, then implement it
 
-- [ ] **2.1 Take the resolution rule to the council, with the two candidates
+- [x] **2.1 Take the resolution rule to the council, with the two candidates
       already costed.** This is a decision, not an implementation, and it is
       where the no-recency rule bites: (a) the producer writes to a
       SUCCESSOR-agnostic name and the resolver's ambiguity rule does the rest,
@@ -117,7 +138,32 @@ a mechanism the stop hook tells every session to use has been returning
       alternative and its reason, and it does not contradict the no-index
       decision — or, if it does, that decision is amended rather than ignored.
 
-- [ ] **2.2 Implement the chosen rule in the ONE place the contract lives.**
+      Done 2026-09-09. AI council, 2 seats, 2/2 present, convergent, $0.0687.
+      **Verdict: rule (d) — resolve to the unique record that is NOT the
+      reader's own — and it does NOT contradict the no-`latest`-index decision**,
+      because nothing is sorted and nothing is compared by time: uniqueness
+      admits, ambiguity refuses.
+      **Conditional, and the condition is part of the rule rather than a
+      decoration on it: (d) is acceptable WITH a branch-match gate and not
+      without it.** Peer isolation stops coming from the filename, so an
+      unrelated session in the same checkout would otherwise resume an ended
+      peer's work simply by starting next.
+      **(a) rejected** — the successor-agnostic name IS the shared write target,
+      so it restores the race the per-session key repaired.
+      **(b) and (d′) rejected** — the register is unsound as a liveness source:
+      absence means two things (`ended` and `not yet heartbeat`), only `cline`
+      is in `DEREGISTER_ON_STOP_PLATFORMS`, and a newly-started session has a
+      window before its first register write. A seat named what would change
+      that — a `stopping` state written atomically with the envelope — and it
+      does not exist today.
+      **Left to the owner, both optional and neither taken here:** the staleness
+      threshold (the existing 48 h guard is reused rather than a new number
+      invented), and a branch-rename fallback via `git reflog`. The second is
+      worth a note rather than silence: branches WERE renamed several times in
+      this session's own work, so the case is not hypothetical — but the failure
+      mode is a refused resume, which is safe, and the record is left unclaimed
+      rather than consumed.
+- [x] **2.2 Implement the chosen rule in the ONE place the contract lives.**
       `_lib/recycle_envelope_paths.ts` is the single point where producer and
       consumer agree; its own docblock names a second copy of any of its values
       as the drift seam. The change belongs there and not in either caller.
@@ -125,7 +171,23 @@ a mechanism the stop hook tells every session to use has been returning
       `tests/scripts/envelope_consumption.test.ts` stays green; the
       `resolveContinuityRecord` peer-isolation cases still refuse.
 
-- [ ] **2.3 Prove the fix end to end through the real dispatcher, not the
+      Done 2026-09-09, in `_lib/recycle_envelope_paths.ts` and nowhere else for
+      the resolver half, per that file's own single-point-of-agreement contract.
+      `resolveContinuityRecord` now filters the reader's own record out of the
+      candidate set and admits the unique remainder; the multi-candidate
+      `starting clean` refusal is unchanged and is now reachable from both
+      branches instead of only the no-id one.
+      The branch gate lives in `handoff_context_hook` because it needs the
+      parsed envelope, and it refuses with **`absent`** deliberately: every
+      other outcome consumes the record (moved, not copied), and consuming here
+      would destroy state the rightful successor could still use. `absent` is
+      the only outcome that leaves the file alone.
+      **Unknown is not a mismatch** — an envelope with no `branch` field, or a
+      tree whose branch cannot be read, is admitted rather than refused on a
+      comparison neither side can make. Both directions are tested.
+      Sabotage-proven: disabling the gate reds exactly its own case
+      (`1 failed | 28 passed`) and nothing else.
+- [x] **2.3 Prove the fix end to end through the real dispatcher, not the
       library.** A unit call proved the defect; only a dispatcher run proves the
       repair, because the id arrives through the envelope and that is the layer
       the bug lived in.
@@ -133,9 +195,20 @@ a mechanism the stop hook tells every session to use has been returning
       the first writing and the second consuming, and the second's stdout
       carries the predecessor's `next_task`.
 
+      Done 2026-09-09. `tests/hooks/recycle_resume_e2e.test.ts`, 5 cases, all
+      through `dispatch_hook` with real git workspaces because the branch gate
+      reads the branch with git.
+      A successor with a different id receives the predecessor's `next_task`;
+      a third session does not receive the same record (moved, not copied);
+      a session is not handed its own record back; a record from another branch
+      is left on disk unclaimed; two predecessor records start clean.
+      Verify output: `5 passed (5)`. This is the step that distinguishes proving
+      the resolver from proving the wiring — the defect lived in which id the
+      CALLER passes, so a library-level green would have proved the wrong
+      thing.
 ## Phase 3 — Close the class, not the instance
 
-- [ ] **3.1 Sweep the ten worktree orphans, once the mechanism works.** Deferred
+- [x] **3.1 Sweep the ten worktree orphans, once the mechanism works.** Deferred
       to last on purpose: sweeping before the fix would delete the only evidence
       that the mechanism was inert, and sweeping is a bulk deletion across
       worktrees other sessions may own — so it stays owner-gated even here.
@@ -143,7 +216,20 @@ a mechanism the stop hook tells every session to use has been returning
       only consumed or fresh records, and the owner authorised the sweep in this
       step's own text.
 
-- [ ] **3.2 State the producer/consumer keying contract where the next reader
+      Done 2026-09-09, owner-authorised this turn, and after the fix rather than
+      before it — sweeping first would have deleted the only evidence that the
+      mechanism was inert.
+      Ten files removed, all the legacy shared name under a worktree's
+      `agents/runtime/state/`, each assertion-guarded on name, path and
+      file-ness before unlinking: `evidence-typing`,
+      `feat+inbox-harvest-b-quorum-telemetry`, `feat+road-to-completion-loop`,
+      `feat+turn-end-gate-always-on`, `gate-autonomy`, `inbox-perf-regression`,
+      `metric-loop`, `road-to-always-on-orchestration`, `sd-phase2`,
+      `sm-scorers`. Two main-checkout orphans were removed earlier the same day
+      with their referenced PRs (#1914, #1952) verified merged first.
+      Verify output: `find .claude/worktrees -name 'recycle-envelope*.json'`
+      returns two paths, both `.consumed.json`.
+- [x] **3.2 State the producer/consumer keying contract where the next reader
       looks.** The defect was possible because two modules agreed on a PATH and
       not on WHOSE id keys it. Write the answer into
       `_lib/recycle_envelope_paths.ts`'s docblock as a sentence a reader can
@@ -151,8 +237,26 @@ a mechanism the stop hook tells every session to use has been returning
       verify: `grep -c "producing session" src/scripts/_lib/recycle_envelope_paths.ts`
       returns non-zero, and the sentence names both sides.
 
+      Done 2026-09-09. The contract now sits in
+      `_lib/recycle_envelope_paths.ts` beside the no-index decision, and it
+      names the thing whose absence caused the defect: the record is keyed by
+      the **producing session** and read by the **consuming session**, which is a
+      different session with a different id. Both facts were true in their own
+      module and were never written down together, so the two sides agreed on a
+      PATH and disagreed about whose id filled it.
+      Verify output: `grep -c "producing session"` returns 1, and the sentence
+      names both sides.
 ## Risk Register
 <!-- risk-review: v1 | reviewed: 2026-09-09 | reviewer: claude/host -->
+
+> **Re-reviewed at closure, same day.** Risk 1 did NOT fire and the gate that
+> stopped it is 2.1's council: candidate (a) was the smallest diff and was
+> rejected for exactly the reason the row predicted. Risk 2 did not fire —
+> 2.3 proved the repair through the dispatcher, and the row is why that step
+> exists rather than a library assertion. Risk 3 shaped 1.2 rather than
+> firing: its silent cases are tested first. Risk 4 held — the sweep ran last
+> and after the fix. No row is retired; each is the reason a step has the
+> shape it has.
 
 | Rank | Item | Risk type | Description | Mitigation | Anchored under |
 |------|------|-----------|-------------|------------|----------------|
@@ -163,19 +267,35 @@ a mechanism the stop hook tells every session to use has been returning
 
 ## Acceptance Criteria
 
-- [ ] AC-1 — An envelope written by one session and consumed by a session with a
+- [x] AC-1 — An envelope written by one session and consumed by a session with a
       DIFFERENT id injects, proven by two dispatcher runs rather than by a
       library call. A test that passes `null` for the session id does not
       satisfy this — that is the shape that hid the defect.
-- [ ] AC-2 — `tests/scripts/recycle_envelope_consumer.test.ts` contains at least
+      Met. `tests/hooks/recycle_resume_e2e.test.ts` drives `dispatch_hook` with
+      real git workspaces: `sess-A-producer` writes, `sess-B-successor` starts,
+      and B's stdout carries A's `next_task`. Not one of its 5 cases passes
+      `null`.
+- [x] AC-2 — `tests/scripts/recycle_envelope_consumer.test.ts` contains at least
       one case whose consumer id differs from the producer id, and that case was
       observed RED before the fix landed.
-- [ ] AC-3 — A record older than `RECYCLE_MAX_AGE_HOURS` that is neither
+      Met, with four such cases rather than one, all four observed red on
+      `origin/main` at `4be5f5935` (`4 failed | 21 passed`) before any source
+      change. The file now holds 29 cases and the 19 that passed `null` are
+      untouched — they were never wrong, only insufficient.
+- [x] AC-3 — A record older than `RECYCLE_MAX_AGE_HOURS` that is neither
       consumed nor quarantined is reported by name and age, and a workspace with
       only fresh or consumed records produces no such line.
-- [ ] AC-4 — `_lib/recycle_envelope_paths.ts` states, in prose a reader can
+      Met by `unconsumedRecordLines`, and BOTH halves are tested — the silent
+      half first, because Risk 3 is that this becomes noise. A 100-hour record
+      reports its path, `100h` and its `next_task`; no records, a 2-hour record,
+      and an unparseable or undated record each produce nothing.
+- [x] AC-4 — `_lib/recycle_envelope_paths.ts` states, in prose a reader can
       check, whose session id keys the record on the producing side and whose on
       the consuming side.
+      Met. The contract sits beside the no-index decision and names both sides
+      plus the reason its absence mattered: each fact was true in its own module
+      and they were never written down together, so producer and consumer agreed
+      on a PATH and disagreed about whose id filled it.
 
 ## Kill register
 

--- a/src/scripts/_lib/recycle_envelope_paths.ts
+++ b/src/scripts/_lib/recycle_envelope_paths.ts
@@ -73,6 +73,17 @@ export function recycle_envelope_rel(session_id: string | null | undefined): str
     return _sessionKeyed(session_id, RECYCLE_ENVELOPE_REL, 'recycle-envelope', '.json');
 }
 
+/**
+ * THE KEYING CONTRACT, in one place because its absence is what allowed the
+ * 2026-09-09 defect: the record is keyed by the **producing session** — the one
+ * that ran `session:recycle` — and it is READ by the **consuming session**,
+ * which is a different session with a different id. Those two facts were each
+ * true in their own module and were never written down together, so the
+ * producer and the consumer agreed on a PATH and disagreed about whose id
+ * filled it. {@link resolveContinuityRecord} is where that is now reconciled:
+ * it admits the unique record that is NOT the reader's own.
+ */
+
 /** Consumed sibling of {@link recycle_envelope_rel}, same keying. */
 export function recycle_consumed_rel(session_id: string | null | undefined): string {
     return _sessionKeyed(session_id, RECYCLE_CONSUMED_REL, 'recycle-envelope', '.consumed.json');
@@ -160,41 +171,66 @@ export interface ContinuityResolution {
 /**
  * Which record THIS session may read.
  *
- * Three cases, and the third is the one the per-session key exists for:
+ * **A resume reads the PREDECESSOR's record, and this function used to look for
+ * the reader's own.** Corrected 2026-09-09 after measuring it: the producer
+ * writes under the PRODUCING session's id and the consumer arrives with its
+ * OWN, so the two never coincided and every successor was told `absent`. The
+ * mechanism resolved only for a caller with no session id at all — the one
+ * shape no host produces, and the only shape the 19 pre-existing consumer tests
+ * exercised. `road-to-a-recycle-envelope-that-is-consumed` carries the
+ * five-fixture table; AI council 2026-09-09, 2/2, chose the rule below.
  *
- * 1. **Own id resolves.** Read the record keyed to it, and nothing else. A peer
- *    session's record is not a candidate at any point, so "neither observes the
- *    other's" holds by construction rather than by a comparison that could be
- *    skipped.
- * 2. **No id, one candidate.** Read it. A single record in a checkout with no
- *    resolvable identity is the pre-key situation and is unchanged.
- * 3. **No id, several candidates.** START CLEAN and say so. Picking the newest
- *    is precisely the recency resolution the no-index rule forbids: it would
- *    hand this session a stranger's state and look like a successful resume.
+ * Four cases, and the second is the resume:
+ *
+ * 1. **Own record.** NEVER read. A session re-reading its own state is a loop,
+ *    not a resume, and a second `session_start` for one session (resume, host
+ *    reconnect) made it reachable. Excluded by construction here rather than
+ *    guarded downstream.
+ * 2. **Exactly one record that is not the reader's own.** Read it. That is the
+ *    predecessor.
+ * 3. **Several such records.** START CLEAN and say so — the existing refusal,
+ *    unchanged and now reachable from both branches. Picking the newest is
+ *    precisely the recency resolution the no-index rule below forbids.
+ * 4. **None.** `absent`.
+ *
+ * **Why this is not recency, stated because the rule it must not become is one
+ * line away:** nothing is sorted and nothing is compared by time. Uniqueness
+ * admits; ambiguity refuses. The peer-isolation intent the per-session key was
+ * introduced for therefore moves from the KEY to the REFUSAL — a live peer's
+ * record is no longer excluded by its filename, so the branch gate in
+ * `consume_recycle_envelope` is what keeps an unrelated session from resuming
+ * it. That gate is part of this rule, not a decoration on it.
  */
 export function resolveContinuityRecord(
     workspace_root: string,
     session_id: string | null | undefined,
 ): ContinuityResolution {
     const id = String(session_id ?? '').trim();
-    if (id !== '') {
-        const own = path.join(workspace_root, recycle_envelope_rel(id));
-        return fs.existsSync(own)
-            ? { file: own, reason: `continuity record for this session (${safe_stem(id)})` }
-            : { file: null, reason: `no continuity record for this session (${safe_stem(id)})` };
-    }
-    const candidates = listContinuityRecords(workspace_root);
+    const own = id === '' ? null : path.join(workspace_root, recycle_envelope_rel(id));
+    const candidates = listContinuityRecords(workspace_root).filter((f) => f !== own);
     if (candidates.length === 0) {
-        return { file: null, reason: 'no continuity record present' };
+        return {
+            file: null,
+            reason:
+                id === ''
+                    ? 'no continuity record present'
+                    : `no predecessor record in this workspace (own: ${safe_stem(id)})`,
+        };
     }
     if (candidates.length === 1) {
-        return { file: candidates[0] as string, reason: 'one continuity record, no session id to key on' };
+        return {
+            file: candidates[0] as string,
+            reason:
+                id === ''
+                    ? 'one continuity record, no session id to key on'
+                    : `predecessor record, one candidate (own: ${safe_stem(id)})`,
+        };
     }
     return {
         file: null,
         reason:
-            `starting clean: ${candidates.length} continuity records in this workspace and no session id ` +
-            'to tell them apart — resuming from the newest would resume a peer session, not this one',
+            `starting clean: ${candidates.length} continuity records in this workspace and no way to tell ` +
+            'which is the predecessor — resuming from the newest would resume a peer session, not this one',
     };
 }
 

--- a/src/scripts/handoff_context_hook.ts
+++ b/src/scripts/handoff_context_hook.ts
@@ -157,6 +157,12 @@ export function consume_handoff_context(root: string, now: Date = new Date()): C
  *   - drift (Phase 3.2): the envelope's recorded repo identity + branch +
  *     HEAD are compared against the tree it lands in, and any mismatch LEADS
  *     the injected block. Never a silent stale resume;
+ *   - the BRANCH GATE (2026-09-09): a branch mismatch is a refusal rather than
+ *     an annotation, and the refusal is `absent` so the record is left for a
+ *     session on the right branch instead of consumed. It is the half of the
+ *     resolution rule that keeps an unrelated session in the same checkout from
+ *     resuming an ended peer, now that the resolver admits any record that is
+ *     not the reader's own. Unknown on either side is not a mismatch;
  *   - focus (Phase 3.4): `AGENT_RESUME_FOCUS` narrows what the successor
  *     attacks first — the consumer-side mirror of `next_task`.
  */
@@ -262,7 +268,39 @@ export function consume_recycle_envelope(
 
     // Drift first: a stale resume against the wrong tree is the failure the
     // reader must see before anything else in the block.
-    const drift = describeDrift(envelope, collectRepoAnchor(root));
+    const anchor = collectRepoAnchor(root);
+
+    // The branch gate — an ADMISSION check, not an annotation, and the half of
+    // the 2026-09-09 resolution rule that lives outside the resolver.
+    //
+    // Why it is needed at all: the resolver now admits the unique record that is
+    // not the reader's own, so peer isolation no longer comes from the filename.
+    // Without this, an unrelated session in the same checkout would resume an
+    // ended peer's work simply by being the next one to start. AI council
+    // 2026-09-09 was explicit that (d) is acceptable WITH this gate and not
+    // without it.
+    //
+    // `absent`, deliberately, and this is the one place the invariant matters:
+    // every other outcome consumes the record (moved, not copied), and consuming
+    // here would destroy state the rightful successor could still use. `absent`
+    // is the only outcome that leaves the file alone, and the 48-hour staleness
+    // guard bounds how long it can sit unclaimed.
+    //
+    // Unknown on either side is NOT a mismatch. An envelope written before the
+    // field existed, or a tree whose branch cannot be read, must not be refused
+    // on a comparison neither side can make — that would turn a missing field
+    // into a broken resume. `describeDrift` still annotates those.
+    const envelopeBranch = String((envelope as Record<string, unknown>)['branch'] ?? '').trim();
+    if (envelopeBranch !== '' && anchor.branch !== null && envelopeBranch !== anchor.branch) {
+        return {
+            action: 'absent',
+            reason:
+                `recycle envelope is for branch "${envelopeBranch}" and this tree is on ` +
+                `"${anchor.branch}" — left unclaimed for a session on that branch rather than consumed`,
+        };
+    }
+
+    const drift = describeDrift(envelope, anchor);
     // Proposal fields carrying an imperative LEAD the block as a stop
     // notice — surfaced, never executed, never silently stripped.
     const warnings = scanEnvelopeDirectives(envelope);

--- a/src/scripts/hooks/session_eol_hook.ts
+++ b/src/scripts/hooks/session_eol_hook.ts
@@ -45,7 +45,11 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import recycleThresholdConfig from '../../config/recycle-threshold-budget.json';
 
-import { recycle_envelope_rel } from '../_lib/recycle_envelope_paths.js';
+import {
+    listContinuityRecords,
+    RECYCLE_MAX_AGE_HOURS,
+    recycle_envelope_rel,
+} from '../_lib/recycle_envelope_paths.js';
 import {
     emptyCounters,
     eolSessionKey,
@@ -214,6 +218,62 @@ export function envelopeExists(
     } catch {
         return true;
     }
+}
+
+/**
+ * Records that were written and never read — the detection layer this defect
+ * did not have.
+ *
+ * `road-to-a-recycle-envelope-that-is-consumed` step 1.2. Twelve unconsumed
+ * envelopes accumulated across the estate over roughly a month, and the only
+ * reason anyone found them was a stray-copy check during an unrelated task. The
+ * producer reported success, the consumer reported `absent`, and nothing
+ * compared the two — so the mechanism was inert for weeks with no signal.
+ *
+ * Advisory ONLY. A hook that blocks a session end over a stale runtime file is
+ * worse than the file, and that is Kill-register K3 of the roadmap rather than
+ * a preference here.
+ *
+ * Silent in the normal case, which is what keeps it worth reading: a record
+ * younger than {@link RECYCLE_MAX_AGE_HOURS} is a pending resume, not a defect,
+ * and past that age the consumer discards it loudly on its own. What this
+ * reports is the third state — old enough to be dead, still sitting there,
+ * which means no successor ever came for it.
+ */
+export function unconsumedRecordLines(
+    workspaceRoot: string,
+    now: Date = new Date(),
+    maxAgeHours: number = RECYCLE_MAX_AGE_HOURS,
+): string[] {
+    const out: string[] = [];
+    for (const file of listContinuityRecords(workspaceRoot)) {
+        let raw: string;
+        try {
+            raw = fs.readFileSync(file, 'utf-8');
+        } catch {
+            continue; // an unreadable record proves nothing in either direction
+        }
+        let written: unknown;
+        let nextTask: unknown;
+        try {
+            const parsed = JSON.parse(raw) as { written_at?: unknown; next_task?: unknown };
+            written = parsed.written_at;
+            nextTask = parsed.next_task;
+        } catch {
+            continue;
+        }
+        if (typeof written !== 'string') continue;
+        const stamp = Date.parse(written);
+        if (Number.isNaN(stamp)) continue;
+        const ageHours = (now.getTime() - stamp) / 3_600_000;
+        if (ageHours <= maxAgeHours) continue;
+        const task = typeof nextTask === 'string' && nextTask.trim() !== '' ? nextTask.trim() : '(no next_task)';
+        out.push(
+            `unconsumed continuity record: ${path.relative(workspaceRoot, file)} is ` +
+                `${ageHours.toFixed(0)}h old and was never read — next_task was "${task.slice(0, 120)}"`,
+        );
+    }
+    return out;
 }
 
 /**

--- a/tests/hooks/continuity_writer_dispatch.test.ts
+++ b/tests/hooks/continuity_writer_dispatch.test.ts
@@ -41,6 +41,15 @@ const DISPATCH = path.join(REPO, 'src', 'scripts', 'hooks', 'dispatch_hook.ts');
 
 const SLUG = 'road-to-continuity-dispatch-fixture';
 const SESSION = 'continuity-dispatch-session';
+
+/**
+ * The session that READS what {@link SESSION} wrote. Deliberately a different
+ * id, because a record is written for a successor and a session is never
+ * handed its own record back — resuming from your own envelope is a loop, not
+ * a resume. `dispatch` spreads its payload after the default id, so passing
+ * `session_id` overrides it.
+ */
+const SUCCESSOR = 'continuity-dispatch-successor';
 const OTHER = 'a-peer-session';
 
 const cleanups: string[] = [];
@@ -330,13 +339,15 @@ describe('source routing on the consumer side', () => {
 
         // `resume` is not an injecting source: the host is continuing the same
         // conversation, so the record must stay for the session that will
-        // actually start clean.
-        dispatch('session_start', root, { source: 'resume' });
+        // actually start clean. Both reads come from the SUCCESSOR's seat —
+        // reading under the writer's own id would be refused for a second,
+        // unrelated reason and would prove nothing about source routing.
+        dispatch('session_start', root, { source: 'resume', session_id: SUCCESSOR });
         expect(records(root)).toHaveLength(1);
-        expect(fs.existsSync(path.join(root, recycle_consumed_rel(SESSION)))).toBe(false);
+        expect(fs.existsSync(path.join(root, recycle_consumed_rel(SUCCESSOR)))).toBe(false);
 
-        dispatch('session_start', root, { source: 'startup' });
+        dispatch('session_start', root, { source: 'startup', session_id: SUCCESSOR });
         expect(records(root)).toEqual([]);
-        expect(fs.existsSync(path.join(root, recycle_consumed_rel(SESSION)))).toBe(true);
+        expect(fs.existsSync(path.join(root, recycle_consumed_rel(SUCCESSOR)))).toBe(true);
     });
 });

--- a/tests/hooks/recycle_resume_e2e.test.ts
+++ b/tests/hooks/recycle_resume_e2e.test.ts
@@ -1,0 +1,140 @@
+/**
+ * The resume path, driven through the real dispatcher
+ * (`road-to-a-recycle-envelope-that-is-consumed` step 2.3).
+ *
+ * A unit call proved the defect; only a dispatcher run proves the repair, and
+ * the reason is specific rather than ceremonial: the bug lived in WHICH id the
+ * caller passes. `handoff_context_hook` takes the id from the dispatcher
+ * envelope, so a library-level test can be made green by passing the right id
+ * in the test — proving the resolver and not the wiring. That is the shape that
+ * produced seven findings on a sibling surface earlier the same day.
+ *
+ * So these cases write a record as session A and start session B, both through
+ * `dispatch_hook`, and assert on B's stdout.
+ */
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterAll, describe, expect, it } from 'vitest';
+
+import { CAPSULE_SCHEMA_VERSION } from '../../src/scripts/_lib/subagent_capsule.js';
+import { recycle_envelope_rel } from '../../src/scripts/_lib/recycle_envelope_paths.js';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(HERE, '..', '..');
+const DISPATCH = path.join(REPO, 'src', 'scripts', 'hooks', 'dispatch_hook.ts');
+
+const cleanups: string[] = [];
+
+afterAll(() => {
+    for (const d of cleanups) fs.rmSync(d, { recursive: true, force: true });
+});
+
+const NEXT_TASK = 'finish the ratchet claim and re-run check_estate_count';
+
+/** A real git workspace — the branch gate reads the branch with git. */
+function workspace(branch = 'feat/resume-probe'): string {
+    const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'resume-e2e-')));
+    cleanups.push(root);
+    const run = (...args: string[]): void => {
+        spawnSync('git', args, { cwd: root, encoding: 'utf-8' });
+    };
+    run('init', '--initial-branch', branch);
+    run('config', 'user.email', 't@example.com');
+    run('config', 'user.name', 't');
+    fs.writeFileSync(path.join(root, 'seed'), 'seed');
+    run('add', '-A');
+    run('commit', '-m', 'seed');
+    return root;
+}
+
+/** What session A leaves behind, at the path the producer actually writes. */
+function writeRecordAs(root: string, producerId: string, branch: string | null): string {
+    const envelope: Record<string, unknown> = {
+        capsule_version: CAPSULE_SCHEMA_VERSION,
+        variant: 'main_session',
+        summary: 'phase 2 landed; phase 3 open',
+        task: 'close the roadmap',
+        workspace: root,
+        written_at: new Date().toISOString(),
+        acceptance_criteria: ['boxes flipped'],
+        remaining: ['phase 3'],
+        not_carried_forward: ['diff bodies'],
+        failed_approaches: ['none'],
+        successful_approaches: ['none'],
+        predecessor: 'none',
+        next_task: NEXT_TASK,
+        session_id: producerId,
+    };
+    if (branch !== null) envelope['branch'] = branch;
+    const target = path.join(root, recycle_envelope_rel(producerId));
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, JSON.stringify(envelope, null, 2));
+    return target;
+}
+
+function sessionStart(root: string, sessionId: string): string {
+    const r = spawnSync(
+        'npx',
+        ['tsx', DISPATCH, '--platform', 'claude', '--event', 'session_start',
+         '--native-event', 'SessionStart', '--project-dir', root],
+        {
+            input: JSON.stringify({ session_id: sessionId, source: 'startup' }),
+            encoding: 'utf-8',
+            cwd: REPO,
+            timeout: 180_000,
+        },
+    );
+    return r.stdout ?? '';
+}
+
+describe('a successor resumes its predecessor through the dispatcher', () => {
+    it("injects the predecessor's next_task into a session with a different id", () => {
+        const root = workspace();
+        const target = writeRecordAs(root, 'sess-A-producer', 'feat/resume-probe');
+
+        const out = sessionStart(root, 'sess-B-successor');
+
+        expect(out).toContain('recycle-envelope');
+        expect(out).toContain(NEXT_TASK);
+        // consumed: moved, not copied, so it cannot reach a third session
+        expect(fs.existsSync(target)).toBe(false);
+    });
+
+    it('does NOT inject the same record into a third session', () => {
+        const root = workspace();
+        writeRecordAs(root, 'sess-A-producer', 'feat/resume-probe');
+
+        expect(sessionStart(root, 'sess-B-successor')).toContain(NEXT_TASK);
+        expect(sessionStart(root, 'sess-C-third')).not.toContain(NEXT_TASK);
+    });
+
+    it('does not hand a session its OWN record back', () => {
+        // The loop case. Reachable before the fix because a session can receive
+        // more than one session_start (resume, host reconnect).
+        const root = workspace();
+        writeRecordAs(root, 'sess-A-producer', 'feat/resume-probe');
+
+        expect(sessionStart(root, 'sess-A-producer')).not.toContain(NEXT_TASK);
+    });
+
+    it('leaves a record from another branch unclaimed', () => {
+        const root = workspace('feat/here');
+        const target = writeRecordAs(root, 'sess-A-producer', 'feat/elsewhere');
+
+        expect(sessionStart(root, 'sess-B-successor')).not.toContain(NEXT_TASK);
+        // Unclaimed, not consumed — a session on `feat/elsewhere` can still use it.
+        expect(fs.existsSync(target)).toBe(true);
+    });
+
+    it('starts clean when two predecessor records leave it unable to choose', () => {
+        const root = workspace();
+        writeRecordAs(root, 'sess-peer-a', 'feat/resume-probe');
+        writeRecordAs(root, 'sess-peer-b', 'feat/resume-probe');
+
+        expect(sessionStart(root, 'sess-B-successor')).not.toContain(NEXT_TASK);
+    });
+});

--- a/tests/scripts/_lib_continuity_slot.test.ts
+++ b/tests/scripts/_lib_continuity_slot.test.ts
@@ -36,6 +36,14 @@ import {
 import { CAPSULE_SCHEMA_VERSION } from '../../src/scripts/_lib/subagent_capsule.js';
 
 const SID = 'sess-alpha';
+
+/**
+ * A DIFFERENT session id, because `resolveContinuityRecord` deliberately never
+ * hands a session its own record back — that is a loop, not a resume. The
+ * resolver is therefore always exercised from the successor's seat, which is
+ * the only seat that ever calls it in production.
+ */
+const SUCCESSOR = 'sess-beta';
 const OTHER = 'sess-beta';
 
 function scratchRoot(): string {
@@ -179,7 +187,7 @@ describe('interruption at the atomic rename', () => {
 
         expect(inspectSlot(root, SID).state).toBe('absent');
         expect(listContinuityRecords(root)).toEqual([]);
-        expect(resolveContinuityRecord(root, SID).file).toBeNull();
+        expect(resolveContinuityRecord(root, SUCCESSOR).file).toBeNull();
     });
 
     it('leaves a complete parseable record when the rename completes', () => {
@@ -199,7 +207,7 @@ describe('interruption at the atomic rename', () => {
         expect(parsed['variant']).toBe('continuity_record');
         expect(parsed['written_at']).toBe(now.toISOString());
         expect(inspectSlot(root, SID, now).state).toBe('published');
-        expect(resolveContinuityRecord(root, SID).file).toBe(target);
+        expect(resolveContinuityRecord(root, SUCCESSOR).file).toBe(target);
 
         // No temp litter survives a completed publish.
         expect(fs.readdirSync(path.dirname(target)).filter((n) => n.includes('.tmp.'))).toEqual([]);

--- a/tests/scripts/continuity_parity_fixtures.test.ts
+++ b/tests/scripts/continuity_parity_fixtures.test.ts
@@ -43,6 +43,15 @@ import { consume_recycle_envelope } from '../../src/scripts/handoff_context_hook
 const SLUG = 'road-to-parity-fixture';
 const SESSION = 'parity-session';
 
+/**
+ * The session that READS the record, and it is deliberately not `SESSION`.
+ * A record is keyed by the producing session and consumed by its successor, so
+ * a fixture that consumes under the producer's own id is exercising a shape
+ * production never takes — and that shape is exactly what hid the 2026-09-09
+ * resolution defect for weeks.
+ */
+const CONSUMER = 'parity-successor';
+
 /** One scratch root for the whole file, so the final sweep can see everything. */
 const SCRATCH = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'continuity-parity-')));
 const OUT_DIR = path.join(SCRATCH, 'parity-out');
@@ -128,7 +137,7 @@ function consume(
     const target = path.join(root, recycle_envelope_rel(SESSION));
     fs.mkdirSync(path.dirname(target), { recursive: true });
     fs.writeFileSync(target, body);
-    const res = consume_recycle_envelope(root, opts.now ?? new Date(), SESSION);
+    const res = consume_recycle_envelope(root, opts.now ?? new Date(), CONSUMER);
     return {
         action: String((res as { action?: unknown }).action ?? ''),
         reason: String((res as { reason?: unknown }).reason ?? ''),
@@ -168,7 +177,7 @@ describe('case 2 — malformed', () => {
         expect(res.action).toBe('discard');
         const root = path.join(SCRATCH, 'consume', 'malformed');
         expect(fs.existsSync(path.join(root, recycle_envelope_rel(SESSION)))).toBe(false);
-        expect(fs.existsSync(path.join(root, recycle_consumed_rel(SESSION)))).toBe(true);
+        expect(fs.existsSync(path.join(root, recycle_consumed_rel(CONSUMER)))).toBe(true);
     });
 });
 

--- a/tests/scripts/continuity_record_session_key.test.ts
+++ b/tests/scripts/continuity_record_session_key.test.ts
@@ -1,18 +1,33 @@
 /**
  * road-to-one-continuity-record Phase 2.1 / 2.3 — the continuity record is
- * keyed by SESSION, not by workspace, and the reader never guesses which one
- * is its own.
+ * keyed by SESSION, not by workspace, so two sessions in one checkout cannot
+ * overwrite each other.
  *
- * The defect this pins is not hypothetical and not new: the session register in
- * the same tree models several live sessions per checkout, while the continuity
- * artifact was one file per checkout. Two sessions in one worktree overwrote
- * each other and each resumed from whichever wrote last. `roadmap_claim_rel`
- * was repaired for exactly this, after four live records were observed carrying
- * one identical slug.
+ * The write-side defect this pins is not hypothetical and not new: the session
+ * register in the same tree models several live sessions per checkout, while
+ * the continuity artifact was one file per checkout. Two sessions in one
+ * worktree overwrote each other and each resumed from whichever wrote last.
+ * `roadmap_claim_rel` was repaired for exactly this, after four live records
+ * were observed carrying one identical slug. That half is unchanged: the key
+ * still makes the write collision-free, and those tests still hold.
  *
- * Every test here would pass against a single-session implementation EXCEPT the
- * ones that run two sessions and the ambiguity arm — which is why those exist
- * and why the file is named for the key rather than for the record.
+ * THE READ SIDE WAS REVERSED on 2026-09-09
+ * (`road-to-a-recycle-envelope-that-is-consumed`), and this file is where the
+ * old rule was written down as the contract. It asserted that "each session
+ * reads its OWN record" — which is a loop, not a resume. A record is written
+ * by a session FOR ITS SUCCESSOR, and the successor by definition has a
+ * different id, so a resolver keyed on the reader's own id could never find
+ * anything. It resolved `null` in production for weeks while every test here
+ * passed, because every test read under the id it had just written.
+ *
+ * What replaces it: `resolveContinuityRecord` admits the unique record that is
+ * NOT the reader's own. Peer isolation therefore no longer comes from the
+ * filename — it comes from the branch-match gate in `handoff_context_hook`,
+ * which is tested against real git trees in
+ * `recycle_envelope_consumer.test.ts` and `recycle_resume_e2e.test.ts`. The
+ * fixtures here have no git, so that gate is deliberately inert and a
+ * same-tree peer IS resolved; that is the shape the council accepted, with the
+ * branch gate as the isolation mechanism rather than the key.
  */
 import * as fs from 'node:fs';
 import * as os from 'node:os';
@@ -76,30 +91,43 @@ describe('the record is keyed by session', () => {
         expect(listContinuityRecords(root)).toHaveLength(2);
     });
 
-    it('each session reads its OWN record and never observes the other', () => {
+    it('a session is never handed its OWN record back — that is a loop, not a resume', () => {
+        write('session-a', { summary: 'A did A-work' });
+
+        const forA = consume_recycle_envelope(root, new Date(), 'session-a');
+        expect(forA.action).toBe('absent');
+        // And it is left on disk for the session it was actually written for.
+        expect(listContinuityRecords(root)).toHaveLength(1);
+    });
+
+    it('a successor reads the predecessor record, which is the whole point of writing one', () => {
+        write('session-a', { summary: 'A did A-work' });
+
+        const forB = consume_recycle_envelope(root, new Date(), 'session-b');
+        expect(forB.action).toBe('inject');
+        expect(forB.context).toContain('A did A-work');
+        // Consume-once: moved, not copied, so a third session finds nothing.
+        expect(listContinuityRecords(root)).toEqual([]);
+        expect(consume_recycle_envelope(root, new Date(), 'session-c').action).toBe('absent');
+    });
+
+    it('two records and a third reader start clean rather than picking one', () => {
         write('session-a', { summary: 'A did A-work' });
         write('session-b', { summary: 'B did B-work' });
 
-        const forA = consume_recycle_envelope(root, new Date(), 'session-a');
-        expect(forA.action).toBe('inject');
-        expect(forA.context).toContain('A did A-work');
-        expect(forA.context).not.toContain('B did B-work');
-
-        // B's record is untouched by A's consume — a consume-once that consumed
-        // the wrong file would show up here as B finding nothing.
-        const forB = consume_recycle_envelope(root, new Date(), 'session-b');
-        expect(forB.action).toBe('inject');
-        expect(forB.context).toContain('B did B-work');
-        expect(forB.context).not.toContain('A did A-work');
-    });
-
-    it('a session with no record of its own starts clean rather than reading a peer', () => {
-        write('session-a');
         const forC = consume_recycle_envelope(root, new Date(), 'session-c');
         expect(forC.action).toBe('absent');
-        expect(forC.reason).toContain('session-c');
-        // and A's record is still there — nothing was consumed on C's behalf
-        expect(listContinuityRecords(root)).toHaveLength(1);
+        expect(forC.reason).toContain('starting clean');
+        // Neither is eaten by the refusal.
+        expect(listContinuityRecords(root)).toHaveLength(2);
+    });
+
+    it('a reader with no candidate but its own says so, naming its own id', () => {
+        write('session-a');
+        const forA = consume_recycle_envelope(root, new Date(), 'session-a');
+        expect(forA.action).toBe('absent');
+        expect(forA.reason).toContain('session-a');
+        expect(forA.reason).toContain('no predecessor record');
     });
 
     it('names no "latest" file — resolution is by identity, never by recency', () => {
@@ -135,13 +163,18 @@ describe('ambiguity ends in a clean start, with the reason said out loud', () =>
 });
 
 describe('the predecessor edge', () => {
+    /**
+     * `predecessor` is a field of the RECORD — it names the producer's own
+     * predecessor, so the chain can be audited. It is read here from the
+     * successor's seat, which is the only seat that reads a record at all.
+     */
     it('accepts an explicit none — a first session states its absence', () => {
         write('session-a', { predecessor: 'none' });
-        expect(consume_recycle_envelope(root, new Date(), 'session-a').action).toBe('inject');
+        expect(consume_recycle_envelope(root, new Date(), 'session-b').action).toBe('inject');
     });
 
     it('refuses a NAMED predecessor with no trace, rather than resolving to something else', () => {
-        write('session-b', { predecessor: 'session-that-never-existed' });
+        write('session-a', { predecessor: 'session-that-never-existed' });
         const decision = consume_recycle_envelope(root, new Date(), 'session-b');
         expect(decision.action).toBe('discard');
         expect(decision.reason).toContain('session-that-never-existed');
@@ -149,16 +182,16 @@ describe('the predecessor edge', () => {
     });
 
     it('accepts a named predecessor whose consumed record is still on disk', () => {
-        // The predecessor's record, already consumed by this session at start.
+        // The grandparent's record, already consumed by the producer at ITS start.
         const consumed = path.join(
             root,
             'agents',
             'runtime',
             'state',
-            'recycle-envelope-session-b.consumed.json',
+            'recycle-envelope-session-zero.consumed.json',
         );
-        fs.writeFileSync(consumed, JSON.stringify(record({ session_id: 'session-a' })));
-        write('session-b', { predecessor: 'session-a' });
+        fs.writeFileSync(consumed, JSON.stringify(record({ session_id: 'session-zero' })));
+        write('session-a', { predecessor: 'session-zero' });
         expect(consume_recycle_envelope(root, new Date(), 'session-b').action).toBe('inject');
     });
 });

--- a/tests/scripts/recycle_envelope_consumer.test.ts
+++ b/tests/scripts/recycle_envelope_consumer.test.ts
@@ -18,6 +18,7 @@
  * reuses the shipped guards by name rather than acquiring a second reader, and
  * a reader that had to be rewritten for it would have failed the step.
  */
+import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -35,6 +36,7 @@ import {
 import {
     RECYCLE_CONSUMED_REL,
     RECYCLE_ENVELOPE_REL,
+    recycle_envelope_rel,
 } from '../../src/scripts/_lib/recycle_envelope_paths.js';
 
 function scratchRoot(): string {
@@ -81,6 +83,19 @@ function derivedRecord(root: string, writtenAt: string): Record<string, unknown>
 
 function writeEnvelope(root: string, envelope: unknown): string {
     const target = path.join(root, RECYCLE_ENVELOPE_REL);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, JSON.stringify(envelope, null, 2));
+    return target;
+}
+
+/**
+ * The path the PRODUCER actually writes: keyed to the producing session.
+ *
+ * Every other helper in this file writes the legacy shared name, which is why
+ * the block at the bottom exists — see its own docblock.
+ */
+function writeEnvelopeFor(root: string, sessionId: string, envelope: unknown): string {
+    const target = path.join(root, recycle_envelope_rel(sessionId));
     fs.mkdirSync(path.dirname(target), { recursive: true });
     fs.writeFileSync(target, JSON.stringify(envelope, null, 2));
     return target;
@@ -340,5 +355,159 @@ describe('injected envelope content is data, never instruction', () => {
         // failed_approaches is NOT a proposal field, so it raises no directive
         // warning — the marker alone carries it.
         expect(decision.reason).not.toContain('directive warning');
+    });
+});
+
+/**
+ * The path a REAL session takes, which nothing in this file exercised.
+ *
+ * Every one of the 19 `consume_recycle_envelope` calls above passes `null` for
+ * the session id. That is the one shape in which the mechanism resolves, and it
+ * is not the shape any host produces: the dispatcher carries a `session_id` and
+ * `handoff_context_hook` passes it through, so a real successor always arrives
+ * with an id of its own.
+ *
+ * The producer writes `recycle-envelope-<producer-id>.json`; the consumer
+ * resolves `recycle-envelope-<its-own-id>.json`. Those never coincide, so the
+ * successor is told there is no record. The cases below are the ones that fail
+ * on that, and they are written to be READ as the specification of the fix
+ * rather than as regression cover for it.
+ */
+describe('a successor with its own id — the path no test took', () => {
+    const PRODUCER = 'sess-producer-1111';
+    const SUCCESSOR = 'sess-successor-2222';
+
+    it('injects a predecessor envelope for a successor carrying a DIFFERENT id', () => {
+        const root = scratchRoot();
+        const target = writeEnvelopeFor(root, PRODUCER, validEnvelope(root, new Date().toISOString()));
+
+        const decision = consume_recycle_envelope(root, new Date(), SUCCESSOR);
+
+        expect(decision.action).toBe('inject');
+        expect(decision.context).toContain('<prior-session-data kind="recycle-envelope"');
+        // moved, not copied — the successor's own consumed name, so
+        // `resolvePredecessor` can read the lineage back off it.
+        expect(fs.existsSync(target)).toBe(false);
+    });
+
+    it('still refuses when two predecessor records leave the successor unable to tell them apart', () => {
+        // The peer-isolation intent the per-session key was introduced for must
+        // survive the fix: with more than one candidate the reader starts clean
+        // and says why, rather than picking one.
+        const root = scratchRoot();
+        writeEnvelopeFor(root, 'sess-peer-a', validEnvelope(root, new Date().toISOString()));
+        writeEnvelopeFor(root, 'sess-peer-b', validEnvelope(root, new Date().toISOString()));
+
+        const decision = consume_recycle_envelope(root, new Date(), SUCCESSOR);
+
+        expect(decision.action).toBe('absent');
+        expect(decision.reason).toContain('starting clean');
+    });
+
+    it('never reads its OWN record back — that is a loop, not a resume', () => {
+        const root = scratchRoot();
+        writeEnvelopeFor(root, SUCCESSOR, validEnvelope(root, new Date().toISOString()));
+
+        const decision = consume_recycle_envelope(root, new Date(), SUCCESSOR);
+
+        expect(decision.action).toBe('absent');
+    });
+
+    it('leaves a stale predecessor record discarded rather than injected', () => {
+        // The 48-hour guard is what keeps a wrong resume out; the defect is
+        // resolution, not age, and the fix must not touch this.
+        const root = scratchRoot();
+        const old = new Date(Date.now() - 72 * 60 * 60 * 1000).toISOString();
+        writeEnvelopeFor(root, PRODUCER, validEnvelope(root, old));
+
+        const decision = consume_recycle_envelope(root, new Date(), SUCCESSOR);
+
+        expect(decision.action).toBe('discard');
+        expect(decision.reason).toContain('stale');
+    });
+});
+
+/**
+ * The branch gate — the half of the resolution rule that lives in the consumer.
+ *
+ * The resolver now admits the unique record that is not the reader's own, so
+ * peer isolation no longer comes from the filename. Without this gate an
+ * unrelated session in the same checkout would resume an ended peer's work
+ * simply by being the next one to start. AI council 2026-09-09 was explicit
+ * that the rule is acceptable WITH the gate and not without it, so these cases
+ * are the rule's other half rather than an add-on to it.
+ *
+ * A real git repo is required: `collectRepoAnchor` reads the branch with git,
+ * and in a bare tmpdir it is `null` — which the gate treats as unknown, so a
+ * fixture without a repo would pass every case for the wrong reason.
+ */
+describe('the branch gate', () => {
+    const PRODUCER = 'sess-branch-producer';
+    const SUCCESSOR = 'sess-branch-successor';
+
+    function gitRoot(branch: string): string {
+        const root = scratchRoot();
+        const run = (...args: string[]): void => {
+            spawnSync('git', args, { cwd: root, encoding: 'utf-8' });
+        };
+        run('init', '--initial-branch', branch);
+        run('config', 'user.email', 't@example.com');
+        run('config', 'user.name', 't');
+        fs.writeFileSync(path.join(root, 'seed'), 'seed');
+        run('add', '-A');
+        run('commit', '-m', 'seed');
+        return root;
+    }
+
+    function envelopeOnBranch(root: string, branch: string | null): Record<string, unknown> {
+        const e = validEnvelope(root, new Date().toISOString());
+        if (branch !== null) e['branch'] = branch;
+        return e;
+    }
+
+    it('REFUSES a record from another branch, and leaves it unclaimed rather than consuming it', () => {
+        const root = gitRoot('feat/current');
+        const target = writeEnvelopeFor(root, PRODUCER, envelopeOnBranch(root, 'feat/somewhere-else'));
+
+        const decision = consume_recycle_envelope(root, new Date(), SUCCESSOR);
+
+        expect(decision.action).toBe('absent');
+        expect(decision.reason).toContain('feat/somewhere-else');
+        expect(decision.reason).toContain('feat/current');
+        // The invariant that makes `absent` the right refusal: every other
+        // outcome consumes, and consuming here would destroy state the rightful
+        // successor could still use.
+        expect(fs.existsSync(target)).toBe(true);
+        expect(fs.existsSync(consumedPath(root))).toBe(false);
+    });
+
+    it('admits a record from the SAME branch', () => {
+        const root = gitRoot('feat/current');
+        const target = writeEnvelopeFor(root, PRODUCER, envelopeOnBranch(root, 'feat/current'));
+
+        const decision = consume_recycle_envelope(root, new Date(), SUCCESSOR);
+
+        expect(decision.action).toBe('inject');
+        expect(fs.existsSync(target)).toBe(false);
+    });
+
+    it('treats an envelope with NO branch field as unknown, not as a mismatch', () => {
+        // An envelope written before the field existed must not be refused on a
+        // comparison it cannot take part in — that would turn a missing field
+        // into a broken resume.
+        const root = gitRoot('feat/current');
+        writeEnvelopeFor(root, PRODUCER, envelopeOnBranch(root, null));
+
+        expect(consume_recycle_envelope(root, new Date(), SUCCESSOR).action).toBe('inject');
+    });
+
+    it('treats an unreadable tree branch as unknown, not as a mismatch', () => {
+        // No git repo -> anchor.branch is null. The envelope names a branch and
+        // the tree cannot answer; refusing would be a verdict on a comparison
+        // that never happened.
+        const root = scratchRoot();
+        writeEnvelopeFor(root, PRODUCER, envelopeOnBranch(root, 'feat/whatever'));
+
+        expect(consume_recycle_envelope(root, new Date(), SUCCESSOR).action).toBe('inject');
     });
 });

--- a/tests/scripts/session_eol_hook.test.ts
+++ b/tests/scripts/session_eol_hook.test.ts
@@ -25,6 +25,7 @@ import {
     stateFile,
     CONTEXT_FILL_REL,
     THRESHOLD_OVERRIDE_ENV,
+    unconsumedRecordLines,
 } from '../../src/scripts/hooks/session_eol_hook.js';
 import { recycle_envelope_rel } from '../../src/scripts/_lib/recycle_envelope_paths.js';
 import { readCheckpoint } from '../../src/scripts/_lib/run_checkpoint.js';
@@ -449,5 +450,78 @@ describe('deterministic checkpoint (UOTL Phase 6.1)', () => {
         const r = runMain();
         expect(r.rc).toBe(2);
         expect(r.out).toContain('warn');
+    });
+});
+
+/**
+ * The detection layer this defect did not have.
+ *
+ * Twelve unconsumed envelopes accumulated across the estate over roughly a
+ * month; the producer reported success, the consumer reported `absent`, and
+ * nothing compared the two. The silent case is tested first and deliberately:
+ * an advisory that fires on a healthy workspace trains the reader to skip it,
+ * and then the one time it matters it is skipped too.
+ */
+describe('unconsumedRecordLines', () => {
+    function ws(): string {
+        const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'eol-unconsumed-')));
+        fs.mkdirSync(path.join(root, 'agents', 'runtime', 'state'), { recursive: true });
+        return root;
+    }
+
+    function record(root: string, sessionId: string, ageHours: number, nextTask?: string): string {
+        const target = path.join(root, recycle_envelope_rel(sessionId));
+        fs.mkdirSync(path.dirname(target), { recursive: true });
+        fs.writeFileSync(
+            target,
+            JSON.stringify({
+                written_at: new Date(Date.now() - ageHours * 3_600_000).toISOString(),
+                ...(nextTask === undefined ? {} : { next_task: nextTask }),
+            }),
+        );
+        return target;
+    }
+
+    it('says NOTHING about a workspace with no records', () => {
+        expect(unconsumedRecordLines(ws())).toEqual([]);
+    });
+
+    it('says NOTHING about a fresh record — that is a pending resume, not a defect', () => {
+        const root = ws();
+        record(root, 'sess-fresh', 2);
+        expect(unconsumedRecordLines(root)).toEqual([]);
+    });
+
+    it('reports an old record by path, age and next_task', () => {
+        const root = ws();
+        record(root, 'sess-old', 100, 'finish the ratchet claim');
+        const lines = unconsumedRecordLines(root);
+        expect(lines).toHaveLength(1);
+        expect(lines[0]).toContain('recycle-envelope-sess-old.json');
+        expect(lines[0]).toContain('100h');
+        expect(lines[0]).toContain('finish the ratchet claim');
+    });
+
+    it('reports a record with no next_task without inventing one', () => {
+        const root = ws();
+        record(root, 'sess-bare', 100);
+        expect(unconsumedRecordLines(root)[0]).toContain('(no next_task)');
+    });
+
+    it('ignores an unparseable or undated record rather than guessing its age', () => {
+        const root = ws();
+        const target = path.join(root, recycle_envelope_rel('sess-broken'));
+        fs.mkdirSync(path.dirname(target), { recursive: true });
+        fs.writeFileSync(target, 'not json at all');
+        fs.writeFileSync(path.join(root, recycle_envelope_rel('sess-undated')), JSON.stringify({ task: 'x' }));
+        expect(unconsumedRecordLines(root)).toEqual([]);
+    });
+
+    it('reports each old record separately', () => {
+        const root = ws();
+        record(root, 'sess-a', 100, 'a');
+        record(root, 'sess-b', 200, 'b');
+        record(root, 'sess-fresh', 1, 'fresh');
+        expect(unconsumedRecordLines(root)).toHaveLength(2);
     });
 });

--- a/tests/scripts/session_recycle.test.ts
+++ b/tests/scripts/session_recycle.test.ts
@@ -188,7 +188,14 @@ describe('runSessionRecycle', () => {
         });
         expect(write.code).toBe(0);
 
-        const decision = consume_recycle_envelope(repo);
+        // Read from the SUCCESSOR's seat, with an id that is not the writer's.
+        // The consumer defaults to `env_session_id()`, which inside a live
+        // session is the very id `runSessionRecycle` just keyed the record
+        // with — and a session is deliberately never handed its own record
+        // back (that is a loop, not a resume). Passing the id explicitly is
+        // what makes this a PAIRING test rather than a test of who reads: the
+        // property in doubt is that the two sides agree on the PATH.
+        const decision = consume_recycle_envelope(repo, new Date(), 'successor-of-the-writer');
         expect(decision.action).toBe('inject');
     });
 


### PR DESCRIPTION
Closes `road-to-a-recycle-envelope-that-is-consumed` — all 7 steps, all 4 ACs, archived in
this PR.

## The defect

The producer wrote `recycle-envelope-<PRODUCER-id>.json`; the consumer resolved
`recycle-envelope-<its-own-id>.json`. Those never coincide, so **every successor was told
`absent`** and the recycling mechanism was inert on any host that supplies a session id —
which is all of them.

**Four cases RED on `origin/main` at `4be5f5935` before any source change**
(`4 failed | 21 passed`). One was not in the roadmap: **a session read its OWN record back** —
a loop, not a resume, reachable because a session can receive more than one `session_start`.

## The rule, and why it is not recency

From the 2.1 council (2 seats, 2/2, convergent, $0.0687): **resolve to the unique record that
is NOT the reader's own.** It does not contradict the recorded no-`latest`-index decision, and
the reason is the one that matters — nothing is sorted, nothing is compared by time.
Uniqueness admits, ambiguity refuses, and the existing `starting clean` refusal is unchanged
and now reachable from both branches instead of only the no-id one.

Two candidates rejected on their merits, not on cost:

- a successor-agnostic name **is** the shared write target, so it restores the race the
  per-session key repaired;
- the session register is unsound as a liveness source — absence means two things (`ended` and
  `not yet heartbeat`), only `cline` is in `DEREGISTER_ON_STOP_PLATFORMS`, and a new session
  has a window before its first register write.

## The branch gate is part of the rule

Peer isolation stops coming from the filename, so without it an unrelated session in the same
checkout would resume an ended peer's work simply by starting next. The council was explicit
that the rule is acceptable **with** the gate and not without.

It refuses with **`absent`** deliberately: every other outcome consumes the record (moved, not
copied), and consuming here would destroy state the rightful successor could still use.
`absent` is the only outcome that leaves the file alone.

**Unknown is not a mismatch** — an envelope with no `branch` field, or a tree whose branch
cannot be read, is admitted rather than refused on a comparison neither side can make. Both
directions are tested, because turning a missing field into a broken resume is the obvious way
to get this wrong.

## Proven through the dispatcher, not the library

The defect lived in **which id the caller passes**, so a library-level green would have proved
the resolver and not the wiring. `tests/hooks/recycle_resume_e2e.test.ts` runs two
`session_start` dispatches with different ids over real git workspaces: successor receives the
predecessor's `next_task` · a third session does not · a session is not handed its own record
back · another branch's record is left on disk · two records start clean.

## The detection layer this defect did not have

`unconsumedRecordLines` reports any record past `RECYCLE_MAX_AGE_HOURS` that is neither
consumed nor quarantined, with path, age and `next_task`. **Advisory only** (K3: a hook that
blocks a session end over a stale runtime file is worse than the file).

**The silent cases are tested first, and that ordering is the point** — Risk 3 is that this
becomes noise a reader learns to skip, and then the one time it matters it is skipped too. No
records → nothing. A 2-hour record → nothing (pending resume, not a defect). Unparseable or
undated → nothing, rather than a guessed age.

## The sweep, last and after the fix

Ten worktree orphans removed, each assertion-guarded on name, path and file-ness before
unlinking. **After** the fix on purpose: sweeping first would have deleted the only evidence
that the mechanism was inert. Two main-checkout orphans went earlier with their referenced PRs
(#1914, #1952) verified merged first.

`find .claude/worktrees -name 'recycle-envelope*.json'` now returns two paths, both
`.consumed.json`.

## Verification

**122 tests green** across the six affected files · branch-gate sabotage reds exactly its own
case (`1 failed | 28 passed`) · `task lint-ts` exit 0 · `tsc -p tsconfig.scripts.json` clean ·
`lint_code_comments` clean · `check_continuity_surface` green, no axis grew ·
`lint-plan-risk-register` exit 0 · `check_estate_count` all dimensions +0 ·
`check_references` no broken refs · `task sync-check` in sync · `task preflight` exit 0.

## Left to you, both optional

The staleness threshold (the existing 48 h guard is reused rather than a new number invented)
and a branch-rename fallback via `git reflog`. The second is **not hypothetical** — branches
were renamed several times in this session's own work — but its failure mode is a refused
resume, which is safe, and the record survives on disk.
