### PR TITLE
review(r2): correct two prose defects in the delivery-for-every-host findings artefact

### DIFF
--- a/agents/evidence/reviews/drain-delivery-for-every-host-4-4-close.findings.md
+++ b/agents/evidence/reviews/drain-delivery-for-every-host-4-4-close.findings.md
@@ -15,7 +15,7 @@ tools: [git-diff-branch-scoped, file-read-branch-paths]
 dispatched: 2026-09-10T06:19:39Z
 -->
 <!-- rebind: v1
-rebound: 2026-09-10T08:55:00Z
+rebound: 2026-09-10T06:41:43Z
   RE-BOUND IN PLACE per contract 2.7 path 1, after every one of the 9 rows
   reached a terminal status. scope 06569f65aa79 -> 4c2de56a7eb2, diff
   1d36c6ca56c5 -> fd54b3585493, roadmap_hash 5dcdd60b7a23 -> 98596f5cd244 (the
@@ -37,7 +37,7 @@ rebound: 2026-09-10T08:55:00Z
   than a chase.
 -->
 <!-- rebind: v1
-rebound: 2026-09-10T09:20:00Z
+rebound: 2026-09-10T07:07:03Z
   SECOND re-bind, same contract 2.7 path 1, all 9 rows still terminal. scope
   4c2de56a7eb2 -> 96359926503, diff fd54b3585493 -> c4658aa959c9. `roadmap_hash`
   and `ac_hash` are both UNCHANGED (98596f5cd244 / b163bc3793e2): this move
@@ -54,7 +54,7 @@ rebound: 2026-09-10T09:20:00Z
   not itself a further move.
 -->
 <!-- rebind: v1
-rebound: 2026-09-10T10:30:00Z
+rebound: 2026-09-10T08:19:04Z
   THIRD re-bind, contract 2.7 path 1, all 9 rows still terminal. scope
   96359926503 -> 4b6338451a69, roadmap_hash 98596f5cd244 -> f996407b4019,
   ac_hash b163bc3793e2 -> 336cf5acce8b.
@@ -86,6 +86,63 @@ rebound: 2026-09-10T10:30:00Z
   them at `ADR-274-the-grace-ceiling-...`, same file, renumbered by this merge.
 -->
 
+<!-- correction: v1
+corrected: 2026-09-10
+  TWO PROSE DEFECTS in this artefact, found by a neutral cross-model review of
+  the merge that renumbered ADR-273 -> ADR-274, and fixed here. No finding is
+  re-opened, no hash moves: `agents/evidence/reviews` is excluded from the review
+  scope, so this artefact is not part of what any round measures.
+
+  1. THE THREE `rebound:` TIMESTAMPS WERE IMPOSSIBLE. Each sat 11-13 minutes
+     AFTER the commit that wrote it, because local CEST was labelled `Z` and then
+     rounded forward. An event cannot post-date the commit recording it. Each now
+     carries the true UTC commit time of its own commit, verified with
+     `git log -1 --format=%cI`:
+       6d7b8334a  2026-09-10T08:41:43+02:00  ->  06:41:43Z  (was 08:55:00Z)
+       f7fb052ff  2026-09-10T09:07:03+02:00  ->  07:07:03Z  (was 09:20:00Z)
+       431024d7e  2026-09-10T10:19:04+02:00  ->  08:19:04Z  (was 10:30:00Z)
+     Read them as the commit time rather than as a moment before it: the block is
+     written before its commit, and the only instant that is a checkable fact
+     afterwards is the commit's own.
+
+  2. FINDING 6's REMEDIATION CELL CITED A CORROBORATION THAT DOES NOT EXIST.
+     It claimed "the census row that independently computes E1". It does not:
+     `agents/evidence/analysis/adr-evidence-census-2026-08.md` has a `Proposed
+     strength` column and a `Current frontmatter` column
+     (`src/scripts/adr/evidence_census.ts`, `r.proposed.strength` vs `r.current`).
+     The row's proposal reads `E2`; the `E1` appears only in `Current
+     frontmatter`, which mirrors the declared value back. Citing it as
+     independent support for that same declared value is circular. The cell is
+     corrected; finding 6's material conclusion is untouched and still holds on
+     `adr-layout.md:178-181` alone.
+
+  THE REVIEW THAT FOUND (2) ALSO GOT IT PARTLY WRONG, and that is worth stating
+  because a reader will otherwise trust the report over the record. It reported
+  the discrepancy as uncorrected. The ADR had already corrected it, more fully
+  than the report did: `ADR-274` § "The evidence grade, and why it came down"
+  states that the corroboration destroyed itself, that re-running the census
+  flips its proposal to `E2`, and names the mechanism -- the census is a keyword
+  scan, and the section's own quotation of the contract's E3 wording ("pre-
+  registered benchmark") is what the scan now matches, attributed to
+  `prereg @ ...:200`. So the stale claim survived in exactly one place, this
+  artefact, and only in the cell the implementer wrote.
+
+  WHAT IS DELIBERATELY NOT EDITED: finding 6's FINDING text still carries the
+  same claim in its closing parenthesis, and the File:Line column still names
+  the old `ADR-273-the-grace-ceiling-...` path on rows 3, 4, 6, 8 and 9. Both are
+  the reviewer's own words, and this artefact does not rewrite them -- the same
+  reason `prompt_hash` and `reviewer` are never updated on a re-bind. The
+  parenthesis is superseded by this block; the paths resolve at
+  `ADR-274-the-grace-ceiling-...`, same file.
+
+  ONE THING NO GATE WOULD HAVE CAUGHT, recorded rather than left implicit. The
+  dead ADR-273 paths in the table are invisible to `check_references`: its
+  `PATH_PATTERN` requires a delimiter from [`"\s,;)\]] immediately after `.md`,
+  and these are followed by `:9`, so the pattern does not match at all.
+  `check_completion_review` reads the table's header row, never the path cells.
+  Leaving them is therefore a decision, not a gate outcome.
+-->
+
 | # | Severity | File:Line | Finding | Status | Reason/Ref |
 |---|----------|-----------|---------|--------|------------|
 | 1 | high | agents/roadmaps/road-to-delivery-for-every-host.md:1061 | The replacement mitigation is itself an unenforced dated commitment - the exact defect this change removes. The corrected Risk 3 cell states the new mitigation is "the shrink-only ratchet ... plus `target_schedule.on_miss`, which requires the 2026-11-10 milestone miss to be PUBLISHED with its measured number - milestones are untouched here and that first miss will land on schedule". No code reads either key: `grep -rn "target_schedule" --include=*.ts --include=*.js --include=*.yml --include=*.yaml --include=*.sh .` (excluding `node_modules` and `dist/`) returns 0 hits, and `grep -rnw on_miss` the same. Nothing will publish anything on 2026-11-10. "requires" and "will land on schedule" describe a mechanism that does not exist, which is precisely what `grace_end_date` was found to be. ADR-273:116 contradicts the cell in the same commit, saying those milestones "were never the enforcement surface". | fixed | `fd54b3585` — Retracted in `road-to-delivery-for-every-host.md` Risk 3: the `target_schedule.on_miss` mitigation claim is removed and replaced with the 0-hit grep, an explicit retraction, and the statement that the only enforced mitigation bounds GROWTH and nothing converges the corpus. `ADR-273` § Consequences now names `on_miss` as an unenforced commitment rather than a forcing function. The finding was correct and this was the same defect one paragraph after removing it. |
@@ -93,7 +150,7 @@ rebound: 2026-09-10T10:30:00Z
 | 3 | medium | docs/decisions/ADR-273-the-grace-ceiling-expiry-was-never-enforced-and-the-date-is-deleted.md:9 | The change acts in a dimension the same roadmap twice recorded as owner-reserved, on council authority, with no owner decision on that dimension. roadmap:801-806 records anthropic verbatim: "Owner-reserved for extending grace_end_date beyond 2026-11-10 - extending the date increases permitted exposure duration and is a substantive relaxation requiring owner authority", and roadmap:841-843 adds "a split council does not acquire authority a converged one was denied". Deleting the bound is an UNBOUNDED relaxation of permitted exposure duration - strictly larger than the extension that was reserved - and the register's own new text concedes the result is "an undated, shrink-only tolerance 30,767 tokens above the design ceiling". The no-enforcement argument answers the executable half only; the reservation was recorded against exposure DURATION, which is what was removed. Compounding: the new record self-assigns `reopen_policy: directional` (council-decidable) while declaring `protected_dimensions: governance`, so the venue for reopening it is set by the body that decided it. | fixed | `fd54b3585` — `reopen_policy` corrected `directional` -> `owner`, and `ADR-273` gains § "The authority question, recorded rather than glossed": the reservation was recorded against exposure DURATION, deleting the bound is larger in that dimension than the reserved extension, the delegation is what the decision rests on, and it does not make the reservation vanish retroactively. A council acting in an owner-reserved dimension may not also set the venue for revisiting it. |
 | 4 | medium | docs/decisions/ADR-273-the-grace-ceiling-expiry-was-never-enforced-and-the-date-is-deleted.md:68 | "a shrink-only ratchet enforced against the base ref by `assertBoundsDidNotRise`" (and roadmap:1061's "real and enforced per PR") overstates a guard that fails OPEN. `src/scripts/_lib/standing_bound_ratchet.ts:94-135` returns `ok: true` on four base-ref failure modes - no base ref resolved, the budget config unreadable at the base ref, unparseable, or no `ci_delivery.grace_ceiling` at the base ref - each with an honest `note` but a passing verdict. So the ratchet is conditional on base-ref resolution (shallow clone, absent `origin/main`, unresolvable merge base) rather than unconditional. The inconsistency is internal to one document: ADR-273:155-158 disqualifies the base-ref-derived ceiling proposal on exactly this property ("returns `null` on every failure, correct for a diagnostic and unacceptable for a ceiling") while relying on the same property unqualified 90 lines earlier. This matters more after the change than before, because the ratchet is now the only enforced mitigation named. | fixed | `fd54b3585` — Both claims qualified. `ADR-273` § Context gains the four fail-open modes at `standing_bound_ratchet.ts:94-135` and states that the same property disqualifies the rival proposal in § Alternatives, so one standard gets one answer. Risk 3 in the roadmap now says "conditional rather than absolute" and "fails open" with the modes enumerated, instead of "real and enforced per PR". |
 | 5 | medium | taskfiles/ci-fast.yml:882 | Half-corrected string: the same `desc` clause that was edited to fix a stale ceiling figure still asserts "The tree measures 138,212". Verified by running the gate on this branch: measured total is 138,413 (`project-scope rules 122822 + preloaded skills catalog 14845 + CLAUDE.md 746`). The diff's own commit note says of the neighbouring clause "the figure was two raises stale as well", so the staleness class was known and the adjacent instance in the same string was left. Same pattern in `src/config/preamble-payload-budget.json:85`, which this diff also rewrites and which still opens "HEAD measures 138,212 ... nobody can reduce 30,566 tokens" (actual gap 30,767) - defensible as historical framing there, not defensible in a present-tense "The tree measures". | fixed | `fd54b3585` — `taskfiles/ci-fast.yml:882` now reads "measured 138,212 when this note was written and measures 138,413 on 2026-09-10". The budget file instance is left as historical framing, which the finding itself allows. |
-| 6 | medium | docs/decisions/ADR-273-the-grace-ceiling-expiry-was-never-enforced-and-the-date-is-deleted.md:17 | `evidence.strength: E3` is not supportable by the declared basis, and the grade is load-bearing. `docs/contracts/adr-layout.md:178-181` defines E1 as "One local observation - one incident, consumer, measurement, tree constraint" and reserves E3 for "pre-registered benchmark, production data, established community standard, applicable vendor guidance". The basis here is one dated inspection of one commit (`Measured 2026-09-10 in a worktree at origin/main 7bf325f3b`) - four greps and one gate run. `adr-layout.md:464` prices the reopen burden on the grade (E3/E4 requires "engaging the original evidence in kind"), so the overclaim raises the bar to reopen a governance record. Cross-check: sibling ADR-264, same subject and a stronger evidence resolution, declares E2. The `agents/evidence/analysis/adr-evidence-census-2026-08.md` row added in this same diff independently computes `E1 - one dated local observation` (that census is biased low by design, so it is corroboration rather than proof). | fixed | `fd54b3585` — `evidence.strength` corrected `E3` -> `E1`, with § "The evidence grade, and why it came down" citing `adr-layout.md:178-181`, the census row that independently computes E1, and `adr-layout.md:464` pricing the reopen burden on the grade. An inflated grade would have raised the bar to reopen a record decided on one day of inspection. |
+| 6 | medium | docs/decisions/ADR-273-the-grace-ceiling-expiry-was-never-enforced-and-the-date-is-deleted.md:17 | `evidence.strength: E3` is not supportable by the declared basis, and the grade is load-bearing. `docs/contracts/adr-layout.md:178-181` defines E1 as "One local observation - one incident, consumer, measurement, tree constraint" and reserves E3 for "pre-registered benchmark, production data, established community standard, applicable vendor guidance". The basis here is one dated inspection of one commit (`Measured 2026-09-10 in a worktree at origin/main 7bf325f3b`) - four greps and one gate run. `adr-layout.md:464` prices the reopen burden on the grade (E3/E4 requires "engaging the original evidence in kind"), so the overclaim raises the bar to reopen a governance record. Cross-check: sibling ADR-264, same subject and a stronger evidence resolution, declares E2. The `agents/evidence/analysis/adr-evidence-census-2026-08.md` row added in this same diff independently computes `E1 - one dated local observation` (that census is biased low by design, so it is corroboration rather than proof). | fixed | `fd54b3585` — `evidence.strength` corrected `E3` -> `E1`, with § "The evidence grade, and why it came down" citing `adr-layout.md:178-181` and `adr-layout.md:464` pricing the reopen burden on the grade. CORRECTED 2026-09-10 (see the correction block above the table): this cell used to cite "the census row that independently computes E1", which the census row does not do. Its `Proposed strength` column reads `E2`; the `E1` sits in `Current frontmatter`, which only mirrors the declared value. The record itself already says so and says why. An inflated grade would have raised the bar to reopen a record decided on one day of inspection. |
 | 7 | low | tests/scripts/check_preamble_payload_budget.test.ts:205 | Two of the four added tests duplicate assertions already in this file. `:205-212` ("still ENFORCES the grace ceiling") asserts `main(['--ceiling', grace]) === 0` and `main([]) !== 0`, which is the entire `describe('the gate reds on growth past whichever ceiling applies')` block at `:265` and `:273`. `:215-219` asserts `evaluate(undefined, undefined, design - 1).ceiling === design`, verbatim the second expectation of `:237-243`, re-deriving a local `design` where a `design()` helper exists 18 lines below - and it sits in a describe about the date, not about override direction. Consequence beyond redundancy: the `main([]) !== 0` copy at `:211` drops the caveat carried at `:266-270` ("HEAD is over the design ceiling today ... when a reduction lands this flips and the assertion must be inverted"), so a future reduction reds two tests and only one carries the instruction. The roadmap's "37 tests ... including two new regression pins" is accurate for the two pins at `:187` and `:194`; the other two additions are not disclosed as duplicates. | fixed | `fd54b3585` — The two duplicates are gone. The block now asserts only what is not asserted elsewhere - that the ceiling exists and is above the design number - and its comment names the two describes that own the exit codes and the override direction, including that the surviving copy of the `main([]) !== 0` caveat lives there. 36 tests green; the two regression pins are untouched and remain the ones proven red under sabotage. |
 | 8 | low | docs/decisions/ADR-273-the-grace-ceiling-expiry-was-never-enforced-and-the-date-is-deleted.md:112 | "`status_2026_08_24.committed_reduction_mechanism` remains the string `NONE`" is not what the field holds. Its value is a multi-sentence paragraph beginning `"NONE. Stated explicitly because its absence is the finding: no mechanism in the tree is committed to closing 35,692 tokens by 2026-11-10 ..."`. The same overstatement appears at `.github/workflows/standing-payload-delta.yml:34` ("the budget file still records `committed_reduction_mechanism: NONE`") and in roadmap:1061 as "still recorded verbatim as `NONE`" - where "verbatim" is exactly wrong. Minor in itself; noted because the whole subject of this change is prose that claims more precision than the config supports. The embedded paragraph also still carries the 35,692/2026-11-10 pairing the change elsewhere corrects. | fixed | `fd54b3585` — Corrected in all three places: `ADR-273` § Consequences ("still opens with `NONE` - its value is a paragraph"), the workflow header comment, and the roadmap Risk 3 cell, which now names its own earlier use of "verbatim" as wrong. |
 | 9 | low | docs/decisions/ADR-273-the-grace-ceiling-expiry-was-never-enforced-and-the-date-is-deleted.md:118 | A known-dead `review_trigger` on an accepted owner-reserved governance record is left with no tracked carrier. ADR-273 correctly identifies that ADR-264's third `review_trigger` clause (verified verbatim at `docs/decisions/ADR-264-standing-payload-grace-ceiling-may-not-rise.md:26-27`) "cannot fire", and declines to edit ADR-264 on the defensible ground that its `reopen_policy` is `owner`. But nothing tracks the repair: no blocker, no stub, no roadmap step, and ADR-273's own `review_trigger` does not cover it. The only record that an accepted record carries an unfirable trigger is a prose bullet in a different ADR - the same discoverability failure that let the original fiction survive. | fixed | `fd54b3585` — `ADR-273`'s `review_trigger` now carries the repair explicitly - reopened when ADR-264's third trigger is repaired or that record superseded - so this record is the tracked carrier, and § Consequences says so. ADR-264 itself stays unedited: its `reopen_policy` is `owner`. |


### PR DESCRIPTION
## What this is

Two prose defects in `agents/evidence/reviews/drain-delivery-for-every-host-4-4-close.findings.md`, both surfaced by a neutral cross-model review of the merge in #1983 that renumbered ADR-273 → ADR-274. Neither is blocking, neither re-opens a finding, and **no hash moves** — `agents/evidence/reviews` is excluded from the review scope, so this artefact is not part of what any round measures.

That last claim is verified rather than asserted: the branch's review scope hash against `origin/main` is `e3b0c44298fc…`, the SHA-256 of the empty string, and `check_completion_review` reports *"No reviewable changes vs origin/main — nothing to review."* This PR owes no completion review because it changes nothing any review reads.

---

## 1. The three `rebound:` timestamps were impossible

Each sat **11–13 minutes after the commit that wrote it**. An event cannot post-date the commit recording it. Cause: local CEST was labelled `Z` and then rounded forward.

| Commit | True commit time | Was | Now |
|---|---|---|---|
| `6d7b8334a` | `2026-09-10T08:41:43+02:00` | `08:55:00Z` | `06:41:43Z` |
| `f7fb052ff` | `2026-09-10T09:07:03+02:00` | `09:20:00Z` | `07:07:03Z` |
| `431024d7e` | `2026-09-10T10:19:04+02:00` | `10:30:00Z` | `08:19:04Z` |

Read from `git log -1 --format=%cI`, not from the review report. Each block now carries the true UTC commit time of its own commit — the block is written *before* its commit, and the commit's own instant is the only one that is a checkable fact afterwards, so that is what it records.

## 2. Finding 6's remediation cell cited a corroboration that does not exist

The cell claimed *"the census row that independently computes E1"*. It does not.

`agents/evidence/analysis/adr-evidence-census-2026-08.md` has a **`Proposed strength`** column and a **`Current frontmatter`** column — `evidence_census.ts:790-791` emits `r.proposed.strength` for the former and `r.current` for the latter. The row for this record **proposes `E2`**; the `E1` appears only in `Current frontmatter`, which mirrors the declared value back. Citing it as independent support for that same declared value is circular.

Corrected in the cell. **Finding 6's material conclusion is untouched** and still stands on `adr-layout.md:178-181` alone: the basis was one dated inspection of one commit, which is an E1 basis, and `adr-layout.md:464` prices the reopen burden on the grade.

---

## The review that found (2) also got it partly wrong

Stated in the artefact rather than left for a reader to trip over, because a reader will otherwise trust the report over the record.

The review reported the discrepancy as **uncorrected**. `ADR-274` had already corrected it, and more fully than the report did. Its § *"The evidence grade, and why it came down"* states that the corroboration destroyed itself, that re-running the census flips its proposal to `E2`, and names the mechanism: the census is a keyword scan, and the section's own quotation of the contract's E3 wording (*"pre-registered benchmark"*) is what the scan now matches, attributed to `prereg @ …:200`.

So the stale claim survived in **exactly one place** — this artefact, in the cell the implementer wrote. The record itself was already honest about it.

## Deliberately not edited

- **Finding 6's FINDING text** still carries the same claim in its closing parenthesis.
- **Rows 3, 4, 6, 8 and 9** still name the old `docs/decisions/ADR-273-the-grace-ceiling-…md` path.

Both are the reviewer's own words, and this artefact does not rewrite them — the same reason `prompt_hash` and `reviewer` are never updated on a re-bind: the column records what was read. The correction block supersedes the parenthesis and points the reader at `ADR-274-the-grace-ceiling-…`, same file.

**One thing no gate would have caught, recorded rather than left implicit.** Those dead paths are invisible to `check_references`: its `PATH_PATTERN` (`check_references.ts:160-161`) requires a delimiter from `` [`"\s,;)\]] `` immediately after `.md`, and these are followed by `:9`, so the pattern does not match at all. `check_completion_review` reads the table's header row, never the path cells. Leaving them is therefore a decision, not a gate outcome — which is worth writing down, because "the gates are green" would otherwise read as "the paths were checked".

---

## Gates

`task preflight` **exit 0, zero ❌** · `check_references` exit 0 · `check_review_dispositions` exit 0 · `check_finding_dispositions` exit 0 · `check_review_prompt_binding` exit 0 · `lint_evidence_artifacts` exit 0 · `check_md_language` no German content · `check_completion_review` no reviewable changes · `dispatch_r2_reviewer --verify-current` empty scope.

One file changed, +61/−4, all of it prose inside one review artefact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)