### PR TITLE
docs(roadmap): the headroom question, asked and answered 2/2

### DIFF
--- a/agents/evidence/reviews/headroom-council-verdict.findings.md
+++ b/agents/evidence/reviews/headroom-council-verdict.findings.md
@@ -1,0 +1,1 @@
+**Skipped:** no code surface for this completion — the diff is one roadmap note transcribing a 2/2 convergent council verdict, quoted rather than summarised, because the response file it came from is gitignored and pruned on the retention window, scope 0d2807367b308d57cb6adbf07af42b5ed89ade251f4e3735393099c9f97421f2, declared 2026-09-10

--- a/agents/roadmaps/road-to-delivery-for-every-host.md
+++ b/agents/roadmaps/road-to-delivery-for-every-host.md
@@ -954,6 +954,70 @@ Defects this roadmap repairs:
       it was one lane choosing a per-PR growth allowance for every pull request in the
       repository, unreviewed. `K9` prescribes `[ ]` with the question quoted; the question is
       now a sharper one.
+
+      **UPDATE 2026-09-10 — THE HEADROOM QUESTION WAS ASKED AND ANSWERED. AI council 2/2
+      convergent (anthropic/claude-sonnet-4-5 + openai/codex-default, blind peer review),
+      under the written owner delegation. The box still stays `[ ]`, and the verdict says so
+      explicitly.**
+
+      **Q1 — may a per-PR allowance compound against a moving base? NO.** Both seats, without
+      qualification. openai: *"Neither a percentage nor a fixed token allowance is safe
+      against a moving base: both authorize cumulative growth."* anthropic put the arithmetic
+      on it — 138,413 × 1.05^10 ≈ 225,000. `headroom_pct` belongs to deriving the FIXED
+      design ceiling from `baseline_tokens` and must not be re-applied to each moving base.
+      A capped variant (`min(base × 1.05, 138490)`) was raised in review and refused by both:
+      it preserves today's overage as permanent, and its reduction tracking is dormant until
+      the base drops below ~131,895, so the first ~6,518 tokens of any reduction become
+      reusable space instead of a lower ceiling — the opposite of shrink-only.
+
+      **THE FORMULA, converged:** `max(design_ceiling, payload_at_base_ref)`. Zero net growth
+      while the tree is over design; the design ceiling once it is at or below.
+
+      **Q2 — how does a necessary addition land with zero headroom?** Normally by a same-PR
+      offset, which the gate enforces mechanically (head payload ≤ base payload). For a
+      change where an offsetting reduction is genuinely unsafe, a break-glass path that both
+      seats specified in the same shape and that is ARCHITECTURAL rather than optional: a
+      fixed token grant · the pre-exception watermark recorded · approval by a designated
+      owner, outside PR-modifiable policy · all later net growth blocked until the debt is
+      repaid · a machine-enforced expiry · and the exceptional measurement must NEVER become
+      the next base. openai on today's slack: *"The current 77 tokens are slack under the
+      obsolete stored exception, not an entitlement that survives its removal."*
+
+      **Q3 — is a measured ceiling an improvement over the stored one? YES, and for one
+      reason.** It captures every merged reduction automatically; a stored ceiling stays at
+      138,490 until someone lowers it by hand, so payload that was removed can be added back
+      into the space it freed. That benefit disappears if an exception becomes the next base,
+      which is why the watermark is not optional.
+
+      **Q4 — may 4.4 close on this? YES, but not on the grep.** openai: *"It closes only when
+      the stored exception has been replaced by an active, required, fail-closed measured
+      ratchet and any exceptional growth preserves repayment debt. Until then, the `grep`
+      exit condition is insufficient evidence and 4.4 must remain open."*
+
+      **PREREQUISITES BOTH SEATS MADE BLOCKING — a measured ceiling without them is a
+      REGRESSION, not an improvement (anthropic's word).**
+      · `_lib/standing_bound_ratchet.ts`'s fail-open returns at `:96`, `:106`, `:121`, `:130`
+        must be replaced or mode-gated; a failed measurement may not read as `ok`.
+      · Base-resolution failure must BLOCK, not warn.
+      · **The trust boundary, which no prior round named and which is the sharpest finding
+        of this one:** the measurement code, the workflow invocation, the catalogue inclusion
+        rules and the base resolver are all editable by the pull request being measured. A
+        stored ceiling is protected from that by ADR-264 plus the shrink-only bound check; a
+        measured one is not, unless those surfaces are review-protected or workflow-pinned.
+
+      **ONE SEAT WENT FURTHER, and it is recorded because it reframes the target rather than
+      the mechanism.** anthropic: neither the stored nor the measured form plans to eliminate
+      the overage — 138,413 against a design ceiling of 107,646 is **30,767 tokens of debt**,
+      and both proposals normalise it. Its refinement makes the design ceiling the organising
+      principle: headroom applies only at or below it, the overage is measured and REPORTED
+      by the gate rather than merely compared against, and an exception carries a repayment
+      schedule. openai did not contradict this and its own mechanism is compatible with it.
+
+      **What this run did NOT do, deliberately: build it.** The verdict names four blocking
+      prerequisites, one of them a trust-boundary question about which surfaces a pull request
+      may edit — which is repository governance rather than a gate edit. Implementing the
+      formula without them is the regression both seats warned about, so the next change is
+      the prerequisites, not the ceiling.
       **Not attempted, deliberately, and unchanged from the earlier note:** raising
       `design_ceiling` is K4 and shortening rule prose is K5. Added to that list by this
       round: closing this roadmap through a stub carrier, which openai forbade in terms —


### PR DESCRIPTION
**Closes nothing, builds nothing.** One roadmap note transcribing a **2/2 convergent** council verdict on step 4.4 of `road-to-delivery-for-every-host`. Quoted rather than summarised, because the response file it came from is gitignored and pruned on the retention window.

The question was the one #1990 established had never been asked: **may a per-PR growth allowance compound against a moving base?**

## The verdict

**Q1 — No.** Both seats, unqualified. Neither a percentage nor a fixed token grant is safe against a moving base; both authorise cumulative growth. anthropic put the arithmetic on it: 138,413 × 1.05¹⁰ ≈ 225,000. `headroom_pct` belongs to deriving the **fixed** design ceiling from `baseline_tokens` and must not be re-applied to each moving base.

A capped variant (`min(base × 1.05, 138490)`) was raised in blind review and refused by both — it makes today's overage permanent, and its reduction tracking stays dormant until the base drops below ≈131,895, so the first ≈6,518 tokens of any reduction become reusable space rather than a lower ceiling. The opposite of shrink-only.

**The formula, converged:** `max(design_ceiling, payload_at_base_ref)`.

**Q2 — a necessary addition lands by same-PR offset**, enforced mechanically (head payload ≤ base payload). Where offsetting is genuinely unsafe, both seats specified the same break-glass path and both called it architectural rather than optional: a fixed token grant · the pre-exception watermark recorded · owner approval **outside PR-modifiable policy** · later net growth blocked until repaid · machine-enforced expiry · and the exceptional measurement **never** becomes the next base.

On today's 77 tokens of slack — openai: *"slack under the obsolete stored exception, not an entitlement that survives its removal."*

**Q3 — the measured ceiling is a real improvement, for one reason.** It captures every merged reduction automatically; a stored ceiling stays at 138,490 until someone lowers it by hand, so payload that was removed can be added back into the space it freed.

**Q4 — 4.4 may close on this, but not on the `grep`.** openai: *"It closes only when the stored exception has been replaced by an active, required, fail-closed measured ratchet and any exceptional growth preserves repayment debt. Until then, the `grep` exit condition is insufficient evidence and 4.4 must remain open."*

## Four blocking prerequisites

Both seats: a measured ceiling without these is a **regression**, not an improvement.

- `_lib/standing_bound_ratchet.ts`'s fail-open returns at `:96`, `:106`, `:121`, `:130` must be replaced or mode-gated — a failed measurement may not read as `ok`.
- Base-resolution failure must **block**, not warn.
- **The trust boundary, which no prior round named.** The measurement code, the workflow invocation, the catalogue inclusion rules and the base resolver are all editable by the pull request being measured. A stored ceiling is protected from that by ADR-264 plus the shrink-only bound check; a measured one is not, unless those surfaces are review-protected or workflow-pinned.

## One seat went further

anthropic reframed the target rather than the mechanism, and openai did not contradict it: neither form plans to **eliminate** the overage. 138,413 against a design ceiling of 107,646 is **30,767 tokens of debt**, and both proposals normalise it. Its refinement makes the design ceiling the organising principle — headroom applies only at or below it, the gate *reports* the overage rather than merely comparing against it, and an exception carries a repayment schedule.

## What this change deliberately does not do

Build it. The verdict names four blocking prerequisites, one of which is repository governance rather than a gate edit. Implementing the formula without them is the regression both seats warned about, so **the next change is the prerequisites, not the ceiling**. 4.4 stays `[ ]`.

## Verified

`lint_roadmap_blockers` clean · `check_council_references` clean — the verdict is transcribed, not linked, because a council path in a durable record rots by construction · dashboard regenerated · `task preflight` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
