### PR TITLE
docs(roadmap): the E3 injection gate is closed by configuration, not by a stale bundle

### DIFF
--- a/agents/evidence/analysis/e3-gate-closed-not-stale-bundle-2026-09-10.md
+++ b/agents/evidence/analysis/e3-gate-closed-not-stale-bundle-2026-09-10.md
@@ -2,7 +2,7 @@
 title: The E3 injection gate is closed by configuration, not by a stale hook bundle
 date: 2026-09-10
 ---
-<!-- evidence-type: v1 | type: analysis | declared: 2026-09-10 -->
+<!-- evidence-type: analysis -->
 
 # The E3 injection gate is closed by configuration, not by a stale hook bundle
 

--- a/agents/evidence/analysis/e3-gate-closed-not-stale-bundle-2026-09-10.md
+++ b/agents/evidence/analysis/e3-gate-closed-not-stale-bundle-2026-09-10.md
@@ -1,0 +1,115 @@
+---
+title: The E3 injection gate is closed by configuration, not by a stale hook bundle
+date: 2026-09-10
+---
+<!-- evidence-type: v1 | type: analysis | declared: 2026-09-10 -->
+
+# The E3 injection gate is closed by configuration, not by a stale hook bundle
+
+`road-to-delivery-on-hook-hosts` step 1.1's second limb has never been met. Since
+2026-09-09 the roadmap and its `no-host-observed-true-injection` blocker both
+explain that with a **stale local hook bundle**, and both prescribe
+`npm run build:hooks` plus one session as the cheap fix.
+
+That explanation is wrong, and the prescription closes nothing. Reproduced here
+at `09d9bc760`, on a bundle rebuilt the same day.
+
+## Four measurements
+
+Identical payload throughout — a `user_prompt_submit` envelope whose prompt
+(`"refactor this legacy module and clean up the duplication"`) trips three
+labelled rules — and identical repository root.
+
+| # | invocation | bytes out | rule bodies |
+|---|---|---:|---|
+| 1 | `npx tsx src/scripts/hooks/dispatch_hook.ts` | 17,823 | 3 (16,378 B) |
+| 2 | the same, with `AGENT_CONFIG_REPLAY=1` | **826** | none |
+| 3 | `node dist/hooks/dispatch.js` (freshly built) | **826** | none |
+| 4 | the same bundle, with `lean_projection.mode: delivery` set | **17,823** | 3 |
+
+Row 3 was taken after `npm run build:hooks` — the prescribed fix — and again
+after `task preflight` had independently rebuilt and verified the bundle
+byte-identical to a rebuild from source (`sha256 72a0909d356d`). The bundle is
+neither stale nor broken.
+
+## What the rows say
+
+**Rows 2 and 3 are the same number, and that is the finding.** The source and
+the built dispatcher agree exactly once the probe branch is switched off. The
+826 B they both emit is the language-mirror pin and nothing else.
+
+**Row 1 is the probe branch, and the module says so in its own words.**
+`gateOpen` (`src/scripts/hooks/rule_inject_hook.ts:314-320`) ends with
+`return cliEntry && process.env['AGENT_CONFIG_REPLAY'] !== '1'`, documented
+directly above as *"A DIRECT CLI invocation is a probe by definition — an
+operator piping an envelope into this file is asking to see what it would
+deliver — so there the gate defaults to open."* `_isCliEntry()` (`:388`) returns
+`false` unconditionally when `__AGENT_CONFIG_BUNDLE__` is set, which is why the
+bundle never takes that branch. `AGENT_CONFIG_REPLAY=1` re-imposes the gate on
+the source path, and row 2 is what that produces.
+
+**Row 4 is the actual cause.** `gateOpen`'s first clause is
+`deliversBodies(mode) && hosts.includes(DELIVERY_HOST)`. `deliversBodies`
+(`src/scripts/_lib/lean_projection_mode.ts:42-44`) returns true for exactly one
+value, `'delivery'`. `DEFAULT_LEAN_PROJECTION_MODE` at `:21` is **`'eager-all'`**.
+There is no `.agent-settings.yml` in this repository — it is gitignored at
+`.gitignore:317` and its absence is deliberate, since absent IS the CI shape — so
+`leanProjectionModeRaw` returns `''`, the mode normalises to `eager-all`, and the
+first clause is false. The second clause (`hooks.rule_inject` opt-in) is false for
+the same reason: no settings file. So in every real session here the gate is
+**closed**, and the concern emits nothing because it is configured not to.
+
+## The two claims this corrects
+
+Both appear in the roadmap's step 1.1 and again in the blocker body:
+
+1. *"`lean_projection.mode` resolves to `delivery` and `lean_projection.hosts` to
+   `["claude-code"]` from the shipped defaults, with nothing set in any settings
+   file."* — The hosts half is right (`DEFAULT_LEAN_PROJECTION_HOSTS` is
+   `['claude-code']`, `:67`). The mode half is not: the shipped default is
+   `eager-all`, and `deliversBodies` accepts only `delivery`.
+2. *"`gateOpen` … therefore returns true here."* — It returns true **under a
+   probe**. Every measurement offered as evidence that the carrier works
+   (5,346 B, 6,458 B, and row 1's 17,823 B) was taken on the probe path, which
+   is the branch that exists precisely so an operator can see what the gate
+   would deliver if it were open.
+
+The second is the sharper error, and it has the shape the roadmap's own K1
+warns about one layer further in: a probe measurement read as a statement about
+the configured tree. The earlier round refused to write `observed-true` off
+byte-equivalence for exactly that reason, then diagnosed the carrier off a probe.
+
+## What actually closes step 1.1's second limb
+
+Not `npm run build:hooks`. Row 4 is the closing move: `.agent-settings.yml` at
+the repository root carrying
+
+```yaml
+lean_projection:
+  mode: delivery
+  hosts:
+    - claude-code
+```
+
+then one live Claude Code session, a prompt that trips a labelled rule, and a
+**second party** reading the transcript for the turn that reflects the delivered
+body. The independence requirement is unchanged and is not satisfied by this
+document: the observer may not be the session that produced the turn.
+
+Two things worth stating about that config edit rather than discovering them
+afterwards. It is local and gitignored, so it changes this machine and no
+consumer. And it is not free: row 4 measures 17,823 bytes of injected context on
+a single prompt, which lands in every turn whose prompt trips a labelled rule.
+
+## Reproduction
+
+```bash
+P='{"session_id":"probe","cwd":"'"$PWD"'","prompt":"refactor this legacy module and clean up the duplication"}'
+printf '%s' "$P" | npx tsx src/scripts/hooks/dispatch_hook.ts --platform claude --event user_prompt_submit | wc -c
+printf '%s' "$P" | AGENT_CONFIG_REPLAY=1 npx tsx src/scripts/hooks/dispatch_hook.ts --platform claude --event user_prompt_submit | wc -c
+npm run build:hooks
+printf '%s' "$P" | node dist/hooks/dispatch.js --platform claude --event user_prompt_submit | wc -c
+printf 'lean_projection:\n  mode: delivery\n  hosts:\n    - claude-code\n' > .agent-settings.yml
+printf '%s' "$P" | node dist/hooks/dispatch.js --platform claude --event user_prompt_submit | wc -c
+rm -f .agent-settings.yml   # absent is the CI shape; do not leave it behind
+```

--- a/agents/evidence/reviews/e3-gate-diagnosis.findings.md
+++ b/agents/evidence/reviews/e3-gate-diagnosis.findings.md
@@ -1,0 +1,4 @@
+# Findings: e3-gate-diagnosis
+<!-- evidence-type: v1 | type: current-binding | declared: 2026-09-10 -->
+
+**Skipped:** no code surface for this completion — the diff is two markdown files (a reproduction artefact and the roadmap step and blocker it corrects); no source, gate or configuration behaviour changes in this commit, scope 7f51e65dda0cfa82cab0ae89eb07ded1e36b3d210db11985d7ad3d12e47e8d08, declared 2026-09-10

--- a/agents/evidence/reviews/e3-gate-diagnosis.findings.md
+++ b/agents/evidence/reviews/e3-gate-diagnosis.findings.md
@@ -1,4 +1,4 @@
 # Findings: e3-gate-diagnosis
 <!-- evidence-type: v1 | type: current-binding | declared: 2026-09-10 -->
 
-**Skipped:** no code surface for this completion — the diff is two markdown files (a reproduction artefact and the roadmap step and blocker it corrects); no source, gate or configuration behaviour changes in this commit, scope 7f51e65dda0cfa82cab0ae89eb07ded1e36b3d210db11985d7ad3d12e47e8d08, declared 2026-09-10
+**Skipped:** no code surface for this completion — the diff is two markdown files (a reproduction artefact and the roadmap step and blocker it corrects); no source, gate or configuration behaviour changes in this commit, scope 7a0f3b551c7d9436c99369456d4c7917d242dd6f5a679a8f1da294e4fe3c19a0, declared 2026-09-10

--- a/agents/roadmaps/road-to-delivery-on-hook-hosts.md
+++ b/agents/roadmaps/road-to-delivery-on-hook-hosts.md
@@ -206,6 +206,52 @@ admission. Cowork is excluded by the existing measurement.
       now carries a rule body, then run a session and have a SECOND party read the
       transcript for the turn that reflects the body. The bar was never the problem; the
       carrier the sessions were running was.
+      **UPDATE 2026-09-10 — THE 2026-09-09 DIAGNOSIS IS WRONG, and the prescribed fix
+      closes nothing. Reproduced at `09d9bc760` on a bundle rebuilt the same day.**
+      `npm run build:hooks` was run, and `task preflight` independently verified the bundle
+      byte-identical to a rebuild from source (`sha256 72a0909d356d`). The built dispatcher
+      still emits **826 B** for the payload the source emits 17,823 B for. The bundle is
+      neither stale nor broken.
+      **Four measurements, one payload, one root:**
+
+      | invocation | bytes | rule bodies |
+      |---|---:|---|
+      | `npx tsx src/scripts/hooks/dispatch_hook.ts` | 17,823 | 3 (16,378 B) |
+      | the same, `AGENT_CONFIG_REPLAY=1` | **826** | none |
+      | `node dist/hooks/dispatch.js`, freshly built | **826** | none |
+      | the same bundle, `lean_projection.mode: delivery` set | **17,823** | 3 |
+
+      **Rows 2 and 3 being the same number is the finding.** Source and bundle agree exactly
+      once the probe branch is off, and 826 B is the language-mirror pin alone.
+      **Row 1 is the PROBE branch, which `gateOpen` documents as such in its own prose** —
+      *"A DIRECT CLI invocation is a probe by definition … so there the gate defaults to
+      open"* (`rule_inject_hook.ts:314-320`). `_isCliEntry()` at `:388` returns false
+      unconditionally under `__AGENT_CONFIG_BUNDLE__`, which is the whole of why the bundle
+      differs, and `AGENT_CONFIG_REPLAY=1` re-imposes the gate on the source path — row 2.
+      **Row 4 is the real cause: the gate is CLOSED BY CONFIGURATION.** `deliversBodies`
+      (`_lib/lean_projection_mode.ts:42-44`) is true for exactly `'delivery'`, and
+      `DEFAULT_LEAN_PROJECTION_MODE` at `:21` is **`eager-all`**. There is no
+      `.agent-settings.yml` here — gitignored at `.gitignore:317`, and absent IS the CI
+      shape — so the mode normalises to `eager-all` and both of `gateOpen`'s clauses are
+      false in every real session.
+      **So two claims this step and its blocker both carried are corrected.** That
+      *"`lean_projection.mode` resolves to `delivery` … from the shipped defaults"* — the
+      hosts half is right, the mode half is not. And that *"`gateOpen` therefore returns
+      true here"* — it returns true under a probe. **Every measurement offered as proof the
+      carrier works (5,346 B, 6,458 B, and row 1) was taken on the probe path.** That is
+      this file's own K1 conflation one layer further in: the round that rightly refused to
+      write `observed-true` off byte-equivalence then diagnosed the carrier off a probe.
+      **What actually closes the second limb**, unchanged in its independence requirement
+      and changed in every other part: write `.agent-settings.yml` with
+      `lean_projection.mode: delivery` and `hosts: [claude-code]`, run one live session with
+      a prompt that trips a labelled rule, and have a SECOND party read the transcript. The
+      config edit is local and gitignored, so it reaches no consumer — and it is not free:
+      row 4 measures 17,823 B of injected context on one prompt.
+      **Still open, and this run could not close it:** the transcript needs a live user
+      prompt after delivery is enabled, which no autonomous run produces for itself. The
+      observer also may not be the session that produced the turn.
+      Full reproduction, with the commands:
+      `agents/evidence/analysis/e3-gate-closed-not-stale-bundle-2026-09-10.md`.
 - [x] **1.2 Run 1.1 on Cursor and Cline** (the two hosts binding `user_prompt_submit` with a
       `.md` rule tree). Record Windsurf, Gemini and Augment as `unobserved` unless a session
       exists.
@@ -531,6 +577,25 @@ admission. Cowork is excluded by the existing measurement.
      a rule body for a prompt that trips a labelled rule, and only then attempt the
      session. Full evidence, including what is deliberately not claimed, is recorded at
      step 1.1.
+     **CORRECTED 2026-09-10, and the correction is the whole of step 1 above.** The
+     stale-bundle diagnosis is false and `npm run build:hooks` closes nothing. It was run,
+     and `task preflight` independently verified the bundle byte-identical to a rebuild
+     from source; the built dispatcher still emits 826 B where the source emits 17,823 B.
+     The two numbers agree exactly once `AGENT_CONFIG_REPLAY=1` re-imposes the gate on the
+     source path — because the source measurements were taken on the **probe branch**,
+     which `gateOpen` documents as opening for a direct CLI invocation, and which
+     `_isCliEntry()` hard-disables under `__AGENT_CONFIG_BUNDLE__`. The 5,346 B and 6,458 B
+     figures quoted just above are probe-path figures and say nothing about the configured
+     tree.
+     The gate is closed **by configuration**: `deliversBodies` accepts only `'delivery'`,
+     the shipped default is `eager-all`, and there is no `.agent-settings.yml` here — so
+     both of `gateOpen`'s clauses are false in every real session, which is exactly why no
+     `rule-inject` session state has ever existed on this machine.
+     **What to do instead:** write `.agent-settings.yml` with `lean_projection.mode:
+     delivery` and `hosts: [claude-code]` (local, gitignored, reaches no consumer), then
+     attempt the session. Costs 17,823 B of injected context on a prompt that trips three
+     labelled rules, which is worth knowing before enabling it. Reproduction with commands:
+     `agents/evidence/analysis/e3-gate-closed-not-stale-bundle-2026-09-10.md`.
   3. Or decide that E3's bar is not reachable for any host this year and re-scope Phase 2 rather than leaving it waiting on an empty set — an owner decision, since E3 is an owner ruling.
 - **Resolved when:** at least one host carries an `observed-true` row in `src/config/host-injection-effect.json` with a full citation (host version, transcript pointer, date), and `report_host_injection_effect` regenerates the census with that row admissible.
 - **Review trigger:** re-read when the blocker above resolves, since `delivery` going live is its precondition; otherwise 2026-12-08, matching the expiry the host table already carries for this observation state.


### PR DESCRIPTION
`road-to-delivery-on-hook-hosts` step 1.1's second limb has never been met. Since 2026-09-09 both the step and the `no-host-observed-true-injection` blocker explain that with a **stale local hook bundle** and prescribe `npm run build:hooks` plus one session as the cheap fix.

That diagnosis is wrong and the prescription closes nothing. Reproduced at `09d9bc760`.

## Four measurements, one payload, one root

| invocation | bytes | rule bodies |
|---|---:|---|
| `npx tsx src/scripts/hooks/dispatch_hook.ts` | 17,823 | 3 (16,378 B) |
| the same, `AGENT_CONFIG_REPLAY=1` | **826** | none |
| `node dist/hooks/dispatch.js`, freshly built | **826** | none |
| the same bundle, `lean_projection.mode: delivery` set | **17,823** | 3 |

Row 3 was taken after running the prescribed fix, and after `task preflight` independently verified the bundle byte-identical to a rebuild from source (`sha256 72a0909d356d`). The bundle is neither stale nor broken.

## What the rows say

**Rows 2 and 3 being the same number is the finding.** Source and bundle agree exactly once the probe branch is off; the 826 B they both emit is the language-mirror pin alone.

**Row 1 is the probe branch, which `gateOpen` documents as such in its own prose** — *"A DIRECT CLI invocation is a probe by definition … so there the gate defaults to open."* `_isCliEntry()` returns false unconditionally under `__AGENT_CONFIG_BUNDLE__`, which is the entire reason the bundle differs, and `AGENT_CONFIG_REPLAY=1` re-imposes the gate on the source path.

**Row 4 is the real cause: the gate is closed by configuration.** `deliversBodies` is true for exactly `'delivery'`; `DEFAULT_LEAN_PROJECTION_MODE` is `'eager-all'`; there is no `.agent-settings.yml` here, and its absence is deliberate because absent is the CI shape. Both of `gateOpen`'s clauses are false in every real session — which is precisely why no `rule-inject` session state has ever existed on this machine, the observation the stale-bundle theory was built to explain.

## Two corrected claims

1. *"`lean_projection.mode` resolves to `delivery` … from the shipped defaults"* — the hosts half is right, the mode half is not.
2. *"`gateOpen` therefore returns true here"* — it returns true **under a probe**. The 5,346 B and 6,458 B figures offered as proof that the carrier works are probe-path figures.

The second has the shape this roadmap's own K1 warns about, one layer further in: the round that rightly refused to write `observed-true` off byte-equivalence then diagnosed the carrier off a probe.

## What actually closes the limb

`.agent-settings.yml` with `lean_projection.mode: delivery` and `hosts: [claude-code]` — local, gitignored, reaching no consumer — then one live session and a **second party** reading the transcript. The independence requirement is unchanged, and this PR does not satisfy it: the transcript needs a live user prompt after delivery is enabled, which no autonomous run produces for itself.

Worth knowing before enabling it: row 4 measures 17,823 bytes of injected context on a single prompt that trips three labelled rules.

Completion review: skip-declared — two markdown files, zero code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)