### PR TITLE
fix(ci): name the payload job what it does, before the name is pinned

### DIFF
--- a/.github/workflows/standing-payload-delta.yml
+++ b/.github/workflows/standing-payload-delta.yml
@@ -74,7 +74,14 @@ concurrency:
 
 jobs:
   standing-payload-delta:
-    name: Standing payload delta (report-only)
+    # The name is the REPORTED CHECK STRING and is about to be pinned into
+    # branch protection, so it says what the job does. It read
+    # "(report-only)" from before 2026-08-24, when the blocking budget step
+    # was added to it — accurate for the delta script, which never fails, and
+    # wrong for the job, which does. Renaming it AFTER pinning would silently
+    # detach the required check from the job that satisfies it, so it happens
+    # here, one PR before.
+    name: Standing payload delta + budget gate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/agents/evidence/reviews/name-the-payload-job-what-it-does.findings.md
+++ b/agents/evidence/reviews/name-the-payload-job-what-it-does.findings.md
@@ -1,0 +1,4 @@
+# Findings: name-the-payload-job-what-it-does
+<!-- evidence-type: v1 | type: current-binding | declared: 2026-09-10 -->
+
+**Skipped:** no code surface for this completion — the diff is one GitHub Actions workflow job name plus the contract row that records reported check names; no source file changes, scope ed992d0431c03b479bce3b39a1f66f5280321755bc7555f37e66cb9a979c43eb, declared 2026-09-10

--- a/agents/evidence/reviews/payload-check-reports-on-every-pr.findings.md
+++ b/agents/evidence/reviews/payload-check-reports-on-every-pr.findings.md
@@ -1,4 +1,4 @@
 # Findings: payload-check-reports-on-every-pr
 <!-- evidence-type: v1 | type: current-binding | declared: 2026-09-10 -->
 
-**Skipped:** no code surface for this completion — the diff is one GitHub Actions workflow (YAML, which the validator does not count as a code path) and one roadmap markdown file; no source file changes, scope ecbf595a3bed6b91512cba81aca24fec211ea781b0425bba030278bcdd2f37ec, declared 2026-09-10
+**Skipped:** no code surface for this completion — the diff is one GitHub Actions workflow (YAML, which the validator does not count as a code path) and one roadmap markdown file; no source file changes, scope fc1c6429c465c6dc9e8dcb7dcf2398b731aa94d966608a4f55af29bf80bf1b8b, declared 2026-09-10

--- a/agents/evidence/reviews/payload-check-reports-on-every-pr.findings.md
+++ b/agents/evidence/reviews/payload-check-reports-on-every-pr.findings.md
@@ -1,4 +1,4 @@
 # Findings: payload-check-reports-on-every-pr
 <!-- evidence-type: v1 | type: current-binding | declared: 2026-09-10 -->
 
-**Skipped:** no code surface for this completion — the diff is one GitHub Actions workflow (YAML, which the validator does not count as a code path) and one roadmap markdown file; no source file changes, scope fc1c6429c465c6dc9e8dcb7dcf2398b731aa94d966608a4f55af29bf80bf1b8b, declared 2026-09-10
+**Skipped:** no code surface for this completion — the diff is one GitHub Actions workflow (YAML, which the validator does not count as a code path) and one roadmap markdown file; no source file changes, scope ecbf595a3bed6b91512cba81aca24fec211ea781b0425bba030278bcdd2f37ec, declared 2026-09-10

--- a/docs/contracts/branch-protection-policy.md
+++ b/docs/contracts/branch-protection-policy.md
@@ -73,6 +73,7 @@ the **reported check names** — the strings a required-check list must match.
 | `skill-lint.yml` | `skill-lint` (+ `skill-lint-strict`, release-gated) |
 | `tests.yml` | `Static Checks (ESLint · typecheck · prepack)` · `Install Script Tests ({ubuntu,macos}-latest, shard N/4)` · `Install Aux Tests ({ubuntu,macos}-latest)` · `Node Tests ({ubuntu,macos}-latest, shard N/4)` · `Golden Tests ({ubuntu,macos}-latest)` · `Workspace Tests ({ubuntu,macos}-latest)` |
 | `smoke-public-install.yml` | `{ubuntu,macos,windows}-latest · node {20,22}` · `tarball E2E · node {20,22}` · `npm publish dry-run · node {20,22}` |
+| `standing-payload-delta.yml` | `Standing payload delta + budget gate` — renamed from `Standing payload delta (report-only)` on 2026-09-10, before it is pinned as a required check; the job carries a blocking budget step and has since 2026-08-24 |
 | `rule-backstops.yml` | `Rule backstops` |
 | `no-python-in-src.yml` | `no-python-in-src` |
 | `commit-subjects.yml` | `lint commit subjects` |


### PR DESCRIPTION
Follow-up to #1998, which merged before this could ride along.

The reported check string is `Standing payload delta (report-only)`. That job has carried the **blocking** budget step since 2026-08-24, so "report-only" is true of the delta script — which never fails — and false of the job, which does.

It matters now rather than as a nit. The next step pins this exact string into `required_status_checks`, and renaming a job *after* pinning silently detaches the required check from the job that satisfies it: the PR then waits forever on a name nothing reports, which is the same never-reports failure #1998 just removed from the trigger.

So: `Standing payload delta + budget gate`, one PR before the pin.

The contract's reported-check table also gains the row it never had for this workflow — which is why a three-month-stale name survived every reader of that table.

Completion review: skip-declared — one workflow job name and one contract row, zero code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)