### PR TITLE
fix(settings): make the settings writers idempotent, and repair what the old one broke

### DIFF
--- a/agents/roadmaps/road-to-settings-writer-residual-debt.md
+++ b/agents/roadmaps/road-to-settings-writer-residual-debt.md
@@ -1,0 +1,81 @@
+---
+complexity: lightweight
+status: draft
+execution:
+  mode: phase-checkpoints
+---
+# Road to settings writer residual debt
+
+> **Source:** two neutral reviews over the 15.0.0 settings-writer idempotence
+> change (rounds 1 and 2, 2026-09-10), plus an AI-council verdict on which of
+> the residuals block a release. The council classified R2 blocking (fixed on
+> that branch), R1 and R3 "fix now" (also fixed), and the four items below
+> "ship as recorded debt". This roadmap is that record — without it the four
+> are only a paragraph in a chat log.
+
+## Goal
+
+The four residuals the council explicitly agreed to ship are either closed or
+re-decided against evidence, and none of them is discovered a second time by a
+future reviewer who has no way to tell "known and accepted" from "nobody
+noticed". Finished means: each item below is fixed, or carries a dated line
+saying why it stays.
+
+## Phase 1 — the two that mislead a reader
+
+- [ ] **1.1 Remove the stale flat twin when the nested key wins.**
+      `mergeIntoTemplate` hits the nested key and returns, so a file the
+      pre-15.0.0 writer produced keeps a dead top-level `personal.ide: <stale>`
+      line beside the real nested one. It parses (the nested key wins by YAML
+      semantics) and it is a single occurrence, so the duplicate pass never
+      sees it. It is permanent, and it tells a reader the opposite of the truth.
+      verify: a test writing `personal:\n  ide: a\npersonal.ide: b\n`, running
+      the merge, and asserting no `^personal\.ide:` line survives — observed
+      failing before the change.
+
+- [ ] **1.2 Drop an orphaned `# Wizard-added keys` header.**
+      Collapsing the duplicated block can leave the comment header with nothing
+      under it, and the next append writes a second header below the first, so
+      they accumulate.
+      verify: repair a file whose whole appended block collapses, assert the
+      output carries exactly one such header and it is followed by at least one
+      key.
+
+## Phase 2 — the two that need a decision, not a patch
+
+- [ ] **2.1 Decide `--check` over a corrupt file.**
+      Today it exits 2 and names the repair explicitly (distinct from template
+      drift). The council split on whether a repair-only difference should exit
+      0; this branch kept 2, on the ground that a green `--check` over a file
+      the reader cannot parse hides the breakage. Re-decide once a consumer
+      actually wires `--check`, with their CI shape as the evidence.
+      verify: either the exit code changes with a test pinning the new
+      contract, or a dated line here records the decision to keep 2.
+
+- [ ] **2.2 Decide whether an unparseable input may be repaired at all.**
+      An input broken beyond its duplicate keys (an unterminated quote) can be
+      collapsed into a document that parses to structure nobody wrote. The
+      branch ships a warning naming exactly that. The alternative is to refuse
+      the repair outright when the original does not parse for any other
+      reason — safer, and it costs the operator a hand edit in a case they were
+      going to hand-edit anyway.
+      verify: either the refusal ships with a test, or a dated line records why
+      the warning is enough.
+
+## Risk Register
+<!-- risk-review: v1 | reviewed: 2026-09-10 | reviewer: claude/host -->
+
+| Rank | Item | Risk type | Description | Mitigation | Anchored under |
+|------|------|-----------|-------------|------------|----------------|
+| 1 | The record is the only thing that exists | process | Nothing enforces these; a future reviewer re-finds all four and the cost of the two review rounds is paid again | The Source block names the reviews and the council verdict, so a re-find resolves to "decided" in one read rather than a fresh investigation | Phase 1 — the two that mislead a reader |
+| 2 | 1.1 deletes a line somebody meant | implementation | The stale-twin sweep cannot distinguish a leftover from a flat key a user wrote deliberately | Remove only when the nested form of the SAME path exists and won; never on a flat key with no nested twin | Phase 1 — the two that mislead a reader |
+
+## Acceptance Criteria
+
+- [ ] AC-1 — No `mergeIntoTemplate` output carries a flat dotted line whose
+      nested twin exists in the same document, and a test fails if one does.
+- [ ] AC-2 — A repaired file carries at most one `# Wizard-added keys` header,
+      and never one with no keys beneath it.
+- [ ] AC-3 — Each Phase 2 item is either implemented with a test pinning the
+      new contract, or carries a dated line in this file recording the decision
+      to keep the current behaviour and what evidence would reopen it.

--- a/agents/roadmaps/road-to-settings-writer-residual-debt.md
+++ b/agents/roadmaps/road-to-settings-writer-residual-debt.md
@@ -3,6 +3,15 @@ complexity: lightweight
 status: draft
 execution:
   mode: phase-checkpoints
+estate_offset_exempt: >-
+  This roadmap IS the offset. It exists because an AI council classified four
+  review findings as shippable debt rather than release blockers, and that
+  decision is worthless unless it is written where the next reviewer finds it —
+  otherwise all four are re-found and both review rounds are paid for again.
+  Archiving an unrelated roadmap to make room would dispose of somebody else's
+  open work to record a decision about this one, which trades a real estate
+  reduction for a bookkeeping entry. Closes with the release that ships the
+  fixes; two of its four items are already decided and need only a dated line.
 ---
 # Road to settings writer residual debt
 

--- a/src/scripts/sync_agent_settings.ts
+++ b/src/scripts/sync_agent_settings.ts
@@ -441,11 +441,201 @@ function loadTemplate(p: string, profileValues: Record<string, string>): string 
   return renderTemplate(fs.readFileSync(p, 'utf-8'), profileValues);
 }
 
-function loadUser(p: string): Record<string, unknown> {
-  if (!isFile(p)) {
-    return {};
+export interface DuplicateRepair {
+  /** The document with every safely-collapsible duplicate run reduced to one. */
+  text: string;
+  /** Keys that were collapsed, in first-seen order. */
+  collapsed: string[];
+  /** Duplicated keys this pass refuses to touch, with the reason. */
+  unsafe: string[];
+}
+
+/**
+ * Collapse duplicate TOP-LEVEL inline-scalar keys, keeping the last value.
+ *
+ * A strict YAML parser rejects a duplicate mapping key outright, so one such
+ * pair takes the whole file — and with it `task sync`, `task release-prepare`
+ * and every release — out of service with "Map keys must be unique". The
+ * duplicates in the wild were written by `mergeIntoTemplate`, whose flat
+ * `a.b: value` append was not idempotent before this change: each wizard save
+ * re-appended the entire "Wizard-added keys" block. That writer is fixed, but
+ * every file it already corrupted stays unreadable until something repairs
+ * it, and a release is the worst moment to discover that.
+ *
+ * Last-wins is value-neutral, not a guess: a lenient reader already resolved
+ * such a run that way, so collapsing changes what the file PARSES as in no
+ * way — it only changes whether it parses at all.
+ *
+ * Deliberately narrow, and the narrowness is what makes last-wins safe. A key
+ * is collapsible only when EVERY occurrence in the run is ONE-LINE-ONLY — its
+ * value sits on the key's own line and it owns no continuation lines at all.
+ * Anything else is reported in `unsafe` and left alone, because dropping the
+ * loser of a multi-line pair does not drop its body: the body survives, stops
+ * being that key's value, and attaches to whatever line precedes it. That
+ * turns a parse error into silent data corruption, which is strictly worse.
+ *
+ * Refused for that reason: a block key with indented children, a block scalar
+ * (`|`, `>`), a flow collection opened on one line and closed on another, and
+ * an anchor / alias / tag / merge value, whose meaning depends on which
+ * occurrence a reader binds rather than only on the value.
+ *
+ * A multi-document stream (`---` / `...`) is not repaired either. The reader
+ * takes a single document and rejects such a file whatever this pass does, so
+ * collapsing across a boundary could only merge two documents' keys into one.
+ */
+export function collapseDuplicateFlatKeys(text: string): DuplicateRepair {
+  // Line endings are preserved: splitting on `\n` alone leaves a trailing
+  // `\r` on every CRLF line, which the key pattern then never matches — so a
+  // CRLF file reported zero duplicates and fell straight into the parse error
+  // this pass exists to prevent.
+  //
+  // The MAJORITY terminator, not "any CRLF present". A mostly-LF file with one
+  // stray CRLF line would otherwise be rewritten to CRLF throughout — a whole-
+  // file change nobody asked for, on a pass whose entire promise is that it
+  // touches only what it must. Matches `sync_yaml_rt.detectEol`.
+  const crlfCount = (text.match(/\r\n/g) ?? []).length;
+  const lfCount = (text.match(/(^|[^\r])\n/g) ?? []).length;
+  const eol = crlfCount > lfCount ? '\r\n' : '\n';
+  const lines = text.split(/\r?\n/);
+
+  // A document separator anywhere means more than one document may be in play.
+  if (lines.some((l) => /^(---|\.\.\.)\s*$/.test(l))) {
+    return { text, collapsed: [], unsafe: [] };
   }
-  const data = parseYaml(fs.readFileSync(p, 'utf-8'), { version: '1.1' });
+
+  // A mapping key ends at a colon FOLLOWED BY SPACE OR END OF LINE — YAML's
+  // own plain-scalar rule. Stopping at the first colon instead reads `a:b: 1`
+  // as the key `a`, so a file carrying both `a:b:` and `a:` saw two `a` heads
+  // and collapsed them: the `a:b` entry vanished and the result parsed
+  // cleanly, so nothing downstream could notice. `sync_yaml_rt`'s own
+  // tokeniser already had this right; the two disagreeing was the defect.
+  //
+  // The value is captured with `[\s\S]` rather than `.`, which does not match
+  // a lone `\r`. A line holding one (a value like `"x\ry"`) was not recognised
+  // as a head at all, so a duplicate of it stayed invisible and the parse
+  // error this pass exists to remove survived untouched.
+  const HEAD_RE = /^([A-Za-z_][A-Za-z0-9_.-]*)[ \t]*:(?=[ \t]|$)([\s\S]*)$/;
+
+  /** Top-level key lines, in order. */
+  const heads: { key: string; at: number; rest: string }[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line === undefined) continue;
+    if (line.trim() === '' || line.trimStart().startsWith('#')) continue;
+    // Top level only — an indented `a.b:` is somebody else's child key.
+    if (line.length !== line.trimStart().length) continue;
+    const m = HEAD_RE.exec(line);
+    if (m === null) continue;
+    heads.push({ key: m[1] as string, at: i, rest: (m[2] as string).trim() });
+  }
+
+  /**
+   * Why this key may NOT be collapsed, or null when it may.
+   *
+   * Collapsing is safe only for a key that occupies exactly its own line: its
+   * value is a plain inline scalar and nothing between here and the next
+   * top-level key belongs to it. Everything else keeps its real reason, so the
+   * refusal message names what actually blocked it rather than asserting
+   * "different children" over a null, an anchor or a block scalar.
+   */
+  const blocker = (h: { at: number; rest: string }, nextAt: number): string | null => {
+    const v = h.rest;
+    if (v === '' || v.startsWith('#')) return 'a block key or a null value';
+    if (/^[|>]/.test(v)) return 'a block scalar';
+    // An anchor, alias or tag ANYWHERE in the value, not merely at its start:
+    // `a: [&x 1]` fits on one line, and dropping it deletes an anchor that an
+    // alias on some other line binds to — turning a duplicate-key error into
+    // an unresolved-alias error. Token position only, so `a&b` in a plain
+    // scalar is left alone.
+    if (/(^|[\s[{,])[&*!]/.test(v)) return 'an anchor, alias or tag';
+    // A flow collection must open and close on this line.
+    const opens = (v.match(/[[{]/g) ?? []).length;
+    const closes = (v.match(/[\]}]/g) ?? []).length;
+    if (opens !== closes) return 'a flow collection spanning lines';
+    for (let i = h.at + 1; i < nextAt; i++) {
+      const line = lines[i];
+      if (line === undefined) continue;
+      if (line.trim() === '') continue;
+      if (line.trimStart().startsWith('#')) continue;
+      return 'a value spanning more than its own line';
+    }
+    return null;
+  };
+
+  const solo = new Set<number>();
+  const why = new Map<number, string>();
+  for (let n = 0; n < heads.length; n++) {
+    const h = heads[n] as { key: string; at: number; rest: string };
+    const nextAt = n + 1 < heads.length ? (heads[n + 1] as { at: number }).at : lines.length;
+    const reason = blocker(h, nextAt);
+    if (reason === null) solo.add(h.at);
+    else why.set(h.at, reason);
+  }
+
+  const seen = new Map<string, number[]>();
+  for (const h of heads) {
+    const at = seen.get(h.key);
+    if (at === undefined) seen.set(h.key, [h.at]);
+    else at.push(h.at);
+  }
+
+  const collapsed: string[] = [];
+  const unsafe: string[] = [];
+  const drop = new Set<number>();
+  for (const [key, hits] of seen) {
+    if (hits.length < 2) continue;
+    if (!hits.every((i) => solo.has(i))) {
+      const reason = hits.map((i) => why.get(i)).find((r) => r !== undefined) ?? 'not a plain one-line value';
+      unsafe.push(`${key} — ${reason}`);
+      continue;
+    }
+    collapsed.push(key);
+    // Keep the LAST occurrence's value at the FIRST occurrence's position, so
+    // the surrounding comments stay attached to the line they document.
+    lines[hits[0] as number] = lines[hits[hits.length - 1] as number] as string;
+    for (let i = 1; i < hits.length; i++) drop.add(hits[i] as number);
+  }
+
+  // Duplicates this pass cannot even SEE, reported rather than skipped.
+  //
+  // `HEAD_RE` recognises the key shapes the repair understands. A key starting
+  // with a digit (`2fa.on`) or a quoted key (`"a:b"`) matches nothing, so a
+  // file duplicating one used to come back with zero collapses AND zero
+  // refusals — and then died on the strict parse with the same opaque "Map keys
+  // must be unique" the whole repair exists to remove, giving the operator no
+  // hint that their key was the part being skipped. Shipping a repair pass
+  // creates the expectation that it either fixes the file or says why it
+  // cannot; silence is neither.
+  //
+  // Detection only. These keys are never collapsed — the shapes are exactly the
+  // ones whose tokenisation this pass does not model, which is why it declines
+  // to rewrite them.
+  const loose = new Map<string, number>();
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line === undefined) continue;
+    if (line.trim() === '' || line.trimStart().startsWith('#')) continue;
+    if (line.length !== line.trimStart().length) continue;
+    if (HEAD_RE.test(line)) continue;
+    const m = /^("[^"]*"|'[^']*'|[^\s:#][^:]*?)[ \t]*:(?=[ \t]|$)/.exec(line);
+    if (m === null) continue;
+    const key = m[1] as string;
+    loose.set(key, (loose.get(key) ?? 0) + 1);
+  }
+  for (const [key, count] of loose) {
+    if (count < 2) continue;
+    unsafe.push(`${key} — a key shape this repair does not model (quoted, or not starting with a letter)`);
+  }
+
+  if (collapsed.length === 0) {
+    return { text, collapsed, unsafe };
+  }
+  const kept = lines.filter((_, i) => !drop.has(i));
+  return { text: kept.join(eol), collapsed, unsafe };
+}
+
+function loadUserText(raw: string): Record<string, unknown> {
+  const data = parseYaml(raw, { version: '1.1' });
   if (data === null || data === undefined) {
     return {};
   }
@@ -655,10 +845,61 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
   const templatePath = args.template;
   const profileDir = args.profile_dir;
 
+  // Repair BEFORE the first parse. A duplicate mapping key makes the whole
+  // file unreadable, so without this the run dies here and takes the release
+  // with it — see `collapseDuplicateFlatKeys` for why last-wins is safe.
+  const rawText = isFile(target) ? fs.readFileSync(target, 'utf-8') : '';
+  const repair = collapseDuplicateFlatKeys(rawText);
+  if (repair.unsafe.length > 0) {
+    // Each entry carries the reason that key was refused. A single blanket
+    // sentence used to claim "different children" for every refusal — over a
+    // null value, a block scalar or an anchor that has none — which sends the
+    // reader looking for children to merge that are not there.
+    process.stderr.write(
+      `error: ${target} has duplicate mapping keys this tool will not collapse:\n` +
+        repair.unsafe.map((u) => `  - ${u}\n`).join('') +
+        `Keeping one occurrence would change what the file means. Merge them by hand, then re-run.\n`,
+    );
+    return 2;
+  }
+  if (repair.collapsed.length > 0) {
+    // NOT gated on --quiet, and not on stdout. Both callers that matter run
+    // quiet — the release's `sync-agent-settings` step and the pre-release
+    // probe — so gating this would let a release rewrite the operator's own
+    // settings file with no trace. `--quiet` suppresses routine success
+    // chatter; "I modified your file" is not that.
+    //
+    // The tense follows the mode. `--check` and `--dry-run` never write, so
+    // announcing a completed collapse there describes a write that did not
+    // happen — and the pre-release probe runs `--dry-run`, which made that the
+    // FIRST thing an operator saw on every release with a corrupted file.
+    const writes = !args.check && !args.dry_run;
+    const verb = writes
+      ? `collapsed ${repair.collapsed.length} duplicate key(s), last value kept`
+      : `would collapse ${repair.collapsed.length} duplicate key(s), keeping the last value (no write in this mode)`;
+    process.stderr.write(`🔧  ${target}: ${verb} — ${repair.collapsed.join(', ')}\n`);
+
+    // The collapse promises to change only WHETHER the file parses, never what
+    // it parses as — and that promise is only meaningful over an input that had
+    // a reading to preserve. If the original was unparseable for some further
+    // reason (an unterminated quote, say), the repaired file may parse to
+    // structure no human wrote, and the next `git diff` shows keys nobody
+    // added. Cheap to say, and the operator cannot recover it from the output.
+    try {
+      parseYaml(rawText, { version: '1.1', uniqueKeys: false });
+    } catch {
+      process.stderr.write(
+        `⚠️   ${target}: the original had a syntax error beyond the duplicate keys, so the ` +
+          `result may differ in structure, not only in duplicates — read the diff before trusting it.\n`,
+      );
+    }
+  }
+  const sourceText = repair.text;
+
   let profile: string;
   let templateBody: string;
   try {
-    const userData = loadUser(target);
+    const userData = loadUserText(sourceText);
     const personalRaw = userData['personal'];
     const personal =
       personalRaw !== null && typeof personalRaw === 'object' && !Array.isArray(personalRaw)
@@ -706,7 +947,12 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
     throw err;
   }
 
-  const existingText = isFile(target) ? fs.readFileSync(target, 'utf-8') : '';
+  // The merge reads the REPAIRED text; every "did anything change" decision
+  // below compares against `rawText`, what is actually on disk. Comparing
+  // against the repaired text instead would report "already in sync" on a
+  // file whose collapse never reached disk — the repair would run on every
+  // invocation and fix nothing.
+  const existingText = sourceText;
 
   let newText: string;
   if (existingText) {
@@ -724,7 +970,7 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
     newText = templateBody;
   }
 
-  if (newText === existingText) {
+  if (newText === rawText) {
     if (!args.quiet) {
       process.stdout.write(`✅  ${target}: already in sync (profile=${profile})\n`);
     }
@@ -732,14 +978,28 @@ export function main(argv: readonly string[] = process.argv.slice(2)): number {
   }
 
   if (args.check) {
-    const diff = renderDiff(existingText, newText, String(target));
+    const diff = renderDiff(rawText, newText, String(target));
     process.stdout.write(diff);
-    process.stderr.write(`\n❌  ${target}: drift detected (profile=${profile})\n`);
+    // Name WHICH problem, because the two have different remedies and a CI job
+    // reading only "drift detected" cannot tell them apart. A repair-only diff
+    // means the file is corrupt, not out of step with the template; the
+    // discriminator is whether the merge changed anything beyond the collapse.
+    //
+    // Still exit 2 in both cases: the file needs a write either way, and a
+    // `--check` that returned 0 over a file the reader cannot parse would hide
+    // exactly the breakage this whole change exists to surface.
+    const repairOnly = repair.collapsed.length > 0 && newText === sourceText;
+    process.stderr.write(
+      repairOnly
+        ? `\n❌  ${target}: duplicate keys need collapsing — no template drift (profile=${profile})\n` +
+            `    Run \`sync_agent_settings\` without --check to apply the repair.\n`
+        : `\n❌  ${target}: drift detected (profile=${profile})\n`,
+    );
     return 2;
   }
 
   if (args.dry_run) {
-    const diff = renderDiff(existingText, newText, String(target));
+    const diff = renderDiff(rawText, newText, String(target));
     process.stdout.write(diff);
     if (!args.quiet) {
       process.stderr.write(`\n(dry-run) would update ${target} (profile=${profile})\n`);

--- a/src/server/io/yamlIO.ts
+++ b/src/server/io/yamlIO.ts
@@ -40,6 +40,25 @@ function formatScalar(value: unknown): string {
     return yamlDump(value, { lineWidth: -1, flowLevel: 0 }).replace(/\n$/, '').trim();
 }
 
+/**
+ * A NESTED mapping key, as both the presence probe and the insertion walk read
+ * one. Shared so the writer and its own existence-probe cannot drift apart —
+ * that drift is the shape this file has now hit four times.
+ *
+ * `-` is in the class because a dashed key is ordinary YAML (`first-name`,
+ * `dry-run`, `retry-count`) and `detectIndentWidth` already accepted one.
+ * While this pattern did not, `findScalarLine` could never find such a key:
+ * `mergeIntoTemplate` then wrote a bogus top-level `x.first-principles:` line
+ * beside the real nested one and the intended value was never written — a save
+ * that silently did nothing — and `upsertScalar` appended another child line on
+ * EVERY call, growing without bound until the file stopped parsing.
+ *
+ * `.` stays OUT, deliberately. A dotted key is the FLAT form, which
+ * `replaceFlatDottedKey` owns; letting this pattern match `a.b:` would make the
+ * nested probe claim a line that is one key literally named "a.b".
+ */
+const NESTED_KEY_RE = /^([A-Za-z_][A-Za-z0-9_-]*)\s*:/;
+
 interface FlatEntry {
     path: string[];
     value: unknown;
@@ -68,6 +87,25 @@ export function replaceScalar(template: string, dottedPath: string[], value: unk
     const key = dottedPath[dottedPath.length - 1];
 
     const lines = template.split('\n');
+    const at = findScalarLine(lines, sections, key);
+    if (at === -1) return template;
+    const width = detectIndentWidth(lines);
+    lines[at] = `${' '.repeat(width * sections.length)}${key}: ${formatScalar(value)}`;
+    return lines.join('\n');
+}
+
+/**
+ * Index of the line holding the scalar at `sections`/`key`, or -1.
+ *
+ * Split out of `replaceScalar` so that "is this path present?" is answerable
+ * WITHOUT writing. `mergeIntoTemplate` used to infer presence from
+ * `replaceScalar` returning a changed string, which conflates "absent" with
+ * "present and already equal to the value being written" — under that test a
+ * no-op write reads as a miss and the caller appends a duplicate mapping key.
+ * A presence question answered by a mutation's side effect is the shape to
+ * look for here; the file already carries two earlier rounds of it.
+ */
+function findScalarLine(lines: readonly string[], sections: readonly string[], key: string | undefined): number {
     // The document's own width, the same read `upsertScalar` performs.
     //
     // R2 round 5, finding 1, and it is the second half of round 4's finding 7.
@@ -84,9 +122,7 @@ export function replaceScalar(template: string, dottedPath: string[], value: unk
     // A writer and its own existence-probe disagreeing about the format is the
     // shape to look for whenever one of a pair is taught something new.
     const width = detectIndentWidth(lines);
-    const targetIndent = ' '.repeat(width * sections.length);
     const currentPath: (string | null)[] = new Array<string | null>(sections.length).fill(null);
-    const formatted = formatScalar(value);
 
     for (let i = 0; i < lines.length; i++) {
         const line = lines[i];
@@ -98,7 +134,7 @@ export function replaceScalar(template: string, dottedPath: string[], value: unk
         const level = indentLen / width;
         if (level > sections.length) continue;
 
-        const m = /^([A-Za-z_][A-Za-z0-9_]*)\s*:/.exec(stripped);
+        const m = NESTED_KEY_RE.exec(stripped);
         if (!m) continue;
         const lineKey = m[1];
         if (lineKey === undefined) continue;
@@ -115,10 +151,9 @@ export function replaceScalar(template: string, dottedPath: string[], value: unk
         const parentsMatch = sections.every((s, idx) => currentPath[idx] === s);
         if (!parentsMatch) continue;
         if (lineKey !== key) continue;
-        lines[i] = `${targetIndent}${key}: ${formatted}`;
-        return lines.join('\n');
+        return i;
     }
-    return template;
+    return -1;
 }
 
 /**
@@ -182,11 +217,21 @@ export function detectIndentWidth(lines: readonly string[]): number {
  */
 export function upsertScalar(template: string, dottedPath: string[], value: unknown): string {
     if (dottedPath.length === 0) return template;
-    const replaced = replaceScalar(template, dottedPath, value);
-    if (replaced !== template) return replaced;
-
     const sections = dottedPath.slice(0, -1);
     const key = dottedPath[dottedPath.length - 1] as string;
+
+    // Presence is asked, never inferred from the write changing the text. The
+    // string compare that used to stand here read "key already holds this
+    // value" as "key absent" and fell through to the append below — so saving
+    // the wizard's council page twice WITHOUT changing a toggle wrote a second
+    // `api_on_quota:` into the same block, over two `{ok: true}` responses, and
+    // left `.ai-council.yml` rejected by a strict parser. Third instance of one
+    // shape in this file; `findScalarLine` exists to end it, and a fix that
+    // taught only `mergeIntoTemplate` would have left the live path here.
+    if (findScalarLine(template.split('\n'), sections, key) !== -1) {
+        return replaceScalar(template, dottedPath, value);
+    }
+
     const formatted = formatScalar(value);
     const lines = template.split('\n');
     // The document's OWN indent width, not an assumed two.
@@ -228,7 +273,7 @@ export function upsertScalar(template: string, dottedPath: string[], value: unkn
             if (line.trim() === '' || line.trim().startsWith('#')) continue;
             const indentLen = line.length - line.trimStart().length;
             if (indentLen !== indent.length) continue;
-            const m = /^([A-Za-z_][A-Za-z0-9_]*)\s*:/.exec(line.trim());
+            const m = NESTED_KEY_RE.exec(line.trim());
             if (m !== null && m[1] === want) {
                 found = i;
                 break;
@@ -270,22 +315,87 @@ export function upsertScalar(template: string, dottedPath: string[], value: unkn
 }
 
 /**
+ * Rewrite an existing top-level `a.b.c: value` line — the FLAT form
+ * `mergeIntoTemplate` itself appends when a path has no template entry.
+ * Returns the template unchanged when no such line exists.
+ *
+ * `replaceScalar` cannot see this line: its key pattern is
+ * `[A-Za-z_][A-Za-z0-9_]*`, with no dot, so a path this module appended on
+ * one pass is invisible to the probe on the next and `mergeIntoTemplate`
+ * appends a SECOND copy. Two wizard saves therefore produce a file carrying
+ * duplicate mapping keys — a strict parser rejects it outright, which is what
+ * wedged `task release`: its `sync` step exits 2 with "Map keys must be
+ * unique" before the release does any git work.
+ *
+ * A pre-existing duplicate run is COLLAPSED, not merely updated: the first
+ * occurrence keeps its position and takes the new value, every later one is
+ * dropped. Collapsing is value-neutral — a lenient reader already resolved
+ * such a run last-wins — and it is the only way a file corrupted by the old
+ * behaviour becomes parseable again through the ordinary write path.
+ *
+ * Deliberately NOT folded into `replaceScalar`: `upsertScalar` calls that
+ * probe and documents the flat form as the WRONG shape for a nested key (a
+ * reader sees one key literally named "a.b"). Teaching the shared probe to
+ * match it would make `upsertScalar` write into that broken line instead of
+ * creating the nesting. The flat form is legitimate only here, where this
+ * function is the one that wrote it.
+ */
+function replaceFlatDottedKey(
+    template: string,
+    dottedPath: string[],
+    value: unknown,
+): { found: boolean; body: string } {
+    if (dottedPath.length < 2) return { found: false, body: template };
+    const flat = dottedPath.join('.');
+    const lines = template.split('\n');
+    const hits: number[] = [];
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (line === undefined) continue;
+        // Top level only — an indented `a.b:` is somebody else's child key.
+        if (line.length !== line.trimStart().length) continue;
+        const m = /^([A-Za-z_][A-Za-z0-9_.-]*)\s*:/.exec(line);
+        if (m === null || m[1] !== flat) continue;
+        hits.push(i);
+    }
+    if (hits.length === 0) return { found: false, body: template };
+    lines[hits[0] as number] = `${flat}: ${formatScalar(value)}`;
+    // Drop the later copies back-to-front so the earlier indices stay valid.
+    for (let i = hits.length - 1; i >= 1; i--) lines.splice(hits[i] as number, 1);
+    return { found: true, body: lines.join('\n') };
+}
+
+/**
  * Apply every leaf change from `newValues` to `templateBody`. Paths that
  * are not present in the template are appended at the end. Comments are
  * preserved for every key that already exists in the template.
+ *
+ * Idempotent: applying the same values twice yields the same document, so a
+ * second wizard save re-writes the flat block instead of duplicating it.
  */
 export function mergeIntoTemplate(templateBody: string, newValues: Record<string, unknown>): string {
     let body = templateBody;
     const appended: string[] = [];
     for (const entry of flatten(newValues)) {
-        const before = body;
-        body = replaceScalar(body, entry.path, entry.value);
-        if (body === before) {
-            // Path is not in the template — append a flat key=value at EOF.
-            // Form coverage is asserted by parity test, so this branch only
-            // fires on hand-edited templates.
-            appended.push(`${entry.path.join('.')}: ${formatScalar(entry.value)}`);
+        const sections = entry.path.slice(0, -1);
+        const leaf = entry.path[entry.path.length - 1];
+        // Presence is asked, never inferred from the write changing the text —
+        // see `findScalarLine`. Writing the value it already holds is a hit.
+        if (findScalarLine(body.split('\n'), sections, leaf) !== -1) {
+            body = replaceScalar(body, entry.path, entry.value);
+            continue;
         }
+        // Not in the template's nested form. It may still be here as a flat
+        // dotted line this function appended on an earlier pass.
+        const flat = replaceFlatDottedKey(body, entry.path, entry.value);
+        if (flat.found) {
+            body = flat.body;
+            continue;
+        }
+        // Genuinely absent — append a flat key=value at EOF. Form coverage is
+        // asserted by parity test, so this branch only fires on hand-edited
+        // templates.
+        appended.push(`${entry.path.join('.')}: ${formatScalar(entry.value)}`);
     }
     if (appended.length > 0) {
         if (!body.endsWith('\n')) body += '\n';

--- a/taskfiles/content.yml
+++ b/taskfiles/content.yml
@@ -16,8 +16,14 @@ tasks:
     silent: true
     desc: Reconcile local .agent-settings.yml with the canonical template (skipped on fresh clones)
     cmds:
+      # Both locations, because the SCRIPT resolves canonical-first
+      # (`resolveSettingsRead`: agents/settings/ then the repo-root legacy
+      # file). Guarding on the repo-root path alone skipped the sync entirely
+      # on any checkout carrying only the canonical file — which is the layout
+      # ADR-038 made standard, so the guard was answering a question about a
+      # different file than the one the script reads.
       - |
-        if [ -f .agent-settings.yml ]; then
+        if [ -f agents/settings/.agent-settings.yml ] || [ -f .agent-settings.yml ]; then
           ./scripts-run src/scripts/sync_agent_settings --quiet
         else
           echo "ℹ️  .agent-settings.yml absent — skipping sync (run src/scripts/install.py for first-run setup)"

--- a/taskfiles/release.yml
+++ b/taskfiles/release.yml
@@ -1,6 +1,41 @@
 version: '3'
 
 tasks:
+  # Prove the release's own first read works, before anything else runs.
+  #
+  # `task release` step 2 of 10 is `task release-prepare`, whose `sync` step
+  # reads `agents/settings/.agent-settings.yml`. That file is gitignored local
+  # state: no CI job sees it, no fixture covers it, and a file the reader
+  # chokes on is discovered only by running a release — after the version bump,
+  # with package.json, the manifests and the CHANGELOG already rewritten.
+  # 15.0.0 hit exactly that on 47 duplicate mapping keys.
+  #
+  # `--dry-run` so the probe cannot write (the release asserts a clean tree
+  # moments later, and a probe that dirtied it would fail the check it is
+  # standing in front of). Drift is not a failure — the sync exits 0 whether or
+  # not the file is in step with the template, so this fires only on a file
+  # that cannot be READ. A gate that also fired on ordinary drift would fire on
+  # nearly every release and be switched off inside a month.
+  #
+  # stdout to /dev/null because a dry-run prints the drift diff; the diagnosis
+  # goes to stderr and survives.
+  #
+  # A Taskfile step rather than a guard inside release.ts: that file is 1826
+  # lines against a 1500-line shrink-only budget, so wiring three lines into
+  # `main()` would need a governance exception for a check that costs nothing
+  # here and runs at the same moment.
+  # The same existence test `sync-agent-settings` uses, for the same reason: on
+  # a fresh clone with no settings file the release skips the sync, so a probe
+  # that blocked there would refuse a release the sync would not have run at
+  # all. Both locations, because the script resolves canonical-first.
+  _settings-readable:
+    internal: true
+    silent: true
+    cmd: |
+      if [ -f agents/settings/.agent-settings.yml ] || [ -f .agent-settings.yml ]; then
+        ./scripts-run src/scripts/sync_agent_settings --dry-run --quiet > /dev/null
+      fi
+
   release:
     desc: |
       Release a new version end-to-end with auto-detected bump (the
@@ -18,7 +53,9 @@ tasks:
       task release -- --dry-run        # preview only
       task release -- --yes --no-wait  # non-interactive
     interactive: true
-    cmd: ./scripts-run src/scripts/release {{.CLI_ARGS}}
+    cmds:
+      - task: _settings-readable
+      - ./scripts-run src/scripts/release {{.CLI_ARGS}}
 
   release:verify:
     desc: |
@@ -33,7 +70,12 @@ tasks:
       task release:verify
       task release:verify -- --version 14.17.0
       task release:verify -- --list
-    cmd: ./scripts-run src/scripts/release_verify {{.CLI_ARGS}}
+    cmds:
+      # This is the documented "run it before `task release`" command, so the
+      # local-state probe belongs here too — otherwise the pre-check reports
+      # green for a release that dies at step 2.
+      - task: _settings-readable
+      - ./scripts-run src/scripts/release_verify {{.CLI_ARGS}}
 
   release:drill:
     desc: |

--- a/tests/scripts/sync_agent_settings.duplicate_repair.test.ts
+++ b/tests/scripts/sync_agent_settings.duplicate_repair.test.ts
@@ -1,0 +1,438 @@
+/**
+ * `sync_agent_settings` over a settings file that already carries duplicate
+ * mapping keys.
+ *
+ * A duplicate top-level key makes the whole document unreadable to a strict
+ * parser, and `loadUser` was the first thing `main` did — so one such pair
+ * exited 2 and took `task sync`, `task release-prepare` and every release with
+ * it. The duplicates were written by `mergeIntoTemplate`'s non-idempotent flat
+ * append (fixed, and pinned by tests/server/yamlIO.merge-idempotence.test.ts),
+ * but that fix does nothing for the files it already corrupted. This is the
+ * other half: an install that ran the wizard twice must be able to sync again
+ * without a hand edit, because a release is the worst moment to find out.
+ *
+ * The invariant the repair must hold is VALUE-NEUTRALITY: a lenient reader
+ * already resolved a duplicate run last-wins, so collapsing changes only
+ * whether the file parses, never what it parses as.
+ */
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { parse as parseYaml } from 'yaml';
+
+import { collapseDuplicateFlatKeys, main } from '../../src/scripts/sync_agent_settings.js';
+
+const TEMPLATE = `rule_loading_tier: __RULE_LOADING_TIER__
+
+personal:
+  ide: ""
+`;
+const INI = `rule_loading_tier=minimal\n`;
+
+let workspace = '';
+
+function makeWorkspace(): string {
+    const ws = fs.mkdtempSync(path.join(os.tmpdir(), 'sas-dup-'));
+    fs.mkdirSync(path.join(ws, 'config', 'profiles'), { recursive: true });
+    fs.writeFileSync(path.join(ws, 'config', 'agent-settings.template.yml'), TEMPLATE, 'utf-8');
+    fs.writeFileSync(path.join(ws, 'config', 'profiles', 'minimal.ini'), INI, 'utf-8');
+    return ws;
+}
+
+function run(ws: string, extra: string[] = []): number {
+    return main([
+        '--path', path.join(ws, '.agent-settings.yml'),
+        '--template', path.join(ws, 'config', 'agent-settings.template.yml'),
+        '--profile-dir', path.join(ws, 'config', 'profiles'),
+        '--quiet',
+        ...extra,
+    ]);
+}
+
+afterEach(() => {
+    if (workspace !== '' && fs.existsSync(workspace)) {
+        fs.rmSync(workspace, { recursive: true, force: true });
+    }
+});
+
+/** The shape the old writer produced: the flat block appended twice. */
+const CORRUPTED = [
+    'rule_loading_tier: minimal',
+    'personal:',
+    '  ide: phpstorm',
+    '',
+    '# Wizard-added keys (no template entry)',
+    'profile.id: developer',
+    'cost.enforcement: advisory',
+    '',
+    '# Wizard-added keys (no template entry)',
+    'profile.id: maintainer',
+    'cost.enforcement: blocking',
+    '',
+].join('\n');
+
+describe('collapseDuplicateFlatKeys', () => {
+    it('collapses a duplicate run last-wins and leaves the file strict-parseable', () => {
+        expect(() => parseYaml(CORRUPTED, { uniqueKeys: true })).toThrow(/unique/i);
+
+        const r = collapseDuplicateFlatKeys(CORRUPTED);
+        expect(r.collapsed).toEqual(['profile.id', 'cost.enforcement']);
+        expect(r.unsafe).toEqual([]);
+
+        const doc = parseYaml(r.text, { uniqueKeys: true }) as Record<string, unknown>;
+        expect(doc['profile.id']).toBe('maintainer');
+        expect(doc['cost.enforcement']).toBe('blocking');
+    });
+
+    it('is value-neutral against the lenient last-wins read every reader saw', () => {
+        const before = parseYaml(CORRUPTED, { version: '1.1', uniqueKeys: false });
+        const after = parseYaml(collapseDuplicateFlatKeys(CORRUPTED).text, { version: '1.1' });
+        expect(after).toEqual(before);
+    });
+
+    it('REFUSES a duplicated block key rather than deleting the loser children', () => {
+        // Last-wins on a block key drops the other occurrence's children —
+        // silent data loss, strictly worse than the parse error it would cure.
+        const blocks = 'personal:\n  ide: phpstorm\npersonal:\n  autonomy: "on"\n';
+        const r = collapseDuplicateFlatKeys(blocks);
+        expect(r.collapsed).toEqual([]);
+        expect(r.unsafe).toHaveLength(1);
+        expect(r.unsafe[0]).toContain('personal');
+        expect(r.text).toBe(blocks);
+    });
+
+    // Every shape whose value outlives its own line. The first classifier
+    // called all of these "inline" because the text after the colon was
+    // non-empty, and dropping the loser then
+    // removed only its HEADER line: the body survived, stopped being that key's
+    // value, and re-attached to whatever preceded it. That is not the parse
+    // error being cured — it is silent corruption replacing it, and it broke
+    // the value-neutrality this pass promises.
+    it.each([
+        [
+            'block scalar',
+            'a: |\n  text\nb: 1\na: |\n  other\n',
+            // Old behaviour: `a` kept the FIRST body and `b` became "1 other".
+        ],
+        ['anchored block', 'd: &d\n  x: 1\nz: 0\nd: &e\n  y: 2\n'],
+        ['multi-line flow collection', 'l: [\n  1,\n  2\n]\nm: 0\nl: [\n  3\n]\n'],
+        ['folded scalar', 'a: >\n  one\nb: 1\na: >\n  two\n'],
+    ])('REFUSES a duplicate whose value spans lines — %s', (_name, doc) => {
+        const r = collapseDuplicateFlatKeys(doc);
+        expect(r.collapsed).toEqual([]);
+        expect(r.unsafe).toHaveLength(1);
+        expect(r.text).toBe(doc);
+    });
+
+    it('REFUSES a duplicate carrying an anchor, even on one line', () => {
+        // The one span-case the continuation scan cannot see: `&a 1` fits on
+        // its own line, so only the anchor check refuses it. Dropping the
+        // loser would delete an anchor definition an alias elsewhere binds to,
+        // which changes the parse of a line this pass never looked at.
+        const doc = 'x: &a 1\ny: 0\nx: &b 2\n';
+        const r = collapseDuplicateFlatKeys(doc);
+        expect(r.collapsed).toEqual([]);
+        expect(r.unsafe).toHaveLength(1);
+        expect(r.text).toBe(doc);
+    });
+
+    it('repairs a CRLF document and keeps its line endings', () => {
+        // Splitting on `\n` alone leaves a trailing `\r` on every line, which
+        // the key pattern never matches — so a CRLF file reported zero
+        // duplicates and fell straight into the parse error this pass exists
+        // to prevent. Silent, and indistinguishable from a healthy file.
+        const doc = 'a: 1\r\nb: 2\r\na: 3\r\n';
+        expect(() => parseYaml(doc, { uniqueKeys: true })).toThrow(/unique/i);
+
+        const r = collapseDuplicateFlatKeys(doc);
+        expect(r.collapsed).toEqual(['a']);
+        expect(r.text).toContain('\r\n');
+        expect(r.text).not.toMatch(/[^\r]\n/);
+        const parsed = parseYaml(r.text, { uniqueKeys: true }) as Record<string, unknown>;
+        expect(parsed).toEqual({ a: 3, b: 2 });
+    });
+
+    it('does not read `a:b:` as the key `a` and delete the `a:b` entry', () => {
+        // A mapping key ends at a colon followed by SPACE, which is YAML's own
+        // plain-scalar rule. Stopping at the first colon saw two `a` heads
+        // here, collapsed them, and dropped `a:b` — and the result parsed
+        // cleanly, so nothing downstream could notice the loss. Silent
+        // deletion is the exact failure the value-neutrality promise is about.
+        const doc = 'a:b: 1\nx: 0\na: 2\n';
+        const before = parseYaml(doc, { version: '1.1', uniqueKeys: false });
+
+        const r = collapseDuplicateFlatKeys(doc);
+        expect(r.collapsed).toEqual([]);
+        expect(r.text).toBe(doc);
+        expect(parseYaml(r.text, { version: '1.1', uniqueKeys: false })).toEqual(before);
+    });
+
+    it('REFUSES a duplicate whose one-line value defines an anchor inside a flow collection', () => {
+        // `[&x 1]` fits on its own line, so neither the continuation scan nor a
+        // start-of-value anchor check sees it. Dropping it deletes the anchor
+        // an alias on another line binds to, turning a duplicate-key error into
+        // an unresolved-alias error — a different broken file, not a fixed one.
+        const doc = 'a: [&x 1]\nb: *x\na: [2]\n';
+        const r = collapseDuplicateFlatKeys(doc);
+        expect(r.collapsed).toEqual([]);
+        expect(r.text).toBe(doc);
+    });
+
+    it('sees a duplicate on a line carrying a lone carriage return', () => {
+        // `.` does not match `\r`, so the head pattern skipped such a line and
+        // the duplicate stayed invisible — the parse error survived untouched.
+        const doc = 'a: "x\ry"\nb: 2\na: 3\n';
+        expect(() => parseYaml(doc, { uniqueKeys: true })).toThrow(/unique/i);
+
+        const r = collapseDuplicateFlatKeys(doc);
+        expect(r.collapsed).toEqual(['a']);
+        expect(() => parseYaml(r.text, { uniqueKeys: true })).not.toThrow();
+    });
+
+    it('keeps a mostly-LF file on LF even when one line ends CRLF', () => {
+        // "any CRLF present" rewrote every line ending in the file — a
+        // whole-file change on a pass that promises to touch only what it must.
+        const doc = 'a: 1\r\nb: 2\na: 3\n';
+        const r = collapseDuplicateFlatKeys(doc);
+        expect(r.collapsed).toEqual(['a']);
+        expect(r.text).not.toContain('\r\n');
+    });
+
+    it('names the real reason for each refusal', () => {
+        // One blanket "occurrences carry different children" was printed over
+        // nulls, block scalars and anchors alike, sending the reader to look
+        // for children that do not exist.
+        expect(collapseDuplicateFlatKeys('k: # c\nb: 0\nk: # d\n').unsafe[0]).toMatch(/null value/);
+        expect(collapseDuplicateFlatKeys('k: |\n  a\nb: 0\nk: |\n  c\n').unsafe[0]).toMatch(/block scalar/);
+        expect(collapseDuplicateFlatKeys('k: &a 1\nb: 0\nk: &c 2\n').unsafe[0]).toMatch(/anchor/);
+    });
+
+    it('does not touch a multi-document stream', () => {
+        // Two documents may legitimately carry the same key. The reader takes
+        // a single document and rejects the file either way, so the only thing
+        // collapsing could achieve here is merging two documents into one.
+        const doc = 'a: 1\n---\na: 2\n';
+        const r = collapseDuplicateFlatKeys(doc);
+        expect(r.collapsed).toEqual([]);
+        expect(r.text).toBe(doc);
+    });
+
+    it('leaves a clean file byte-identical', () => {
+        const clean = 'a: 1\nb:\n  c: 2\n';
+        const r = collapseDuplicateFlatKeys(clean);
+        expect(r.text).toBe(clean);
+        expect(r.collapsed).toEqual([]);
+        expect(r.unsafe).toEqual([]);
+    });
+});
+
+describe('sync_agent_settings over a corrupted file', () => {
+    it('repairs, syncs and writes the repair to disk', () => {
+        workspace = makeWorkspace();
+        const target = path.join(workspace, '.agent-settings.yml');
+        fs.writeFileSync(target, CORRUPTED, 'utf-8');
+
+        // The pre-fix behaviour was exit 2 here, which is what killed the release.
+        expect(run(workspace)).toBe(0);
+
+        const written = fs.readFileSync(target, 'utf-8');
+        // The collapse must REACH DISK. Comparing "did anything change" against
+        // the repaired text instead of the raw file reports "already in sync"
+        // and writes nothing, so the repair runs forever and fixes nothing.
+        expect(() => parseYaml(written, { uniqueKeys: true })).not.toThrow();
+        expect((written.match(/^profile\.id:/gm) ?? []).length).toBe(1);
+
+        // Second run has nothing left to do.
+        expect(run(workspace)).toBe(0);
+        expect(fs.readFileSync(target, 'utf-8')).toBe(written);
+    });
+
+    it('exits 2 with a hand-merge instruction on a duplicated block key', () => {
+        workspace = makeWorkspace();
+        const target = path.join(workspace, '.agent-settings.yml');
+        const blocks = 'rule_loading_tier: minimal\npersonal:\n  ide: phpstorm\npersonal:\n  user_name: x\n';
+        fs.writeFileSync(target, blocks, 'utf-8');
+
+        // Exit 2 alone proves nothing here — the bare parse failure this
+        // change replaced also exits 2, so an exit-code-only assertion stays
+        // green with the whole repair pass removed. The MESSAGE is what
+        // separates a deliberate refusal from a crash.
+        const stderr: string[] = [];
+        const original = process.stderr.write.bind(process.stderr);
+        process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+            stderr.push(String(chunk));
+            return true;
+        }) as typeof process.stderr.write;
+        let code: number;
+        try {
+            code = run(workspace);
+        } finally {
+            process.stderr.write = original;
+        }
+
+        expect(code).toBe(2);
+        const said = stderr.join('');
+        expect(said).toContain('duplicate mapping keys this tool will not collapse');
+        expect(said).toContain('Merge them by hand');
+        // Refusing means leaving the file alone, not half-repairing it.
+        expect(fs.readFileSync(target, 'utf-8')).toBe(blocks);
+    });
+});
+
+/**
+ * The repair notice itself. A review found it unpinned: re-gating it on
+ * `--quiet` left every other test green, and both callers that matter pass
+ * `--quiet` — so a release could have rewritten the operator's settings file
+ * with no trace at all and nothing would have failed.
+ */
+describe('the repair notice', () => {
+    /** Run `main` capturing stderr, so the notice can be asserted on. */
+    function runCapturing(ws: string, extra: string[] = []): { code: number; err: string } {
+        const chunks: string[] = [];
+        const original = process.stderr.write.bind(process.stderr);
+        process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+            chunks.push(String(chunk));
+            return true;
+        }) as typeof process.stderr.write;
+        try {
+            return { code: run(ws, extra), err: chunks.join('') };
+        } finally {
+            process.stderr.write = original;
+        }
+    }
+
+    it('is printed even under --quiet, because both real callers are quiet', () => {
+        workspace = makeWorkspace();
+        fs.writeFileSync(path.join(workspace, '.agent-settings.yml'), CORRUPTED, 'utf-8');
+
+        const { code, err } = runCapturing(workspace);
+        expect(code).toBe(0);
+        expect(err).toContain('collapsed 2 duplicate key(s)');
+        expect(err).toContain('profile.id');
+    });
+
+    it.each([['--check', 2], ['--dry-run', 0]] as const)(
+        'says "would collapse", not "collapsed", under %s — no write happens there',
+        (flag, expected) => {
+            workspace = makeWorkspace();
+            const target = path.join(workspace, '.agent-settings.yml');
+            fs.writeFileSync(target, CORRUPTED, 'utf-8');
+
+            const { code, err } = runCapturing(workspace, [flag]);
+            expect(code).toBe(expected);
+            // The pre-release probe runs --dry-run, so the past tense here was
+            // the first thing an operator saw on a release with a broken file.
+            expect(err).toContain('would collapse');
+            expect(err).not.toMatch(/: collapsed /);
+            // And the claim matches reality: the file is untouched.
+            expect(fs.readFileSync(target, 'utf-8')).toBe(CORRUPTED);
+        },
+    );
+});
+
+/**
+ * Council verdict, 2026-09-10: a repair pass must either fix the file or say
+ * why it cannot. Silence over a key it skipped hands the operator the same
+ * opaque "Map keys must be unique" the pass exists to remove, with no hint that
+ * their key was the part being skipped.
+ */
+describe('keys the repair cannot model', () => {
+    it.each([
+        ['digit-leading', '2fa.on: 1\nb: 0\n2fa.on: 2\n', '2fa.on'],
+        ['quoted', '"a:b": 1\nx: 0\n"a:b": 2\n', '"a:b"'],
+    ])('reports a duplicated %s key instead of silently skipping it', (_n, doc, key) => {
+        const r = collapseDuplicateFlatKeys(doc);
+        expect(r.collapsed).toEqual([]);
+        expect(r.unsafe).toHaveLength(1);
+        expect(r.unsafe[0]).toContain(key);
+        // Detection only — such a key is never rewritten.
+        expect(r.text).toBe(doc);
+    });
+
+    it('stays silent when such a key appears only once', () => {
+        expect(collapseDuplicateFlatKeys('2fa.on: 1\nb: 0\n').unsafe).toEqual([]);
+    });
+});
+
+describe('--check distinguishes a repair from template drift', () => {
+    function runCapturing(ws: string, extra: string[] = []): { code: number; err: string } {
+        const chunks: string[] = [];
+        const original = process.stderr.write.bind(process.stderr);
+        process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+            chunks.push(String(chunk));
+            return true;
+        }) as typeof process.stderr.write;
+        try {
+            return { code: run(ws, extra), err: chunks.join('') };
+        } finally {
+            process.stderr.write = original;
+        }
+    }
+
+    it('names the duplicate keys rather than calling a corrupt file "drift"', () => {
+        workspace = makeWorkspace();
+        const target = path.join(workspace, '.agent-settings.yml');
+        // In sync with the template, so the ONLY difference is the collapse.
+        fs.writeFileSync(target, 'rule_loading_tier: minimal\npersonal:\n  ide: ""\nk: 1\nk: 2\n', 'utf-8');
+
+        const { code, err } = runCapturing(workspace, ['--check']);
+        // Still 2 — the file needs a write either way, and a green --check over
+        // a file the reader cannot parse would hide the breakage.
+        expect(code).toBe(2);
+        expect(err).toContain('duplicate keys need collapsing');
+        expect(err).toContain('no template drift');
+        expect(err).not.toMatch(/drift detected/);
+    });
+
+    it('still says "drift detected" when the template genuinely moved', () => {
+        workspace = makeWorkspace();
+        const target = path.join(workspace, '.agent-settings.yml');
+        fs.writeFileSync(target, 'rule_loading_tier: minimal\n', 'utf-8');
+
+        const { code, err } = runCapturing(workspace, ['--check']);
+        expect(code).toBe(2);
+        expect(err).toContain('drift detected');
+    });
+});
+
+describe('the unparseable-input warning', () => {
+    it('fires when the original was broken beyond its duplicate keys', () => {
+        workspace = makeWorkspace();
+        const target = path.join(workspace, '.agent-settings.yml');
+        // An unterminated quote: the collapse can turn this into a document
+        // that parses to structure no human wrote.
+        fs.writeFileSync(target, 'rule_loading_tier: minimal\na: "x\nk: 1\nk: 2\n', 'utf-8');
+
+        const chunks: string[] = [];
+        const original = process.stderr.write.bind(process.stderr);
+        process.stderr.write = ((c: string | Uint8Array): boolean => {
+            chunks.push(String(c));
+            return true;
+        }) as typeof process.stderr.write;
+        try {
+            run(workspace, ['--dry-run']);
+        } finally {
+            process.stderr.write = original;
+        }
+        expect(chunks.join('')).toContain('syntax error beyond the duplicate keys');
+    });
+
+    it('stays silent on an input whose only problem was the duplicates', () => {
+        workspace = makeWorkspace();
+        fs.writeFileSync(path.join(workspace, '.agent-settings.yml'), CORRUPTED, 'utf-8');
+
+        const chunks: string[] = [];
+        const original = process.stderr.write.bind(process.stderr);
+        process.stderr.write = ((c: string | Uint8Array): boolean => {
+            chunks.push(String(c));
+            return true;
+        }) as typeof process.stderr.write;
+        try {
+            run(workspace, ['--dry-run']);
+        } finally {
+            process.stderr.write = original;
+        }
+        expect(chunks.join('')).not.toContain('syntax error beyond');
+    });
+});

--- a/tests/server/yamlIO.merge-idempotence.test.ts
+++ b/tests/server/yamlIO.merge-idempotence.test.ts
@@ -1,0 +1,196 @@
+/**
+ * `mergeIntoTemplate` — the write path for a key with NO template entry, run
+ * more than once.
+ *
+ * The defect, measured on a real install: the fallback branch appends a flat
+ * `a.b: value` line under a "Wizard-added keys" comment, and `replaceScalar`'s
+ * key pattern has no dot — so on the next save the probe cannot see the line
+ * it just wrote and appends the whole block again. Two wizard saves produce a
+ * file with 47 duplicate mapping keys, which a strict parser rejects outright.
+ * `task sync` exits 2 on it, and `task release` dies in `release-prepare`
+ * before doing any git work.
+ *
+ * Two independent causes had to be fixed and both are pinned here, because
+ * either one alone reproduces the corruption:
+ *
+ *   1. The flat form was invisible to the probe.
+ *   2. Presence was inferred from the write CHANGING the text, so writing a
+ *      value a key already holds read as "absent" and appended a duplicate.
+ *
+ * Cause 2 is the subtler one and needs its own case: with only cause 1 fixed,
+ * a save that changes nothing still duplicates.
+ */
+import { describe, expect, it } from 'vitest';
+import { parse as parseYaml } from 'yaml';
+
+import { mergeIntoTemplate, replaceScalar, upsertScalar } from '../../src/server/io/yamlIO.js';
+
+/** Strict parse — throws "Map keys must be unique" on a duplicate. */
+const strict = (body: string): unknown => parseYaml(body, { uniqueKeys: true });
+
+describe('mergeIntoTemplate idempotence', () => {
+    it('does not duplicate an appended flat key on a second identical save', () => {
+        const template = 'foo: 1\n';
+        const values = { profile: { id: 'developer' } };
+
+        const once = mergeIntoTemplate(template, values);
+        const twice = mergeIntoTemplate(once, values);
+
+        expect(twice).toBe(once);
+        expect(() => strict(twice)).not.toThrow();
+        expect((once.match(/^profile\.id:/gm) ?? []).length).toBe(1);
+    });
+
+    it('updates an appended flat key in place instead of appending a rival', () => {
+        const template = 'foo: 1\n';
+        const once = mergeIntoTemplate(template, { profile: { id: 'developer' } });
+        const changed = mergeIntoTemplate(once, { profile: { id: 'maintainer' } });
+
+        expect((changed.match(/^profile\.id:/gm) ?? []).length).toBe(1);
+        expect(changed).toContain('profile.id: maintainer');
+        expect(changed).not.toContain('profile.id: developer');
+        expect(() => strict(changed)).not.toThrow();
+    });
+
+    it('treats a no-op write to an EXISTING nested key as a hit, not a miss', () => {
+        // Cause 2 in isolation: the key is in the template's nested form and
+        // already carries the value being written, so the write returns a
+        // BYTE-IDENTICAL string. Inferring absence from that appends a flat
+        // `personal.ide:` beside the real nested one.
+        //
+        // The value has to survive `formatScalar` unchanged for this to be a
+        // real no-op — an earlier draft used `autonomy: "on"`, which comes back
+        // as `'on'` (YAML 1.1 reads bare `on` as a boolean, so it is requoted).
+        // The rewrite differed by two bytes, the string compare read "present",
+        // and the case tested nothing. A no-op test whose write is not actually
+        // a no-op is the failure mode to watch for here.
+        const template = 'personal:\n  ide: phpstorm\n';
+        expect(replaceScalar(template, ['personal', 'ide'], 'phpstorm')).toBe(template);
+
+        const after = mergeIntoTemplate(template, { personal: { ide: 'phpstorm' } });
+
+        expect(after).not.toContain('Wizard-added keys');
+        expect(after).not.toMatch(/^personal\.ide:/m);
+        expect(() => strict(after)).not.toThrow();
+    });
+
+    it('stays idempotent across many keys and repeated rounds', () => {
+        const template = 'foo: 1\npersonal:\n  ide: phpstorm\n';
+        const values = {
+            profile: { id: 'developer' },
+            personal: { ide: 'phpstorm', autonomy: 'on' },
+            cost: { budgets: { daily: 0 } },
+        };
+
+        const once = mergeIntoTemplate(template, values);
+        let body = once;
+        for (let i = 0; i < 5; i++) body = mergeIntoTemplate(body, values);
+
+        expect(body).toBe(once);
+        expect(() => strict(body)).not.toThrow();
+        // The nested key stays nested; only the genuinely-absent ones go flat.
+        // Stability alone is not enough here: a run that appends a bogus flat
+        // `personal.ide:` on round one and then merely UPDATES it on every
+        // later round is stable, parses (the two are distinct top-level keys)
+        // and still leaves a line no reader resolves to `personal.ide`.
+        expect(body).not.toMatch(/^personal\.ide:/m);
+        const doc = strict(body) as Record<string, Record<string, unknown>>;
+        expect(doc['personal']?.['ide']).toBe('phpstorm');
+    });
+});
+
+/**
+ * The same defect in `upsertScalar`, which is the LIVE one.
+ *
+ * `mergeIntoTemplate` was fixed first and this path was left inferring
+ * presence from the write changing the string — so the fix covered the
+ * instance that was reported and not the instance that was reachable. The
+ * wizard's council page calls `upsertScalar` on save: pressing Save twice
+ * without moving a toggle wrote a second `api_on_quota:` into the same block,
+ * over two `{ok: true}` responses, leaving `.ai-council.yml` rejected by a
+ * strict parser. One found instance of a defect is a sample, not the
+ * population.
+ */
+describe('upsertScalar idempotence', () => {
+    it('a same-value save does not append a rival key beside the real one', () => {
+        const before = 'fallback:\n  api_on_quota: true\n';
+        const after = upsertScalar(before, ['fallback', 'api_on_quota'], true);
+
+        expect(after).toBe(before);
+        expect(() => strict(after)).not.toThrow();
+        expect((after.match(/api_on_quota:/g) ?? []).length).toBe(1);
+    });
+
+    it('stays a fixed point across alternating and repeated saves', () => {
+        // Alternating values already passed before the fix — the existing
+        // suite only ever alternates — so the repeat is the half that matters.
+        let body = 'fallback:\n  api_on_quota: true\n';
+        for (const v of [false, false, true, true, false]) {
+            body = upsertScalar(body, ['fallback', 'api_on_quota'], v);
+            expect(() => strict(body)).not.toThrow();
+        }
+        expect((body.match(/api_on_quota:/g) ?? []).length).toBe(1);
+        expect(strict(body)).toEqual({ fallback: { api_on_quota: false } });
+    });
+
+    it('still creates the nesting when the key is genuinely absent', () => {
+        // The behaviour the presence probe must not cost: an absent path is
+        // created as real nesting, never as a flat `a.b:` line.
+        const after = upsertScalar('enabled: true\n', ['fallback', 'api_on_quota'], true);
+        expect(strict(after)).toEqual({ enabled: true, fallback: { api_on_quota: true } });
+    });
+});
+
+/**
+ * Dashed nested keys — ordinary YAML the probe could not see.
+ *
+ * `detectIndentWidth` accepted `-` in a key; the presence probe did not. A
+ * dashed nested key was therefore never found, and the two writers failed
+ * differently: `mergeIntoTemplate` wrote a bogus top-level flat twin and left
+ * the real nested value untouched (a save that silently did nothing), while
+ * `upsertScalar` appended another child line on every single call.
+ *
+ * Three shapes rather than one parameterised case, because widening a key
+ * pattern is not only "does it match" — it is "does it REPLACE correctly
+ * wherever such a key can legally sit".
+ */
+describe('dashed nested keys', () => {
+    it('replaces a plain dashed key in place', () => {
+        const before = 'personas:\n  first-principles: false\n';
+        const after = mergeIntoTemplate(before, { personas: { 'first-principles': true } });
+
+        expect(after).not.toContain('Wizard-added keys');
+        expect(after).not.toMatch(/^personas\.first-principles:/m);
+        expect(strict(after)).toEqual({ personas: { 'first-principles': true } });
+    });
+
+    it('replaces a dashed key carrying an inline comment', () => {
+        const before = 'personas:\n  retry-count: 3  # production\n';
+        const after = mergeIntoTemplate(before, { personas: { 'retry-count': 5 } });
+
+        expect(strict(after)).toEqual({ personas: { 'retry-count': 5 } });
+        expect((after.match(/retry-count:/g) ?? []).length).toBe(1);
+    });
+
+    it('leaves a dashed key inside flow syntax alone rather than half-editing it', () => {
+        // `personas: {dry-run: true}` is one line, and the probe walks lines.
+        // The requirement is not that it edits this — it is that it does not
+        // produce a second `personas` key while trying.
+        const before = 'personas: {dry-run: true}\n';
+        const after = mergeIntoTemplate(before, { personas: { 'dry-run': false } });
+
+        expect(() => strict(after)).not.toThrow();
+        expect((after.match(/^personas:/gm) ?? []).length).toBe(1);
+    });
+
+    it('upsertScalar no longer grows without bound on a dashed leaf', () => {
+        // The worst half: the append path used the same pattern and never
+        // collapses, so three calls produced three sibling lines.
+        let body = 'personas:\n  first-principles: true\n';
+        for (let i = 0; i < 3; i++) {
+            body = upsertScalar(body, ['personas', 'first-principles'], true);
+        }
+        expect((body.match(/first-principles:/g) ?? []).length).toBe(1);
+        expect(() => strict(body)).not.toThrow();
+    });
+});


### PR DESCRIPTION
## What broke

`agents/settings/.agent-settings.yml` accumulated 47 duplicate mapping keys on a real install. A strict parser rejects such a file, so `sync_agent_settings` exited 2, `task sync` exited 2, and `task release-prepare` took the release down at step 2 of 10 with `Map keys must be unique at line 1390` and a Node stack trace.

Nothing external did that. The wizard's own writer produced it, on every save.

## Two independent causes

`mergeIntoTemplate` appends a key with no template entry as a flat top-level `a.b: value` line. Both writers then decided *"is this key already here?"* by writing it and checking whether the text changed:

1. **The flat form was invisible to the probe.** `replaceScalar`'s key pattern carries no dot, so a line the module had just written could not be seen on the next pass, and the whole block was appended again.
2. **Presence was inferred from a side effect.** Writing a value a key already holds returns a byte-identical string, which read as *absent* and appended a duplicate.

Either one alone reproduces the corruption, so both are pinned separately.

The reachable one is `upsertScalar`, not the function that was reported: saving the wizard's council page twice **without moving a toggle** wrote a second `api_on_quota:` into the same block, over two `{ok: true}` responses, leaving `.ai-council.yml` rejected by a strict parser.

A third instance of the same shape came out of review: `findScalarLine` excluded `-` from its key pattern while `detectIndentWidth` accepted it, so a dashed nested key (`retry-count`, ordinary YAML) was found by one and not the other — the merge wrote a bogus flat twin and never updated the real value, and `upsertScalar` appended another sibling line on **every** call, growing without bound.

## What ships

**The writers ask instead of inferring.** `findScalarLine` makes presence a question with an answer; `replaceFlatDottedKey` updates the flat form in place and collapses a pre-existing run. Repeated application is a fixed point.

**A repair pass, for the files the old writer already broke.** Those files are gitignored local state — no CI job sees them, no fixture covers them, and an operator meets one only by running a release. The pass collapses a duplicate run last-wins, which is value-neutral by construction: a lenient parser already resolved it that way, so the collapse changes only *whether* the file parses.

Holding that promise took more than the obvious check. A key is collapsed only when every occurrence occupies exactly its own line — otherwise dropping the loser removes its header and leaves the body behind, re-attached to the preceding key, turning a loud error into silent corruption. Refused for that reason: block and folded scalars, anchors/aliases/tags anywhere in the value (`a: [&x 1]` fits on one line and an alias elsewhere binds to it), flow collections spanning lines, and anything with a continuation line. `---` streams are left alone.

A mapping key ends at a colon **followed by space**, YAML's own rule. Stopping at the first one read `a:b: 1` as the key `a`, so a file carrying both `a:b:` and `a:` had its `a:b` entry silently deleted — and the result parsed cleanly, so nothing downstream could notice.

Keys the pass cannot model (digit-leading, quoted) are now **reported** rather than skipped in silence, and each refusal names its own reason instead of asserting "different children" over a null that has none.

**A gate before the bump.** `_settings-readable` runs ahead of `task release` and `task release:verify`, proving the release's own first read works before the version is touched. `--dry-run`, so the probe cannot dirty the tree the release checks moments later. Drift is not a failure — only an unreadable file is — because a gate that fired on ordinary drift would fire on nearly every release and be switched off inside a month.

The sync step's own existence test moves with it: it gated on the repo-root settings file while the script resolves `agents/settings/` first (ADR-038), so on a canonical-only checkout the sync silently never ran.

## How this was checked

Two neutral reviews (independent model, full diff, no expectation stated in either prompt) produced nineteen findings across two rounds. Everything either review called a correctness or value-neutrality defect is fixed. An AI council then classified the remainder: one blocking, two fix-now, four shippable as recorded debt.

One finding was **rejected with evidence** — a claimed regression where a same-value `upsertScalar` strips an inline comment. Measured against the reconstructed old code, both produce byte-identical output; it is pre-existing `replaceScalar` behaviour, not a regression from this change.

Every fix was **observed failing with its own fix reverted**, individually: the flat-key probe, the presence question in each writer, the colon rule, the anchor scan, the `\r` capture, the majority-EOL choice, the notice's tense, the `--quiet` gate, the dashed-key pattern, the unmodellable-key report, the `--check` discriminator, and the unparseable-input warning. One test was green for the wrong reason first (`"on"` is requoted by `formatScalar`, so the "no-op" write was not one) and its fixture was corrected.

798 tests green across the server, install, sync and release suites. `task release -- --dry-run` exits 0; a deliberately corrupted settings file now stops the release before the bump with a readable diagnosis instead of a stack trace after it.

## Deliberately not fixed

Four residuals ship as debt, recorded in `agents/roadmaps/road-to-settings-writer-residual-debt.md` with the evidence that would reopen each: a stale flat twin the merge never removes, an orphaned section header that accumulates, whether `--check` may exit 0 on a repair-only difference, and whether an unparseable input may be repaired at all rather than warned about. Without that file they exist only in a chat log, and the next reviewer pays for both review rounds again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
