### PR TITLE
fix(release): read the remote before pushing, never from the rejection

### DIFF
--- a/src/scripts/release.ts
+++ b/src/scripts/release.ts
@@ -1109,9 +1109,9 @@ function execute(
     if (pr_merged) {
         _step(4, total, 'PR already merged — skip push');
     } else {
-        // `git push -u` is naturally idempotent — it prints "Everything
-        // up-to-date" when remote already matches. push_release_branch
-        // additionally absorbs a remote that moved under us.
+        // push_release_branch reads the remote FIRST — it skips the push when
+        // the remote is already at head (a no-op push still runs the pre-push
+        // hook, which then refuses over pending CI) and merges one that moved.
         // Not a `_step`: a second `[4/11]` makes the cited evidence anchors ambiguous.
         process.stdout.write('        · verifying release gates locally (`task release:verify -- --cheap`)\n');
         run(local_release_gate_argv());

--- a/src/scripts/release_drill.ts
+++ b/src/scripts/release_drill.ts
@@ -127,6 +127,33 @@ interface WorldConfig {
      */
     branch_behind_main?: number;
     /**
+     * Commits `origin/<release-branch>` carries that this checkout does not.
+     *
+     * Sibling of `branch_behind_main`, one ref over: that one fakes `git
+     * rev-list --count HEAD..origin/main`, this one the distance to the
+     * release branch's OWN remote — the divergence a GitHub *Update branch*
+     * press or a concurrent resume run produces.
+     */
+    branch_behind_remote?: number;
+    /**
+     * Commits this checkout carries that `origin/<release-branch>` does not.
+     *
+     * Defaults to 1 so every pre-existing scenario keeps the local-ahead shape
+     * it was written against. Set to 0 together with `branch_behind_remote: 0`
+     * to reach the state where the remote is already AT head and the push must
+     * therefore not be issued at all.
+     */
+    branch_ahead_remote?: number;
+    /**
+     * Whether `origin/<release-branch>` exists at the start of the run.
+     *
+     * Internal state until 2026-09-12 — a scenario could only reach `false`
+     * indirectly, by having the run delete the branch. The remote-position
+     * probe added with `_remote_branch_state` has a never-pushed arm that no
+     * scenario could otherwise enter, so the knob is now declared.
+     */
+    branch_exists_remote?: boolean;
+    /**
      * Whether `execute()` is invoked with `--resume`. Defaults to TRUE so every
      * pre-existing scenario keeps the shape it was written against.
      *
@@ -319,6 +346,8 @@ class FakeWorld {
     private push_rejections: number;
     private behind_probes: number;
     private branch_behind_main: number;
+    private branch_behind_remote: number;
+    private readonly branch_ahead_remote: number;
     private merge_races_once: boolean;
     private merge_fails_hard: boolean;
     private checks_fail: boolean;
@@ -341,6 +370,9 @@ class FakeWorld {
         this.tag_remote = cfg.tag_already_remote ?? false;
         this.behind_probes = cfg.behind_probes ?? 0;
         this.branch_behind_main = cfg.branch_behind_main ?? 0;
+        this.branch_exists_remote = cfg.branch_exists_remote ?? true;
+        this.branch_behind_remote = cfg.branch_behind_remote ?? 0;
+        this.branch_ahead_remote = cfg.branch_ahead_remote ?? 1;
         this.merge_races_once = cfg.merge_races_once ?? false;
         this.merge_fails_hard = cfg.merge_fails_hard ?? false;
         this.checks_fail = cfg.checks_fail ?? false;
@@ -373,6 +405,18 @@ class FakeWorld {
             // A real merge closes the gap, so a second probe reads 0. Without
             // this the scenario could not tell one merge from a loop.
             this.branch_behind_main = 0;
+            return OK;
+        }
+        if (cmd === `git rev-list --left-right --count HEAD...origin/${this.branch}`) {
+            return {
+                ...OK,
+                stdout: `${String(this.branch_ahead_remote)}\t${String(this.branch_behind_remote)}\n`,
+            };
+        }
+        if (cmd === `git merge --no-edit origin/${this.branch}`) {
+            // A real merge closes the gap, so the re-read sees 0 — the same
+            // reason the origin/main handler above zeroes its own counter.
+            this.branch_behind_remote = 0;
             return OK;
         }
         if (cmd === `git rev-parse --verify --quiet refs/heads/${this.branch}`) {
@@ -747,6 +791,81 @@ const SCENARIOS: Record<string, Scenario> = {
             _expect(
                 _count(w, 'git merge origin/main --no-edit') === 1,
                 'merged main more than once — the probe is not being re-read after the merge',
+                f,
+            );
+            return f;
+        },
+    },
+    'remote-branch-moved-merges-before-push': {
+        summary:
+            'step 4: a release branch that diverged on the remote is merged in BEFORE the push — not after a rejection the local preflight never lets git produce',
+        // Measured 2026-09-12 on 16.0.0. `origin/release/16.0.0` carried five
+        // commits this checkout did not have. `push_release_branch` has a
+        // merge-and-retry for exactly that, keyed on git's rejection wording —
+        // but the local pre-push preflight refused first, with
+        // `check_pr_ci_current`'s own message naming the divergence. git never
+        // printed `[rejected]`, `_is_non_fast_forward` correctly answered
+        // "not the fetch-and-retry case" on the text it was given, and the
+        // recovery was unreachable from the state it was written for.
+        config: { branch_behind_remote: 5 },
+        expect_success: true,
+        verify: (w) => {
+            const f: string[] = [];
+            const merge = w.calls.indexOf(`git merge --no-edit origin/${w.branch}`);
+            const push = w.calls.indexOf(`git push -u origin ${w.branch}`);
+            _expect(merge >= 0, 'the diverged remote branch was never merged in', f);
+            _expect(push >= 0, 'the branch was never pushed', f);
+            // Ordering is the whole point: a merge only AFTER the push means
+            // the reactive path ran, and that path is what the gate pre-empts.
+            _expect(
+                merge >= 0 && push >= 0 && merge < push,
+                'the remote branch was merged after the push, not before it',
+                f,
+            );
+            _expect(
+                _count(w, `git merge --no-edit origin/${w.branch}`) === 1,
+                'merged the remote branch more than once — the probe is not re-read after the merge',
+                f,
+            );
+            return f;
+        },
+    },
+    'remote-already-at-head-skips-the-push': {
+        summary:
+            'step 4: a remote already carrying this commit is not pushed to again — the no-op push still runs the pre-push hook, and the hook refuses',
+        // The second half of the same 16.0.0 failure, and the one no rejection
+        // text can reach. The push had succeeded; a resumed run re-entered
+        // step 4 and pushed again. `git push -u` is idempotent on the network
+        // side, but git runs the pre-push hook BEFORE discovering there is
+        // nothing to send — so the preflight was handed the head this run had
+        // just pushed, found its CI still pending, and killed the release.
+        config: { branch_ahead_remote: 0, branch_behind_remote: 0 },
+        expect_success: true,
+        verify: (w) => {
+            const f: string[] = [];
+            _expect(
+                !w.calls.includes(`git push -u origin ${w.branch}`),
+                'pushed a branch the remote already carries — that push runs the pre-push hook for nothing',
+                f,
+            );
+            return f;
+        },
+    },
+    'unpushed-branch-still-pushes': {
+        summary:
+            'step 4: a branch that was never pushed is pushed, and no distance is probed against a remote ref that does not exist',
+        // The near-miss for the direction the new probe opens: `git rev-list
+        // HEAD...origin/<branch>` against a missing ref is the 9.26.0 shape all
+        // over again — an exit from the recovery masking the real state.
+        // `--exit-code` on the ls-remote probe is what keeps it closed.
+        config: { branch_exists_remote: false },
+        expect_success: true,
+        verify: (w) => {
+            const f: string[] = [];
+            _expect(w.calls.includes(`git push -u origin ${w.branch}`), 'the branch was never pushed', f);
+            _expect(
+                !w.calls.includes(`git rev-list --left-right --count HEAD...origin/${w.branch}`),
+                'probed the distance to a remote ref that does not exist',
                 f,
             );
             return f;

--- a/src/scripts/release_publication.ts
+++ b/src/scripts/release_publication.ts
@@ -745,8 +745,59 @@ export function guard_release_curation(version: string, prMerged = false): void 
     );
 }
 
+/**
+ * What `REMOTE/<branch>` holds relative to HEAD, before anything is pushed.
+ *
+ * `push_release_branch` used to issue the push and learn the remote's position
+ * only from the rejection that came back. That reading is unavailable in two
+ * measured states, both on 16.0.0 (2026-09-12): the local pre-push gate refuses
+ * a diverged branch before git can print `[rejected]`, and a remote already AT
+ * head produces no rejection at all — git runs the pre-push hook before it
+ * discovers there is nothing to send, so the hook refuses over CI still pending
+ * on the head this run had already pushed. Asking first is the only place both
+ * are visible.
+ */
+type RemoteBranchState = 'absent' | 'in-sync' | 'remote-ahead' | 'local-ahead';
+
+function _remote_branch_state(branch: string): RemoteBranchState {
+    // `--exit-code` so a never-pushed branch reads as a clean non-zero rather
+    // than an empty success the count below would then run against a missing
+    // ref — the exit-128 masking this file already carries a test for.
+    const exists = run(['git', 'ls-remote', '--exit-code', '--heads', REMOTE, branch], {
+        check: false,
+        capture: true,
+    });
+    if (exists.returncode !== 0) return 'absent';
+    run(['git', 'fetch', REMOTE, branch], { check: false, capture: true });
+    const counts = run(['git', 'rev-list', '--left-right', '--count', `HEAD...${REMOTE}/${branch}`], {
+        check: false,
+        capture: true,
+    });
+    // Unreadable → push and let git judge, which is the pre-2026-09-12 behaviour.
+    if (counts.returncode !== 0) return 'local-ahead';
+    const [ahead = '0', behind = '0'] = counts.stdout.trim().split(/\s+/);
+    if (Number(behind) > 0) return 'remote-ahead';
+    return Number(ahead) > 0 ? 'local-ahead' : 'in-sync';
+}
+
 function push_release_branch(branch: string): void {
+    let state = _remote_branch_state(branch);
+    if (state === 'remote-ahead') {
+        process.stdout.write(`↻  ${REMOTE}/${branch} moved under us — merging it in before the push\n`);
+        run(['git', 'merge', '--no-edit', `${REMOTE}/${branch}`]);
+        // Re-read: a fast-forward merge lands HEAD exactly on the remote, and
+        // the push that followed would then be the no-op case below.
+        state = _remote_branch_state(branch);
+    }
+
     guard_release_branch_push(branch);
+
+    // Ahead of the skip on purpose: the guard validates the release content,
+    // which has to be right whether or not this run is the one that sends it.
+    if (state === 'in-sync') {
+        process.stdout.write(`✅  ${REMOTE}/${branch} already carries this commit — nothing to push\n`);
+        return;
+    }
     const first = run(['git', 'push', '-u', REMOTE, branch], { check: false, capture: true });
     if (first.returncode === 0) {
         process.stdout.write(first.stdout);


### PR DESCRIPTION
`task release` died twice at step 4 on 16.0.0, two different-looking errors, one cause: `push_release_branch` never asked what the remote held — it issued the push and learned the remote's position only from the error that came back. Two states never produce that error.

**A diverged remote.** `origin/release/16.0.0` carried five commits the checkout lacked. The merge-and-retry written for exactly that is keyed on git's rejection wording, but the local pre-push preflight refuses first (`check_pr_ci_current`: *"not reachable from the local branch (diverged)"*). git never printed `[rejected]`, `_is_non_fast_forward` answered "not the fetch-and-retry case" correctly on the text it was given, and the recovery was unreachable from the state it exists for. The operator was told to go fix a pre-push gate that was reporting the very condition the recovery clears.

**A remote already at head.** After the push succeeded, a resumed run re-entered step 4 and pushed again. The call site justified that with *"`git push -u` is naturally idempotent"* — true of the wire, false of the hook. git runs `pre-push` before it discovers there is nothing to send, so the gate was handed the head this run had just pushed, found its CI still pending, and killed the release. A no-op push is not a no-op.

## The change

`_remote_branch_state` resolves `absent` / `in-sync` / `remote-ahead` / `local-ahead` before anything is sent (`ls-remote --exit-code` → `fetch` → `rev-list --left-right --count`). `in-sync` skips the push entirely; `remote-ahead` merges and re-reads, because a fast-forward merge lands exactly on the remote and is then the in-sync case. The reactive path stays — the remote can still move between the read and the push, which is why a pre-check never replaces handling the rejection.

`guard_release_branch_push` stays ahead of the skip: it validates the release content, which has to be right whether or not this run is the one that sends it.

## Coverage

Three `release:drill` scenarios — `remote-branch-moved-merges-before-push`, `remote-already-at-head-skips-the-push`, `unpushed-branch-still-pushes` (the near-miss for the direction the new probe opens: no distance probe against a ref that does not exist).

`branch_exists_remote` becomes a declared `WorldConfig` knob. It was internal state, so the never-pushed arm was unreachable from a scenario — and a scenario setting it was being silently ignored, which is how the near-miss first went red.

**Sensitivity proven:** neutralising `_remote_branch_state` to always return `local-ahead` reds the first two scenarios; restoring it greens them.

## Verification

- `task release:drill` — 22/22 green
- 67/67 in `release_push_failure_masking`, `release_drill`, `release_gate_locality`, `check_source_size_budget`
- `tsc --noEmit`, `eslint`, `lint_code_comments` clean
- `check_source_size_budget` held at baseline (17,947) — the `release.ts` comment was rewritten line-neutral, since that file sits past the 1500-line cap
- `task preflight` exit 0