### PR TITLE
docs(pr-merge): pin the straggler batch to preparation and close the disposition set

### DIFF
--- a/agents/evidence/reviews/pr-merge-straggler-and-disposition-set.findings.md
+++ b/agents/evidence/reviews/pr-merge-straggler-and-disposition-set.findings.md
@@ -1,0 +1,5 @@
+<!-- evidence-type: review -->
+
+# Completion review — /pr:merge straggler batch and disposition set
+
+**Skipped:** no code surface for this completion — the diff is one command body and its two generated projections — a pack token-passport count and the dist copy; the gate measures 0 code path(s) of 3 changed file(s), scope 559eb78ef7593742f457a04278a03e986f29e52bed725ded306aed862bc3378c, declared 2026-09-12

--- a/dist/agent-src/commands/pr/merge.md
+++ b/dist/agent-src/commands/pr/merge.md
@@ -127,8 +127,8 @@ So the record carries **two** SHAs per PR and they mean different things:
 Before every merge, re-read the PR and refuse when the live head is **neither**
 the snapshot head **nor** the head this run last pushed. That is the
 force-push-after-authorization case, and it is the only one the check exists
-for. A PR that appeared after the snapshot is not in scope for this run — § 6
-says what happens to it.
+for. A PR that appeared after the snapshot is never merged by this run — § 6
+says what happens to it instead.
 
 ## 2. Sync with the base
 
@@ -258,10 +258,18 @@ a PR its own predecessor invalidated, because it has no predecessor that
 landed. The cutoff below bounds both forms.
 
 **Cutoff.** When the manifest is exhausted, recompute the open-PR list
-**exactly once**. PRs that appeared during the run are drained as ONE final
+**exactly once**. PRs that appeared during the run are **prepared** as ONE final
 straggler batch. After that batch the run ends unconditionally; anything
 arriving during or after it is recorded as `arrived-after-cutoff` and is not
 processed.
+
+**The straggler batch is prepared and never merged — in both forms.** It is not
+in § 1's manifest, so the invocation does not reach it (the Iron Law above § 1,
+and § 7's first rule). "Drained" is therefore preparation here: each straggler
+is synced, classified, greened and reported, ends at mergeable-and-open exactly
+as under `--no-merge`, and is recorded `unauthorized` with the go-ahead it needs.
+Reading "drained" as "merged" is the one way `all` could merge a PR the owner
+never named, which is why the word is pinned rather than left to context.
 
 ```
 THE CUTOFF IS THE TERMINATION PROOF.
@@ -314,6 +322,11 @@ follow, and they are stricter than the ones they replace:
 Write the summary as-is with an `unauthorized` disposition per unprocessed PR
 and name the exact authorization needed. Then STOP and wait — do not end the
 run, and do not proceed to the next PR.
+
+That is the same `unauthorized` row § 6's straggler batch carries, and
+deliberately one token rather than two: both mean *prepared by this run, not
+authorized for it to merge*, and a reader of the summary needs the distinction
+between merged and not-merged, not between two reasons for the same outcome.
 
 ## 8. Kill switches, and what happens after a merge
 
@@ -369,7 +382,14 @@ conflict classes hit, CI iterations used, disposition, and any edits dropped in
 conflict resolution. The disposition set is closed:
 
 `merged <sha>` · `superseded-closed` · `blocked-external` · `twice-exhausted` ·
-`window-expired` · `arrived-after-cutoff`
+`unauthorized` · `arrived-after-cutoff`
+
+`unauthorized` replaces `window-expired`, and the swap is one-for-one on
+purpose. `window-expired` named a clock ADR-254 removed on 2026-09-04, so no run
+can produce that row any more, and a closed set holding an unproducible member
+is a set nobody can check a run against. `unauthorized` names what actually
+happens in its place — § 7's pause and § 6's straggler batch, the two ways a PR
+ends this run prepared and unmerged.
 
 ## Rules
 

--- a/src/domains/git/pack.yaml
+++ b/src/domains/git/pack.yaml
@@ -19,8 +19,8 @@ surface_tier: core
 token_passport:
   basis: chars/4
   catalog_tokens: 0
-  commands_tokens: 18550
+  commands_tokens: 18876
   other_tokens: 0
   rules_tokens: 0
-  total_tokens: 18550
+  total_tokens: 18876
 trust_level_default: core

--- a/src/domains/git/pr/merge/command.md
+++ b/src/domains/git/pr/merge/command.md
@@ -127,8 +127,8 @@ So the record carries **two** SHAs per PR and they mean different things:
 Before every merge, re-read the PR and refuse when the live head is **neither**
 the snapshot head **nor** the head this run last pushed. That is the
 force-push-after-authorization case, and it is the only one the check exists
-for. A PR that appeared after the snapshot is not in scope for this run — § 6
-says what happens to it.
+for. A PR that appeared after the snapshot is never merged by this run — § 6
+says what happens to it instead.
 
 ## 2. Sync with the base
 
@@ -258,10 +258,18 @@ a PR its own predecessor invalidated, because it has no predecessor that
 landed. The cutoff below bounds both forms.
 
 **Cutoff.** When the manifest is exhausted, recompute the open-PR list
-**exactly once**. PRs that appeared during the run are drained as ONE final
+**exactly once**. PRs that appeared during the run are **prepared** as ONE final
 straggler batch. After that batch the run ends unconditionally; anything
 arriving during or after it is recorded as `arrived-after-cutoff` and is not
 processed.
+
+**The straggler batch is prepared and never merged — in both forms.** It is not
+in § 1's manifest, so the invocation does not reach it (the Iron Law above § 1,
+and § 7's first rule). "Drained" is therefore preparation here: each straggler
+is synced, classified, greened and reported, ends at mergeable-and-open exactly
+as under `--no-merge`, and is recorded `unauthorized` with the go-ahead it needs.
+Reading "drained" as "merged" is the one way `all` could merge a PR the owner
+never named, which is why the word is pinned rather than left to context.
 
 ```
 THE CUTOFF IS THE TERMINATION PROOF.
@@ -314,6 +322,11 @@ follow, and they are stricter than the ones they replace:
 Write the summary as-is with an `unauthorized` disposition per unprocessed PR
 and name the exact authorization needed. Then STOP and wait — do not end the
 run, and do not proceed to the next PR.
+
+That is the same `unauthorized` row § 6's straggler batch carries, and
+deliberately one token rather than two: both mean *prepared by this run, not
+authorized for it to merge*, and a reader of the summary needs the distinction
+between merged and not-merged, not between two reasons for the same outcome.
 
 ## 8. Kill switches, and what happens after a merge
 
@@ -369,7 +382,14 @@ conflict classes hit, CI iterations used, disposition, and any edits dropped in
 conflict resolution. The disposition set is closed:
 
 `merged <sha>` · `superseded-closed` · `blocked-external` · `twice-exhausted` ·
-`window-expired` · `arrived-after-cutoff`
+`unauthorized` · `arrived-after-cutoff`
+
+`unauthorized` replaces `window-expired`, and the swap is one-for-one on
+purpose. `window-expired` named a clock ADR-254 removed on 2026-09-04, so no run
+can produce that row any more, and a closed set holding an unproducible member
+is a set nobody can check a run against. `unauthorized` names what actually
+happens in its place — § 7's pause and § 6's straggler batch, the two ways a PR
+ends this run prepared and unmerged.
 
 ## Rules
 


### PR DESCRIPTION
Two self-contradictions in `/pr:merge` (`src/domains/git/pr/merge/command.md`), both found by reading the command against its own Iron Law rather than by a gate. Neither widens behaviour: both edits narrow what `all` may do.

## 1. Section 6 vs section 7 — the straggler batch was undecidable

Section 6 said PRs arriving during a run are "drained as ONE final straggler batch". Section 7 and the Rules block said a PR arriving after the authorizing sentence "needs its own go-ahead". For `/pr:merge all` it was not derivable from the text whether that batch merges or only prepares — exactly the kind of ambiguity an autonomous run resolves silently.

Section 6 was the loose one, and the command already settles it elsewhere: the Iron Law above section 1 says the invocation "reaches exactly the PRs section 1 manifest snapshotted from it" and "never reaches a PR that arrived later", and the Dispatch table row for `all` merges "the manifest", not the recomputed list.

**Fix.** "Drained" is pinned to preparation, in both forms. The batch is synced, classified, greened and reported, ends at mergeable-and-open exactly as under `--no-merge`, and each straggler is recorded `unauthorized` with the go-ahead it needs. The paragraph also states why the word is pinned rather than left to context. Section 1 pointer reworded from "not in scope for this run" to "never merged by this run", which is what it now means.

The termination proof is untouched: the bound is still initial manifest plus one batch.

## 2. Section 9 — the closed disposition set did not match what a run writes

Section 7 instructs the run to write an `unauthorized` disposition. The closed set in section 9 did not contain it, and still carried `window-expired` — a row naming the mechanical authorization window ADR-254 removed on 2026-09-04. No run can produce that row any more, and a closed set holding an unproducible member is a set nobody can check a run against.

**Fix.** One-for-one swap: `unauthorized` replaces `window-expired`, with the reason stated inline. One token rather than two for the two cases (section 7 pause, section 6 straggler batch), because a summary reader needs the merged/not-merged distinction, not two reasons for the same outcome. Section 7 now names the shared row.

## Scope

- Only `src/domains/git/pr/merge/command.md` is hand-edited. `dist/agent-src/commands/pr/merge.md` and the `src/domains/git/pack.yaml` token passport are regenerated output (`task sync`, then `task generate-tools`).
- `window-expired` survives in `docs/decisions/ADR-251-*` and in archived roadmaps and evidence. Those are historical records and are deliberately not rewritten.
- `task preflight` green, exit 0. Completion-review skip declared — the diff carries 0 code paths.
